### PR TITLE
fix(oauth): resolve redirect_uri_mismatch and improve error handling

### DIFF
--- a/components/sync/sync-auth-dialog.tsx
+++ b/components/sync/sync-auth-dialog.tsx
@@ -123,7 +123,9 @@ export function SyncAuthDialog({ isOpen, onClose, onSuccess }: SyncAuthDialogPro
           onSuccess();
         }
       } else {
-        if (activeState && activeState !== event.state) {
+        // Skip if this is for a different OAuth flow, but always process error-only events
+        const isErrorOnlyEvent = event.state === '__error_only__';
+        if (!isErrorOnlyEvent && activeState && activeState !== event.state) {
           return;
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "6.8.0",
+	"version": "6.8.1",
 	"private": true,
 	"scripts": {
 		"dev": "next dev",

--- a/worker/package.json
+++ b/worker/package.json
@@ -21,16 +21,16 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "itty-router": "^5.0.18",
+    "itty-router": "^5.0.22",
     "jose": "^5.10.0",
-    "zod": "^4.3.5"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250110.0",
-    "@types/node": "^25.0.3",
+    "@cloudflare/workers-types": "^4.20260124.0",
+    "@types/node": "^25.0.10",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.16",
-    "wrangler": "^4.43.0"
+    "vitest": "^4.0.18",
+    "wrangler": "^4.60.0"
   },
   "license": "MIT"
 }

--- a/worker/src/handlers/oidc/initiate.ts
+++ b/worker/src/handlers/oidc/initiate.ts
@@ -28,11 +28,13 @@ export async function initiateOAuth(
     }
 
     // Determine the worker's callback URI (where OAuth provider redirects)
-    // In development: http://localhost:8787/api/auth/oauth/callback
-    // In production: https://gsd-api.vinny.dev/api/auth/oauth/callback
+    // IMPORTANT: Use OAUTH_CALLBACK_BASE to ensure callback domain matches cookie domain.
+    // When behind CloudFront proxy, request.host might be the worker's direct domain,
+    // but cookies are set for the frontend domain. Using OAUTH_CALLBACK_BASE ensures
+    // Google redirects to the same domain where the session cookie was set.
     const requestUrl = new URL(request.url);
-    const workerOrigin = `${requestUrl.protocol}//${requestUrl.host}`;
-    const workerCallbackUri = `${workerOrigin}/api/auth/oauth/callback`;
+    const callbackBase = env.OAUTH_CALLBACK_BASE || `${requestUrl.protocol}//${requestUrl.host}`;
+    const workerCallbackUri = `${callbackBase}/api/auth/oauth/callback`;
 
     // Determine the app origin (where we'll redirect after processing)
     // Use OAUTH_CALLBACK_BASE if set, otherwise use Origin header


### PR DESCRIPTION
## Summary
- Fix OAuth `redirect_uri_mismatch` error when deployed behind CloudFront by using `OAUTH_CALLBACK_BASE` env var
- Improve error handling for OAuth popup windows with proper BroadcastChannel communication
- Handle edge case of error-only OAuth events that lack a state parameter

## Changes
- **worker/src/handlers/oidc/initiate.ts**: Use `OAUTH_CALLBACK_BASE` to construct callback URI, ensuring Google redirects to the frontend domain (not the worker's direct domain) when behind CloudFront proxy
- **components/oauth-callback-handler.tsx**: Detect popup context and broadcast errors via BroadcastChannel before attempting to close
- **lib/sync/oauth-handshake/initializer.ts**: Support error-only messages with `__error_only__` placeholder state
- **components/sync/sync-auth-dialog.tsx**: Process error-only events properly
- **worker/package.json**: Update dependencies (wrangler, vitest, cloudflare-workers-types)

## Test plan
- [x] Deploy worker to production
- [x] Verify Google OAuth login works at https://gsd.vinny.dev
- [ ] Test OAuth session expiry error handling
- [ ] Verify popup windows close properly on error

🤖 Generated with [Claude Code](https://claude.com/claude-code)