### PR TITLE
feat(user-guide): add step-through wizard with dual-mode support (v6.7.0)

### DIFF
--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+  value: number;
+  max?: number;
+}
+
+/**
+ * Simple progress bar component for wizard flows
+ * Shows visual progress with filled/empty segments
+ */
+export function Progress({ value, max = 100, className, ...props }: ProgressProps) {
+  const percentage = Math.min(Math.max((value / max) * 100, 0), 100);
+
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={value}
+      aria-valuemin={0}
+      aria-valuemax={max}
+      className={cn("h-2 w-full overflow-hidden rounded-full bg-background-muted", className)}
+      {...props}
+    >
+      <div
+        className="h-full bg-accent transition-all duration-300 ease-in-out"
+        style={{ width: `${percentage}%` }}
+      />
+    </div>
+  );
+}
+
+interface StepIndicatorProps {
+  currentStep: number;
+  totalSteps: number;
+  className?: string;
+}
+
+/**
+ * Step indicator showing current position in a wizard flow
+ * Displays step dots and a text label
+ */
+export function StepIndicator({ currentStep, totalSteps, className }: StepIndicatorProps) {
+  return (
+    <div className={cn("flex flex-col gap-2", className)}>
+      <div className="flex items-center justify-between">
+        <div className="flex gap-1.5">
+          {Array.from({ length: totalSteps }, (_, i) => (
+            <div
+              key={i}
+              className={cn(
+                "h-2 w-2 rounded-full transition-colors",
+                i < currentStep ? "bg-accent" : "bg-background-muted"
+              )}
+            />
+          ))}
+        </div>
+        <span className="text-xs text-foreground-muted">
+          Step {currentStep} of {totalSteps}
+        </span>
+      </div>
+      <Progress value={currentStep} max={totalSteps} />
+    </div>
+  );
+}

--- a/components/user-guide-dialog.tsx
+++ b/components/user-guide-dialog.tsx
@@ -1,171 +1,89 @@
-/* eslint-disable react/no-unescaped-entities */
 "use client";
 
-import { useState } from "react";
-import { BookOpenIcon, LightbulbIcon } from "lucide-react";
+import { BookOpenIcon, WandSparklesIcon, ListIcon } from "lucide-react";
 import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogHeader,
-	DialogTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
 } from "@/components/ui/dialog";
