### PR TITLE
fix(security): update @modelcontextprotocol/sdk to fix high severity vulnerabilities

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -77,7 +77,7 @@
     "url": "https://github.com/vscarpenter/gsd-taskmanager/issues"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.25.1",
+    "@modelcontextprotocol/sdk": "^1.25.2",
     "zod": "^4.3.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Update @modelcontextprotocol/sdk from ^1.25.1 to ^1.25.2 to resolve:
- GHSA-8r9q-7v3j-jr4g: ReDoS vulnerability in MCP TypeScript SDK
- GHSA-3vhc-576x-3qv4: Hono JWK Auth Middleware JWT algorithm confusion
- GHSA-f67f-6cw9-8mq4: Hono JWT Middleware algorithm confusion auth bypass