### PR TITLE
fix(worker): use waitUntil for non-blocking session updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "6.6.0",
+	"version": "6.6.1",
 	"private": true,
 	"scripts": {
 		"dev": "next dev",

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -26,9 +26,9 @@ router.get('/health', (request: Request) => {
 });
 
 // OAuth endpoints (rate limited, no auth required)
-router.get('/api/auth/oauth/:provider/start', async (request: IRequest, env: Env) => {
+router.get('/api/auth/oauth/:provider/start', async (request: IRequest, env: Env, executionCtx: ExecutionContext) => {
   const origin = request.headers.get('Origin');
-  const ctx: RequestContext = {};
+  const ctx: RequestContext = { executionCtx };
   const rateLimitResult = await rateLimitMiddleware(request as unknown as Request, env, ctx);
   if (rateLimitResult) return rateLimitResult;
 
@@ -39,24 +39,24 @@ router.get('/api/auth/oauth/:provider/start', async (request: IRequest, env: Env
   return oidcHandlers.initiateOAuth(request as unknown as Request, env, provider);
 });
 
-router.post('/api/auth/oauth/callback', async (request: Request, env: Env) => {
-  const ctx: RequestContext = {};
+router.post('/api/auth/oauth/callback', async (request: Request, env: Env, executionCtx: ExecutionContext) => {
+  const ctx: RequestContext = { executionCtx };
   const rateLimitResult = await rateLimitMiddleware(request, env, ctx);
   if (rateLimitResult) return rateLimitResult;
 
   return oidcHandlers.handleOAuthCallback(request, env);
 });
 
-router.get('/api/auth/oauth/callback', async (request: Request, env: Env) => {
-  const ctx: RequestContext = {};
+router.get('/api/auth/oauth/callback', async (request: Request, env: Env, executionCtx: ExecutionContext) => {
+  const ctx: RequestContext = { executionCtx };
   const rateLimitResult = await rateLimitMiddleware(request, env, ctx);
   if (rateLimitResult) return rateLimitResult;
 
   return oidcHandlers.handleOAuthCallback(request, env);
 });
 
-router.get('/api/auth/oauth/result', async (request: Request, env: Env) => {
-  const ctx: RequestContext = {};
+router.get('/api/auth/oauth/result', async (request: Request, env: Env, executionCtx: ExecutionContext) => {
+  const ctx: RequestContext = { executionCtx };
   const rateLimitResult = await rateLimitMiddleware(request, env, ctx);
   if (rateLimitResult) return rateLimitResult;
 
@@ -64,9 +64,9 @@ router.get('/api/auth/oauth/result', async (request: Request, env: Env) => {
 });
 
 // Get encryption salt
-router.get('/api/auth/encryption-salt', async (request: Request, env: Env) => {
+router.get('/api/auth/encryption-salt', async (request: Request, env: Env, executionCtx: ExecutionContext) => {
   const origin = request.headers.get('Origin');
-  const ctx: RequestContext = {};
+  const ctx: RequestContext = { executionCtx };
   const authResult = await authMiddleware(request, env, ctx);
   if (authResult) return authResult;
 
@@ -89,9 +89,9 @@ router.get('/api/auth/encryption-salt', async (request: Request, env: Env) => {
 });
 
 // Save encryption salt
-router.post('/api/auth/encryption-salt', async (request: Request, env: Env) => {
+router.post('/api/auth/encryption-salt', async (request: Request, env: Env, executionCtx: ExecutionContext) => {
   const origin = request.headers.get('Origin');
-  const ctx: RequestContext = {};
+  const ctx: RequestContext = { executionCtx };
   const authResult = await authMiddleware(request, env, ctx);
   if (authResult) return authResult;
 
@@ -118,9 +118,9 @@ router.post('/api/auth/encryption-salt', async (request: Request, env: Env) => {
 });
 
 // Protected endpoints (auth required)
-router.post('/api/auth/logout', async (request: Request, env: Env) => {
+router.post('/api/auth/logout', async (request: Request, env: Env, executionCtx: ExecutionContext) => {
   const origin = request.headers.get('Origin');
-  const ctx: RequestContext = {};
+  const ctx: RequestContext = { executionCtx };
   const authResult = await authMiddleware(request, env, ctx);
   if (authResult) return authResult;
 
@@ -150,9 +150,9 @@ router.post('/api/auth/logout', async (request: Request, env: Env) => {
   }
 });
 
-router.post('/api/auth/refresh', async (request: Request, env: Env) => {
+router.post('/api/auth/refresh', async (request: Request, env: Env, executionCtx: ExecutionContext) => {
   const origin = request.headers.get('Origin');
-  const ctx: RequestContext = {};
+  const ctx: RequestContext = { executionCtx };
   const authResult = await authMiddleware(request, env, ctx);
   if (authResult) return authResult;
 
@@ -199,8 +199,8 @@ router.post('/api/auth/refresh', async (request: Request, env: Env) => {
 });
 
 // Sync endpoints (auth + rate limiting)
-router.post('/api/sync/push', async (request: Request, env: Env) => {
-  const ctx: RequestContext = {};
+router.post('/api/sync/push', async (request: Request, env: Env, executionCtx: ExecutionContext) => {
+  const ctx: RequestContext = { executionCtx };
   const authResult = await authMiddleware(request, env, ctx);
   if (authResult) return authResult;
   const rateLimitResult = await rateLimitMiddleware(request, env, ctx);
@@ -208,8 +208,8 @@ router.post('/api/sync/push', async (request: Request, env: Env) => {
   return syncHandlers.push(request, env, ctx);
 });
 
-router.post('/api/sync/pull', async (request: Request, env: Env) => {
-  const ctx: RequestContext = {};
+router.post('/api/sync/pull', async (request: Request, env: Env, executionCtx: ExecutionContext) => {
+  const ctx: RequestContext = { executionCtx };
   const authResult = await authMiddleware(request, env, ctx);
   if (authResult) return authResult;
   const rateLimitResult = await rateLimitMiddleware(request, env, ctx);
@@ -217,37 +217,37 @@ router.post('/api/sync/pull', async (request: Request, env: Env) => {
   return syncHandlers.pull(request, env, ctx);
 });
 
-router.post('/api/sync/resolve', async (request: Request, env: Env) => {
-  const ctx: RequestContext = {};
+router.post('/api/sync/resolve', async (request: Request, env: Env, executionCtx: ExecutionContext) => {
+  const ctx: RequestContext = { executionCtx };
   const authResult = await authMiddleware(request, env, ctx);
   if (authResult) return authResult;
   return syncHandlers.resolve(request, env, ctx);
 });
 
-router.get('/api/sync/status', async (request: Request, env: Env) => {
-  const ctx: RequestContext = {};
+router.get('/api/sync/status', async (request: Request, env: Env, executionCtx: ExecutionContext) => {
+  const ctx: RequestContext = { executionCtx };
   const authResult = await authMiddleware(request, env, ctx);
   if (authResult) return authResult;
   return syncHandlers.status(request, env, ctx);
 });
 
-router.get('/api/stats', async (request: Request, env: Env) => {
-  const ctx: RequestContext = {};
+router.get('/api/stats', async (request: Request, env: Env, executionCtx: ExecutionContext) => {
+  const ctx: RequestContext = { executionCtx };
   const authResult = await authMiddleware(request, env, ctx);
   if (authResult) return authResult;
   return syncHandlers.stats(request, env, ctx);
 });
 
 // Device management endpoints
-router.get('/api/devices', async (request: Request, env: Env) => {
-  const ctx: RequestContext = {};
+router.get('/api/devices', async (request: Request, env: Env, executionCtx: ExecutionContext) => {
+  const ctx: RequestContext = { executionCtx };
   const authResult = await authMiddleware(request, env, ctx);
   if (authResult) return authResult;
   return syncHandlers.listDevices(request, env, ctx);
 });
 
-router.delete('/api/devices/:id', async (request: Request, env: Env) => {
-  const ctx: RequestContext = {};
+router.delete('/api/devices/:id', async (request: Request, env: Env, executionCtx: ExecutionContext) => {
+  const ctx: RequestContext = { executionCtx };
   const authResult = await authMiddleware(request, env, ctx);
   if (authResult) return authResult;
   return syncHandlers.revokeDevice(request, env, ctx);

--- a/worker/src/middleware/auth.ts
+++ b/worker/src/middleware/auth.ts
@@ -1,6 +1,9 @@
 import { jwtVerify } from 'jose';
 import type { Env, RequestContext } from '../types';
 import { errorResponse } from './cors';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('AUTH');
 
 export interface AuthMiddleware {
   (request: Request, env: Env, ctx: RequestContext): Promise<Response | void>;
@@ -35,22 +38,35 @@ export const authMiddleware: AuthMiddleware = async (request, env, ctx) => {
       return errorResponse('Token has been revoked', 401);
     }
 
-    // Update last activity timestamp in KV (fire-and-forget, non-blocking)
-    // This is just for activity tracking, so we don't need to await
+    // Update last activity timestamp in KV (non-blocking via waitUntil)
+    // This is for activity tracking - uses waitUntil to guarantee completion
     const sessionKey = `session:${ctx.userId}:${payload.jti}`;
-    env.KV.get(sessionKey, 'json').then((session) => {
-      if (session) {
-        env.KV.put(
-          sessionKey,
-          JSON.stringify({ ...session, lastActivity: Date.now() }),
-          { expirationTtl: 60 * 60 * 24 * 7 } // 7 days
-        ).catch(() => {
-          // Silently ignore session update failures - not critical
+    const updateSession = async () => {
+      try {
+        const session = await env.KV.get(sessionKey, 'json');
+        if (session) {
+          await env.KV.put(
+            sessionKey,
+            JSON.stringify({ ...session, lastActivity: Date.now() }),
+            { expirationTtl: 60 * 60 * 24 * 7 } // 7 days
+          );
+        }
+      } catch (error) {
+        // Log but don't fail the request - session tracking is non-critical
+        logger.warn('Session activity update failed', {
+          userId: ctx.userId,
+          error: (error as Error).message,
         });
       }
-    }).catch(() => {
-      // Silently ignore session read failures - not critical
-    });
+    };
+
+    // Use waitUntil if available (Cloudflare Workers), otherwise fire-and-forget
+    if (ctx.executionCtx?.waitUntil) {
+      ctx.executionCtx.waitUntil(updateSession());
+    } else {
+      // Fallback for environments without ExecutionContext
+      updateSession().catch(() => {});
+    }
 
     // Continue to next handler
     return;

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -23,6 +23,7 @@ export interface RequestContext {
   deviceId?: string;
   email?: string;
   rateLimitHeaders?: Record<string, string>;
+  executionCtx?: ExecutionContext; // For waitUntil() in non-blocking operations
 }
 
 // Vector Clock for causality tracking


### PR DESCRIPTION
## Summary

Addresses external code review feedback on the auth middleware fire-and-forget pattern introduced in #e7afd73.

### Changes

- **Extended `RequestContext`** — Added `executionCtx?: ExecutionContext` field to enable `waitUntil()` access in middleware
- **Updated route handlers** — All 14 authenticated route handlers now pass `ExecutionContext` to the request context
- **Improved session updates** — Replaced fire-and-forget promises with proper `waitUntil()` pattern
- **Added error logging** — Session update failures now logged via structured logger instead of silently caught
- **Version bump** — 6.6.0 → 6.6.1

### Code Review Findings Addressed

| Finding | Verdict | Resolution |
|---------|---------|------------|
| pull.ts logging removal | False positive | None needed — per-task logging intentionally removed for performance |
| status.ts parallelization | Valid optimization | None needed — correctly bundled with timeout fixes |
| **auth.ts fire-and-forget** | **Real issue** | ✅ Fixed with `waitUntil()` + error logging |

### Why `waitUntil()` matters

In Cloudflare Workers, the runtime may terminate a Worker as soon as the response is sent. Fire-and-forget promises can be cancelled prematurely. `waitUntil()` tells the runtime: "I have background work that must complete even after the response is sent."

### Test plan

- [x] TypeScript compilation passes (worker and main app)
- [x] All 1,697 tests pass (86 test files)
- [ ] Manual test: verify session `lastActivity` updates after authenticated requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)