-import { GettingStartedSection } from "@/components/user-guide/getting-started-section";
-import { PowerFeaturesSection } from "@/components/user-guide/power-features-section";
-import { MatrixSection } from "@/components/user-guide/matrix-section";
-import { TaskManagementSection } from "@/components/user-guide/task-management-section";
-import { AdvancedFeaturesSection } from "@/components/user-guide/advanced-features-section";
-import { SmartViewsSection } from "@/components/user-guide/smart-views-section";
-import { BatchOperationsSection } from "@/components/user-guide/batch-operations-section";
-import { DashboardSection } from "@/components/user-guide/dashboard-section";
-import { WorkflowsSection } from "@/components/user-guide/workflows-section";
-import { DataPrivacySection } from "@/components/user-guide/data-privacy-section";
-import { ShortcutsSection } from "@/components/user-guide/shortcuts-section";
-import { PwaSection } from "@/components/user-guide/pwa-section";
+import { Button } from "@/components/ui/button";
+import { useGuideMode } from "@/lib/hooks/use-guide-mode";
+import { WizardView } from "@/components/user-guide/wizard-view";
+import { AccordionView } from "@/components/user-guide/accordion-view";
 
 interface UserGuideDialogProps {
-	open: boolean;
-	onOpenChange: (open: boolean) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
 export function UserGuideDialog({ open, onOpenChange }: UserGuideDialogProps) {
-	const [expandedSections, setExpandedSections] = useState({
-		gettingStarted: true,
-		powerFeatures: false,
-		matrix: false,
-		taskManagement: false,
-		advancedFeatures: false,
-		smartViews: false,
-		batchOps: false,
-		dashboard: false,
-		workflows: false,
-		dataPrivacy: false,
-		shortcuts: false,
-		pwa: false,
-	});
+  const { toggleMode, isWizard } = useGuideMode("wizard");
 
-	const toggleSection = (section: keyof typeof expandedSections) => {
-		setExpandedSections((prev) => ({
-			...prev,
-			[section]: !prev[section],
-		}));
-	};
+  const handleClose = () => {
+    onOpenChange(false);
+  };
 
-	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="max-h-[85vh] max-w-4xl overflow-y-auto">
-				<DialogHeader>
-					<DialogTitle className="flex items-center gap-2 text-2xl">
-						<BookOpenIcon className="h-6 w-6 text-accent" />
-						GSD Task Manager - User Guide
-					</DialogTitle>
-					<DialogDescription>
-						Master productivity with the Eisenhower Matrix and GSD's powerful
-						features
-					</DialogDescription>
-				</DialogHeader>
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] max-w-2xl flex flex-col">
+        <DialogHeader className="flex-shrink-0">
+          <div className="flex items-center justify-between">
+            <DialogTitle className="flex items-center gap-2 text-xl">
+              <BookOpenIcon className="h-5 w-5 text-accent" />
+              User Guide
+            </DialogTitle>
 
-				<div className="space-y-2">
-					{/* Getting Started */}
-					<GettingStartedSection
-						expanded={expandedSections.gettingStarted}
-						onToggle={() => toggleSection("gettingStarted")}
-					/>
+            {/* Mode toggle */}
+            <ModeToggle isWizard={isWizard} onToggle={toggleMode} />
+          </div>
+          <DialogDescription>
+            {isWizard
+              ? "Step-by-step guide to mastering GSD"
+              : "Quick reference for all GSD features"}
+          </DialogDescription>
+        </DialogHeader>
 
-					{/* Power Features (v5.10.0) */}
-					<PowerFeaturesSection
-						expanded={expandedSections.powerFeatures}
-						onToggle={() => toggleSection("powerFeatures")}
-					/>
+        {/* Content area - flex-1 for remaining space */}
+        <div className="flex-1 min-h-0 overflow-hidden">
+          {isWizard ? (
+            <WizardView onComplete={handleClose} />
+          ) : (
+            <div className="h-full overflow-y-auto pr-1">
+              <AccordionView />
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
 
-					{/* Eisenhower Matrix */}
-					<MatrixSection
-						expanded={expandedSections.matrix}
-						onToggle={() => toggleSection("matrix")}
-					/>
+interface ModeToggleProps {
+  isWizard: boolean;
+  onToggle: () => void;
+}
 
-					{/* Core Task Management */}
-					<TaskManagementSection
-						expanded={expandedSections.taskManagement}
-						onToggle={() => toggleSection("taskManagement")}
-					/>
-
-					{/* Advanced Features */}
-					<AdvancedFeaturesSection
-						expanded={expandedSections.advancedFeatures}
-						onToggle={() => toggleSection("advancedFeatures")}
-					/>
-
-					{/* Smart Views & Filtering */}
-					<SmartViewsSection
-						expanded={expandedSections.smartViews}
-						onToggle={() => toggleSection("smartViews")}
-					/>
-
-					{/* Batch Operations */}
-					<BatchOperationsSection
-						expanded={expandedSections.batchOps}
-						onToggle={() => toggleSection("batchOps")}
-					/>
-
-					{/* Dashboard & Analytics */}
-					<DashboardSection
-						expanded={expandedSections.dashboard}
-						onToggle={() => toggleSection("dashboard")}
-					/>
-
-					{/* Workflows & Best Practices */}
-					<WorkflowsSection
-						expanded={expandedSections.workflows}
-						onToggle={() => toggleSection("workflows")}
-					/>
-
-					{/* Data & Privacy */}
-					<DataPrivacySection
-						expanded={expandedSections.dataPrivacy}
-						onToggle={() => toggleSection("dataPrivacy")}
-					/>
-
-					{/* Keyboard Shortcuts */}
-					<ShortcutsSection
-						expanded={expandedSections.shortcuts}
-						onToggle={() => toggleSection("shortcuts")}
-					/>
-
-					{/* PWA Features */}
-					<PwaSection
-						expanded={expandedSections.pwa}
-						onToggle={() => toggleSection("pwa")}
-					/>
-
-					{/* Final Tips */}
-					<div className="rounded-lg bg-gradient-to-r from-accent/10 to-accent/5 border border-accent/20 p-4 mt-4">
-						<div className="flex items-start gap-3">
-							<LightbulbIcon className="h-5 w-5 text-accent flex-shrink-0 mt-0.5" />
-							<div className="space-y-2 text-sm">
-								<h4 className="font-semibold text-foreground">
-									Remember: The Matrix is a Tool, Not a Rule
-								</h4>
-								<p className="text-foreground-muted">
-									There's no "perfect" way to use GSD. Experiment with
-									workflows, adjust quadrants as you learn, and adapt the system
-									to your life. The goal isn't perfect categorization—it's
-									intentional action toward what matters most.
-								</p>
-								<p className="text-foreground-muted">
-									<strong>Start small.</strong> Master one section at a time.
-									Even using just the basic matrix will transform your
-									productivity. The advanced features are here when you're
-									ready.
-								</p>
-								<p className="text-accent font-medium">
-									Now go get stuff done! 🚀
-								</p>
-							</div>
-						</div>
-					</div>
-				</div>
-			</DialogContent>
-		</Dialog>
-	);
+function ModeToggle({ isWizard, onToggle }: ModeToggleProps) {
+  return (
+    <Button
+      variant="ghost"
+      onClick={onToggle}
+      className="gap-2 text-sm h-8 px-3"
+      aria-label={isWizard ? "Switch to reference mode" : "Switch to wizard mode"}
+    >
+      {isWizard ? (
+        <>
+          <ListIcon className="h-4 w-4" />
+          <span className="hidden sm:inline">Reference</span>
+        </>
+      ) : (
+        <>
+          <WandSparklesIcon className="h-4 w-4" />
+          <span className="hidden sm:inline">Wizard</span>
+        </>
+      )}
+    </Button>
+  );
 }

--- a/components/user-guide/accordion-view.tsx
+++ b/components/user-guide/accordion-view.tsx
@@ -1,0 +1,136 @@
+/* eslint-disable react/no-unescaped-entities */
+"use client";
+
+import { useState } from "react";
+import { LightbulbIcon } from "lucide-react";
+import { GettingStartedSection } from "@/components/user-guide/getting-started-section";
+import { PowerFeaturesSection } from "@/components/user-guide/power-features-section";
+import { MatrixSection } from "@/components/user-guide/matrix-section";
+import { TaskManagementSection } from "@/components/user-guide/task-management-section";
+import { AdvancedFeaturesSection } from "@/components/user-guide/advanced-features-section";
+import { SmartViewsSection } from "@/components/user-guide/smart-views-section";
+import { BatchOperationsSection } from "@/components/user-guide/batch-operations-section";
+import { DashboardSection } from "@/components/user-guide/dashboard-section";
+import { WorkflowsSection } from "@/components/user-guide/workflows-section";
+import { DataPrivacySection } from "@/components/user-guide/data-privacy-section";
+import { ShortcutsSection } from "@/components/user-guide/shortcuts-section";
+import { PwaSection } from "@/components/user-guide/pwa-section";
+
+/**
+ * Accordion-style view for the user guide
+ * Shows all sections as collapsible accordions for quick reference
+ */
+export function AccordionView() {
+  const [expandedSections, setExpandedSections] = useState({
+    gettingStarted: true,
+    powerFeatures: false,
+    matrix: false,
+    taskManagement: false,
+    advancedFeatures: false,
+    smartViews: false,
+    batchOps: false,
+    dashboard: false,
+    workflows: false,
+    dataPrivacy: false,
+    shortcuts: false,
+    pwa: false,
+  });
+
+  const toggleSection = (section: keyof typeof expandedSections) => {
+    setExpandedSections((prev) => ({
+      ...prev,
+      [section]: !prev[section],
+    }));
+  };
+
+  return (
+    <div className="space-y-2">
+      <GettingStartedSection
+        expanded={expandedSections.gettingStarted}
+        onToggle={() => toggleSection("gettingStarted")}
+      />
+
+      <PowerFeaturesSection
+        expanded={expandedSections.powerFeatures}
+        onToggle={() => toggleSection("powerFeatures")}
+      />
+
+      <MatrixSection
+        expanded={expandedSections.matrix}
+        onToggle={() => toggleSection("matrix")}
+      />
+
+      <TaskManagementSection
+        expanded={expandedSections.taskManagement}
+        onToggle={() => toggleSection("taskManagement")}
+      />
+
+      <AdvancedFeaturesSection
+        expanded={expandedSections.advancedFeatures}
+        onToggle={() => toggleSection("advancedFeatures")}
+      />
+
+      <SmartViewsSection
+        expanded={expandedSections.smartViews}
+        onToggle={() => toggleSection("smartViews")}
+      />
+
+      <BatchOperationsSection
+        expanded={expandedSections.batchOps}
+        onToggle={() => toggleSection("batchOps")}
+      />
+
+      <DashboardSection
+        expanded={expandedSections.dashboard}
+        onToggle={() => toggleSection("dashboard")}
+      />
+
+      <WorkflowsSection
+        expanded={expandedSections.workflows}
+        onToggle={() => toggleSection("workflows")}
+      />
+
+      <DataPrivacySection
+        expanded={expandedSections.dataPrivacy}
+        onToggle={() => toggleSection("dataPrivacy")}
+      />
+
+      <ShortcutsSection
+        expanded={expandedSections.shortcuts}
+        onToggle={() => toggleSection("shortcuts")}
+      />
+
+      <PwaSection
+        expanded={expandedSections.pwa}
+        onToggle={() => toggleSection("pwa")}
+      />
+
+      {/* Final Tips */}
+      <div className="rounded-lg bg-gradient-to-r from-accent/10 to-accent/5 border border-accent/20 p-4 mt-4">
+        <div className="flex items-start gap-3">
+          <LightbulbIcon className="h-5 w-5 text-accent flex-shrink-0 mt-0.5" />
+          <div className="space-y-2 text-sm">
+            <h4 className="font-semibold text-foreground">
+              Remember: The Matrix is a Tool, Not a Rule
+            </h4>
+            <p className="text-foreground-muted">
+              There's no "perfect" way to use GSD. Experiment with
+              workflows, adjust quadrants as you learn, and adapt the system
+              to your life. The goal isn't perfect categorization—it's
+              intentional action toward what matters most.
+            </p>
+            <p className="text-foreground-muted">
+              <strong>Start small.</strong> Master one section at a time.
+              Even using just the basic matrix will transform your
+              productivity. The advanced features are here when you're
+              ready.
+            </p>
+            <p className="text-accent font-medium">
+              Now go get stuff done!
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/user-guide/wizard-container.tsx
+++ b/components/user-guide/wizard-container.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import { ChevronLeftIcon, ChevronRightIcon, XIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { StepIndicator } from "@/components/ui/progress";
+
+interface WizardContainerProps {
+  currentStep: number;
+  totalSteps: number;
+  onNext: () => void;
+  onPrevious: () => void;
+  onSkip: () => void;
+  children: React.ReactNode;
+}
+
+/**
+ * Container for wizard-style step navigation
+ * Includes progress indicator, content area, and navigation buttons
+ */
+export function WizardContainer({
+  currentStep,
+  totalSteps,
+  onNext,
+  onPrevious,
+  onSkip,
+  children,
+}: WizardContainerProps) {
+  const isFirstStep = currentStep === 1;
+  const isLastStep = currentStep === totalSteps;
+
+  // Keyboard navigation
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "ArrowLeft" && !isFirstStep) {
+        onPrevious();
+      } else if (event.key === "ArrowRight" && !isLastStep) {
+        onNext();
+      } else if (event.key === "Enter" && isLastStep) {
+        onSkip();
+      }
+    },
+    [isFirstStep, isLastStep, onNext, onPrevious, onSkip]
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Progress indicator */}
+      <div className="flex-shrink-0 pb-4 border-b border-border">
+        <StepIndicator currentStep={currentStep} totalSteps={totalSteps} />
+      </div>
+
+      {/* Content area - scrollable */}
+      <div className="flex-1 overflow-y-auto py-6 min-h-0">
+        {children}
+      </div>
+
+      {/* Navigation footer */}
+      <div className="flex-shrink-0 pt-4 border-t border-border">
+        <div className="flex items-center justify-between">
+          {/* Previous button */}
+          <Button
+            variant="ghost"
+            onClick={onPrevious}
+            disabled={isFirstStep}
+            className="gap-1"
+          >
+            <ChevronLeftIcon className="h-4 w-4" />
+            Previous
+          </Button>
+
+          {/* Skip button */}
+          <Button variant="ghost" onClick={onSkip} className="gap-1">
+            <XIcon className="h-4 w-4" />
+            Skip
+          </Button>
+
+          {/* Next/Finish button */}
+          <Button onClick={isLastStep ? onSkip : onNext} className="gap-1">
+            {isLastStep ? "Finish" : "Next"}
+            {!isLastStep && <ChevronRightIcon className="h-4 w-4" />}
+          </Button>
+        </div>
+
+        {/* Keyboard hint */}
+        <p className="text-center text-xs text-foreground-muted mt-2">
+          Use <kbd className="px-1 py-0.5 bg-background-muted rounded text-xs">←</kbd>{" "}
+          <kbd className="px-1 py-0.5 bg-background-muted rounded text-xs">→</kbd> to navigate
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/user-guide/wizard-steps/index.ts
+++ b/components/user-guide/wizard-steps/index.ts
@@ -1,0 +1,17 @@
+export { StepWelcome } from "./step-welcome";
+export { StepMatrix } from "./step-matrix";
+export { StepTasks } from "./step-tasks";
+export { StepPowerFeatures } from "./step-power-features";
+export { StepWorkflows } from "./step-workflows";
+export { StepFinal } from "./step-final";
+
+export const WIZARD_STEPS = [
+  { id: 1, component: "StepWelcome", title: "Welcome" },
+  { id: 2, component: "StepMatrix", title: "The Matrix" },
+  { id: 3, component: "StepTasks", title: "Task Management" },
+  { id: 4, component: "StepPowerFeatures", title: "Power Features" },
+  { id: 5, component: "StepWorkflows", title: "Workflows" },
+  { id: 6, component: "StepFinal", title: "Get Started" },
+] as const;
+
+export const TOTAL_STEPS = WIZARD_STEPS.length;

--- a/components/user-guide/wizard-steps/step-final.tsx
+++ b/components/user-guide/wizard-steps/step-final.tsx
@@ -1,0 +1,102 @@
+/* eslint-disable react/no-unescaped-entities */
+"use client";
+
+import {
+  RocketIcon,
+  ShieldCheckIcon,
+  KeyboardIcon,
+  SmartphoneIcon,
+  CloudIcon,
+} from "lucide-react";
+
+/**
+ * Step 6: Data, Privacy & Next Steps
+ * Privacy info, key shortcuts, PWA, and final CTA
+ */
+export function StepFinal() {
+  return (
+    <div className="space-y-5">
+      {/* Header */}
+      <div className="text-center space-y-2">
+        <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-accent/10 mb-1">
+          <RocketIcon className="h-6 w-6 text-accent" />
+        </div>
+        <h2 className="text-xl font-bold text-foreground">You're Ready!</h2>
+        <p className="text-sm text-foreground-muted">A few more things to know...</p>
+      </div>
+
+      {/* Privacy & Data */}
+      <div className="rounded-lg border border-card-border bg-card p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <ShieldCheckIcon className="h-5 w-5 text-green-500" />
+          <h3 className="font-semibold text-foreground text-sm">Your Data, Your Control</h3>
+        </div>
+        <div className="space-y-2 text-xs text-foreground-muted">
+          <p>
+            <strong>Local-first:</strong> All data stored on YOUR device. Works completely offline.
+          </p>
+          <div className="flex items-center gap-2">
+            <CloudIcon className="h-4 w-4 text-blue-500" />
+            <p>
+              <strong>Optional Cloud Sync:</strong> End-to-end encrypted (AES-256).
+              We can't read your tasks.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Quick shortcuts */}
+      <div className="rounded-lg border border-card-border bg-card p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <KeyboardIcon className="h-5 w-5 text-accent" />
+          <h3 className="font-semibold text-foreground text-sm">Essential Shortcuts</h3>
+        </div>
+        <div className="grid grid-cols-2 gap-2 text-xs">
+          <ShortcutItem shortcut="⌘K" description="Command palette" />
+          <ShortcutItem shortcut="N" description="New task" />
+          <ShortcutItem shortcut="/" description="Search" />
+          <ShortcutItem shortcut="?" description="This guide" />
+          <ShortcutItem shortcut="1-9" description="Smart views" />
+          <ShortcutItem shortcut="0" description="Clear filter" />
+        </div>
+      </div>
+
+      {/* PWA */}
+      <div className="rounded-lg border border-card-border bg-card p-3">
+        <div className="flex items-center gap-2 mb-2">
+          <SmartphoneIcon className="h-4 w-4 text-accent" />
+          <h4 className="font-semibold text-foreground text-sm">Install as App</h4>
+        </div>
+        <p className="text-xs text-foreground-muted">
+          Add GSD to your home screen for faster access. Click the install icon in your browser
+          or use Share → "Add to Home Screen" on mobile.
+        </p>
+      </div>
+
+      {/* Final CTA */}
+      <div className="rounded-xl bg-gradient-to-r from-accent/20 to-accent/10 border border-accent/30 p-5 text-center">
+        <h3 className="font-bold text-foreground text-lg mb-2">
+          Now Go Get Stuff Done!
+        </h3>
+        <p className="text-sm text-foreground-muted mb-3">
+          The matrix is a tool, not a rule. Start small, experiment, and adapt it to your life.
+        </p>
+        <p className="text-xs text-foreground-muted">
+          Press <kbd className="px-1.5 py-0.5 bg-white/50 dark:bg-black/30 rounded font-mono">?</kbd> anytime
+          to open the full reference guide.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ShortcutItem({ shortcut, description }: { shortcut: string; description: string }) {
+  return (
+    <div className="flex items-center justify-between bg-background-muted rounded px-2 py-1.5">
+      <span className="text-foreground-muted">{description}</span>
+      <kbd className="px-1.5 py-0.5 bg-background rounded border border-border text-xs font-mono text-foreground">
+        {shortcut}
+      </kbd>
+    </div>
+  );
+}

--- a/components/user-guide/wizard-steps/step-matrix.tsx
+++ b/components/user-guide/wizard-steps/step-matrix.tsx
@@ -1,0 +1,93 @@
+/* eslint-disable react/no-unescaped-entities */
+"use client";
+
+import { GridIcon, AlertTriangleIcon } from "lucide-react";
+
+/**
+ * Step 2: The Eisenhower Matrix
+ * Explains the 4 quadrants and their purpose
+ */
+export function StepMatrix() {
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="text-center space-y-2">
+        <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-accent/10 mb-1">
+          <GridIcon className="h-6 w-6 text-accent" />
+        </div>
+        <h2 className="text-xl font-bold text-foreground">The Eisenhower Matrix</h2>
+        <p className="text-sm text-foreground-muted max-w-lg mx-auto">
+          <em>"What is important is seldom urgent, and what is urgent is seldom important."</em>
+          <span className="block mt-1">— President Eisenhower</span>
+        </p>
+      </div>
+
+      {/* 4 Quadrants Grid */}
+      <div className="grid grid-cols-2 gap-3">
+        {/* Q1 - Do First */}
+        <div className="rounded-xl border border-blue-200 bg-blue-50 dark:bg-blue-950/30 dark:border-blue-800 p-4">
+          <div className="flex items-center gap-2 mb-2">
+            <div className="h-3 w-3 rounded-full bg-blue-500" />
+            <h3 className="font-semibold text-blue-900 dark:text-blue-300 text-sm">Q1: Do First</h3>
+          </div>
+          <p className="text-xs text-blue-700 dark:text-blue-400 mb-2">Urgent + Important</p>
+          <p className="text-xs text-blue-600 dark:text-blue-400">
+            Crises, deadlines, emergencies. Target: 15-20%
+          </p>
+        </div>
+
+        {/* Q2 - Schedule */}
+        <div className="rounded-xl border-2 border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 p-4">
+          <div className="flex items-center gap-2 mb-2">
+            <div className="h-3 w-3 rounded-full bg-amber-500" />
+            <h3 className="font-semibold text-amber-900 dark:text-amber-300 text-sm">Q2: Schedule</h3>
+          </div>
+          <p className="text-xs text-amber-700 dark:text-amber-400 mb-2">Not Urgent + Important</p>
+          <p className="text-xs text-amber-600 dark:text-amber-400 font-medium">
+            YOUR GOAL! Strategic work, growth. Target: 60-70%
+          </p>
+        </div>
+
+        {/* Q3 - Delegate */}
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50 dark:bg-emerald-950/30 dark:border-emerald-800 p-4">
+          <div className="flex items-center gap-2 mb-2">
+            <div className="h-3 w-3 rounded-full bg-emerald-500" />
+            <h3 className="font-semibold text-emerald-900 dark:text-emerald-300 text-sm">Q3: Delegate</h3>
+          </div>
+          <p className="text-xs text-emerald-700 dark:text-emerald-400 mb-2">Urgent + Not Important</p>
+          <p className="text-xs text-emerald-600 dark:text-emerald-400">
+            Interruptions, busywork. Target: 15-20%
+          </p>
+        </div>
+
+        {/* Q4 - Eliminate */}
+        <div className="rounded-xl border border-purple-200 bg-purple-50 dark:bg-purple-950/30 dark:border-purple-800 p-4">
+          <div className="flex items-center gap-2 mb-2">
+            <div className="h-3 w-3 rounded-full bg-purple-500" />
+            <h3 className="font-semibold text-purple-900 dark:text-purple-300 text-sm">Q4: Eliminate</h3>
+          </div>
+          <p className="text-xs text-purple-700 dark:text-purple-400 mb-2">Not Urgent + Not Important</p>
+          <p className="text-xs text-purple-600 dark:text-purple-400">
+            Time-wasters, distractions. Target: 0-5%
+          </p>
+        </div>
+      </div>
+
+      {/* Warning */}
+      <div className="rounded-xl bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-900 p-4">
+        <div className="flex items-start gap-3">
+          <AlertTriangleIcon className="h-5 w-5 text-red-500 flex-shrink-0 mt-0.5" />
+          <div>
+            <h4 className="font-semibold text-sm text-red-600 dark:text-red-400 mb-1">
+              Common Mistake: Living in Q1
+            </h4>
+            <p className="text-xs text-red-600 dark:text-red-400">
+              Many people spend 80% in Q1, firefighting constantly. This leads to burnout.
+              <strong> Schedule Q2 time daily</strong> (even 30 min) to prevent future crises.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/user-guide/wizard-steps/step-power-features.tsx
+++ b/components/user-guide/wizard-steps/step-power-features.tsx
@@ -1,0 +1,104 @@
+/* eslint-disable react/no-unescaped-entities */
+"use client";
+
+import { ZapIcon, CommandIcon, KeyboardIcon, SettingsIcon, UsersIcon } from "lucide-react";
+
+/**
+ * Step 4: Power Features
+ * Command palette, smart views, batch operations
+ */
+export function StepPowerFeatures() {
+  return (
+    <div className="space-y-5">
+      {/* Header */}
+      <div className="text-center space-y-2">
+        <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-accent/10 mb-1">
+          <ZapIcon className="h-6 w-6 text-accent" />
+        </div>
+        <h2 className="text-xl font-bold text-foreground">Power Features</h2>
+        <p className="text-sm text-foreground-muted">Navigate like a pro with keyboard shortcuts</p>
+      </div>
+
+      {/* Command Palette - Hero */}
+      <div className="rounded-xl border-2 border-accent/30 bg-accent/5 p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <CommandIcon className="h-5 w-5 text-accent" />
+          <h3 className="font-semibold text-foreground">Command Palette</h3>
+          <kbd className="ml-auto px-2 py-1 bg-accent/20 border border-accent/30 rounded text-xs font-mono text-accent">
+            ⌘K
+          </kbd>
+        </div>
+        <p className="text-sm text-foreground-muted mb-3">
+          Your gateway to everything in GSD. Press <strong>⌘K</strong> (or Ctrl+K) to:
+        </p>
+        <div className="grid grid-cols-2 gap-2 text-xs">
+          <div className="flex items-center gap-1.5">
+            <span className="text-accent">🔍</span>
+            <span className="text-foreground-muted">Search any task</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="text-accent">⚡</span>
+            <span className="text-foreground-muted">Quick actions</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="text-accent">🧭</span>
+            <span className="text-foreground-muted">Navigate views</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="text-accent">⚙️</span>
+            <span className="text-foreground-muted">Open settings</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Smart Views & Batch Ops */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-lg border border-card-border bg-card p-3">
+          <div className="flex items-center gap-2 mb-2">
+            <KeyboardIcon className="h-4 w-4 text-accent" />
+            <h4 className="font-semibold text-foreground text-sm">Smart Views</h4>
+          </div>
+          <ul className="text-xs text-foreground-muted space-y-1">
+            <li>• Pin views to header</li>
+            <li>• Press <kbd className="px-1 bg-background-muted rounded">1-9</kbd> to activate</li>
+            <li>• Press <kbd className="px-1 bg-background-muted rounded">0</kbd> to clear</li>
+          </ul>
+        </div>
+
+        <div className="rounded-lg border border-card-border bg-card p-3">
+          <div className="flex items-center gap-2 mb-2">
+            <UsersIcon className="h-4 w-4 text-accent" />
+            <h4 className="font-semibold text-foreground text-sm">Batch Operations</h4>
+          </div>
+          <ul className="text-xs text-foreground-muted space-y-1">
+            <li>• Click tasks to select</li>
+            <li>• Complete, move, or tag</li>
+            <li>• Delete multiple at once</li>
+          </ul>
+        </div>
+      </div>
+
+      {/* Quick Settings */}
+      <div className="rounded-lg border border-card-border bg-card p-3">
+        <div className="flex items-center gap-2 mb-2">
+          <SettingsIcon className="h-4 w-4 text-accent" />
+          <h4 className="font-semibold text-foreground text-sm">Quick Settings Panel</h4>
+        </div>
+        <p className="text-xs text-foreground-muted">
+          Click the gear icon for fast access to: theme toggle, show/hide completed,
+          notifications, and sync interval.
+        </p>
+      </div>
+
+      {/* Workflow example */}
+      <div className="rounded-lg bg-gradient-to-r from-blue-50 to-purple-50 dark:from-blue-950/30 dark:to-purple-950/30 border border-blue-200 dark:border-blue-800 p-3">
+        <p className="text-xs text-foreground">
+          <strong>Pro Workflow:</strong> Press <kbd className="px-1 bg-white/50 dark:bg-black/30 rounded">1</kbd> (Today's Focus)
+          → <kbd className="px-1 bg-white/50 dark:bg-black/30 rounded">n</kbd> (new task)
+          → <kbd className="px-1 bg-white/50 dark:bg-black/30 rounded">⌘K</kbd> "dashboard"
+          — all in seconds!
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/user-guide/wizard-steps/step-tasks.tsx
+++ b/components/user-guide/wizard-steps/step-tasks.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import {
+  ListIcon,
+  RepeatIcon,
+  TagIcon,
+  CheckSquareIcon,
+  LinkIcon,
+  CalendarIcon,
+} from "lucide-react";
+
+/**
+ * Step 3: Task Management
+ * Covers core task operations and advanced features
+ */
+export function StepTasks() {
+  return (
+    <div className="space-y-5">
+      {/* Header */}
+      <div className="text-center space-y-2">
+        <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-accent/10 mb-1">
+          <ListIcon className="h-6 w-6 text-accent" />
+        </div>
+        <h2 className="text-xl font-bold text-foreground">Task Management</h2>
+        <p className="text-sm text-foreground-muted">Master the essentials and unlock advanced features</p>
+      </div>
+
+      {/* Core operations */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-lg border border-card-border bg-card p-3">
+          <h4 className="font-semibold text-foreground text-sm mb-2">Creating Tasks</h4>
+          <ul className="text-xs text-foreground-muted space-y-1">
+            <li>• Press <kbd className="px-1 bg-background-muted rounded">N</kbd> to create</li>
+            <li>• Use action-oriented titles</li>
+            <li>• Set due dates for deadlines</li>
+          </ul>
+        </div>
+
+        <div className="rounded-lg border border-card-border bg-card p-3">
+          <h4 className="font-semibold text-foreground text-sm mb-2">Completing Tasks</h4>
+          <ul className="text-xs text-foreground-muted space-y-1">
+            <li>• Click checkmark to complete</li>
+            <li>• Recurring tasks auto-create new</li>
+            <li>• Toggle visibility with eye icon</li>
+          </ul>
+        </div>
+      </div>
+
+      {/* Advanced features */}
+      <div>
+        <h3 className="font-semibold text-foreground text-sm mb-3">Advanced Features</h3>
+        <div className="grid grid-cols-2 gap-2">
+          <FeatureChip icon={<RepeatIcon className="h-3.5 w-3.5" />} title="Recurring" desc="Daily, weekly, monthly" />
+          <FeatureChip icon={<TagIcon className="h-3.5 w-3.5" />} title="Tags" desc="#project, #context" />
+          <FeatureChip icon={<CheckSquareIcon className="h-3.5 w-3.5" />} title="Subtasks" desc="Break down complex work" />
+          <FeatureChip icon={<LinkIcon className="h-3.5 w-3.5" />} title="Dependencies" desc="Task B waits for A" />
+          <FeatureChip icon={<CalendarIcon className="h-3.5 w-3.5" />} title="Due Dates" desc="Red overdue, amber today" />
+        </div>
+      </div>
+
+      {/* Search tip */}
+      <div className="rounded-lg bg-accent/10 border border-accent/20 p-3">
+        <p className="text-sm text-foreground">
+          <strong>Quick Search:</strong> Press{" "}
+          <kbd className="px-1.5 py-0.5 bg-background-muted rounded text-xs font-mono">/</kbd>{" "}
+          to focus search. Finds tasks by title, description, tags, or subtasks.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function FeatureChip({ icon, title, desc }: { icon: React.ReactNode; title: string; desc: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-card-border bg-background-muted/50 p-2">
+      <div className="text-accent mt-0.5">{icon}</div>
+      <div>
+        <p className="text-xs font-medium text-foreground">{title}</p>
+        <p className="text-xs text-foreground-muted">{desc}</p>
+      </div>
+    </div>
+  );
+}

--- a/components/user-guide/wizard-steps/step-welcome.tsx
+++ b/components/user-guide/wizard-steps/step-welcome.tsx
@@ -1,0 +1,67 @@
+/* eslint-disable react/no-unescaped-entities */
+"use client";
+
+import { RocketIcon, SparklesIcon } from "lucide-react";
+
+/**
+ * Step 1: Welcome & Getting Started
+ * Introduces GSD and the Eisenhower Matrix concept
+ */
+export function StepWelcome() {
+  return (
+    <div className="space-y-6">
+      {/* Hero section */}
+      <div className="text-center space-y-3">
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-accent/10 mb-2">
+          <RocketIcon className="h-8 w-8 text-accent" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground">
+          Welcome to GSD Task Manager!
+        </h2>
+        <p className="text-foreground-muted max-w-md mx-auto">
+          <span className="font-semibold">Get Stuff Done</span> helps you prioritize what matters
+          using the Eisenhower Matrix — a proven productivity framework.
+        </p>
+      </div>
+
+      {/* Quick intro */}
+      <div className="rounded-xl border border-card-border bg-card p-5 space-y-4">
+        <div className="flex items-center gap-2">
+          <SparklesIcon className="h-5 w-5 text-accent" />
+          <h3 className="font-semibold text-foreground">Creating Your First Task</h3>
+        </div>
+
+        <ol className="text-sm text-foreground-muted space-y-2 list-decimal list-inside ml-1">
+          <li>
+            Click the <strong>New Task</strong> button (or press{" "}
+            <kbd className="px-2 py-1 bg-background-muted rounded text-xs font-mono">N</kbd>)
+          </li>
+          <li>Enter a clear, actionable title (e.g., "Review Q4 budget proposal")</li>
+          <li>
+            Categorize: Is it <strong>Urgent</strong>? Is it <strong>Important</strong>?
+          </li>
+          <li>Optionally set a due date, add tags, or create subtasks</li>
+          <li>
+            Click <strong>Add Task</strong>
+          </li>
+        </ol>
+      </div>
+
+      {/* Pro tip */}
+      <div className="rounded-xl bg-accent/10 border border-accent/20 p-4">
+        <p className="text-sm text-foreground">
+          <strong>Pro Tip:</strong> Start with 5-10 tasks to get familiar with the matrix.
+          Don't worry about perfect categorization — you can always move tasks later!
+        </p>
+      </div>
+
+      {/* What you'll learn */}
+      <div className="text-center text-sm text-foreground-muted">
+        <p>In this guide, you'll learn:</p>
+        <p className="font-medium text-foreground mt-1">
+          The Matrix • Task Management • Power Features • Workflows
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/user-guide/wizard-steps/step-workflows.tsx
+++ b/components/user-guide/wizard-steps/step-workflows.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { TrendingUpIcon, BarChart3Icon, CalendarIcon, SunIcon, CalendarDaysIcon } from "lucide-react";
+
+/**
+ * Step 5: Workflows & Analytics
+ * Daily/weekly/monthly reviews and dashboard features
+ */
+export function StepWorkflows() {
+  return (
+    <div className="space-y-5">
+      {/* Header */}
+      <div className="text-center space-y-2">
+        <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-accent/10 mb-1">
+          <TrendingUpIcon className="h-6 w-6 text-accent" />
+        </div>
+        <h2 className="text-xl font-bold text-foreground">Workflows & Analytics</h2>
+        <p className="text-sm text-foreground-muted">Build habits and track your progress</p>
+      </div>
+
+      {/* Review Workflows */}
+      <div className="space-y-3">
+        <WorkflowCard
+          icon={<SunIcon className="h-4 w-4" />}
+          title="Daily Review"
+          time="10 min"
+          steps={[
+            "Check 'Today's Focus' view",
+            "Review Q1 — what's urgent?",
+            "Pick 1-2 Q2 tasks to protect",
+          ]}
+        />
+
+        <WorkflowCard
+          icon={<CalendarIcon className="h-4 w-4" />}
+          title="Weekly Planning"
+          time="30 min"
+          steps={[
+            "Review completed — celebrate wins!",
+            "Check 'Overdue Backlog'",
+            "Plan next week's Q2 blocks",
+          ]}
+        />
+
+        <WorkflowCard
+          icon={<CalendarDaysIcon className="h-4 w-4" />}
+          title="Monthly Review"
+          time="1 hour"
+          steps={[
+            "Check Dashboard patterns",
+            "Review quadrant distribution",
+            "Set intention for next month",
+          ]}
+        />
+      </div>
+
+      {/* Dashboard */}
+      <div className="rounded-xl border border-card-border bg-card p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <BarChart3Icon className="h-5 w-5 text-accent" />
+          <h3 className="font-semibold text-foreground">Dashboard Analytics</h3>
+        </div>
+        <div className="grid grid-cols-2 gap-2 text-xs">
+          <div className="flex items-center gap-2 p-2 rounded bg-background-muted">
+            <span className="text-accent">📊</span>
+            <span className="text-foreground-muted">Completion trends</span>
+          </div>
+          <div className="flex items-center gap-2 p-2 rounded bg-background-muted">
+            <span className="text-accent">🔥</span>
+            <span className="text-foreground-muted">Streak tracking</span>
+          </div>
+          <div className="flex items-center gap-2 p-2 rounded bg-background-muted">
+            <span className="text-accent">🏷️</span>
+            <span className="text-foreground-muted">Tag analytics</span>
+          </div>
+          <div className="flex items-center gap-2 p-2 rounded bg-background-muted">
+            <span className="text-accent">📅</span>
+            <span className="text-foreground-muted">Upcoming deadlines</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WorkflowCard({
+  icon,
+  title,
+  time,
+  steps,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  time: string;
+  steps: string[];
+}) {
+  return (
+    <div className="rounded-lg border border-card-border bg-card p-3">
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <div className="text-accent">{icon}</div>
+          <h4 className="font-semibold text-foreground text-sm">{title}</h4>
+        </div>
+        <span className="text-xs text-foreground-muted">{time}</span>
+      </div>
+      <ol className="text-xs text-foreground-muted space-y-0.5 list-decimal list-inside">
+        {steps.map((step, idx) => (
+          <li key={idx}>{step}</li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/components/user-guide/wizard-view.tsx
+++ b/components/user-guide/wizard-view.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { WizardContainer } from "./wizard-container";
+import {
+  StepWelcome,
+  StepMatrix,
+  StepTasks,
+  StepPowerFeatures,
+  StepWorkflows,
+  StepFinal,
+  TOTAL_STEPS,
+} from "./wizard-steps";
+
+interface WizardViewProps {
+  onComplete: () => void;
+}
+
+/**
+ * Wizard-style view for the user guide
+ * Guides users through 6 steps with navigation controls
+ */
+export function WizardView({ onComplete }: WizardViewProps) {
+  const [currentStep, setCurrentStep] = useState(1);
+
+  const handleNext = useCallback(() => {
+    if (currentStep < TOTAL_STEPS) {
+      setCurrentStep((prev) => prev + 1);
+    } else {
+      onComplete();
+    }
+  }, [currentStep, onComplete]);
+
+  const handlePrevious = useCallback(() => {
+    if (currentStep > 1) {
+      setCurrentStep((prev) => prev - 1);
+    }
+  }, [currentStep]);
+
+  const renderStep = () => {
+    switch (currentStep) {
+      case 1:
+        return <StepWelcome />;
+      case 2:
+        return <StepMatrix />;
+      case 3:
+        return <StepTasks />;
+      case 4:
+        return <StepPowerFeatures />;
+      case 5:
+        return <StepWorkflows />;
+      case 6:
+        return <StepFinal />;
+      default:
+        return <StepWelcome />;
+    }
+  };
+
+  return (
+    <WizardContainer
+      currentStep={currentStep}
+      totalSteps={TOTAL_STEPS}
+      onNext={handleNext}
+      onPrevious={handlePrevious}
+      onSkip={onComplete}
+    >
+      {renderStep()}
+    </WizardContainer>
+  );
+}

--- a/lib/hooks/use-guide-mode.ts
+++ b/lib/hooks/use-guide-mode.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState, useCallback } from "react";
+
+export type GuideMode = "wizard" | "accordion";
+
+interface UseGuideModeReturn {
+  mode: GuideMode;
+  setMode: (mode: GuideMode) => void;
+  toggleMode: () => void;
+  isWizard: boolean;
+  isAccordion: boolean;
+}
+
+/**
+ * Hook for managing user guide display mode
+ * Wizard mode: Step-by-step guided experience
+ * Accordion mode: Traditional expandable sections for quick reference
+ */
+export function useGuideMode(defaultMode: GuideMode = "wizard"): UseGuideModeReturn {
+  const [mode, setMode] = useState<GuideMode>(defaultMode);
+
+  const toggleMode = useCallback(() => {
+    setMode((prev) => (prev === "wizard" ? "accordion" : "wizard"));
+  }, []);
+
+  return {
+    mode,
+    setMode,
+    toggleMode,
+    isWizard: mode === "wizard",
+    isAccordion: mode === "accordion",
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "6.6.2",
+	"version": "6.7.0",
 	"private": true,
 	"scripts": {
 		"dev": "next dev",


### PR DESCRIPTION
## Summary
- Add 6-step guided wizard experience for user guide onboarding
- Preserve existing accordion-style reference mode with toggle button
- Add keyboard navigation support (← → arrows)
- Create reusable Progress and StepIndicator UI components

## Changes
**New files (10):**
- `components/ui/progress.tsx` - Reusable progress indicator
- `components/user-guide/accordion-view.tsx` - Extracted accordion view  
- `components/user-guide/wizard-container.tsx` - Navigation wrapper
- `components/user-guide/wizard-view.tsx` - Wizard orchestration
- `components/user-guide/wizard-steps/*.tsx` - 6 step components
- `lib/hooks/use-guide-mode.ts` - Mode state management

**Modified files (1):**
- `components/user-guide-dialog.tsx` - Simplified with mode toggle
- `package.json` - Version bump to 6.7.0

## Wizard Steps
1. Welcome & Getting Started
2. The Eisenhower Matrix
3. Task Management (core + advanced features)
4. Power Features (command palette, smart views, batch ops)
5. Workflows & Analytics
6. Data, Privacy & Next Steps

## Test plan
- [x] TypeScript type checking passes
- [x] ESLint passes (no new errors)
- [x] Production build succeeds
- [x] Wizard opens with `?` keyboard shortcut
- [x] All 6 steps render correctly
- [x] Keyboard navigation (← →) works
- [x] Mode toggle switches between Wizard/Reference
- [x] Accordion sections expand/collapse in Reference mode

🤖 Generated with [Claude Code](https://claude.ai/code)