### PR TITLE
Fix sync initial setup and token expiration issues (v4.7.7)

### DIFF
--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -65,6 +65,7 @@ export function AppHeader({
   const [lastSyncTime, setLastSyncTime] = useState<number | null>(null);
   const [pendingCount, setPendingCount] = useState(0);
   const [retryCountdown, setRetryCountdown] = useState<number | null>(null);
+  const [, setTick] = useState(0); // Force re-render for relative time updates
 
   // Poll last sync time from coordinator
   useEffect(() => {
@@ -86,6 +87,15 @@ export function AppHeader({
     const interval = setInterval(updateLastSync, 5000);
     return () => clearInterval(interval);
   }, [isEnabled]);
+
+  // Force re-render every 30 seconds to update relative time display
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTick(t => t + 1);
+    }, 30000); // Update every 30 seconds
+    
+    return () => clearInterval(interval);
+  }, []);
 
   // Poll pending operation count
   useEffect(() => {

--- a/components/oauth-callback-handler.tsx
+++ b/components/oauth-callback-handler.tsx
@@ -78,6 +78,12 @@ export function OAuthCallbackHandler() {
           ? 'http://localhost:8787'
           : window.location.origin);
 
+      // Convert expiresAt from seconds to milliseconds if needed
+      // JWT tokens typically use seconds, but JavaScript Date uses milliseconds
+      const tokenExpiresAt = authData.expiresAt < 10000000000 
+        ? authData.expiresAt * 1000  // Convert seconds to milliseconds
+        : authData.expiresAt;         // Already in milliseconds
+
       await db.syncMetadata.put({
         key: 'sync_config',
         enabled: true,
@@ -86,7 +92,7 @@ export function OAuthCallbackHandler() {
         deviceName: existingSyncConfig?.deviceName || 'Device',
         email: authData.email,
         token: authData.token,
-        tokenExpiresAt: authData.expiresAt,
+        tokenExpiresAt,
         lastSyncAt: existingSyncConfig?.lastSyncAt || null,
         vectorClock: existingSyncConfig?.vectorClock || {},
         conflictStrategy: existingSyncConfig?.conflictStrategy || 'last_write_wins',

--- a/lib/sync/token-manager.ts
+++ b/lib/sync/token-manager.ts
@@ -140,10 +140,16 @@ export class TokenManager {
       throw new Error('Sync config not found');
     }
 
+    // Convert expiresAt from seconds to milliseconds if needed
+    // JWT tokens typically use seconds, but JavaScript Date uses milliseconds
+    const tokenExpiresAt = expiresAt < 10000000000 
+      ? expiresAt * 1000  // Convert seconds to milliseconds
+      : expiresAt;         // Already in milliseconds
+
     await db.syncMetadata.put({
       ...config,
       token,
-      tokenExpiresAt: expiresAt,
+      tokenExpiresAt,
       key: 'sync_config',
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-taskmanager",
-  "version": "4.7.5",
+  "version": "4.8.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
This PR fixes three critical sync issues discovered during testing:

### 1. Initial Sync Setup Bug 🐛
**Problem:** When users enabled sync for the first time, their existing tasks were never uploaded to the server.

**Solution:** 
- Added `queueExistingTasks()` method to SyncEngine
- Automatically called after encryption setup completes
- Queues all existing local tasks as 'create' operations
- Includes duplicate prevention to avoid re-queueing

**Impact:** Users can now sync existing tasks when first enabling sync across devices.

### 2. Token Expiration False Alarm 🔐
**Problem:** "Authentication token has expired" error appeared immediately after login because the worker returns JWT expiration in seconds, but client expected milliseconds.

**Solution:**
- Added automatic conversion from seconds to milliseconds
- Applied in both OAuth callback handler and token refresh flows
- Uses heuristic: if timestamp < 10 billion, multiply by 1000

**Impact:** No more false token expiration errors on login.

### 3. Stale "Last Sync" Timestamp ⏰
**Problem:** "Last sync: Just now" message never updated, even after 15+ minutes.

**Solution:**
- Added 30-second tick state to force component re-render
- Relative time now updates: "Just now" → "1 minute ago" → "15 minutes ago"

**Impact:** Users see accurate sync timing information.

## Changes
- `lib/sync/engine.ts` - Added queueExistingTasks() method
- `components/sync/encryption-passphrase-dialog.tsx` - Call queueExistingTasks() after setup
- `components/oauth-callback-handler.tsx` - Convert token expiration to milliseconds
- `lib/sync/token-manager.ts` - Convert token expiration on refresh
- `components/app-header.tsx` - Add 30-second tick for time updates
- `package.json` - Bump version to 4.7.7

## Testing
- ✅ Typecheck passes
- ✅ Manual testing confirmed all three issues resolved
- ✅ No worker changes required (client-side only)

## Deployment
Ready to merge and deploy. No breaking changes.