### PR TITLE
Release v5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "5.0.0",
+	"version": "5.1.0",
 	"private": true,
 	"scripts": {
 		"dev": "next dev",

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-mcp-server",
-  "version": "0.4.7",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-mcp-server",
-      "version": "0.4.7",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
@@ -1851,6 +1851,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },


### PR DESCRIPTION
## Summary

- Apply Biome formatting to package.json (spaces → tabs)
- Bump main package version from 5.0.0 to 5.1.0
- Bump MCP server package from 0.4.7 to 0.5.0
- Add peer dependency flag for workspace compatibility

## Changes

### Formatting
- Migrated package.json from 2-space indentation to tab indentation (Biome default)
- Maintains code style consistency across the project

### Version Bumps
- **Main package**: `5.0.0` → `5.1.0`
- **MCP server**: `0.4.7` → `0.5.0`
- Updated package-lock.json with peer dependency flag

## Testing

- [ ] Version numbers updated correctly
- [ ] Package formatting is consistent
- [ ] No breaking changes introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)