### PR TITLE
chore: configure SonarQube to exclude test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,6 @@ sync.md
 *.tsbuildinfo
 
 # SonarQube
-sonar-project.properties
 .scannerwork
 
 # Cloudflare Worker

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,32 @@
+sonar.projectKey=gsd-task-manager
+sonar.host.url=http://localhost:9000
+# Token should be provided via SONAR_TOKEN environment variable or -Dsonar.token=xxx
+
+# Source and test directories
+sonar.sources=app,components,lib,packages,worker
+sonar.tests=tests
+
+# Exclusions from source analysis
+sonar.exclusions=\
+  **/node_modules/**,\
+  **/.next/**,\
+  **/dist/**,\
+  **/coverage/**,\
+  **/*.test.ts,\
+  **/*.test.tsx,\
+  **/*.spec.ts,\
+  **/*.spec.tsx,\
+  **/tests/**,\
+  **/__tests__/**,\
+  **/__mocks__/**
+
+# Test file patterns
+sonar.test.inclusions=\
+  **/*.test.ts,\
+  **/*.test.tsx,\
+  **/*.spec.ts,\
+  **/*.spec.tsx,\
+  tests/**/*
+
+# TypeScript configuration
+sonar.typescript.tsconfigPath=tsconfig.json


### PR DESCRIPTION
## Summary
- Configure SonarQube to properly separate source and test files
- Exclude test files from reliability analysis (fixes false positive D grades)
- Remove token from config file (use `SONAR_TOKEN` env var instead)

## Changes
- **sonar-project.properties**: New file with proper configuration
  - `sonar.sources`: Explicit source directories (app, components, lib, packages, worker)
  - `sonar.tests`: Test directory (tests)
  - `sonar.exclusions`: Excludes test files, node_modules, .next, dist, coverage
  - `sonar.test.inclusions`: Patterns for test files
  - `sonar.typescript.tsconfigPath`: Points to tsconfig.json
- **.gitignore**: Remove `sonar-project.properties` from ignore list (token removed)

## Usage
Run SonarQube scanner with token as environment variable:
```bash
SONAR_TOKEN=your_token sonar-scanner
# or
sonar-scanner -Dsonar.token=your_token
```

## Test plan
- [ ] Re-run SonarQube analysis
- [ ] Verify test files no longer affect reliability rating
- [ ] Confirm production code files are still analyzed

🤖 Generated with [Claude Code](https://claude.com/claude-code)