### PR TITLE
fix: prevent PWA install prompt from reappearing after dismissal on SPA navigation

### DIFF
--- a/components/install-pwa-prompt.tsx
+++ b/components/install-pwa-prompt.tsx
@@ -55,9 +55,19 @@ export function InstallPwaPrompt() {
       }
     }
 
-    // Listen for the beforeinstallprompt event
+    // Listen for the beforeinstallprompt event.
+    // Chrome fires this on every SPA navigation, so we must re-check the
+    // dismissal state each time the event fires — not just on mount.
     const handleBeforeInstallPrompt = (e: Event) => {
       e.preventDefault();
+      const currentDismissed = localStorage.getItem("gsd-pwa-dismissed");
+      if (currentDismissed) {
+        const dismissedTime = Number.parseInt(currentDismissed, 10);
+        const daysSinceDismissed = (Date.now() - dismissedTime) / TIME_MS.DAY;
+        if (daysSinceDismissed < 7) {
+          return;
+        }
+      }
       setDeferredPrompt(e as BeforeInstallPromptEvent);
       setShowPrompt(true);
     };

--- a/tests/ui/gap-closing-2.test.tsx
+++ b/tests/ui/gap-closing-2.test.tsx
@@ -184,7 +184,7 @@ describe('BulkTagDialog', () => {
 describe('InstallPwaPrompt', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    localStorage.clear();
+    localStorage.removeItem('gsd-pwa-dismissed');
 
     // Mock matchMedia to return not standalone
     Object.defineProperty(window, 'matchMedia', {
@@ -313,6 +313,42 @@ describe('InstallPwaPrompt', () => {
     expect(
       screen.queryByText('Install GSD Task Manager')
     ).not.toBeInTheDocument();
+  });
+
+  it('should not re-show after dismissal when beforeinstallprompt fires again', async () => {
+    const user = userEvent.setup();
+    render(<InstallPwaPrompt />);
+
+    // Fire the event the first time
+    act(() => {
+      const event = new Event('beforeinstallprompt', { cancelable: true });
+      Object.defineProperty(event, 'prompt', { value: vi.fn() });
+      Object.defineProperty(event, 'userChoice', {
+        value: Promise.resolve({ outcome: 'dismissed' }),
+      });
+      window.dispatchEvent(event);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Install GSD Task Manager')).toBeInTheDocument();
+    });
+
+    // Dismiss the prompt
+    await user.click(screen.getByText('Not Now'));
+    expect(screen.queryByText('Install GSD Task Manager')).not.toBeInTheDocument();
+
+    // Browser fires beforeinstallprompt again (e.g., on SPA navigation)
+    act(() => {
+      const event = new Event('beforeinstallprompt', { cancelable: true });
+      Object.defineProperty(event, 'prompt', { value: vi.fn() });
+      Object.defineProperty(event, 'userChoice', {
+        value: Promise.resolve({ outcome: 'dismissed' }),
+      });
+      window.dispatchEvent(event);
+    });
+
+    // Prompt should NOT reappear within the 7-day cooldown window
+    expect(screen.queryByText('Install GSD Task Manager')).not.toBeInTheDocument();
   });
 
   it('should have role="dialog" with proper aria attributes', async () => {


### PR DESCRIPTION
Fixes #205

**Root cause:** Chrome fires `beforeinstallprompt` on every SPA navigation. The event handler was unconditionally calling `setShowPrompt(true)`, ignoring the localStorage dismissal flag that was only checked once at component mount.

**Fix:** Added dismissal check inside `handleBeforeInstallPrompt` so the 7-day cooldown is respected on every event firing.

Also added a regression test and fixed `localStorage.clear()` → `removeItem()` per project standards.

Generated with [Claude Code](https://claude.ai/code)