### PR TITLE
fix: resolve PWA update notification race condition

### DIFF
--- a/components/pwa-update-toast.tsx
+++ b/components/pwa-update-toast.tsx
@@ -30,14 +30,15 @@ export function PwaUpdateToast() {
   const handleUpdate = () => {
     if (!waitingWorker) return;
 
-    // Tell the waiting service worker to take over
-    waitingWorker.postMessage({ type: "SKIP_WAITING" });
-
     // Listen for the service worker to actually take over
+    // IMPORTANT: Attach listener BEFORE posting message to avoid race condition
     navigator.serviceWorker.addEventListener("controllerchange", () => {
       // Reload the page to use the new service worker
       window.location.reload();
     });
+
+    // Tell the waiting service worker to take over
+    waitingWorker.postMessage({ type: "SKIP_WAITING" });
   };
 
   const handleDismiss = () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-taskmanager",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
Fixes a critical bug where the PWA update notification "Refresh Now" button would not reload the page with the new service worker version.

## Problem
When a user clicked the "Refresh Now" button in the update notification, nothing happened. The issue was a race condition in `components/pwa-update-toast.tsx` where:
1. The `SKIP_WAITING` message was posted to the service worker
2. The `controllerchange` event listener was attached afterward
3. If the service worker processed the message quickly, the controller change event fired before the listener was ready
4. Result: No page reload, user stuck on old version

## Solution
Reordered the code to attach the `controllerchange` event listener **before** sending the `SKIP_WAITING` message. This ensures the listener is always in place when the service worker takes control and triggers the page reload.

## Changes
- Fixed race condition in `components/pwa-update-toast.tsx:30-42`
- Bumped version to 2.1.7 in `package.json`
- Deployed to production (live at https://gsd.vinny.dev)

## Test Plan
- [x] TypeScript type checking passes
- [x] Built and deployed to production
- [ ] Manual testing: Deploy another update and verify "Refresh Now" button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)