### PR TITLE
fix(sync,form): update CSP/COOP headers and fix silent form error handling

### DIFF
--- a/SECURITY_HEADERS.md
+++ b/SECURITY_HEADERS.md
@@ -20,7 +20,7 @@ aws cloudfront create-response-headers-policy \
   "Comment": "Security headers for GSD Task Manager",
   "SecurityHeadersConfig": {
     "ContentSecurityPolicy": {
-      "ContentSecurityPolicy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://gsd.vinny.dev https://gsd-dev.vinny.dev http://localhost:8787; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests",
+      "ContentSecurityPolicy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.vinny.io https://accounts.google.com https://oauth2.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';",
       "Override": true
     },
     "ContentTypeOptions": {
@@ -76,7 +76,7 @@ exports.handler = async (event) => {
 
   headers['content-security-policy'] = [{
     key: 'Content-Security-Policy',
-    value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://gsd.vinny.dev https://gsd-dev.vinny.dev http://localhost:8787; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+    value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.vinny.io https://accounts.google.com https://oauth2.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
   }];
 
   headers['x-content-type-options'] = [{
@@ -121,7 +121,7 @@ Create a `_headers` file in the `public/` directory:
 
 ```
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://gsd.vinny.dev https://gsd-dev.vinny.dev http://localhost:8787; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.vinny.io https://accounts.google.com https://oauth2.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   X-XSS-Protection: 1; mode=block
@@ -142,7 +142,7 @@ Create a `vercel.json` file in the project root:
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://gsd.vinny.dev https://gsd-dev.vinny.dev http://localhost:8787; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.vinny.io https://accounts.google.com https://oauth2.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
         },
         {
           "key": "X-Content-Type-Options",
@@ -193,11 +193,15 @@ Or use online tools:
 - **style-src 'self' 'unsafe-inline'**: Allow styles from same origin + inline styles (required for Tailwind)
 - **img-src 'self' data: https:**: Allow images from same origin, data URIs, and HTTPS sources
 - **font-src 'self' data:**: Allow fonts from same origin and data URIs
-- **connect-src 'self' https://gsd.vinny.dev https://gsd-dev.vinny.dev http://localhost:8787**: Allow API connections to Worker endpoints
+- **connect-src 'self' https://api.vinny.io https://accounts.google.com https://oauth2.googleapis.com**: Allow connections to PocketBase server and OAuth providers
 - **frame-ancestors 'none'**: Prevent clickjacking
 - **base-uri 'self'**: Prevent base tag injection
 - **form-action 'self'**: Restrict form submissions to same origin
 - **upgrade-insecure-requests**: Automatically upgrade HTTP to HTTPS
+
+## Cross-Origin-Opener-Policy (COOP)
+
+The `Cross-Origin-Opener-Policy: same-origin-allow-popups` header is required for the PocketBase OAuth2 popup flow. Google's OAuth pages set `COOP: same-origin`, which severs the popup-opener relationship. Setting `same-origin-allow-popups` on our site allows the OAuth popup to maintain its opener reference and call `window.close()` after authentication completes.
 
 ## Notes
 

--- a/components/matrix-board/matrix-dialogs.tsx
+++ b/components/matrix-board/matrix-dialogs.tsx
@@ -87,7 +87,7 @@ interface MatrixDialogsProps {
   closeDialog: () => void;
   taskBeingEdited?: TaskRecord;
   activeTaskDraft?: TaskDraft;
-  onSubmit: (draft: TaskDraft) => void;
+  onSubmit: (draft: TaskDraft) => Promise<void> | void;
   onDelete?: (task: TaskRecord) => void;
 }
 

--- a/components/task-form/index.tsx
+++ b/components/task-form/index.tsx
@@ -226,6 +226,12 @@ export function TaskForm({
         onChange={(dependencies) => updateField("dependencies", dependencies)}
       />
 
+      {errors.general ? (
+        <p className="rounded-lg bg-red-50 p-3 text-sm text-red-600 dark:bg-red-950/30">
+          {errors.general}
+        </p>
+      ) : null}
+
       <div className="flex flex-wrap items-center justify-between gap-2 pt-2">
         {onDelete ? (
           <Button

--- a/components/task-form/use-task-form.ts
+++ b/components/task-form/use-task-form.ts
@@ -67,19 +67,31 @@ export function useTaskForm({
     updateField("dueDate", nextIso);
   };
 
+  const FIELD_ERROR_KEYS: ReadonlySet<keyof FormErrors> = new Set([
+    "title", "description", "dueDate", "tags", "subtasks"
+  ]);
+
+  const FIELD_OVERRIDES: Partial<Record<keyof FormErrors, string>> = {
+    dueDate: "Please choose a valid date"
+  };
+
   const parseValidationErrors = (error: z.ZodError): FormErrors => {
     const fieldErrors: FormErrors = {};
+    const unmappedMessages: string[] = [];
+
     for (const issue of error.issues) {
-      if (issue.path[0] === "title") {
-        fieldErrors.title = issue.message;
-      }
-      if (issue.path[0] === "description") {
-        fieldErrors.description = issue.message;
-      }
-      if (issue.path[0] === "dueDate") {
-        fieldErrors.dueDate = "Please choose a valid date";
+      const field = issue.path[0] as keyof FormErrors;
+      if (FIELD_ERROR_KEYS.has(field)) {
+        fieldErrors[field] = FIELD_OVERRIDES[field] ?? issue.message;
+      } else {
+        unmappedMessages.push(issue.message);
       }
     }
+
+    if (unmappedMessages.length > 0) {
+      fieldErrors.general = unmappedMessages.join(". ");
+    }
+
     return fieldErrors;
   };
 
@@ -101,8 +113,10 @@ export function useTaskForm({
     } catch (error) {
       if (error instanceof z.ZodError) {
         setErrors(parseValidationErrors(error));
+      } else {
+        const message = error instanceof Error ? error.message : "An unexpected error occurred";
+        setErrors({ general: message });
       }
-      // Note: onSubmit handler in parent component will handle non-validation errors
       setSubmitting(false);
       return;
     }

--- a/components/task-form/validation.ts
+++ b/components/task-form/validation.ts
@@ -8,6 +8,7 @@ export interface FormErrors {
   dueDate?: string;
   tags?: string;
   subtasks?: string;
+  general?: string;
 }
 
 // Generate time options in 15-minute increments with 12-hour AM/PM format

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "6.9.3",
+	"version": "7.0.1",
 	"private": true,
 	"scripts": {
 		"dev": "next dev",

--- a/tests/ui/task-form.test.tsx
+++ b/tests/ui/task-form.test.tsx
@@ -375,6 +375,68 @@ describe("TaskForm", () => {
     }, { timeout: 3000 });
   });
 
+  it("submits form in edit mode with changed due date", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    const initialValues: TaskDraft = {
+      title: "Finalize AWS Multi-region deck",
+      description: "Create the new current state slide to help state the problem.",
+      urgent: false,
+      important: true,
+      dueDate: "2026-02-20T05:00:00.000Z",
+      recurrence: "none",
+      tags: ["work", "aws", "presentation"],
+      subtasks: [],
+      dependencies: [],
+      notifyBefore: 15,
+      notificationEnabled: true,
+    };
+
+    render(
+      <TaskForm
+        taskId="test-task-123"
+        initialValues={initialValues}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        onDelete={vi.fn()}
+        submitLabel="Update task"
+      />
+    );
+
+    // Change the due date
+    const dueDateInput = screen.getByLabelText(/due date/i);
+    await user.clear(dueDateInput);
+    await user.type(dueDateInput, "2026-03-28");
+
+    // Click "Update task"
+    await user.click(screen.getByRole("button", { name: /update task/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    const submittedData = onSubmit.mock.calls[0][0];
+    expect(submittedData.title).toBe("Finalize AWS Multi-region deck");
+    // Due date should be set (exact value varies by timezone due to UTC conversion)
+    expect(submittedData.dueDate).toBeDefined();
+    expect(submittedData.dueDate).toContain("2026-03");
+  });
+
+  it("shows general error when non-Zod error occurs during submit", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockRejectedValue(new Error("Database write failed"));
+
+    render(<TaskForm {...defaultHandlers} onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/title/i), "Test task");
+    await user.click(screen.getByRole("button", { name: /save task/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Database write failed")).toBeInTheDocument();
+    });
+  });
+
   it("ignores empty tags and subtasks", async () => {
     const user = userEvent.setup();
     render(<TaskForm {...defaultHandlers} />);


### PR DESCRIPTION
## Summary
- **CSP fix**: Updated CloudFront Content-Security-Policy `connect-src` to allow `api.vinny.io`, `accounts.google.com`, and `oauth2.googleapis.com` (replaced old Cloudflare Workers URL that was blocking PocketBase sync and OAuth)
- **COOP fix**: Added `Cross-Origin-Opener-Policy: same-origin-allow-popups` header to CloudFront response headers policy so Google OAuth popup can close itself after authentication
- **Form error handling fix**: Task form was silently swallowing validation errors — now maps all field errors and surfaces unmapped/non-Zod errors via a general error banner above form buttons
- **Type fix**: Corrected `onSubmit` prop type in `MatrixDialogs` from `void` to `Promise<void> | void`

## Changes
| File | Change |
|------|--------|
| `SECURITY_HEADERS.md` | Updated CSP examples + added COOP documentation |
| `components/task-form/validation.ts` | Added `general` field to `FormErrors` |
| `components/task-form/use-task-form.ts` | Data-driven error mapping + non-Zod error handling |
| `components/task-form/index.tsx` | General error banner display |
| `components/matrix-board/matrix-dialogs.tsx` | Fixed `onSubmit` type signature |
| `package.json` | Version bump to 7.0.1 |
| `tests/ui/task-form.test.tsx` | 2 new tests (edit mode due date, non-Zod error) |

## Test plan
- [x] `bun typecheck` passes
- [x] `bun run test` passes (1282 tests)
- [x] `bun lint` passes
- [x] Manually verify sync + Google OAuth flow on gsd.vinny.dev
- [x] Manually verify task edit with due date change submits correctly
- [x] Verify error banner appears when form submission fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)