### PR TITLE
feat(ui): redesign settings dialog with iOS-style grouped layout

### DIFF
--- a/components/settings/about-section.tsx
+++ b/components/settings/about-section.tsx
@@ -1,69 +1,67 @@
 "use client";
 
-import { InfoIcon, ChevronRightIcon } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-} from "@/components/ui/collapsible";
+import { ExternalLinkIcon, ShieldCheckIcon } from "lucide-react";
 
-interface AboutSectionProps {
-	isExpanded: boolean;
-	onToggle: () => void;
+/**
+ * iOS-style about section
+ */
+export function AboutSection() {
+	const version = process.env.NEXT_PUBLIC_BUILD_NUMBER || "6.1.1";
+	const buildDate = process.env.NEXT_PUBLIC_BUILD_DATE || "dev build";
+
+	return (
+		<>
+			{/* Version Row */}
+			<SettingsRow label="Version">
+				<span className="text-sm text-foreground-muted">{version}</span>
+			</SettingsRow>
+
+			{/* Build Date Row */}
+			<SettingsRow label="Build">
+				<span className="text-sm text-foreground-muted">{buildDate}</span>
+			</SettingsRow>
+
+			{/* Privacy Row */}
+			<div className="px-4 py-3.5 min-h-[52px]">
+				<div className="flex items-start gap-3">
+					<ShieldCheckIcon className="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" />
+					<div>
+						<p className="text-sm font-medium text-foreground">Privacy First</p>
+						<p className="text-xs text-foreground-muted mt-1 leading-relaxed">
+							All data is stored locally in your browser. Nothing is sent to any
+							server unless you enable cloud sync.
+						</p>
+					</div>
+				</div>
+			</div>
+
+			{/* GitHub Link Row */}
+			<button
+				onClick={() => window.open("https://github.com/vscarpenter/gsd-task-manager", "_blank")}
+				className="w-full flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px]
+				           text-left hover:bg-background-muted/50 transition-colors"
+			>
+				<span className="text-sm font-medium text-accent">View on GitHub</span>
+				<ExternalLinkIcon className="w-4 h-4 text-foreground-muted/50" />
+			</button>
+		</>
+	);
 }
 
-export function AboutSection({ isExpanded, onToggle }: AboutSectionProps) {
+/**
+ * Settings row with inline content
+ */
+function SettingsRow({
+	label,
+	children,
+}: {
+	label: string;
+	children: React.ReactNode;
+}) {
 	return (
-		<Collapsible open={isExpanded} onOpenChange={onToggle}>
-			<CollapsibleTrigger className="flex w-full items-center justify-between rounded-lg bg-background-muted p-4 hover:bg-background-muted/80">
-				<div className="flex items-center gap-3">
-					<InfoIcon className="h-5 w-5 text-accent" />
-					<span className="font-semibold text-foreground">About</span>
-				</div>
-				<ChevronRightIcon
-					className={`h-5 w-5 text-foreground-muted transition-transform ${
-						isExpanded ? "rotate-90" : ""
-					}`}
-				/>
-			</CollapsibleTrigger>
-			<CollapsibleContent className="px-4 pb-4 pt-4 space-y-3">
-				<div className="space-y-2 text-sm">
-					<div className="flex justify-between">
-						<span className="text-foreground-muted">Version</span>
-						<span className="font-medium text-foreground">
-							{process.env.NEXT_PUBLIC_BUILD_NUMBER || "5.3.0"}
-						</span>
-					</div>
-					<div className="flex justify-between">
-						<span className="text-foreground-muted">Build Date</span>
-						<span className="font-medium text-foreground">
-							{process.env.NEXT_PUBLIC_BUILD_DATE || "dev build"}
-						</span>
-					</div>
-				</div>
-
-				<div className="rounded-lg border border-border bg-background-muted/50 p-3">
-					<p className="text-xs text-foreground-muted mb-2">
-						🔒{" "}
-						<span className="font-semibold text-foreground">Privacy First</span>
-					</p>
-					<p className="text-xs text-foreground-muted">
-						All your data is stored locally in your browser. Nothing is sent to any
-						server. Your tasks, preferences, and settings stay on your device.
-					</p>
-				</div>
-
-				<Button
-					variant="subtle"
-					className="w-full justify-start"
-					onClick={() =>
-						window.open("https://github.com/vscarpenter/gsd-task-manager", "_blank")
-					}
-				>
-					View on GitHub →
-				</Button>
-			</CollapsibleContent>
-		</Collapsible>
+		<div className="flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px]">
+			<p className="text-sm font-medium text-foreground">{label}</p>
+			<div className="flex-shrink-0">{children}</div>
+		</div>
 	);
 }

--- a/components/settings/appearance-settings.tsx
+++ b/components/settings/appearance-settings.tsx
@@ -1,91 +1,120 @@
 "use client";
 
 import { useTheme } from "next-themes";
-import { PaletteIcon, EyeIcon, EyeOffIcon, ChevronRightIcon } from "lucide-react";
-import { Label } from "@/components/ui/label";
+import { SunIcon, MoonIcon, MonitorIcon, CheckIcon } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
-import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-} from "@/components/ui/collapsible";
 
 interface AppearanceSettingsProps {
-	isExpanded: boolean;
-	onToggle: () => void;
 	showCompleted: boolean;
 	onToggleCompleted: () => void;
 }
 
+/**
+ * iOS-style appearance settings with inline controls
+ */
 export function AppearanceSettings({
-	isExpanded,
-	onToggle,
 	showCompleted,
 	onToggleCompleted,
 }: AppearanceSettingsProps) {
 	const { theme, setTheme } = useTheme();
 
 	return (
-		<Collapsible open={isExpanded} onOpenChange={onToggle}>
-			<CollapsibleTrigger className="flex w-full items-center justify-between rounded-lg bg-background-muted p-4 hover:bg-background-muted/80">
-				<div className="flex items-center gap-3">
-					<PaletteIcon className="h-5 w-5 text-accent" />
-					<span className="font-semibold text-foreground">Appearance</span>
-				</div>
-				<ChevronRightIcon
-					className={`h-5 w-5 text-foreground-muted transition-transform ${
-						isExpanded ? "rotate-90" : ""
-					}`}
-				/>
-			</CollapsibleTrigger>
-			<CollapsibleContent className="px-4 pb-4 pt-4 space-y-4">
-				{/* Theme Selection */}
-				<div className="space-y-2">
-					<Label htmlFor="theme-select">Theme</Label>
-					<Select value={theme} onValueChange={setTheme}>
-						<SelectTrigger id="theme-select">
-							<SelectValue placeholder="Select theme" />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectItem value="system">System</SelectItem>
-							<SelectItem value="light">Light</SelectItem>
-							<SelectItem value="dark">Dark</SelectItem>
-						</SelectContent>
-					</Select>
-					<p className="text-xs text-foreground-muted">
-						Choose your preferred theme. Changes apply immediately.
-					</p>
-				</div>
-
-				{/* Show Completed Tasks */}
-				<div className="flex items-center justify-between">
-					<div className="flex items-center gap-3">
-						{showCompleted ? (
-							<EyeIcon className="h-4 w-4 text-foreground-muted" />
-						) : (
-							<EyeOffIcon className="h-4 w-4 text-foreground-muted" />
-						)}
-						<div>
-							<Label htmlFor="show-completed">Show completed tasks</Label>
-							<p className="text-xs text-foreground-muted">
-								Display completed tasks in the matrix view
-							</p>
-						</div>
-					</div>
-					<Switch
-						id="show-completed"
-						checked={showCompleted}
-						onCheckedChange={onToggleCompleted}
+		<>
+			{/* Theme Selection Row */}
+			<SettingsRow
+				label="Theme"
+				description="Choose your visual style"
+			>
+				<div className="flex gap-1 bg-background-muted rounded-lg p-1">
+					<ThemeOption
+						icon={SunIcon}
+						label="Light"
+						isActive={theme === "light"}
+						onClick={() => setTheme("light")}
+					/>
+					<ThemeOption
+						icon={MoonIcon}
+						label="Dark"
+						isActive={theme === "dark"}
+						onClick={() => setTheme("dark")}
+					/>
+					<ThemeOption
+						icon={MonitorIcon}
+						label="Auto"
+						isActive={theme === "system"}
+						onClick={() => setTheme("system")}
 					/>
 				</div>
-			</CollapsibleContent>
-		</Collapsible>
+			</SettingsRow>
+
+			{/* Show Completed Toggle Row */}
+			<SettingsRow
+				label="Show completed"
+				description="Display finished tasks in the matrix"
+			>
+				<Switch
+					checked={showCompleted}
+					onCheckedChange={onToggleCompleted}
+				/>
+			</SettingsRow>
+		</>
+	);
+}
+
+/**
+ * Reusable settings row component
+ */
+function SettingsRow({
+	label,
+	description,
+	children,
+}: {
+	label: string;
+	description?: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px]">
+			<div className="flex-1 min-w-0">
+				<p className="text-sm font-medium text-foreground">{label}</p>
+				{description && (
+					<p className="text-xs text-foreground-muted mt-0.5 truncate">{description}</p>
+				)}
+			</div>
+			<div className="flex-shrink-0">{children}</div>
+		</div>
+	);
+}
+
+/**
+ * Theme option button
+ */
+function ThemeOption({
+	icon: Icon,
+	label,
+	isActive,
+	onClick,
+}: {
+	icon: React.ComponentType<{ className?: string }>;
+	label: string;
+	isActive: boolean;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			onClick={onClick}
+			className={`
+				relative flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium
+				transition-all duration-200
+				${isActive
+					? "bg-card text-foreground shadow-sm"
+					: "text-foreground-muted hover:text-foreground"
+				}
+			`}
+			aria-pressed={isActive}
+		>
+			<Icon className="w-3.5 h-3.5" />
+			<span>{label}</span>
+		</button>
 	);
 }

