### PR TITLE
fix(sw): skip cross-origin requests in service worker fetch handler

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -51,6 +51,12 @@ self.addEventListener("fetch", (event) => {
 		return;
 	}
 
+	// Don't intercept cross-origin requests (PocketBase API, OAuth, etc.)
+	const requestUrl = new URL(request.url);
+	if (requestUrl.hostname !== self.location.hostname) {
+		return;
+	}
+
 	if (request.method !== "GET") {
 		return;
 	}


### PR DESCRIPTION
Fixes the service worker intercepting cross-origin API requests to `https://api.vinny.io`, which was causing CSP violations, broken SSE realtime sync, and repeated health check failures.

Closes #153

Generated with [Claude Code](https://claude.ai/code)