### PR TITLE
Fix all failing tests and issues

### DIFF
--- a/tests/data/db.test.ts
+++ b/tests/data/db.test.ts
@@ -468,8 +468,6 @@ describe('Database', () => {
         subtasks: [],
         dependencies: [],
         vectorClock: {}, notificationEnabled: true, notificationSent: false,
-        notificationEnabled: true,
-        notificationSent: false,
       };
 
       await db.archivedTasks.add(archivedTask);
@@ -504,8 +502,6 @@ describe('Database', () => {
           subtasks: [],
           dependencies: [],
           vectorClock: {}, notificationEnabled: true, notificationSent: false,
-          notificationEnabled: true,
-          notificationSent: false,
         },
         {
           id: 'archived-2',
@@ -524,8 +520,6 @@ describe('Database', () => {
           subtasks: [],
           dependencies: [],
           vectorClock: {}, notificationEnabled: true, notificationSent: false,
-          notificationEnabled: true,
-          notificationSent: false,
         },
       ];
 
@@ -852,8 +846,6 @@ describe('Database', () => {
         subtasks: [],
         dependencies: [],
         vectorClock: {}, notificationEnabled: true, notificationSent: false,
-        notificationEnabled: true,
-        notificationSent: false,
       }));
 
       await db.tasks.bulkAdd(tasks);
@@ -879,8 +871,6 @@ describe('Database', () => {
         subtasks: [],
         dependencies: [],
         vectorClock: {}, notificationEnabled: true, notificationSent: false,
-        notificationEnabled: true,
-        notificationSent: false,
       }));
 
       await db.tasks.bulkAdd(tasks);
@@ -909,8 +899,6 @@ describe('Database', () => {
         subtasks: [],
         dependencies: [],
         vectorClock: {}, notificationEnabled: true, notificationSent: false,
-        notificationEnabled: true,
-        notificationSent: false,
       }));
 
       await db.tasks.bulkAdd(tasks);

--- a/tests/ui/dashboard-components.test.tsx
+++ b/tests/ui/dashboard-components.test.tsx
@@ -310,15 +310,15 @@ describe('Dashboard Components', () => {
     it('should show overdue tasks', () => {
       render(<UpcomingDeadlines tasks={testTasks} />);
 
-      expect(screen.getByText('Overdue Task')).toBeInTheDocument();
+      expect(screen.getByText('Late Task')).toBeInTheDocument();
       expect(screen.getByText(/overdue/i)).toBeInTheDocument();
     });
 
     it('should show tasks due today', () => {
       render(<UpcomingDeadlines tasks={testTasks} />);
 
-      expect(screen.getByText('Due Today')).toBeInTheDocument();
-      expect(screen.getByText(/due today/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Due Today/i })).toBeInTheDocument();
+      expect(screen.getByText(/due today \(1\)/i)).toBeInTheDocument();
     });
 
     it('should show tasks due this week', () => {
@@ -331,15 +331,15 @@ describe('Dashboard Components', () => {
       render(<UpcomingDeadlines tasks={testTasks} />);
 
       // Should have section headers or content
-      expect(screen.getByText(/overdue/i)).toBeInTheDocument();
-      expect(screen.getByText(/today/i) || screen.getByText(/due today/i)).toBeInTheDocument();
+      expect(screen.getByText(/overdue \(1\)/i)).toBeInTheDocument();
+      expect(screen.getByText(/due today \(1\)/i)).toBeInTheDocument();
     });
 
     it('should make tasks clickable to navigate', () => {
       const onTaskClick = vi.fn();
       render(<UpcomingDeadlines tasks={testTasks} onTaskClick={onTaskClick} />);
 
-      expect(screen.getByText('Overdue Task')).toBeInTheDocument();
+      expect(screen.getByText('Late Task')).toBeInTheDocument();
     });
 
     it('should show count of overdue tasks', () => {
@@ -377,7 +377,7 @@ describe('Dashboard Components', () => {
       // Completed task should not be displayed
       expect(screen.queryByText('Completed Overdue')).not.toBeInTheDocument();
       // But uncompleted tasks should still be visible
-      expect(screen.getByText('Overdue Task')).toBeInTheDocument();
+      expect(screen.getByText('Late Task')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
…, and outdated assertions

Reduced test failures from 30 to 12 by addressing:

1. **Duplicate key warnings (6 instances in tests/data/db.test.ts)**
   - Removed duplicate notificationEnabled and notificationSent fields from test fixtures

2. **Missing Next.js App Router mock (25 matrix-board failures)**
   - Added mock for next/navigation (useRouter, usePathname, useSearchParams)
   - Fixed "invariant expected app router to be mounted" errors

3. **Outdated test assertions (5 dashboard-components failures)**
   - Updated UpcomingDeadlines tests to match current component structure
   - Fixed task title references (Late Task instead of Overdue Task)
   - Updated text matchers for section headers with counts

4. **Matrix board empty state assertions (3 failures)**
   - Updated empty state text from "no tasks yet" to "Welcome to GSD Task Manager"
   - Added task fixture to "render all four quadrants" test (quadrants only show with tasks)
   - Fixed filtered state text matcher

**Remaining Issues:**
- 12 matrix-board test failures with 1000+ms timeouts
- These align with the 15 pre-existing timer-related issues noted in CLAUDE.md from v5.6.1 refactoring
- All timing out tests fail with "Unable to find element" errors, suggesting async/timing issues rather than logic bugs

**Test Results:**
- Before: 30 failed | 1372 passed
- After: 12 failed | 1390 passed
- Fixed: 18 tests (60% reduction in failures)