### PR TITLE
fix(ci): force IPv4 for bun install on GitHub runners

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Prefer IPv4 for npm registry
+        run: echo 'precedence ::ffff:0:0/96 100' | sudo tee -a /etc/gai.conf
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 


### PR DESCRIPTION
Bun attempts IPv6 connections to the npm registry by default. On
GitHub-hosted Ubuntu runners, IPv6 networking is intermittently flaky,
causing ConnectionRefused/FailedToOpenSocket errors for every tarball
download. Adding `precedence ::ffff:0:0/96 100` to /etc/gai.conf before
`bun install` forces the resolver to prefer IPv4, eliminating the
transient failures.

https://claude.ai/code/session_01CwGda3xt3SX23DUxjCZ5JM