### PR TITLE
fix(docs): add global TooltipProvider to resolve beautiful-mermaid error

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from "next/font/local";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { ToastProvider } from "@/components/ui/toast";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "sonner";
 import "./globals.css";
 import { cn } from "@/lib/utils";
@@ -81,14 +82,16 @@ export default function RootLayout({
         <ErrorBoundary>
           <ThemeProvider>
             <ToastProvider>
-              <ClientLayout>
-                {children}
-              </ClientLayout>
-              <PwaRegister />
-              <InstallPwaPrompt />
-              <PwaUpdateToast />
-              <SyncDebugInstaller />
-              <Toaster richColors position="top-center" />
+              <TooltipProvider>
+                <ClientLayout>
+                  {children}
+                </ClientLayout>
+                <PwaRegister />
+                <InstallPwaPrompt />
+                <PwaUpdateToast />
+                <SyncDebugInstaller />
+                <Toaster richColors position="top-center" />
+              </TooltipProvider>
             </ToastProvider>
           </ThemeProvider>
         </ErrorBoundary>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "6.8.1",
+	"version": "6.8.2",
 	"private": true,
 	"scripts": {
 		"dev": "next dev",


### PR DESCRIPTION
## Summary
- Add `TooltipProvider` to root layout to fix docs page crash
- The `beautiful-mermaid` library uses Radix UI Tooltip internally which requires a provider ancestor
- Bump version to 6.8.2

## Test plan
- [x] Navigate to `/docs` page
- [x] Verify diagrams render without "Tooltip must be used within TooltipProvider" error
- [x] Verify existing tooltips throughout the app still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)