### PR TITLE
fix(bulk-actions): Restore bulk tag dialog functionality

### DIFF
--- a/components/matrix-board/index.tsx
+++ b/components/matrix-board/index.tsx
@@ -68,7 +68,7 @@ export function MatrixBoard() {
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   // Use custom hooks for bulk selection and task operations
-  const bulkSelection = useBulkSelection(all);
+  const bulkSelection = useBulkSelection(all, () => dialogs.setBulkTagDialogOpen(true));
   const taskOps = useTaskOperations(
     dialogs.dialogState,
     dialogs.closeDialog,

--- a/components/matrix-board/use-bulk-selection.ts
+++ b/components/matrix-board/use-bulk-selection.ts
@@ -9,7 +9,10 @@ import * as bulkOps from "@/lib/bulk-operations";
  * Custom hook for managing bulk selection and bulk operations
  * Handles selection mode, selected task IDs, and bulk action callbacks
  */
-export function useBulkSelection(allTasks: TaskRecord[]) {
+export function useBulkSelection(
+  allTasks: TaskRecord[],
+  onOpenBulkTagDialog: () => void
+) {
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedTaskIds, setSelectedTaskIds] = useState<Set<string>>(new Set());
   const { showToast } = useToast();
@@ -92,9 +95,8 @@ export function useBulkSelection(allTasks: TaskRecord[]) {
   }, [selectedTaskIds, allTasks, handleClearSelection, showToast, handleError]);
 
   const handleBulkAddTags = useCallback(() => {
-    // This just opens the dialog, actual adding is handled by a separate callback
-    return true;
-  }, []);
+    onOpenBulkTagDialog();
+  }, [onOpenBulkTagDialog]);
 
   return {
     selectionMode,


### PR DESCRIPTION
## Summary
Fixes a regression introduced during the Phase 3 refactor where the bulk tag dialog could not be opened.

## Problem
During the modular refactor in v5.2.0, bulk selection logic was extracted from `matrix-board.tsx` into the `useBulkSelection` hook. The `handleBulkAddTags` handler was left as a no-op stub that returned `true` instead of opening the dialog. This broke the bulk tagging feature - users could select multiple tasks but clicking the "Tag" button did nothing.

**Root cause:** The hook didn't have access to the `dialogs` state object to call `setBulkTagDialogOpen(true)`.

## Solution
- Added `onOpenBulkTagDialog` callback parameter to `useBulkSelection` hook
- Updated `handleBulkAddTags` to invoke the callback
- MatrixBoard component passes `() => dialogs.setBulkTagDialogOpen(true)` to the hook

This maintains proper separation of concerns - the hook handles selection logic while the parent component controls dialog state.

## Changes
- `components/matrix-board/use-bulk-selection.ts` - Added callback parameter and implemented handler
- `components/matrix-board/index.tsx` - Pass dialog opener function to hook

## Test Plan
- [x] Verify no new TypeScript errors introduced
- [x] Verify bulk operations test suite passes (14/14 tests)
- [ ] Manual testing:
  - Select multiple tasks in the matrix view
  - Click the "Tag" button in the bulk actions bar
  - Verify the bulk tag dialog opens
  - Add tags and confirm they're applied to all selected tasks

## Impact
- **Severity:** High - bulk tagging is completely broken without this fix
- **Risk:** Low - minimal change, restores original functionality
- **Breaking changes:** None

🤖 Generated with [Claude Code](https://claude.com/claude-code)