### PR TITLE
fix: prevent toggle pill label text from being cut off

### DIFF
--- a/components/toggle-pill.tsx
+++ b/components/toggle-pill.tsx
@@ -23,8 +23,8 @@ export function TogglePill({ active, label, onSelect, variant }: TogglePillProps
       className={`flex-1 rounded-xl border px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-[0.14em] transition-all duration-200 ${className}`}
       aria-pressed={active}
     >
-      <span className="flex items-center justify-between gap-3">
-        <span>{label}</span>
+      <span className="flex items-center justify-between gap-2">
+        <span className="min-w-0 leading-tight">{label}</span>
         <span
           className={`h-2.5 w-2.5 shrink-0 rounded-full transition-all ${
             active


### PR DESCRIPTION
Fixes #199

Adds `min-w-0` to the label span inside `TogglePill` so "NOT IMPORTANT" wraps gracefully instead of clipping when the pill is width-constrained. Also adds `leading-tight` for clean two-line wrapping and reduces the inner gap from gap-3 to gap-2.

Generated with [Claude Code](https://claude.ai/code)