### PR TITLE
fix: resolve npm warnings from pnpm-specific config options

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
-# Disable workspace auto-detection
-# Only the root package should be built
-shared-workspace-lockfile=false
+# This file intentionally minimal to avoid npm warnings
+# pnpm-specific settings are in package.json under "pnpm" key

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "6.1.4",
+	"version": "6.1.5",
 	"private": true,
 	"scripts": {
 		"dev": "next dev",
@@ -15,7 +15,7 @@
 		"export": "next export",
 		"deploy:s3": "bash -c 'aws s3 sync out/ s3://gsd.vinny.dev/ --delete --exclude \"*.html\" --exclude \"sw.js\" --cache-control \"public,max-age=31536000,immutable\" && aws s3 sync out/ s3://gsd.vinny.dev/ --exclude \"*\" --include \"*.html\" --include \"sw.js\" --cache-control \"public,max-age=0,must-revalidate\" && aws s3 cp s3://gsd.vinny.dev/index.html s3://gsd.vinny.dev/index.html --metadata-directive REPLACE --cache-control \"no-cache,no-store,must-revalidate\" --content-type \"text/html\"'",
 		"deploy:cf": "aws cloudfront create-invalidation --distribution-id E1T6GDX0TQEP94 --paths '/*'",
-		"deploy": "npm run build && npm run deploy:s3 && npm run deploy:cf",
+		"deploy": "pnpm run build && pnpm run deploy:s3 && pnpm run deploy:cf",
 		"deploy:dev": "bash scripts/deploy-dev.sh"
 	},
 	"dependencies": {
@@ -71,6 +71,7 @@
 		"wrangler": "^4.54.0"
 	},
 	"pnpm": {
+		"sharedWorkspaceLockfile": false,
 		"overrides": {
 			"js-yaml": ">=4.1.1",
 			"baseline-browser-mapping": "^2.9.7",


### PR DESCRIPTION
## Summary
- Fix npm warnings that appear when running pnpm commands (`verify-deps-before-run`, `_jsr-registry`, `overrides`, `shared-workspace-lockfile`)
- Change deploy script to use `pnpm run` instead of `npm run` for consistency
- Move pnpm-specific settings from `.npmrc` to `package.json` under the `pnpm` key
- Bump version to 6.1.5

## Test plan
- [x] Run `pnpm run typecheck` - no npm warnings
- [x] Run `pnpm run lint` - no npm warnings
- [ ] Run `pnpm run deploy` - verify no warnings and successful deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)