### PR TITLE
refactor: cache dependencies array in import/export remapping

### DIFF
--- a/lib/tasks/import-export.ts
+++ b/lib/tasks/import-export.ts
@@ -63,12 +63,13 @@ function remapTaskReferences(
   }
 
   return tasks.map(task => {
-    const updatedDependencies = (task.dependencies ?? []).map(depId => idMap.get(depId) ?? depId);
+    const originalDeps = task.dependencies ?? [];
+    const updatedDependencies = originalDeps.map(depId => idMap.get(depId) ?? depId);
     const updatedParentTaskId = task.parentTaskId ? (idMap.get(task.parentTaskId) ?? task.parentTaskId) : undefined;
 
     const dependenciesChanged =
-      updatedDependencies.length !== (task.dependencies ?? []).length ||
-      updatedDependencies.some((depId, index) => depId !== (task.dependencies ?? [])[index]);
+      updatedDependencies.length !== originalDeps.length ||
+      updatedDependencies.some((depId, index) => depId !== originalDeps[index]);
 
     const parentChanged = updatedParentTaskId !== task.parentTaskId;
 


### PR DESCRIPTION
## Summary
- Cache `task.dependencies ?? []` once in `remapTaskReferences` instead of evaluating it three times per iteration
- Improves code clarity and avoids redundant null coalescing operations

## Test plan
- [x] TypeScript type checking passes
- [x] Existing import/export tests pass (pre-existing unrelated fixture issue noted)
- [x] No breaking changes - purely internal optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)