### PR TITLE
chore: bump version to 6.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "6.8.3",
+	"version": "6.8.4",
 	"private": true,
 	"scripts": {
 		"dev": "next dev",


### PR DESCRIPTION
## Summary
- Bumps version 6.8.3 → 6.8.4 to reflect the dependency security fixes and updates landed in `433c36b`

## Context
The prior commit resolved all 10 `bun audit` vulnerabilities (3 high, 6 moderate, 1 low) and updated patch/minor dependencies. This PR adds the corresponding version bump that was missed.

## Test plan
- [ ] `bun typecheck` passes
- [ ] `bun audit` reports 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)