### PR TITLE
fix(worker): remove duplicate 'now' variable declaration in OAuth cal…

### DIFF
--- a/worker/src/handlers/oidc/callback.ts
+++ b/worker/src/handlers/oidc/callback.ts
@@ -93,8 +93,6 @@ export async function handleOAuthCallback(request: Request, env: Env): Promise<R
     // Verify ID token and extract user info
     const { email, providerUserId } = await verifyIdToken(provider, tokens.id_token!, env);
 
-    const now = Date.now();
-
     // Find or create user
     let user = await env.DB.prepare(
       'SELECT id, email, account_status, encryption_salt FROM users WHERE auth_provider = ? AND provider_user_id = ?'


### PR DESCRIPTION
…lback

Removes duplicate 'const now = Date.now()' at line 96 that was causing build errors during deployment. The 'now' variable declared at line 77 for timing diagnostics is used throughout the function for both timing calculations and database timestamps.

Fixes deployment error:
  The symbol 'now' has already been declared