### PR TITLE
fix(security): add origin validation to postMessage handler

### DIFF
--- a/lib/sync/oauth-handshake/initializer.ts
+++ b/lib/sync/oauth-handshake/initializer.ts
@@ -60,8 +60,15 @@ function setupEventListeners(): void {
 
 /**
  * Handle postMessage events
+ * Validates origin to prevent cross-origin message injection attacks (CWE-346)
  */
 function handleMessageEvent(event: MessageEvent): void {
+  // Validate origin - only accept messages from same origin
+  // OAuth callback page (public/oauth-callback.html) is hosted on same origin
+  if (event.origin !== window.location.origin) {
+    return;
+  }
+
   if (!event.data || event.data.type !== 'oauth_handshake') return;
   handleBroadcastPayload(event.data as BroadcastPayload);
 }


### PR DESCRIPTION
## Summary

- Add origin validation to OAuth handshake postMessage event handler to prevent cross-origin message injection attacks (CWE-346)
- Resolves SonarQube security rating issue (D → should improve to A/B)

## Problem

The `handleMessageEvent` function in `lib/sync/oauth-handshake/initializer.ts` was accepting postMessage events from any origin without validation. This vulnerability could allow a malicious site to:

1. Embed the app in an iframe or open it in a popup
2. Send crafted postMessage with fake OAuth credentials
3. Potentially inject malicious authentication data

## Solution

Added origin validation that only accepts messages from `window.location.origin`. This is correct because the OAuth callback page (`public/oauth-callback.html`) is hosted on the same domain.

```typescript
// Before (Noncompliant)
function handleMessageEvent(event: MessageEvent): void {
  if (!event.data || event.data.type !== 'oauth_handshake') return;
  handleBroadcastPayload(event.data as BroadcastPayload);
}

// After (Compliant)
function handleMessageEvent(event: MessageEvent): void {
  if (event.origin !== window.location.origin) {
    return;
  }
  if (!event.data || event.data.type !== 'oauth_handshake') return;
  handleBroadcastPayload(event.data as BroadcastPayload);
}
```

## Test plan

- [x] Production build passes (`pnpm build`)
- [x] TypeScript compilation succeeds
- [ ] Manual test: OAuth login flow still works correctly
- [ ] Re-run SonarQube scan to verify security rating improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)