--- a/components/settings/data-management.tsx
+++ b/components/settings/data-management.tsx
@@ -1,18 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { DatabaseIcon, DownloadIcon, UploadIcon, ChevronRightIcon, Trash2Icon } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-} from "@/components/ui/collapsible";
+import { DownloadIcon, UploadIcon, ChevronRightIcon, Trash2Icon } from "lucide-react";
 import { ResetEverythingDialog } from "@/components/reset-everything-dialog";
 
 interface DataManagementProps {
-	isExpanded: boolean;
-	onToggle: () => void;
 	activeTasks: number;
 	completedTasks: number;
 	totalTasks: number;
@@ -24,9 +16,10 @@ interface DataManagementProps {
 	pendingSync?: number;
 }
 
+/**
+ * iOS-style data management settings
+ */
 export function DataManagement({
-	isExpanded,
-	onToggle,
 	activeTasks,
 	completedTasks,
 	totalTasks,
@@ -40,87 +33,54 @@ export function DataManagement({
 	const [resetDialogOpen, setResetDialogOpen] = useState(false);
 
 	return (
-		<Collapsible open={isExpanded} onOpenChange={onToggle}>
-			<CollapsibleTrigger className="flex w-full items-center justify-between rounded-lg bg-background-muted p-4 hover:bg-background-muted/80">
-				<div className="flex items-center gap-3">
-					<DatabaseIcon className="h-5 w-5 text-accent" />
-					<span className="font-semibold text-foreground">Data & Backup</span>
+		<>
+			{/* Storage Stats Row */}
+			<SettingsRow label="Local storage">
+				<div className="text-right">
+					<p className="text-sm font-medium text-foreground">{estimatedSize} KB</p>
+					<p className="text-xs text-foreground-muted">{totalTasks} tasks</p>
 				</div>
-				<ChevronRightIcon
-					className={`h-5 w-5 text-foreground-muted transition-transform ${
-						isExpanded ? "rotate-90" : ""
-					}`}
-				/>
-			</CollapsibleTrigger>
-			<CollapsibleContent className="px-4 pb-4 pt-4 space-y-4">
-				{/* Storage Stats */}
-				<div className="rounded-lg border border-border bg-background-muted/50 p-4">
-					<h4 className="text-sm font-semibold text-foreground mb-2">Storage</h4>
-					<div className="space-y-1 text-xs text-foreground-muted">
-						<p>
-							Active tasks:{" "}
-							<span className="font-medium text-foreground">{activeTasks}</span>
-						</p>
-						<p>
-							Completed tasks:{" "}
-							<span className="font-medium text-foreground">{completedTasks}</span>
-						</p>
-						<p>
-							Total tasks:{" "}
-							<span className="font-medium text-foreground">{totalTasks}</span>
-						</p>
-						<p>
-							Estimated size:{" "}
-							<span className="font-medium text-foreground">{estimatedSize} KB</span>
-						</p>
-					</div>
-				</div>
+			</SettingsRow>
 
-				{/* Export/Import Actions */}
-				<div className="space-y-2">
-					<Button
-						variant="subtle"
-						className="w-full justify-start"
-						onClick={onExport}
-						disabled={isLoading}
-					>
-						<DownloadIcon className="mr-2 h-4 w-4" />
-						Export Tasks
-					</Button>
-					<Button
-						variant="subtle"
-						className="w-full justify-start"
-						onClick={onImportClick}
-						disabled={isLoading}
-					>
-						<UploadIcon className="mr-2 h-4 w-4" />
-						Import Tasks
-					</Button>
-					<p className="text-xs text-foreground-muted px-2">
-						Export your tasks as JSON for backup or transfer. Import to restore or
-						merge tasks.
-					</p>
+			{/* Task Breakdown Row */}
+			<SettingsRow label="Tasks breakdown">
+				<div className="flex gap-4 text-xs">
+					<span className="text-foreground-muted">
+						Active: <span className="font-medium text-foreground">{activeTasks}</span>
+					</span>
+					<span className="text-foreground-muted">
+						Done: <span className="font-medium text-foreground">{completedTasks}</span>
+					</span>
 				</div>
+			</SettingsRow>
 
-				{/* Reset Everything Section */}
-				<div className="pt-2 border-t border-border">
-					<div className="rounded-lg border border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950/20 p-3 mb-3">
-						<p className="text-xs text-red-600 dark:text-red-400">
-							⚠️ Clearing data is permanent and cannot be undone. Export your tasks
-							first.
-						</p>
-					</div>
-					<Button
-						variant="subtle"
-						className="w-full justify-start text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/20"
-						onClick={() => setResetDialogOpen(true)}
-						disabled={isLoading}
-					>
-						<Trash2Icon className="mr-2 h-4 w-4" />
-						Reset Everything
-					</Button>
-				</div>
-			</CollapsibleContent>
+			{/* Export Row */}
+			<ActionRow
+				icon={DownloadIcon}
+				label="Export tasks"
+				description="Download as JSON backup"
+				onClick={onExport}
+				disabled={isLoading}
+			/>
+
+			{/* Import Row */}
+			<ActionRow
+				icon={UploadIcon}
+				label="Import tasks"
+				description="Restore from JSON file"
+				onClick={onImportClick}
+				disabled={isLoading}
+			/>
+
+			{/* Danger Zone - Reset */}
+			<ActionRow
+				icon={Trash2Icon}
+				label="Reset everything"
+				description="Delete all local data"
+				onClick={() => setResetDialogOpen(true)}
+				disabled={isLoading}
+				variant="danger"
+			/>
 
 			{/* Reset Dialog */}
 			<ResetEverythingDialog
@@ -132,6 +92,71 @@ export function DataManagement({
 				syncEnabled={syncEnabled}
 				pendingSync={pendingSync}
 			/>
-		</Collapsible>
+		</>
+	);
+}
+
+/**
+ * Settings row with inline content
+ */
+function SettingsRow({
+	label,
+	children,
+}: {
+	label: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px]">
+			<p className="text-sm font-medium text-foreground">{label}</p>
+			<div className="flex-shrink-0">{children}</div>
+		</div>
+	);
+}
+
+/**
+ * Actionable row with icon and disclosure indicator
+ */
+function ActionRow({
+	icon: Icon,
+	label,
+	description,
+	onClick,
+	disabled,
+	variant = "default",
+}: {
+	icon: React.ComponentType<{ className?: string }>;
+	label: string;
+	description?: string;
+	onClick: () => void;
+	disabled?: boolean;
+	variant?: "default" | "danger";
+}) {
+	const isDanger = variant === "danger";
+
+	return (
+		<button
+			onClick={onClick}
+			disabled={disabled}
+			className={`
+				w-full flex items-center gap-3 px-4 py-3.5 min-h-[52px] text-left
+				transition-colors disabled:opacity-50
+				${isDanger
+					? "hover:bg-red-50 dark:hover:bg-red-950/20"
+					: "hover:bg-background-muted/50"
+				}
+			`}
+		>
+			<Icon className={`w-5 h-5 ${isDanger ? "text-red-500" : "text-accent"}`} />
+			<div className="flex-1 min-w-0">
+				<p className={`text-sm font-medium ${isDanger ? "text-red-600 dark:text-red-400" : "text-foreground"}`}>
+					{label}
+				</p>
+				{description && (
+					<p className="text-xs text-foreground-muted mt-0.5">{description}</p>
+				)}
+			</div>
+			<ChevronRightIcon className="w-4 h-4 text-foreground-muted/50 flex-shrink-0" />
+		</button>
 	);
 }

--- a/components/settings/settings-dialog.tsx
+++ b/components/settings/settings-dialog.tsx
@@ -23,6 +23,22 @@ import { AboutSection } from "./about-section";
 import { useRouter } from "next/navigation";
 import { getSyncStatus } from "@/lib/sync/config";
 
+/**
+ * iOS-style settings group container
+ */
+function SettingsGroup({ label, children }: { label: string; children: React.ReactNode }) {
+	return (
+		<div className="space-y-2">
+			<h3 className="text-xs font-medium uppercase tracking-wider text-foreground-muted px-4">
+				{label}
+			</h3>
+			<div className="bg-card rounded-xl border border-card-border shadow-sm overflow-hidden divide-y divide-border">
+				{children}
+			</div>
+		</div>
+	);
+}
+
 interface SettingsDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
@@ -143,69 +159,75 @@ export function SettingsDialog({
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="sm:max-w-lg max-h-[80vh] overflow-y-auto">
-				<DialogHeader>
-					<DialogTitle className="text-2xl font-bold text-foreground">
-						Settings
-					</DialogTitle>
-					<DialogDescription className="text-foreground-muted">
-						Configure appearance, notifications, and data management preferences
-					</DialogDescription>
-				</DialogHeader>
-				<div className="space-y-4">
-					{/* Appearance Section */}
-					<AppearanceSettings
-						isExpanded={expandedSections.appearance}
-						onToggle={() => toggleSection("appearance")}
-						showCompleted={showCompleted}
-						onToggleCompleted={onToggleCompleted}
-					/>
+			<DialogContent className="sm:max-w-lg max-h-[85vh] overflow-y-auto bg-background-muted/50 dark:bg-background p-0">
+				<div className="sticky top-0 z-10 bg-background-muted/80 dark:bg-background/80 backdrop-blur-xl px-6 pt-6 pb-4 border-b border-border/50">
+					<DialogHeader>
+						<DialogTitle className="text-xl font-semibold text-foreground">
+							Settings
+						</DialogTitle>
+						<DialogDescription className="text-sm text-foreground-muted">
+							Preferences and configuration
+						</DialogDescription>
+					</DialogHeader>
+				</div>
 
-					{/* Notifications Section */}
-					<NotificationSettingsSection
-						isExpanded={expandedSections.notifications}
-						onToggle={() => toggleSection("notifications")}
-						settings={notificationSettings}
-						onNotificationToggle={handleNotificationToggle}
-						onDefaultReminderChange={handleDefaultReminderChange}
-					/>
-
-					{/* Cloud Sync Section - Only show when sync is enabled */}
-					{syncEnabled && (
-						<SyncSettings
-							isExpanded={expandedSections.sync}
-							onToggle={() => toggleSection("sync")}
-							onViewHistory={handleViewSyncHistory}
+				<div className="px-4 py-6 space-y-8">
+					{/* Appearance Group */}
+					<SettingsGroup label="Appearance">
+						<AppearanceSettings
+							showCompleted={showCompleted}
+							onToggleCompleted={onToggleCompleted}
 						/>
+					</SettingsGroup>
+
+					{/* Notifications Group */}
+					<SettingsGroup label="Notifications">
+						<NotificationSettingsSection
+							settings={notificationSettings}
+							onNotificationToggle={handleNotificationToggle}
+							onDefaultReminderChange={handleDefaultReminderChange}
+						/>
+					</SettingsGroup>
+
+					{/* Cloud Sync Group - Only show when sync is enabled */}
+					{syncEnabled && (
+						<SettingsGroup label="Cloud Sync">
+							<SyncSettings
+								isExpanded={expandedSections.sync}
+								onToggle={() => toggleSection("sync")}
+								onViewHistory={handleViewSyncHistory}
+							/>
+						</SettingsGroup>
 					)}
 
-					{/* Archive Section */}
-					<ArchiveSettings
-						isExpanded={expandedSections.archive}
-						onToggle={() => toggleSection("archive")}
-						onViewArchive={handleViewArchive}
-					/>
+					{/* Archive Group */}
+					<SettingsGroup label="Archive">
+						<ArchiveSettings
+							isExpanded={expandedSections.archive}
+							onToggle={() => toggleSection("archive")}
+							onViewArchive={handleViewArchive}
+						/>
+					</SettingsGroup>
 
-					{/* Data & Backup Section */}
-					<DataManagement
-						isExpanded={expandedSections.data}
-						onToggle={() => toggleSection("data")}
-						activeTasks={activeTasks}
-						completedTasks={completedTasks}
-						totalTasks={tasks.length}
-						estimatedSize={estimatedSize}
-						onExport={onExport}
-						onImportClick={handleImportClick}
-						isLoading={isLoading}
-						syncEnabled={syncEnabled}
-						pendingSync={pendingSync}
-					/>
+					{/* Data & Storage Group */}
+					<SettingsGroup label="Data & Storage">
+						<DataManagement
+							activeTasks={activeTasks}
+							completedTasks={completedTasks}
+							totalTasks={tasks.length}
+							estimatedSize={estimatedSize}
+							onExport={onExport}
+							onImportClick={handleImportClick}
+							isLoading={isLoading}
+							syncEnabled={syncEnabled}
+							pendingSync={pendingSync}
+						/>
+					</SettingsGroup>
 
-					{/* About Section */}
-					<AboutSection
-						isExpanded={expandedSections.about}
-						onToggle={() => toggleSection("about")}
-					/>
+					{/* About Group */}
+					<SettingsGroup label="About">
+						<AboutSection />
+					</SettingsGroup>
 				</div>
 			</DialogContent>
 		</Dialog>


### PR DESCRIPTION
## Summary

- Modernizes the settings dialog with an iOS-inspired grouped design
- Replaces collapsible accordions with inline controls for better UX
- Adds segmented theme picker (Light/Dark/Auto) instead of dropdown
- Consistent row heights and spacing throughout all sections

## Changes

### Visual Updates
- **Grouped sections** with labeled card containers (`SettingsGroup` component)
- **Sticky header** with backdrop blur effect
- **Inline controls** on the right side of each row
- **Status badges** for notification permissions (Granted/Denied/Not set)
- **Action rows** with icons and pill-style buttons

### Settings Sections Updated
| Section | Changes |
|---------|---------|
| Appearance | Segmented theme picker + show completed toggle |
| Notifications | Inline toggle + styled reminder dropdown + permission badge |
| Data Management | Storage stats display + action rows with icons |
| Archive | Auto-archive toggle + interval dropdown + archive now button |
| Sync | Auto-sync toggle + interval dropdown + smart triggers info |
| About | Version/build info + privacy badge + GitHub link |

## Screenshots

_Run `pnpm dev` and open Settings to preview_

## Test plan

- [ ] Open Settings dialog and verify all sections display correctly
- [ ] Toggle theme between Light/Dark/Auto - changes apply immediately
- [ ] Toggle "Show completed" - persists correctly
- [ ] Toggle notifications - permission prompt appears if needed
- [ ] Change notification reminder time - toast confirms change
- [ ] Export/Import tasks work from Data section
- [ ] Archive settings toggle and "Run" button work
- [ ] Sync settings (if enabled) toggle and interval work
- [ ] "View on GitHub" link opens in new tab
- [ ] Verify dark mode styling looks correct

🤖 Generated with [Claude Code](https://claude.ai/claude-code)