### PR TITLE
refactor(settings): extract shared components and improve code quality

### DIFF
--- a/components/settings/about-section.tsx
+++ b/components/settings/about-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ExternalLinkIcon, ShieldCheckIcon } from "lucide-react";
+import { SettingsRow } from "./shared-components";
 
 /**
  * iOS-style about section
@@ -48,20 +49,3 @@ export function AboutSection() {
 	);
 }
 
-/**
- * Settings row with inline content
- */
-function SettingsRow({
-	label,
-	children,
-}: {
-	label: string;
-	children: React.ReactNode;
-}) {
-	return (
-		<div className="flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px]">
-			<p className="text-sm font-medium text-foreground">{label}</p>
-			<div className="flex-shrink-0">{children}</div>
-		</div>
-	);
-}

--- a/components/settings/appearance-settings.tsx
+++ b/components/settings/appearance-settings.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useTheme } from "next-themes";
-import { SunIcon, MoonIcon, MonitorIcon, CheckIcon } from "lucide-react";
+import { SunIcon, MoonIcon, MonitorIcon } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
+import { SettingsRow } from "./shared-components";
 
 interface AppearanceSettingsProps {
 	showCompleted: boolean;
@@ -58,31 +59,6 @@ export function AppearanceSettings({
 				/>
 			</SettingsRow>
 		</>
-	);
-}
-
-/**
- * Reusable settings row component
- */
-function SettingsRow({
-	label,
-	description,
-	children,
-}: {
-	label: string;
-	description?: string;
-	children: React.ReactNode;
-}) {
-	return (
-		<div className="flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px]">
-			<div className="flex-1 min-w-0">
-				<p className="text-sm font-medium text-foreground">{label}</p>
-				{description && (
-					<p className="text-xs text-foreground-muted mt-0.5 truncate">{description}</p>
-				)}
-			</div>
-			<div className="flex-shrink-0">{children}</div>
-		</div>
 	);
 }
 

--- a/components/settings/archive-settings.tsx
+++ b/components/settings/archive-settings.tsx
@@ -6,10 +6,9 @@ import { Switch } from "@/components/ui/switch";
 import { getArchiveSettings, updateArchiveSettings, archiveOldTasks, getArchivedCount } from "@/lib/archive";
 import type { ArchiveSettings as ArchiveSettingsType } from "@/lib/types";
 import { toast } from "sonner";
+import { SettingsRow, SettingsSelectRow } from "./shared-components";
 
 interface ArchiveSettingsProps {
-	isExpanded: boolean;
-	onToggle: () => void;
 	onViewArchive: () => void;
 }
 
@@ -23,8 +22,6 @@ const ARCHIVE_DAYS_OPTIONS = [
  * iOS-style archive settings
  */
 export function ArchiveSettings({
-	isExpanded,
-	onToggle,
 	onViewArchive,
 }: ArchiveSettingsProps) {
 	const [settings, setSettings] = useState<ArchiveSettingsType | null>(null);
@@ -143,70 +140,7 @@ export function ArchiveSettings({
 }
 
 /**
- * Settings row with inline content
- */
-function SettingsRow({
-	label,
-	description,
-	children,
-}: {
-	label: string;
-	description?: string;
-	children: React.ReactNode;
-}) {
-	return (
-		<div className="flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px]">
-			<div className="flex-1 min-w-0">
-				<p className="text-sm font-medium text-foreground">{label}</p>
-				{description && (
-					<p className="text-xs text-foreground-muted mt-0.5">{description}</p>
-				)}
-			</div>
-			<div className="flex-shrink-0">{children}</div>
-		</div>
-	);
-}
-
-/**
- * Settings row with dropdown select
- */
-function SettingsSelectRow({
-	label,
-	value,
-	options,
-	onChange,
-}: {
-	label: string;
-	value: string;
-	options: { value: string; label: string }[];
-	onChange: (value: string) => void;
-}) {
-	return (
-		<div className="relative">
-			<label className="flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px] cursor-pointer">
-				<span className="text-sm font-medium text-foreground">{label}</span>
-				<div className="flex items-center gap-1">
-					<select
-						value={options.find(opt => opt.label === value)?.value || options[0].value}
-						onChange={(e) => onChange(e.target.value)}
-						className="appearance-none bg-transparent text-sm text-foreground-muted
-						           text-right pr-5 cursor-pointer focus:outline-none"
-					>
-						{options.map((opt) => (
-							<option key={opt.value} value={opt.value}>
-								{opt.label}
-							</option>
-						))}
-					</select>
-					<ChevronRightIcon className="w-4 h-4 text-foreground-muted/50 absolute right-4" />
-				</div>
-			</label>
-		</div>
-	);
-}
-
-/**
- * Action row with button
+ * Action row with button (unique to archive settings)
  */
 function ActionRow({
 	icon: Icon,

--- a/components/settings/data-management.tsx
+++ b/components/settings/data-management.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { DownloadIcon, UploadIcon, ChevronRightIcon, Trash2Icon } from "lucide-react";
 import { ResetEverythingDialog } from "@/components/reset-everything-dialog";
+import { SettingsRow } from "./shared-components";
 
 interface DataManagementProps {
 	activeTasks: number;
@@ -93,24 +94,6 @@ export function DataManagement({
 				pendingSync={pendingSync}
 			/>
 		</>
-	);
-}
-
-/**
- * Settings row with inline content
- */
-function SettingsRow({
-	label,
-	children,
-}: {
-	label: string;
-	children: React.ReactNode;
-}) {
-	return (
-		<div className="flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px]">
-			<p className="text-sm font-medium text-foreground">{label}</p>
-			<div className="flex-shrink-0">{children}</div>
-		</div>
 	);
 }
 

--- a/components/settings/notification-settings.tsx
+++ b/components/settings/notification-settings.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { ChevronRightIcon } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import type { NotificationSettings } from "@/lib/types";
+import { SettingsRow, SettingsSelectRow } from "./shared-components";
 
 interface NotificationSettingsProps {
 	settings: NotificationSettings | null;
@@ -65,69 +65,6 @@ export function NotificationSettingsSection({
 				</SettingsRow>
 			)}
 		</>
-	);
-}
-
-/**
- * Settings row with inline content
- */
-function SettingsRow({
-	label,
-	description,
-	children,
-}: {
-	label: string;
-	description?: string;
-	children: React.ReactNode;
-}) {
-	return (
-		<div className="flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px]">
-			<div className="flex-1 min-w-0">
-				<p className="text-sm font-medium text-foreground">{label}</p>
-				{description && (
-					<p className="text-xs text-foreground-muted mt-0.5">{description}</p>
-				)}
-			</div>
-			<div className="flex-shrink-0">{children}</div>
-		</div>
-	);
-}
-
-/**
- * Settings row with dropdown select (iOS-style disclosure)
- */
-function SettingsSelectRow({
-	label,
-	value,
-	options,
-	onChange,
-}: {
-	label: string;
-	value: string;
-	options: { value: string; label: string }[];
-	onChange: (value: string) => void;
-}) {
-	return (
-		<div className="relative">
-			<label className="flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px] cursor-pointer">
-				<span className="text-sm font-medium text-foreground">{label}</span>
-				<div className="flex items-center gap-1">
-					<select
-						value={options.find(opt => opt.label === value)?.value || options[0].value}
-						onChange={(e) => onChange(e.target.value)}
-						className="appearance-none bg-transparent text-sm text-foreground-muted
-						           text-right pr-5 cursor-pointer focus:outline-none"
-					>
-						{options.map((opt) => (
-							<option key={opt.value} value={opt.value}>
-								{opt.label}
-							</option>
-						))}
-					</select>
-					<ChevronRightIcon className="w-4 h-4 text-foreground-muted/50 absolute right-4" />
-				</div>
-			</label>
-		</div>
 	);
 }
 

--- a/components/settings/settings-dialog.tsx
+++ b/components/settings/settings-dialog.tsx
@@ -66,15 +66,6 @@ export function SettingsDialog({
 	const [syncEnabled, setSyncEnabled] = useState(false);
 	const [pendingSync, setPendingSync] = useState(0);
 
-	// Section expansion state
-	const [expandedSections, setExpandedSections] = useState({
-		appearance: true,
-		notifications: false,
-		sync: false,
-		archive: false,
-		data: false,
-		about: false,
-	});
 
 	const loadNotificationSettings = async () => {
 		const settings = await getNotificationSettings();
@@ -129,13 +120,6 @@ export function SettingsDialog({
 			}
 		};
 		input.click();
-	};
-
-	const toggleSection = (section: keyof typeof expandedSections) => {
-		setExpandedSections((prev) => ({
-			...prev,
-			[section]: !prev[section],
-		}));
 	};
 
 	const handleViewArchive = () => {
@@ -193,8 +177,6 @@ export function SettingsDialog({
 					{syncEnabled && (
 						<SettingsGroup label="Cloud Sync">
 							<SyncSettings
-								isExpanded={expandedSections.sync}
-								onToggle={() => toggleSection("sync")}
 								onViewHistory={handleViewSyncHistory}
 							/>
 						</SettingsGroup>
@@ -203,8 +185,6 @@ export function SettingsDialog({
 					{/* Archive Group */}
 					<SettingsGroup label="Archive">
 						<ArchiveSettings
-							isExpanded={expandedSections.archive}
-							onToggle={() => toggleSection("archive")}
 							onViewArchive={handleViewArchive}
 						/>
 					</SettingsGroup>

--- a/components/settings/shared-components.tsx
+++ b/components/settings/shared-components.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { ChevronRightIcon } from "lucide-react";
+
+/**
+ * Shared settings row components for iOS-style settings UI
+ * Extracted to avoid duplication across settings components
+ */
+
+interface SettingsRowProps {
+	label: string;
+	description?: string;
+	children: React.ReactNode;
+}
+
+/**
+ * Settings row with label, optional description, and inline content
+ */
+export function SettingsRow({ label, description, children }: SettingsRowProps) {
+	return (
+		<div className="flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px]">
+			<div className="flex-1 min-w-0">
+				<p className="text-sm font-medium text-foreground">{label}</p>
+				{description && (
+					<p className="text-xs text-foreground-muted mt-0.5 truncate">
+						{description}
+					</p>
+				)}
+			</div>
+			<div className="flex-shrink-0">{children}</div>
+		</div>
+	);
+}
+
+interface SettingsSelectRowProps {
+	label: string;
+	value: string;
+	options: { value: string; label: string }[];
+	onChange: (value: string) => void;
+}
+
+/**
+ * Settings row with dropdown select (iOS-style disclosure)
+ */
+export function SettingsSelectRow({
+	label,
+	value,
+	options,
+	onChange,
+}: SettingsSelectRowProps) {
+	return (
+		<div className="relative">
+			<label className="flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px] cursor-pointer">
+				<span className="text-sm font-medium text-foreground">{label}</span>
+				<div className="flex items-center gap-1">
+					<select
+						aria-label={label}
+						value={options.find((opt) => opt.label === value)?.value || options[0].value}
+						onChange={(e) => onChange(e.target.value)}
+						className="appearance-none bg-transparent text-sm text-foreground-muted
+						           text-right pr-5 cursor-pointer focus:outline-none"
+					>
+						{options.map((opt) => (
+							<option key={opt.value} value={opt.value}>
+								{opt.label}
+							</option>
+						))}
+					</select>
+					<ChevronRightIcon className="w-4 h-4 text-foreground-muted/50 absolute right-4" />
+				</div>
+			</label>
+		</div>
+	);
+}

--- a/components/settings/sync-settings.tsx
+++ b/components/settings/sync-settings.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { ChevronRightIcon, HistoryIcon, ZapIcon } from "lucide-react";
+import { HistoryIcon, ZapIcon, ChevronRightIcon } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { getAutoSyncConfig, updateAutoSyncConfig } from "@/lib/sync/config";
 import { toast } from "sonner";
+import { createLogger } from "@/lib/logger";
+import { SettingsRow, SettingsSelectRow } from "./shared-components";
+
+const logger = createLogger("UI");
 
 interface SyncSettingsProps {
-	isExpanded: boolean;
-	onToggle: () => void;
 	onViewHistory: () => void;
 }
 
@@ -25,8 +27,6 @@ const SYNC_INTERVAL_OPTIONS = [
  * iOS-style sync settings
  */
 export function SyncSettings({
-	isExpanded,
-	onToggle,
 	onViewHistory,
 }: SyncSettingsProps) {
 	const [autoSyncEnabled, setAutoSyncEnabled] = useState(true);
@@ -52,7 +52,7 @@ export function SyncSettings({
 			setAutoSyncEnabled(config.enabled);
 			setSyncInterval(config.intervalMinutes);
 		} catch (error) {
-			console.error('[SYNC SETTINGS] Failed to load config:', error);
+			logger.error("Failed to load sync config", error instanceof Error ? error : undefined);
 		}
 	};
 
@@ -63,7 +63,7 @@ export function SyncSettings({
 			setAutoSyncEnabled(checked);
 			toast.success(checked ? 'Auto-sync enabled' : 'Auto-sync disabled');
 		} catch (error) {
-			console.error('[SYNC SETTINGS] Failed to toggle auto-sync:', error);
+			logger.error("Failed to toggle auto-sync", error instanceof Error ? error : undefined);
 			toast.error('Failed to update auto-sync settings');
 		} finally {
 			setIsLoading(false);
@@ -83,7 +83,7 @@ export function SyncSettings({
 				await updateAutoSyncConfig(autoSyncEnabled, newInterval);
 				toast.success(`Sync interval set to ${newInterval} minute${newInterval !== 1 ? 's' : ''}`);
 			} catch (error) {
-				console.error('[SYNC SETTINGS] Failed to update interval:', error);
+				logger.error("Failed to update sync interval", error instanceof Error ? error : undefined);
 				toast.error('Failed to update sync interval');
 			}
 		}, 500);
@@ -145,65 +145,3 @@ export function SyncSettings({
 	);
 }
 
-/**
- * Settings row with inline content
- */
-function SettingsRow({
-	label,
-	description,
-	children,
-}: {
-	label: string;
-	description?: string;
-	children: React.ReactNode;
-}) {
-	return (
-		<div className="flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px]">
-			<div className="flex-1 min-w-0">
-				<p className="text-sm font-medium text-foreground">{label}</p>
-				{description && (
-					<p className="text-xs text-foreground-muted mt-0.5">{description}</p>
-				)}
-			</div>
-			<div className="flex-shrink-0">{children}</div>
-		</div>
-	);
-}
-
-/**
- * Settings row with dropdown select
- */
-function SettingsSelectRow({
-	label,
-	value,
-	options,
-	onChange,
-}: {
-	label: string;
-	value: string;
-	options: { value: string; label: string }[];
-	onChange: (value: string) => void;
-}) {
-	return (
-		<div className="relative">
-			<label className="flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px] cursor-pointer">
-				<span className="text-sm font-medium text-foreground">{label}</span>
-				<div className="flex items-center gap-1">
-					<select
-						value={options.find(opt => opt.label === value)?.value || options[0].value}
-						onChange={(e) => onChange(e.target.value)}
-						className="appearance-none bg-transparent text-sm text-foreground-muted
-						           text-right pr-5 cursor-pointer focus:outline-none"
-					>
-						{options.map((opt) => (
-							<option key={opt.value} value={opt.value}>
-								{opt.label}
-							</option>
-						))}
-					</select>
-					<ChevronRightIcon className="w-4 h-4 text-foreground-muted/50 absolute right-4" />
-				</div>
-			</label>
-		</div>
-	);
-}


### PR DESCRIPTION
## Summary
- Extract `SettingsRow` and `SettingsSelectRow` to `shared-components.tsx` to eliminate code duplication (DRY principle)
- Remove ~226 lines of duplicated component code across 6 files
- Add `aria-label` to select elements for better accessibility (WCAG compliance)
- Replace `console.error` with structured logger in `sync-settings.tsx`
- Remove unused `isExpanded`/`onToggle` props from `SyncSettings` and `ArchiveSettings`
- Remove dead `expandedSections` state from `settings-dialog.tsx`

## Code Review Findings Addressed

| Issue | Status | Details |
|-------|--------|---------|
| Component Duplication (DRY) | ✅ Fixed | Extracted shared components |
| Missing aria-labels | ✅ Fixed | Added to select elements |
| console.error usage | ✅ Fixed | Using structured logger |
| Unused props | ✅ Fixed | Removed dead code |
| Unused state | ✅ Fixed | Removed expandedSections |

## Files Changed
- **New:** `components/settings/shared-components.tsx` - Shared SettingsRow and SettingsSelectRow
- **Modified:** 7 settings component files updated to use shared components

## Test plan
- [x] `pnpm build` passes successfully
- [ ] Manual verification: Settings dialog renders correctly
- [ ] Manual verification: Theme switching works
- [ ] Manual verification: Notification settings work
- [ ] Manual verification: Sync settings work (if sync enabled)
- [ ] Manual verification: Archive settings work
- [ ] Manual verification: Data management (export/import) works

🤖 Generated with [Claude Code](https://claude.com/claude-code)