### PR TITLE
fix(mcp-server): resolve TypeScript build error in sync-status

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"@vitest/coverage-v8": "^4.0.9",
 		"autoprefixer": "^10.4.22",
 		"babel-plugin-react-compiler": "^1.0.0",
+		"baseline-browser-mapping": "^2.8.32",
 		"eslint": "^9.39.1",
 		"eslint-config-next": "16.0.5",
 		"fake-indexeddb": "^6.2.4",

--- a/packages/mcp-server/src/tools/sync-status.ts
+++ b/packages/mcp-server/src/tools/sync-status.ts
@@ -1,6 +1,5 @@
-import { z } from 'zod';
 import { apiRequest } from '../api/client.js';
-import { syncStatusSchema, taskStatsSchema } from '../types.js';
+import { syncStatusSchema, statsResponseSchema } from '../types.js';
 import type { GsdConfig, SyncStatus, TaskStats } from '../types.js';
 
 /**
@@ -27,7 +26,8 @@ export async function getTaskStats(config: GsdConfig): Promise<TaskStats> {
     });
 
     if (response.ok) {
-      const data = await response.json();
+      const json: unknown = await response.json();
+      const data = statsResponseSchema.parse(json);
       return {
         totalTasks: data.metadata.totalCount,
         activeTasks: data.metadata.activeCount,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
+      baseline-browser-mapping:
+        specifier: ^2.8.32
+        version: 2.8.32
       eslint:
         specifier: ^9.39.1
         version: 9.39.1(jiti@1.21.7)


### PR DESCRIPTION
## Summary
- Fix TS18046 error where `data` was typed as `unknown` after `response.json()`
- Use existing `statsResponseSchema` with Zod `.parse()` for proper type safety
- Remove unused `z` import, import `statsResponseSchema` instead of `taskStatsSchema`
- Update root lockfile with dependency changes

## Context
This fix enables the `gsd-mcp-server` v0.6.0 npm publish to succeed. The build was failing due to TypeScript strict mode treating `response.json()` return type as `unknown`.

## Changes
| File | Change |
|------|--------|
| `packages/mcp-server/src/tools/sync-status.ts` | Use Zod schema parsing for type-safe API response |
| `package.json` | Dependency updates |
| `pnpm-lock.yaml` | Lockfile sync |

## Test plan
- [x] `npm run build` in `packages/mcp-server` succeeds
- [ ] `npm publish` succeeds (requires OTP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)