### PR TITLE
fix: Correct JSON formatting in CloudFront deployment scripts

### DIFF
--- a/scripts/deploy-cloudfront-function.sh
+++ b/scripts/deploy-cloudfront-function.sh
@@ -28,7 +28,7 @@ if [ -z "$FUNCTION_EXISTS" ]; then
   # Create the function
   FUNCTION_ARN=$(aws cloudfront create-function \
     --name "$FUNCTION_NAME" \
-    --function-config Comment="URL rewrite for Next.js static export with trailing slashes",Runtime="cloudfront-js-2.0" \
+    --function-config '{"Comment":"URL rewrite for Next.js static export with trailing slashes","Runtime":"cloudfront-js-2.0"}' \
     --function-code fileb://"$FUNCTION_FILE" \
     --query 'FunctionSummary.FunctionMetadata.FunctionARN' \
     --output text)
@@ -44,7 +44,7 @@ else
   FUNCTION_ARN=$(aws cloudfront update-function \
     --name "$FUNCTION_NAME" \
     --if-match "$ETAG" \
-    --function-config Comment="URL rewrite for Next.js static export with trailing slashes",Runtime="cloudfront-js-2.0" \
+    --function-config '{"Comment":"URL rewrite for Next.js static export with trailing slashes","Runtime":"cloudfront-js-2.0"}' \
     --function-code fileb://"$FUNCTION_FILE" \
     --query 'FunctionSummary.FunctionMetadata.FunctionARN' \
     --output text)

--- a/scripts/deploy-security-headers.sh
+++ b/scripts/deploy-security-headers.sh
@@ -28,7 +28,7 @@ if [ -z "$FUNCTION_EXISTS" ]; then
   # Create the function
   FUNCTION_ARN=$(aws cloudfront create-function \
     --name "$FUNCTION_NAME" \
-    --function-config Comment="Security headers (CSP, X-Frame-Options, etc.) for GSD Task Manager",Runtime="cloudfront-js-2.0" \
+    --function-config '{"Comment":"Security headers for GSD Task Manager","Runtime":"cloudfront-js-2.0"}' \
     --function-code fileb://"$FUNCTION_FILE" \
     --query 'FunctionSummary.FunctionMetadata.FunctionARN' \
     --output text)
@@ -44,7 +44,7 @@ else
   FUNCTION_ARN=$(aws cloudfront update-function \
     --name "$FUNCTION_NAME" \
     --if-match "$ETAG" \
-    --function-config Comment="Security headers (CSP, X-Frame-Options, etc.) for GSD Task Manager",Runtime="cloudfront-js-2.0" \
+    --function-config '{"Comment":"Security headers for GSD Task Manager","Runtime":"cloudfront-js-2.0"}' \
     --function-code fileb://"$FUNCTION_FILE" \
     --query 'FunctionSummary.FunctionMetadata.FunctionARN' \
     --output text)


### PR DESCRIPTION
## Problem

The deployment scripts were failing with AWS CLI parameter validation errors when attempting to deploy CloudFront Functions:

```
Invalid type for parameter FunctionConfig.Comment, value: ['Security headers (CSP', 'X-Frame-Options', 'etc.) for GSD Task Manager'], type: <class 'list'>, valid types: <class 'str'>
```

The AWS CLI was incorrectly parsing the comma-separated parameters as arrays instead of a single string value.

## Root Cause

The `--function-config` parameter was using an incorrect format:
```bash
--function-config Comment="Security headers (CSP, X-Frame-Options, etc.) for GSD Task Manager",Runtime="cloudfront-js-2.0"
```

The comma in the comment string was being interpreted as a parameter separator, causing the AWS CLI to create an array `['Security headers (CSP', 'X-Frame-Options', 'etc.) for GSD Task Manager']` instead of a single string.

## Solution

Changed the `--function-config` parameter to use proper JSON format:
```bash
--function-config '{"Comment":"Security headers for GSD Task Manager","Runtime":"cloudfront-js-2.0"}'
```

This ensures the AWS CLI correctly parses the configuration as a single JSON object.

## Files Changed

- ✅ `scripts/deploy-cloudfront-function.sh` - Fixed both create and update function commands
- ✅ `scripts/deploy-security-headers.sh` - Fixed both create and update function commands

## Testing

- ✅ Verified `./scripts/deploy-security-headers.sh` executes successfully
- ✅ CloudFront Function deployed and published correctly
- ✅ Both scripts now use consistent JSON formatting

## Impact

- **Bug Fix**: Scripts now work correctly for all users
- **No Breaking Changes**: Existing deployed functions are not affected
- **Consistency**: Both deployment scripts now use the same parameter format

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)