### PR TITLE
chore: update coding standards thresholds and task form layout

### DIFF
--- a/coding-standards.md
+++ b/coding-standards.md
@@ -177,7 +177,7 @@ Each increment is one red/green/refactor cycle (see Part 3). Do not write a seco
 ### Naming & Clarity
 
 - Use descriptive names; avoid generic terms like 'data', 'temp', or single letters.
-- Functions should be 30 lines or fewer with single responsibility.
+- Functions should be 40 lines or fewer with single responsibility.
 - Maximum 3 levels of nesting; use early returns.
 - Comments explain WHY, not WHAT.
 - Document public APIs with usage examples.
@@ -193,7 +193,7 @@ Each increment is one red/green/refactor cycle (see Part 3). Do not write a seco
 
 ### Structure & Abstraction
 
-- Apply DRY only after 3+ repetitions.
+- Apply DRY only after 2+ repetitions.
 - Follow YAGNI: do not build for hypothetical futures.
 - Prefer composition over inheritance.
 - Duplicate if it is clearer than abstracting.
@@ -712,7 +712,7 @@ Enforces the red/green/refactor cycle (Part 3) for a named behavior: writes a fa
 
 ### Red Flags
 
-- Functions exceeding 30 lines
+- Functions exceeding 40 lines
 - More than 3 nesting levels
 - Unused abstractions or commented-out code
 - TODOs without ticket links

--- a/components/task-form/index.tsx
+++ b/components/task-form/index.tsx
@@ -71,7 +71,7 @@ export function TaskForm({
         ) : null}
       </div>
 
-      <div className="grid gap-3 md:grid-cols-2">
+      <div className="grid gap-3">
         <div className="space-y-3 rounded-3xl border border-border/70 bg-background-muted/60 p-4 shadow-sm shadow-black/[0.02]">
           <div className="space-y-1">
             <p className="text-xs font-semibold uppercase tracking-[0.16em] text-foreground-muted">Urgency</p>


### PR DESCRIPTION
## Summary
- Relaxed function length limit from 30 to 40 lines in coding standards (both the guideline and red flags sections) to better match practical usage
- Tightened the DRY threshold from 3+ to 2+ repetitions to encourage earlier extraction of duplicated logic
- Removed `md:grid-cols-2` from the task form urgency/importance grid, switching to a single-column stacked layout

## Test plan
- [ ] Verify coding-standards.md renders correctly with updated thresholds
- [ ] Verify task form layout displays urgency/importance sections in a single column on all screen sizes
- [ ] Run `bun typecheck` and `bun lint` to confirm no regressions