### PR TITLE
fix(worker): increase OAuth state TTL and improve error diagnostics f…

### DIFF
--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -14,7 +14,7 @@ export const ALLOWED_ORIGINS = [
 // Session and token TTL values (in seconds)
 export const TTL = {
   SESSION: 60 * 60 * 24 * 7,      // 7 days - session lifetime
-  OAUTH_STATE: 600,               // 10 minutes - OAuth state validity
+  OAUTH_STATE: 1800,              // 30 minutes - OAuth state validity (increased for mobile/PWA flows)
   REVOCATION: 60 * 60 * 24 * 7,   // 7 days - keep revocation records
 } as const;
 


### PR DESCRIPTION
…or PWA flows

Problem:
Users on iPad PWA getting "Invalid or expired state" error when attempting to authenticate with Google OAuth. This error occurs when the OAuth state parameter cannot be found in KV storage during the callback phase.

Root Cause Analysis:
1. OAuth state TTL was 10 minutes (600s) - too short for mobile/PWA flows
2. Mobile users often experience:
   - Context switching (notifications, calls, app switching)
   - Safari PWA opens OAuth in new tab (slower than popup)
   - Additional delays for 2FA, reading permissions, etc.
   - iOS Safari strict privacy controls may add latency
3. No diagnostic logging to understand timing or failure patterns
4. Generic error messages don't help users understand the issue

Solution - Two-Part Fix:

Part 1: Increase OAuth State TTL (config.ts)
- Changed OAUTH_STATE from 600s (10 min) to 1800s (30 min)
- Provides 3x more time for mobile OAuth flows
- Industry standard: Google/Microsoft use 10-60 min for OAuth state
- Still secure: state is single-use and deleted after consumption

Part 2: Enhanced Error Diagnostics (callback.ts)
- Added detailed logging when state not found:
  * State prefix (first 8 chars) for correlation
  * State length and key for validation
  * Request URL and user agent for device tracking
  * Timestamp for timing analysis
- Added timing diagnostics for successful callbacks:
  * Flow duration in ms and seconds
  * Provider and device info
  * Helps identify if timeouts are still occurring
- Improved error message to be more actionable:
  * Old: "Invalid or expired state"
  * New: "OAuth session expired or invalid. Please try signing in again. (State not found - this may happen if the sign-in flow took longer than 30 minutes)"
- Added logging for invalid callback parameters

Technical Details:
- Uses createdAt timestamp from state data to calculate flow duration
- Logging uses structured logger (OIDC:Callback context)
- No breaking changes - fully backward compatible
- State is still deleted after use (security best practice)

Files Changed:
- worker/src/config.ts: Updated OAUTH_STATE TTL (600 → 1800)
- worker/src/handlers/oidc/callback.ts: Added diagnostic logging

Impact:
- Resolves "Invalid or expired state" errors for mobile/PWA users
- Better visibility into OAuth flow timing and failures
- More actionable error messages for users
- Improved troubleshooting capabilities for production issues

Testing:
- Config change is straightforward (numeric constant)
- Callback logging is additive (no logic changes)
- Will monitor production logs for flow duration metrics