### PR TITLE
fix(pwa): use network-first for RSC flight data to prevent stale cache errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.3.1",
+	"version": "8.3.2",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/public/sw.js
+++ b/public/sw.js
@@ -6,6 +6,7 @@ const OFFLINE_ASSETS = [
 	"/archive/",
 	"/dashboard/",
 	"/install/",
+	"/settings/",
 	"/sync-history/",
 	"/manifest.json",
 	"/icons/icon-192.png",
@@ -65,13 +66,17 @@ self.addEventListener("fetch", (event) => {
 		return;
 	}
 
-	// Network-first strategy for HTML to ensure fresh content on iOS
-	const isHTMLRequest =
+	// Network-first for HTML pages and Next.js RSC flight data.
+	// RSC data (__next.*.txt) contains build-specific module IDs that
+	// must stay in sync with the JS chunks. Serving stale RSC data from
+	// a previous build causes React error #130 (undefined component).
+	const isNetworkFirst =
 		request.headers.get("accept")?.includes("text/html") ||
 		request.url.endsWith("/") ||
-		request.url.endsWith(".html");
+		request.url.endsWith(".html") ||
+		request.url.includes("/__next.");
 
-	if (isHTMLRequest) {
+	if (isNetworkFirst) {
 		event.respondWith(
 			fetch(request)
 				.then((response) => {
@@ -102,7 +107,7 @@ self.addEventListener("fetch", (event) => {
 				}),
 		);
 	} else {
-		// Cache-first for static assets
+		// Cache-first for static assets (JS chunks, CSS, fonts, images)
 		event.respondWith(
 			caches.match(request).then((cachedResponse) => {
 				if (cachedResponse) {
@@ -126,7 +131,11 @@ self.addEventListener("fetch", (event) => {
 						}
 						return response;
 					})
-					.catch(() => caches.match("/"));
+					.catch(() => {
+						// Only fall back to cached root for navigation-like requests.
+						// Returning HTML for a JS/CSS/font request would cause errors.
+						return caches.match(request);
+					});
 			}),
 		);
 	}


### PR DESCRIPTION
## Summary
- **Fix React error #130** when navigating from Settings → Matrix after a deployment
- Service worker was using cache-first for Next.js RSC flight data (`__next.*.txt`), serving stale module IDs from a previous build that don't match the current JS chunks
- RSC files now use network-first strategy, matching HTML page behavior
- Added missing `/settings/` to `OFFLINE_ASSETS`
- Removed dangerous `caches.match("/")` fallback that could return HTML content for failed JS/CSS/font requests

## Root Cause
RSC flight data files contain build-specific module IDs (e.g., `I[68385,...,"MatrixBoard"]`) that reference specific JS chunk filenames. After a deployment:
1. Old service worker cache serves previous build's RSC data
2. Old module IDs don't exist in the new build's JS chunks
3. Component resolves to `undefined`
4. React error #130: "Element type is invalid: expected a string or class/function but got: undefined"

This only affected **client-side navigation** (not initial page loads) because initial loads have RSC data inline in the HTML.

## Test plan
- [x] Deploy to staging/production
- [x] Hard-refresh to pick up new service worker
- [x] Navigate to Settings from the left rail
- [x] Click "Back to matrix" — should navigate cleanly without error
- [x] Repeat after clearing service worker cache to verify fresh behavior
- [x] Verify offline mode still works for cached pages