### PR TITLE
Sync help screen version with package.json

### DIFF
--- a/components/settings/about-section.tsx
+++ b/components/settings/about-section.tsx
@@ -32,13 +32,13 @@ export function AboutSection({ isExpanded, onToggle }: AboutSectionProps) {
 					<div className="flex justify-between">
 						<span className="text-foreground-muted">Version</span>
 						<span className="font-medium text-foreground">
-							{process.env.NEXT_PUBLIC_BUILD_VERSION || "3.0.1"}
+							{process.env.NEXT_PUBLIC_BUILD_NUMBER || "5.3.0"}
 						</span>
 					</div>
 					<div className="flex justify-between">
 						<span className="text-foreground-muted">Build Date</span>
 						<span className="font-medium text-foreground">
-							{process.env.NEXT_PUBLIC_BUILD_DATE || "Oct 12, 2025"}
+							{process.env.NEXT_PUBLIC_BUILD_DATE || "dev build"}
 						</span>
 					</div>
 				</div>


### PR DESCRIPTION
Fixed version display in Settings > About section to correctly read from NEXT_PUBLIC_BUILD_NUMBER environment variable (generated by build script) instead of incorrect NEXT_PUBLIC_BUILD_VERSION.

Changes:
- Updated env var from NEXT_PUBLIC_BUILD_VERSION to NEXT_PUBLIC_BUILD_NUMBER
- Updated fallback version from "3.0.1" to "5.3.0" (current package.json version)
- Updated fallback build date from "Oct 12, 2025" to "dev build" for clarity

The build script (scripts/generate-build-info.js) generates NEXT_PUBLIC_BUILD_NUMBER, not NEXT_PUBLIC_BUILD_VERSION. This mismatch caused the About section to always show the hardcoded fallback "3.0.1" instead of the actual build version.

Fixes issue where version number in help/settings was not synced with package.json version.