### PR TITLE
[codex] Polish dashboard and task controls

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -41,6 +41,7 @@ export default function DashboardPage() {
   const [trendPeriod, setTrendPeriod] = useState<7 | 30 | 90>(30);
 
   const metrics = useMemo(() => calculateMetrics(tasks), [tasks]);
+  const last7TrendData = useMemo(() => getCompletionTrend(tasks, 7), [tasks]);
   const trendData = useMemo(
     () => getCompletionTrend(tasks, trendPeriod),
     [tasks, trendPeriod],
@@ -51,6 +52,35 @@ export default function DashboardPage() {
     [tasks],
   );
   const timeByQuadrant = useMemo(() => getTimeByQuadrant(tasks), [tasks]);
+  const todayTrend = last7TrendData.at(-1)?.completed ?? 0;
+  const previousSixDays = last7TrendData.slice(0, -1);
+  const previousSixAverage = previousSixDays.length > 0
+    ? previousSixDays.reduce((sum, point) => sum + point.completed, 0) / previousSixDays.length
+    : 0;
+  const completedTrend = previousSixAverage > 0
+    ? Math.round(((todayTrend - previousSixAverage) / previousSixAverage) * 100)
+    : todayTrend > 0 ? 100 : 0;
+  const completionPeak = Math.max(1, ...last7TrendData.map((point) => point.completed));
+  const completedInsight = metrics.completedToday === 0
+    ? "Ready to start today"
+    : completedTrend > 10
+      ? "Above your recent pace"
+      : completedTrend < -10
+        ? "Below your recent pace"
+        : "Holding steady";
+  const plannedActiveShare = metrics.activeTasks > 0
+    ? Math.round(((metrics.activeTasks - metrics.noDueDateCount) / metrics.activeTasks) * 100)
+    : 0;
+  const activeInsight = metrics.overdueCount > 0
+    ? `${metrics.overdueCount} overdue`
+    : metrics.noDueDateCount > 0
+      ? `${metrics.noDueDateCount} unscheduled`
+      : "Well scoped";
+  const completionInsight = metrics.completionRate >= 80
+    ? "Strong follow-through"
+    : metrics.completionRate >= 60
+      ? "Healthy momentum"
+      : "Room to tighten execution";
 
   return (
     <TooltipProvider delayDuration={300}>
@@ -98,6 +128,10 @@ export default function DashboardPage() {
                   value={metrics.completedToday}
                   subtitle={`${metrics.completedThisWeek} this week`}
                   icon={CheckCircle2Icon}
+                  trend={previousSixAverage > 0 ? { value: completedTrend, isPositive: completedTrend >= 0 } : undefined}
+                  insight={completedInsight}
+                  progressValue={Math.round((metrics.completedToday / completionPeak) * 100)}
+                  progressLabel="Vs. recent best day"
                   accentColor="emerald"
                 />
                 <StatsCard
@@ -105,6 +139,9 @@ export default function DashboardPage() {
                   value={metrics.activeTasks}
                   subtitle={`${metrics.totalTasks} total tasks`}
                   icon={ListTodoIcon}
+                  insight={activeInsight}
+                  progressValue={plannedActiveShare}
+                  progressLabel="Have a due date"
                   accentColor="blue"
                 />
                 <StatsCard
@@ -112,6 +149,9 @@ export default function DashboardPage() {
                   value={`${metrics.completionRate}%`}
                   subtitle={`${metrics.completedTasks} completed`}
                   icon={TrendingUpIcon}
+                  insight={completionInsight}
+                  progressValue={metrics.completionRate}
+                  progressLabel="Done overall"
                   accentColor="amber"
                 />
                 <StreakIndicator streakData={streakData} />

--- a/components/dashboard/completion-chart.tsx
+++ b/components/dashboard/completion-chart.tsx
@@ -30,20 +30,33 @@ export function CompletionChart({ data }: CompletionChartProps) {
   }, [data]);
 
   return (
-    <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
-      <h3 className="mb-4 text-lg font-semibold text-foreground">
-        Completion Trend
-      </h3>
+    <div className="rounded-3xl border border-border/70 bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-foreground">
+            Completion Trend
+          </h3>
+          <p className="mt-1 text-sm text-foreground-muted">
+            Recent throughput across completed and newly created tasks.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 rounded-full border border-border/70 bg-background-muted/70 px-3 py-1.5">
+          <div className="h-2.5 w-2.5 rounded-full bg-[rgb(var(--accent))]" />
+          <span className="text-xs font-medium text-foreground-muted">Completed</span>
+          <div className="ml-2 h-2.5 w-2.5 rounded-full bg-blue-500" />
+          <span className="text-xs font-medium text-foreground-muted">Created</span>
+        </div>
+      </div>
       <ResponsiveContainer width="100%" height={280}>
         <AreaChart data={chartData}>
           <defs>
             <linearGradient id="gradientCompleted" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.3} />
-              <stop offset="95%" stopColor="#3b82f6" stopOpacity={0.02} />
+              <stop offset="0%" stopColor="rgb(var(--accent))" stopOpacity={0.3} />
+              <stop offset="95%" stopColor="rgb(var(--accent))" stopOpacity={0.02} />
             </linearGradient>
             <linearGradient id="gradientCreated" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor="#10b981" stopOpacity={0.2} />
-              <stop offset="95%" stopColor="#10b981" stopOpacity={0.02} />
+              <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.22} />
+              <stop offset="95%" stopColor="#3b82f6" stopOpacity={0.02} />
             </linearGradient>
           </defs>
           <CartesianGrid
@@ -82,39 +95,31 @@ export function CompletionChart({ data }: CompletionChartProps) {
           <Area
             type="monotone"
             dataKey="Completed"
-            stroke="#3b82f6"
+            stroke="rgb(var(--accent))"
             strokeWidth={2}
             fill="url(#gradientCompleted)"
             dot={false}
-            activeDot={{ r: 5, fill: "#3b82f6", stroke: "#fff", strokeWidth: 2 }}
+            activeDot={{ r: 5, fill: "rgb(var(--accent))", stroke: "#fff", strokeWidth: 2 }}
           />
           <Area
             type="monotone"
             dataKey="Created"
-            stroke="#10b981"
+            stroke="#3b82f6"
             strokeWidth={2}
             fill="url(#gradientCreated)"
             dot={false}
-            activeDot={{ r: 5, fill: "#10b981", stroke: "#fff", strokeWidth: 2 }}
+            activeDot={{ r: 5, fill: "#3b82f6", stroke: "#fff", strokeWidth: 2 }}
           />
         </AreaChart>
       </ResponsiveContainer>
-      {/* Legend */}
-      <div className="mt-3 flex items-center justify-center gap-6">
-        <div className="flex items-center gap-2">
-          <div className="h-2.5 w-2.5 rounded-full bg-blue-500" />
-          <span className="text-xs text-foreground-muted">Completed</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="h-2.5 w-2.5 rounded-full bg-emerald-500" />
-          <span className="text-xs text-foreground-muted">Created</span>
-        </div>
-      </div>
     </div>
   );
 }
 
 function formatDate(isoDate: string): string {
   const date = new Date(isoDate);
-  return `${date.getMonth() + 1}/${date.getDate()}`;
+  return new Intl.DateTimeFormat("en-US", {
+    month: "numeric",
+    day: "numeric",
+  }).format(date);
 }

--- a/components/dashboard/dashboard-skeleton.tsx
+++ b/components/dashboard/dashboard-skeleton.tsx
@@ -3,16 +3,26 @@ import { Skeleton } from "@/components/ui/skeleton";
 function StatsCardSkeleton() {
   return (
     <div
-      className="rounded-2xl border-2 border-border/80 bg-card p-6"
+      className="rounded-3xl border border-border/70 bg-card p-6"
       style={{ boxShadow: "var(--shadow-column)" }}
     >
-      <div className="flex items-start justify-between">
+      <div className="flex items-start justify-between gap-4">
         <div className="flex-1 space-y-3">
-          <Skeleton className="h-3 w-20" />
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="h-5 w-24 rounded-full" />
+          </div>
           <Skeleton className="h-9 w-14" />
           <Skeleton className="h-3 w-28" />
         </div>
-        <Skeleton className="h-12 w-12 rounded-full" />
+        <Skeleton className="h-12 w-12 rounded-2xl" />
+      </div>
+      <div className="mt-5 space-y-2">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-3 w-8" />
+        </div>
+        <Skeleton className="h-2 w-full rounded-full" />
       </div>
     </div>
   );
@@ -20,27 +30,30 @@ function StatsCardSkeleton() {
 
 function ChartSkeleton() {
   return (
-    <div className="rounded-xl border border-border bg-card p-6 shadow-sm space-y-4">
-      <Skeleton className="h-5 w-40" />
-      <Skeleton className="h-[280px] w-full rounded-lg" />
-      <div className="flex justify-center gap-6">
-        <Skeleton className="h-3 w-20" />
-        <Skeleton className="h-3 w-20" />
+    <div className="rounded-3xl border border-border/70 bg-card p-6 space-y-4" style={{ boxShadow: "var(--shadow-column)" }}>
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-2">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-56" />
+        </div>
+        <Skeleton className="h-9 w-40 rounded-full" />
       </div>
+      <Skeleton className="h-[280px] w-full rounded-lg" />
     </div>
   );
 }
 
 function DonutSkeleton() {
   return (
-    <div className="rounded-xl border border-border bg-card p-6 shadow-sm space-y-4">
+    <div className="rounded-3xl border border-border/70 bg-card p-6 space-y-4" style={{ boxShadow: "var(--shadow-column)" }}>
       <Skeleton className="h-5 w-44" />
+      <Skeleton className="h-4 w-44" />
       <div className="flex items-center justify-center py-4">
         <Skeleton className="h-[190px] w-[190px] rounded-full" />
       </div>
       <div className="grid grid-cols-2 gap-2">
         {Array.from({ length: 4 }, (_, i) => (
-          <Skeleton key={i} className="h-4 w-full" />
+          <Skeleton key={i} className="h-10 w-full rounded-2xl" />
         ))}
       </div>
     </div>

--- a/components/dashboard/quadrant-distribution.tsx
+++ b/components/dashboard/quadrant-distribution.tsx
@@ -40,10 +40,13 @@ export function QuadrantDistribution({ distribution }: QuadrantDistributionProps
 
   if (data.length === 0) {
     return (
-      <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
-        <h3 className="mb-4 text-lg font-semibold text-foreground">
+      <div className="rounded-3xl border border-border/70 bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
+        <h3 className="text-lg font-semibold text-foreground">
           Quadrant Distribution
         </h3>
+        <p className="mt-1 text-sm text-foreground-muted">
+          Active work split across the matrix.
+        </p>
         <div className="flex h-[280px] items-center justify-center">
           <p className="text-sm text-foreground-muted">No active tasks to display</p>
         </div>
@@ -52,10 +55,13 @@ export function QuadrantDistribution({ distribution }: QuadrantDistributionProps
   }
 
   return (
-    <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
-      <h3 className="mb-4 text-lg font-semibold text-foreground">
+    <div className="rounded-3xl border border-border/70 bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
+      <h3 className="text-lg font-semibold text-foreground">
         Quadrant Distribution
       </h3>
+      <p className="mt-1 text-sm text-foreground-muted">
+        Active work split across the matrix.
+      </p>
       <div className="relative">
         <ResponsiveContainer width="100%" height={240}>
           <PieChart>
@@ -73,7 +79,7 @@ export function QuadrantDistribution({ distribution }: QuadrantDistributionProps
                 <Cell
                   key={`cell-${entry.id}`}
                   fill={COLORS[entry.id as QuadrantId]}
-                  className="transition-opacity hover:opacity-80"
+                  className="transition-opacity hover:opacity-85"
                 />
               ))}
             </Pie>
@@ -104,15 +110,12 @@ export function QuadrantDistribution({ distribution }: QuadrantDistributionProps
       {/* Legend */}
       <div className="mt-2 grid grid-cols-2 gap-2">
         {data.map((entry) => (
-          <div key={entry.id} className="flex items-center gap-2">
-            <div
-              className="h-2.5 w-2.5 shrink-0 rounded-full"
-              style={{ backgroundColor: COLORS[entry.id as QuadrantId] }}
-            />
-            <span className="truncate text-xs text-foreground-muted">
+          <div key={entry.id} className="flex items-center gap-2 rounded-2xl border border-border/60 bg-background-muted/40 px-3 py-2">
+            <div className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ backgroundColor: COLORS[entry.id as QuadrantId] }} />
+            <span className="truncate text-xs font-medium text-foreground-muted">
               {entry.shortName}
             </span>
-            <span className="ml-auto text-xs font-medium tabular-nums text-foreground">
+            <span className="ml-auto text-xs font-semibold tabular-nums text-foreground">
               {entry.value}
             </span>
           </div>

--- a/components/dashboard/stats-card.tsx
+++ b/components/dashboard/stats-card.tsx
@@ -10,51 +10,169 @@ interface StatsCardProps {
     value: number;
     isPositive: boolean;
   };
+  insight?: string;
+  progressValue?: number;
+  progressLabel?: string;
   accentColor?: "blue" | "emerald" | "amber" | "red";
   className?: string;
 }
 
-function getAccentClasses(color?: string): { bg: string; text: string } {
-  const map: Record<string, { bg: string; text: string }> = {
-    blue: { bg: "bg-blue-100 dark:bg-blue-900/40", text: "text-blue-600 dark:text-blue-400" },
-    emerald: { bg: "bg-emerald-100 dark:bg-emerald-900/40", text: "text-emerald-600 dark:text-emerald-400" },
-    amber: { bg: "bg-amber-100 dark:bg-amber-900/40", text: "text-amber-600 dark:text-amber-400" },
-    red: { bg: "bg-red-100 dark:bg-red-900/40", text: "text-red-600 dark:text-red-400" },
+function getAccentClasses(color?: string): {
+  iconBg: string;
+  iconText: string;
+  chipBg: string;
+  chipText: string;
+  railBg: string;
+  railFill: string;
+  glow: string;
+} {
+  const map: Record<string, {
+    iconBg: string;
+    iconText: string;
+    chipBg: string;
+    chipText: string;
+    railBg: string;
+    railFill: string;
+    glow: string;
+  }> = {
+    blue: {
+      iconBg: "bg-blue-100/80 dark:bg-blue-900/40",
+      iconText: "text-blue-600 dark:text-blue-400",
+      chipBg: "bg-blue-500/10",
+      chipText: "text-blue-700 dark:text-blue-300",
+      railBg: "bg-blue-500/10",
+      railFill: "from-blue-500 to-cyan-400",
+      glow: "from-blue-500/14 via-blue-500/6 to-transparent",
+    },
+    emerald: {
+      iconBg: "bg-emerald-100/80 dark:bg-emerald-900/40",
+      iconText: "text-emerald-600 dark:text-emerald-400",
+      chipBg: "bg-emerald-500/10",
+      chipText: "text-emerald-700 dark:text-emerald-300",
+      railBg: "bg-emerald-500/10",
+      railFill: "from-emerald-500 to-teal-400",
+      glow: "from-emerald-500/14 via-emerald-500/6 to-transparent",
+    },
+    amber: {
+      iconBg: "bg-amber-100/80 dark:bg-amber-900/40",
+      iconText: "text-amber-600 dark:text-amber-400",
+      chipBg: "bg-amber-500/10",
+      chipText: "text-amber-700 dark:text-amber-300",
+      railBg: "bg-amber-500/10",
+      railFill: "from-amber-500 to-orange-400",
+      glow: "from-amber-500/14 via-amber-500/6 to-transparent",
+    },
+    red: {
+      iconBg: "bg-red-100/80 dark:bg-red-900/40",
+      iconText: "text-red-600 dark:text-red-400",
+      chipBg: "bg-red-500/10",
+      chipText: "text-red-700 dark:text-red-300",
+      railBg: "bg-red-500/10",
+      railFill: "from-red-500 to-rose-400",
+      glow: "from-red-500/14 via-red-500/6 to-transparent",
+    },
   };
   if (color && map[color]) return map[color];
-  return { bg: "bg-accent/10", text: "text-accent" };
+  return {
+    iconBg: "bg-accent/10",
+    iconText: "text-accent",
+    chipBg: "bg-accent/10",
+    chipText: "text-accent",
+    railBg: "bg-accent/10",
+    railFill: "from-[rgb(var(--accent))] to-[rgb(var(--accent-hover))]",
+    glow: "from-accent/14 via-accent/6 to-transparent",
+  };
 }
 
 /**
  * Reusable card for displaying a single metric
  */
-export function StatsCard({ title, value, subtitle, icon: Icon, trend, accentColor, className = "" }: StatsCardProps) {
+export function StatsCard({
+  title,
+  value,
+  subtitle,
+  icon: Icon,
+  trend,
+  insight,
+  progressValue,
+  progressLabel,
+  accentColor,
+  className = "",
+}: StatsCardProps) {
   const animatedValue = useCountUp(value);
-  const { bg: iconBg, text: iconText } = getAccentClasses(accentColor);
+  const {
+    iconBg,
+    iconText,
+    chipBg,
+    chipText,
+    railBg,
+    railFill,
+    glow,
+  } = getAccentClasses(accentColor);
+  const clampedProgress = progressValue === undefined
+    ? undefined
+    : Math.max(0, Math.min(100, progressValue));
+
   return (
-    <div className={`rounded-2xl border-2 border-border/80 bg-card p-6 ${className}`} style={{ boxShadow: 'var(--shadow-column)' }}>
-      <div className="flex items-start justify-between">
-        <div className="flex-1">
-          <p className="text-xs font-semibold uppercase tracking-wide text-foreground-muted">{title}</p>
-          <p className="mt-2 text-4xl font-bold tabular-nums tracking-tight text-foreground">{animatedValue}</p>
+    <div
+      className={`relative overflow-hidden rounded-3xl border border-border/70 bg-card/95 p-6 ${className}`}
+      style={{ boxShadow: "var(--shadow-column)" }}
+    >
+      <div className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${glow}`} />
+      <div className="pointer-events-none absolute inset-x-6 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent dark:via-white/10" />
+
+      <div className="relative flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-foreground-muted">
+              {title}
+            </p>
+            {insight ? (
+              <span className={`inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold ${chipBg} ${chipText}`}>
+                {insight}
+              </span>
+            ) : null}
+          </div>
+          <p className="mt-3 text-4xl font-bold tabular-nums tracking-tight text-foreground">
+            {animatedValue}
+          </p>
           {subtitle && (
             <p className="mt-1.5 text-sm text-foreground-muted">{subtitle}</p>
           )}
           {trend && (
-            <div className="mt-2 flex items-center gap-1">
-              <span className={`text-xs font-medium ${trend.isPositive ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-                {trend.isPositive ? '↑' : '↓'} {Math.abs(trend.value)}%
+            <div className="mt-3 flex items-center gap-1">
+              <span className={`text-xs font-medium ${trend.isPositive ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}`}>
+                {trend.isPositive ? "↑" : "↓"} {Math.abs(trend.value)}%
               </span>
               <span className="text-xs text-foreground-muted">from last week</span>
             </div>
           )}
         </div>
         {Icon && (
-          <div className={`flex h-12 w-12 items-center justify-center rounded-full ${iconBg}`}>
+          <div className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-white/40 dark:border-white/5 ${iconBg}`}>
             <Icon className={`h-6 w-6 ${iconText}`} />
           </div>
         )}
       </div>
+
+      {clampedProgress !== undefined ? (
+        <div className="relative mt-5">
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-foreground-muted">
+              {progressLabel ?? "Progress"}
+            </span>
+            <span className="text-xs font-semibold tabular-nums text-foreground">
+              {Math.round(clampedProgress)}%
+            </span>
+          </div>
+          <div className={`h-2 rounded-full ${railBg}`}>
+            <div
+              className={`h-full rounded-full bg-gradient-to-r ${railFill}`}
+              style={{ width: `${clampedProgress}%` }}
+            />
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/components/task-card/task-card-header.tsx
+++ b/components/task-card/task-card-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CheckCircle2Icon, GripVerticalIcon } from "lucide-react";
+import { CheckCircle2Icon, CircleIcon, GripVerticalIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import type { TaskRecord } from "@/lib/types";
@@ -25,6 +25,8 @@ export function TaskCardHeader({
   sortableAttributes,
   sortableListeners,
 }: TaskCardHeaderProps) {
+  const completionLabel = task.completed ? "Mark as incomplete" : "Mark as complete";
+
   return (
     <div className="flex items-start justify-between gap-2">
       <div className="flex items-start gap-2 min-w-0 flex-1">
@@ -65,20 +67,28 @@ export function TaskCardHeader({
             type="button"
             onClick={() => onToggleComplete(task, !task.completed)}
             className={cn(
-              "button-reset flex shrink-0 items-center justify-center rounded-full border text-xs font-semibold uppercase transition-all duration-200",
-              "h-7 w-7 md:h-7 md:w-7",
-              "sm:h-9 sm:w-9",
+              "button-reset relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border transition-all duration-200 sm:h-9 sm:w-9",
               task.completed
-                ? "border-emerald-400 bg-emerald-500/15 text-emerald-600 dark:border-emerald-500 dark:text-emerald-400 scale-100"
-                : "border-border text-foreground-muted hover:border-accent hover:text-accent hover:bg-accent/5 hover:scale-110"
+                ? "border-emerald-400 bg-emerald-500/15 text-emerald-600 shadow-sm shadow-emerald-500/10 dark:border-emerald-500 dark:text-emerald-400"
+                : "border-border bg-background/90 text-foreground-muted shadow-sm shadow-black/[0.04] hover:border-accent hover:text-accent hover:bg-accent/5 hover:scale-105 hover:shadow-accent/10"
             )}
             aria-pressed={task.completed}
-            aria-label={task.completed ? "Mark as incomplete" : "Mark as complete"}
+            aria-label={completionLabel}
           >
-            <CheckCircle2Icon className={cn("h-4 w-4 sm:h-4 sm:w-4", !task.completed && "opacity-30")} />
+            {task.completed ? (
+              <CheckCircle2Icon className="h-4 w-4 shrink-0" />
+            ) : (
+              <>
+                <CircleIcon className="h-4 w-4 shrink-0" />
+                <span
+                  aria-hidden="true"
+                  className="absolute h-1.5 w-1.5 rounded-full bg-current opacity-0 transition-opacity duration-200 group-hover:opacity-40"
+                />
+              </>
+            )}
           </button>
         </TooltipTrigger>
-        <TooltipContent>{task.completed ? "Mark as incomplete" : "Mark as complete"}</TooltipContent>
+        <TooltipContent>{completionLabel}</TooltipContent>
       </Tooltip>
     </div>
   );

--- a/components/task-form/index.tsx
+++ b/components/task-form/index.tsx
@@ -40,6 +40,9 @@ export function TaskForm({
     handleSubmit
   } = useTaskForm({ initialValues, onSubmit, onCancel });
 
+  const selectClassName =
+    "flex h-11 w-full rounded-xl border border-border/70 bg-background px-3 py-2 text-sm text-foreground shadow-sm shadow-black/[0.02] ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
+
   return (
     <form className="space-y-4" onSubmit={handleSubmit}>
       <div className="space-y-1">
@@ -69,8 +72,11 @@ export function TaskForm({
       </div>
 
       <div className="grid gap-3 md:grid-cols-2">
-        <div className="space-y-2 rounded-2xl border border-card-border bg-background-muted p-3">
-          <p className="text-xs font-medium uppercase tracking-wide text-foreground">Urgency</p>
+        <div className="space-y-3 rounded-3xl border border-border/70 bg-background-muted/60 p-4 shadow-sm shadow-black/[0.02]">
+          <div className="space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-foreground-muted">Urgency</p>
+            <p className="text-sm font-medium text-foreground">Decide whether this needs attention now.</p>
+          </div>
           <div className="flex gap-2">
             <TogglePill
               label="Urgent"
@@ -86,8 +92,11 @@ export function TaskForm({
             />
           </div>
         </div>
-        <div className="space-y-2 rounded-2xl border border-card-border bg-background-muted p-3">
-          <p className="text-xs font-medium uppercase tracking-wide text-foreground">Importance</p>
+        <div className="space-y-3 rounded-3xl border border-border/70 bg-background-muted/60 p-4 shadow-sm shadow-black/[0.02]">
+          <div className="space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-foreground-muted">Importance</p>
+            <p className="text-sm font-medium text-foreground">Keep the long-term value of the task explicit.</p>
+          </div>
           <div className="flex gap-2">
             <TogglePill
               label="Important"
@@ -120,7 +129,7 @@ export function TaskForm({
               id="due-time"
               value={selectedTime}
               onChange={(event) => updateTime(event.target.value)}
-              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              className={selectClassName}
             >
               <option value="">No specific time</option>
               {TIME_OPTIONS.map((timeOption) => (
@@ -141,7 +150,7 @@ export function TaskForm({
             id="recurrence"
             value={values.recurrence}
             onChange={(event) => updateField("recurrence", event.target.value as RecurrenceType)}
-            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            className={selectClassName}
           >
             <option value="none">None</option>
             <option value="daily">Daily</option>
@@ -157,7 +166,7 @@ export function TaskForm({
             id="estimatedMinutes"
             value={values.estimatedMinutes ?? ""}
             onChange={(event) => updateField("estimatedMinutes", event.target.value === "" ? undefined : Number(event.target.value))}
-            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            className={selectClassName}
           >
             <option value="">No estimate</option>
             <option value="15">15 minutes</option>
@@ -184,7 +193,7 @@ export function TaskForm({
             value={values.notifyBefore ?? 15}
             onChange={(event) => updateField("notifyBefore", event.target.value === "" ? undefined : Number(event.target.value))}
             disabled={values.notificationEnabled === false}
-            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            className={selectClassName}
           >
             <option value="0">At due time</option>
             <option value="5">5 minutes before</option>

--- a/components/toggle-pill.tsx
+++ b/components/toggle-pill.tsx
@@ -8,9 +8,9 @@ interface TogglePillProps {
 }
 
 export function TogglePill({ active, label, onSelect, variant }: TogglePillProps) {
-  const activeBlue = "bg-blue-600 text-white border border-blue-600";
-  const activeAmber = "bg-amber-500 text-white border border-amber-500";
-  const inactive = "bg-background text-foreground border border-border hover:bg-background-muted hover:border-border";
+  const activeBlue = "border-blue-500 bg-gradient-to-b from-blue-500 to-blue-600 text-white shadow-sm shadow-blue-600/25";
+  const activeAmber = "border-amber-500 bg-gradient-to-b from-amber-400 to-amber-500 text-white shadow-sm shadow-amber-500/25";
+  const inactive = "border-border/80 bg-background/80 text-foreground hover:border-border hover:bg-background";
 
   const className = active
     ? (variant === "blue" ? activeBlue : activeAmber)
@@ -20,10 +20,20 @@ export function TogglePill({ active, label, onSelect, variant }: TogglePillProps
     <button
       type="button"
       onClick={onSelect}
-      className={`flex-1 rounded-lg px-3 py-2 text-xs font-semibold uppercase tracking-wide transition-all ${className}`}
+      className={`flex-1 rounded-xl border px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-[0.14em] transition-all duration-200 ${className}`}
       aria-pressed={active}
     >
-      {label}
+      <span className="flex items-center justify-between gap-3">
+        <span>{label}</span>
+        <span
+          className={`h-2.5 w-2.5 shrink-0 rounded-full transition-all ${
+            active
+              ? "bg-white/95 shadow-[0_0_0_4px_rgba(255,255,255,0.18)]"
+              : "bg-foreground-muted/35"
+          }`}
+          aria-hidden="true"
+        />
+      </span>
     </button>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,6 +43,7 @@
     "node_modules",
     "worker",
     "packages",
+    "design-suggestions",
     "tests",
     "figma-gsd",
     "vitest.config.ts",


### PR DESCRIPTION
## What changed

This PR refines the visual hierarchy of the dashboard and task creation flow, and improves the task-card completion affordance.

- redesigned the top dashboard metric cards with contextual insight chips and progress rails
- aligned dashboard chart styling more closely with the app theme and matrix color system
- updated dashboard skeletons to match the new card structure
- polished task form urgency and importance controls plus select styling
- improved the task-card completion control so it reads as a clearer checkbox-style action without using a text label
- excluded the `design-suggestions/` sandbox from the main app TypeScript project so production builds do not fail on its missing optional dependencies

## Why it changed

The app's matrix view already had a stronger visual system than the dashboard and task form. This work brings those weaker surfaces up to the same level and fixes the build issue caused by Next typechecking a non-app sandbox directory.

## Impact

- dashboard metrics are more informative and visually distinct
- task creation controls feel more deliberate and easier to scan
- task completion affordance is clearer without adding copy noise
- `bun run build` now succeeds again

## Validation

- `bun run vitest run tests/ui/dashboard-components.test.tsx tests/ui/task-form.test.tsx`
- `bun run vitest run tests/ui/task-card.test.tsx tests/ui/task-card-coverage.test.tsx tests/ui/coverage-boost-ui.test.tsx`
- `bun run tsc --noEmit`
- `bun run build`
