### PR TITLE
feat: editorial redesign with Focus / Matrix / Canvas views (v8.4.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ coverage/
 # IDE settings
 .vscode/
 
+
+# Design reference bundle — not for deploy
+design_handoff_gsd_redesign/

--- a/app/(matrix)/page.tsx
+++ b/app/(matrix)/page.tsx
@@ -1,5 +1,5 @@
-import { MatrixBoard } from "@/components/matrix-board";
+import { RedesignMatrix } from "@/components/redesign/redesign-matrix";
 
 export default function MatrixPage() {
-  return <MatrixBoard />;
+  return <RedesignMatrix />;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -430,3 +430,181 @@ main {
   }
 }
 
+/* ─────────────────────────────────────────────── */
+/* Redesign palette — scoped to .redesign-scope     */
+/* ─────────────────────────────────────────────── */
+
+.redesign-scope {
+  --bg: #f6f5f1;
+  --bg-inset: #efede7;
+  --paper: #fbfaf6;
+  --ink: #18181b;
+  --ink-2: #3f3f46;
+  --ink-3: #71717a;
+  --ink-4: #a1a1aa;
+  --line: #e6e3db;
+  --line-soft: #efede7;
+  --rd-accent: #4338ca;
+  --rd-accent-soft: #eef2ff;
+
+  --q1: #c2410c;
+  --q1-soft: #fdf1e7;
+  --q1-tint: #faebdd;
+  --q2: #1d4ed8;
+  --q2-soft: #eef2fd;
+  --q2-tint: #e3e9fb;
+  --q3: #15803d;
+  --q3-soft: #e8f2ec;
+  --q3-tint: #dbebe1;
+  --q4: #854d0e;
+  --q4-soft: #f5efdf;
+  --q4-tint: #ede4cd;
+
+  --rd-radius: 14px;
+  --rd-radius-sm: 10px;
+  --rd-radius-lg: 20px;
+  --rd-shadow-sm: 0 1px 0 rgba(24, 24, 27, 0.04), 0 1px 2px rgba(24, 24, 27, 0.04);
+  --rd-shadow: 0 1px 0 rgba(24, 24, 27, 0.04), 0 6px 18px -8px rgba(24, 24, 27, 0.12);
+  --rd-shadow-lg: 0 20px 50px -20px rgba(24, 24, 27, 0.25);
+
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--font-geist, var(--font-sans, ui-sans-serif, system-ui, sans-serif));
+  font-feature-settings: "ss01", "cv11";
+}
+
+.dark .redesign-scope {
+  --bg: #0c0c0d;
+  --bg-inset: #17171a;
+  --paper: #141416;
+  --ink: #f4f4f5;
+  --ink-2: #d4d4d8;
+  --ink-3: #a1a1aa;
+  --ink-4: #52525b;
+  --line: #27272a;
+  --line-soft: #1f1f22;
+  --rd-accent: #818cf8;
+  --rd-accent-soft: #1e1b4b;
+
+  --q1-soft: #2a1609;
+  --q1-tint: #3a1e0c;
+  --q2-soft: #0f1a3a;
+  --q2-tint: #152350;
+  --q3-soft: #0b241a;
+  --q3-tint: #0f2e22;
+  --q4-soft: #2c2009;
+  --q4-tint: #3a2a0d;
+}
+
+.redesign-scope .rd-serif {
+  font-family: var(--font-instrument-serif, ui-serif, Georgia, serif);
+  font-weight: 400;
+  letter-spacing: -0.01em;
+}
+
+.redesign-scope .rd-mono {
+  font-family: var(--font-geist-mono, var(--font-mono, ui-monospace, monospace));
+}
+
+.redesign-scope kbd {
+  font-family: var(--font-geist-mono, var(--font-mono, ui-monospace, monospace));
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 5px;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--ink-2);
+  box-shadow: 0 1px 0 var(--line);
+}
+
+.redesign-scope .rd-checkbox {
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  border: 1.5px solid var(--line);
+  background: var(--paper);
+  display: inline-grid;
+  place-items: center;
+  transition: all 0.15s;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+.redesign-scope .rd-checkbox:hover {
+  border-color: var(--ink-3);
+}
+.redesign-scope .rd-checkbox:checked {
+  background: var(--ink);
+  border-color: var(--ink);
+}
+.redesign-scope .rd-checkbox:checked::after {
+  content: "";
+  width: 10px;
+  height: 10px;
+  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none'><path d='M2.5 6.5L5 9L9.5 3.5' stroke='white' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/></svg>") center/contain no-repeat;
+}
+.dark .redesign-scope .rd-checkbox:checked::after {
+  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none'><path d='M2.5 6.5L5 9L9.5 3.5' stroke='%2318181b' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/></svg>") center/contain no-repeat;
+}
+
+.redesign-scope .rd-fade-in {
+  animation: rd-fade-in 0.35s cubic-bezier(0.22, 0.9, 0.3, 1);
+}
+@keyframes rd-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Density */
+.redesign-scope[data-density="compact"] .rd-task-card {
+  padding: 10px 12px;
+}
+.redesign-scope[data-density="compact"] .rd-task-card .rd-task-meta,
+.redesign-scope[data-density="compact"] .rd-task-card .rd-task-desc {
+  display: none;
+}
+.redesign-scope[data-density="roomy"] .rd-task-card {
+  padding: 18px 18px 16px;
+}
+
+/* Focus view grid */
+.redesign-scope .rd-focus-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 260px;
+  gap: 40px;
+  align-items: flex-start;
+}
+
+/* Responsive — collapse to single column / stack sidebar at narrower widths */
+@media (max-width: 900px) {
+  .redesign-scope .rd-focus-grid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 28px;
+  }
+  .redesign-scope .rd-editorial-grid {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+}
+
+@media (max-width: 720px) {
+  .redesign-scope {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+  .redesign-scope .rd-sidebar {
+    display: none !important;
+  }
+  .redesign-scope .rd-topbar {
+    padding: 12px 16px !important;
+    flex-wrap: wrap;
+  }
+  .redesign-scope main {
+    padding: 18px 16px 40px !important;
+  }
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import localFont from "next/font/local";
+import { Geist, Geist_Mono, Instrument_Serif } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { ToastProvider } from "@/components/ui/toast";
@@ -27,6 +28,26 @@ const jetbrainsMono = localFont({
   variable: "--font-mono",
   display: "swap",
   weight: "100 800",
+});
+
+const geist = Geist({
+  subsets: ["latin"],
+  variable: "--font-geist",
+  display: "swap",
+});
+
+const geistMono = Geist_Mono({
+  subsets: ["latin"],
+  variable: "--font-geist-mono",
+  display: "swap",
+});
+
+const instrumentSerif = Instrument_Serif({
+  subsets: ["latin"],
+  weight: "400",
+  style: ["normal", "italic"],
+  variable: "--font-instrument-serif",
+  display: "swap",
 });
 
 export const viewport: Viewport = {
@@ -79,7 +100,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={cn(inter.variable, jetbrainsMono.variable, "font-sans bg-canvas text-foreground antialiased")}>
+      <body className={cn(inter.variable, jetbrainsMono.variable, geist.variable, geistMono.variable, instrumentSerif.variable, "font-sans bg-canvas text-foreground antialiased")}>
         <ErrorBoundary>
           <ThemeProvider>
             <ToastProvider>

--- a/components/redesign/composer-drawer.tsx
+++ b/components/redesign/composer-drawer.tsx
@@ -1,0 +1,487 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ArrowRight, Flame, Sparkles, X } from "lucide-react";
+import { quadrantByRdKey, quadrants, type RedesignQuadrantKey } from "@/lib/quadrants";
+import { isSamePresetDue, presetDueDate, presetLabel } from "@/lib/redesign/due";
+
+import type { TaskRecord } from "@/lib/types";
+
+export interface ComposerSubmit {
+  title: string;
+  description: string;
+  urgent: boolean;
+  important: boolean;
+  dueDate?: string;
+  tags: string[];
+}
+
+export interface ComposerDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (draft: ComposerSubmit, editingId?: string) => void;
+  presetQuadrant?: RedesignQuadrantKey | null;
+  editingTask?: TaskRecord | null;
+}
+
+const DUE_KEYS = ["none", "today", "tomorrow", "thisfri", "nextweek"] as const;
+type DueKey = (typeof DUE_KEYS)[number];
+
+interface Draft {
+  title: string;
+  description: string;
+  urgent: boolean;
+  important: boolean;
+  dueDate?: string;
+  tags: string[];
+}
+
+function emptyDraft(preset?: RedesignQuadrantKey | null): Draft {
+  const q = preset ? quadrantByRdKey(preset) : null;
+  return {
+    title: "",
+    description: "",
+    urgent: q?.urgent ?? true,
+    important: q?.important ?? true,
+    dueDate: undefined,
+    tags: [],
+  };
+}
+
+function draftFromTask(task: TaskRecord): Draft {
+  return {
+    title: task.title,
+    description: task.description,
+    urgent: task.urgent,
+    important: task.important,
+    dueDate: task.dueDate,
+    tags: [...task.tags],
+  };
+}
+
+export function ComposerDrawer({ open, onClose, onSubmit, presetQuadrant, editingTask }: ComposerDrawerProps) {
+  const [draft, setDraft] = useState<Draft>(() =>
+    editingTask ? draftFromTask(editingTask) : emptyDraft(presetQuadrant)
+  );
+  const [tagInput, setTagInput] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setDraft(editingTask ? draftFromTask(editingTask) : emptyDraft(presetQuadrant));
+      setTagInput("");
+    }
+  }, [open, presetQuadrant, editingTask]);
+
+  useEffect(() => {
+    if (!open) return;
+    const h = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", h);
+    return () => window.removeEventListener("keydown", h);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const activeKey: RedesignQuadrantKey =
+    draft.urgent && draft.important ? "q1" : !draft.urgent && draft.important ? "q2" : draft.urgent ? "q3" : "q4";
+  const q = quadrantByRdKey(activeKey);
+
+  function addTag(raw: string) {
+    const clean = raw.trim().replace(/^#/, "").toLowerCase();
+    if (!clean || draft.tags.includes(clean)) return;
+    setDraft((d) => ({ ...d, tags: [...d.tags, clean] }));
+    setTagInput("");
+  }
+
+  function submit() {
+    const trimmed = draft.title.trim();
+    if (!trimmed) return;
+    onSubmit(
+      {
+        title: trimmed,
+        description: draft.description.trim(),
+        urgent: draft.urgent,
+        important: draft.important,
+        dueDate: draft.dueDate,
+        tags: draft.tags,
+      },
+      editingTask?.id
+    );
+    onClose();
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="New task"
+      className="redesign-scope"
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 60,
+        background: "rgba(24,24,27,0.38)",
+        display: "flex",
+        justifyContent: "flex-end",
+      }}
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="rd-fade-in"
+        style={{
+          width: "min(460px, 100vw)",
+          height: "100vh",
+          background: "var(--paper)",
+          display: "flex",
+          flexDirection: "column",
+          boxShadow: "var(--rd-shadow-lg)",
+        }}
+      >
+        <div
+          style={{
+            padding: "18px 22px 16px",
+            background: `var(--${activeKey}-soft)`,
+            borderBottom: "1px solid var(--line)",
+            display: "flex",
+            alignItems: "flex-start",
+            justifyContent: "space-between",
+            gap: 10,
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontSize: 11,
+                letterSpacing: 0.12,
+                textTransform: "uppercase",
+                color: `var(--${activeKey})`,
+                fontWeight: 600,
+              }}
+            >
+              {editingTask ? "Editing · " : "Goes in · "}
+              {q.rdTag}
+            </div>
+            <h2 className="rd-serif" style={{ margin: "4px 0 0", fontSize: 26, lineHeight: 1 }}>
+              {q.title}
+            </h2>
+            <div style={{ fontSize: 12.5, color: "var(--ink-3)", marginTop: 4 }}>{q.rdHint}</div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="inline-flex items-center justify-center"
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: 10,
+              border: 0,
+              background: "transparent",
+              color: "var(--ink-3)",
+              cursor: "pointer",
+            }}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div
+          style={{
+            flex: 1,
+            overflow: "auto",
+            padding: 22,
+            display: "flex",
+            flexDirection: "column",
+            gap: 20,
+          }}
+        >
+          <Field label="Task">
+            <input
+              autoFocus
+              value={draft.title}
+              onChange={(e) => setDraft((d) => ({ ...d, title: e.target.value }))}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) submit();
+              }}
+              placeholder="What needs doing?"
+              style={inputStyle}
+            />
+          </Field>
+
+          <Field label="Notes">
+            <textarea
+              rows={3}
+              value={draft.description}
+              onChange={(e) => setDraft((d) => ({ ...d, description: e.target.value }))}
+              placeholder="Optional context, links, next step…"
+              style={{ ...inputStyle, resize: "vertical", minHeight: 70, lineHeight: 1.45, padding: "10px 12px", height: "auto" }}
+            />
+          </Field>
+
+          <Field label="Priority">
+            <div
+              style={{
+                background: "var(--bg-inset)",
+                borderRadius: 14,
+                padding: 14,
+              }}
+            >
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+                <ToggleTile
+                  active={draft.urgent}
+                  onClick={() => setDraft((d) => ({ ...d, urgent: !d.urgent }))}
+                  icon={<Flame size={14} strokeWidth={2.2} />}
+                  label="Urgent"
+                  sub="Time-sensitive"
+                  activeColor="var(--q1)"
+                />
+                <ToggleTile
+                  active={draft.important}
+                  onClick={() => setDraft((d) => ({ ...d, important: !d.important }))}
+                  icon={<Sparkles size={14} strokeWidth={2.2} />}
+                  label="Important"
+                  sub="Moves the needle"
+                  activeColor="var(--q2)"
+                />
+              </div>
+              <div
+                style={{
+                  marginTop: 12,
+                  display: "grid",
+                  gridTemplateColumns: "1fr 1fr",
+                  gridTemplateRows: "34px 34px",
+                  gap: 4,
+                }}
+              >
+                {(["q2", "q1", "q4", "q3"] as RedesignQuadrantKey[]).map((id) => {
+                  const quadrant = quadrants.find((x) => x.rdKey === id)!;
+                  const active = id === activeKey;
+                  return (
+                    <div
+                      key={id}
+                      style={{
+                        background: active ? `var(--${id})` : "var(--paper)",
+                        color: active ? "#fff" : "var(--ink-3)",
+                        borderRadius: 8,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        fontSize: 11.5,
+                        fontWeight: 600,
+                        transition: "all .15s",
+                      }}
+                    >
+                      {quadrant.title}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </Field>
+
+          <Field label="Due">
+            <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+              {DUE_KEYS.map((key) => {
+                const active = isSamePresetDue(draft.dueDate, key);
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setDraft((d) => ({ ...d, dueDate: presetDueDate(key) }))}
+                    style={{
+                      height: 30,
+                      padding: "0 12px",
+                      borderRadius: 8,
+                      border: "1px solid var(--line)",
+                      background: active ? "var(--ink)" : "var(--paper)",
+                      color: active ? "var(--paper)" : "var(--ink-2)",
+                      fontSize: 12.5,
+                      fontWeight: 500,
+                      cursor: "pointer",
+                    }}
+                  >
+                    {presetLabel(key)}
+                  </button>
+                );
+              })}
+            </div>
+          </Field>
+
+          <Field label="Tags">
+            <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignItems: "center" }}>
+              {draft.tags.map((t) => (
+                <span
+                  key={t}
+                  className="inline-flex items-center gap-1"
+                  style={{
+                    height: 26,
+                    padding: "0 8px 0 10px",
+                    borderRadius: 6,
+                    background: "var(--bg-inset)",
+                    color: "var(--ink-2)",
+                    fontSize: 12,
+                    fontWeight: 500,
+                  }}
+                >
+                  #{t}
+                  <button
+                    type="button"
+                    onClick={() => setDraft((d) => ({ ...d, tags: d.tags.filter((x) => x !== t) }))}
+                    aria-label={`Remove tag ${t}`}
+                    style={{
+                      background: "none",
+                      border: 0,
+                      color: "var(--ink-3)",
+                      padding: 0,
+                      marginLeft: 4,
+                      cursor: "pointer",
+                      display: "inline-flex",
+                    }}
+                  >
+                    <X size={11} />
+                  </button>
+                </span>
+              ))}
+              <input
+                value={tagInput}
+                onChange={(e) => setTagInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === ",") {
+                    e.preventDefault();
+                    addTag(tagInput);
+                  }
+                }}
+                placeholder="Add tag…"
+                style={{ ...inputStyle, width: 120, height: 26, padding: "0 8px", fontSize: 12 }}
+              />
+            </div>
+          </Field>
+        </div>
+
+        <div
+          style={{
+            padding: 16,
+            borderTop: "1px solid var(--line)",
+            display: "flex",
+            gap: 8,
+            justifyContent: "flex-end",
+          }}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              height: 36,
+              padding: "0 14px",
+              borderRadius: 10,
+              border: "1px solid transparent",
+              background: "transparent",
+              color: "var(--ink-2)",
+              fontSize: 13.5,
+              fontWeight: 500,
+              cursor: "pointer",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={!draft.title.trim()}
+            className="inline-flex items-center gap-2"
+            style={{
+              height: 36,
+              padding: "0 14px",
+              borderRadius: 10,
+              border: "1px solid var(--ink)",
+              background: "var(--ink)",
+              color: "var(--paper)",
+              fontSize: 13.5,
+              fontWeight: 500,
+              cursor: draft.title.trim() ? "pointer" : "not-allowed",
+              opacity: draft.title.trim() ? 1 : 0.5,
+            }}
+          >
+            {editingTask ? "Save" : `Add to ${q.title}`}
+            <ArrowRight size={13} strokeWidth={2.2} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label
+        style={{
+          display: "block",
+          fontSize: 11,
+          fontWeight: 600,
+          letterSpacing: 0.08,
+          textTransform: "uppercase",
+          color: "var(--ink-3)",
+          marginBottom: 8,
+        }}
+      >
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function ToggleTile({
+  active,
+  onClick,
+  icon,
+  label,
+  sub,
+  activeColor,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+  sub: string;
+  activeColor: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        border: 0,
+        background: active ? activeColor : "var(--paper)",
+        color: active ? "#fff" : "var(--ink-2)",
+        borderRadius: 10,
+        padding: "10px 12px",
+        textAlign: "left",
+        transition: "all .15s",
+        cursor: "pointer",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, fontWeight: 600 }}>
+        {icon}
+        {label}
+      </div>
+      <div style={{ fontSize: 11.5, opacity: active ? 0.85 : 0.7, marginTop: 2 }}>{sub}</div>
+    </button>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  height: 38,
+  padding: "0 12px",
+  borderRadius: 10,
+  border: "1px solid var(--line)",
+  background: "var(--paper)",
+  color: "var(--ink)",
+  fontSize: 14,
+  outline: 0,
+  transition: "border-color .15s, box-shadow .15s",
+};

--- a/components/redesign/draggable-task-card.tsx
+++ b/components/redesign/draggable-task-card.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useDraggable } from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+import { TaskCard, type TaskCardProps } from "./task-card";
+
+/**
+ * Wraps a TaskCard so the whole card becomes a drag source.
+ * An 8px activation distance (from DND_CONFIG.POINTER_DISTANCE via the
+ * pointer sensor) prevents clicks from being interpreted as drags —
+ * so the card's onClick (which opens the composer in edit mode) still
+ * fires on a plain click.
+ */
+export function DraggableTaskCard(props: TaskCardProps) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: props.task.id,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      style={{
+        transform: CSS.Translate.toString(transform),
+        opacity: isDragging ? 0.35 : 1,
+        cursor: isDragging ? "grabbing" : undefined,
+        touchAction: "manipulation",
+      }}
+    >
+      <TaskCard {...props} />
+    </div>
+  );
+}

--- a/components/redesign/help-drawer.tsx
+++ b/components/redesign/help-drawer.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { X } from "lucide-react";
+import { ROUTES } from "@/lib/routes";
+
+export interface HelpDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function HelpDrawer({ open, onClose }: HelpDrawerProps) {
+  useEffect(() => {
+    if (!open) return;
+    const h = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", h);
+    return () => window.removeEventListener("keydown", h);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Help"
+      className="redesign-scope"
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 60,
+        background: "rgba(24,24,27,0.38)",
+        display: "flex",
+        justifyContent: "flex-end",
+      }}
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="rd-fade-in"
+        style={{
+          width: "min(520px, 100vw)",
+          height: "100vh",
+          background: "var(--paper)",
+          display: "flex",
+          flexDirection: "column",
+          boxShadow: "var(--rd-shadow-lg)",
+        }}
+      >
+        <header
+          style={{
+            padding: "20px 24px 16px",
+            borderBottom: "1px solid var(--line)",
+            display: "flex",
+            alignItems: "flex-start",
+            justifyContent: "space-between",
+            gap: 12,
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontSize: 11,
+                letterSpacing: 0.12,
+                textTransform: "uppercase",
+                color: "var(--ink-3)",
+                fontWeight: 600,
+              }}
+            >
+              Field guide
+            </div>
+            <h2 className="rd-serif" style={{ margin: "4px 0 0", fontSize: 28, lineHeight: 1.1 }}>
+              How to use <em style={{ fontStyle: "italic", color: "var(--q2)" }}>GSD</em>
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="inline-flex items-center justify-center"
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: 10,
+              border: 0,
+              background: "transparent",
+              color: "var(--ink-3)",
+              cursor: "pointer",
+            }}
+          >
+            <X size={16} />
+          </button>
+        </header>
+
+        <div style={{ flex: 1, overflowY: "auto", padding: "22px 24px 40px", display: "flex", flexDirection: "column", gap: 28 }}>
+          <Section label="Three lenses on one list">
+            <Concept title="Focus" accent="var(--q2)">
+              Default view. An editorial feed grouped{" "}
+              <em className="rd-serif" style={{ fontStyle: "italic" }}>Now → Today → Next → Later</em>. Answers{" "}
+              <strong>&ldquo;what should I do next?&rdquo;</strong> A small compass shows how many tasks live in each quadrant.
+            </Concept>
+            <Concept title="Matrix" accent="var(--q1)">
+              The classic 2×2 Eisenhower board. Drag a task between quadrants to reclassify it. Hover a quadrant while dragging to
+              see the drop target highlight.
+            </Concept>
+            <Concept title="Canvas" accent="var(--q3)">
+              Tasks plotted on a real urgency × importance plane. Useful when you want to see distribution at a glance. Click any
+              pill to open its editor.
+            </Concept>
+          </Section>
+
+          <Section label="The four quadrants">
+            <QuadrantLine rdKey="q1" title="Do First" hint="Urgent & important — crises, deadlines. Handle now." />
+            <QuadrantLine rdKey="q2" title="Schedule" hint="Important, not urgent — strategy, growth. Protect time." />
+            <QuadrantLine rdKey="q3" title="Delegate" hint="Urgent, not important — interruptions. Hand these off." />
+            <QuadrantLine rdKey="q4" title="Eliminate" hint="Neither — noise. Stop doing these." />
+          </Section>
+
+          <Section label="Quick-add smart syntax">
+            <p style={bodyStyle}>
+              Type into the bar at the top. It parses priority markers from your text as you type — the dot on the left previews
+              which quadrant the task will land in.
+            </p>
+            <SyntaxRow symbol="!" meaning="Marks the task urgent" />
+            <SyntaxRow symbol="!!" meaning="Urgent and important (Do First)" />
+            <SyntaxRow symbol="*" meaning="Marks the task important" />
+            <SyntaxRow symbol="#tag" meaning="Adds a tag — any word-like token" />
+            <p style={{ ...bodyStyle, color: "var(--ink-3)" }}>
+              Example: <code style={codeStyle}>!! ship the deck #work #q2</code> creates an urgent + important task tagged{" "}
+              <code style={codeStyle}>#work</code> and <code style={codeStyle}>#q2</code>.
+            </p>
+          </Section>
+
+          <Section label="Keyboard shortcuts">
+            <ShortcutRow keys={["N"]} action="Open the full composer" />
+            <ShortcutRow keys={["/"]} action="Focus the search field" />
+            <ShortcutRow keys={["1"]} action="Switch to Focus view" />
+            <ShortcutRow keys={["2"]} action="Switch to Matrix view" />
+            <ShortcutRow keys={["3"]} action="Switch to Canvas view" />
+            <ShortcutRow keys={["?"]} action="Open this help drawer" />
+            <ShortcutRow keys={["Esc"]} action="Close any open drawer" />
+            <p style={{ ...bodyStyle, color: "var(--ink-3)", fontSize: 12 }}>
+              Shortcuts are suppressed while a text field is focused.
+            </p>
+          </Section>
+
+          <Section label="Editing, completing, and drag-drop">
+            <p style={bodyStyle}>
+              <strong>Complete</strong> — tap the checkbox on any task card. Recurring tasks automatically spawn the next instance.
+            </p>
+            <p style={bodyStyle}>
+              <strong>Edit</strong> — click anywhere on a task card (except the checkbox) to open the composer pre-filled with that
+              task&rsquo;s details. Save to update, close without saving to cancel.
+            </p>
+            <p style={bodyStyle}>
+              <strong>Drag to reclassify</strong> — in the Matrix view, drag a task onto any other quadrant. An 8-pixel activation
+              distance means plain clicks still open the editor.
+            </p>
+          </Section>
+
+          <Section label="Cloud sync (optional)">
+            <p style={bodyStyle}>
+              The cloud icon in the top bar is your sync control. Click it to sign in with Google or GitHub — once enabled, your
+              tasks sync across devices against a self-hosted PocketBase backend.
+            </p>
+            <p style={{ ...bodyStyle, color: "var(--ink-3)" }}>
+              A blue badge means there are pending changes to push; a red&nbsp;<em>!</em> badge means the session expired and you
+              need to re-authenticate. Visit{" "}
+              <Link href={"/sync-history" as const} style={linkStyle} onClick={onClose}>
+                Sync history
+              </Link>{" "}
+              for a recent log, or{" "}
+              <Link href={ROUTES.SETTINGS} style={linkStyle} onClick={onClose}>
+                Settings
+              </Link>{" "}
+              to change the auto-sync interval or disable sync entirely.
+            </p>
+          </Section>
+
+          <Section label="Privacy">
+            <p style={bodyStyle}>
+              Tasks live in your browser&rsquo;s IndexedDB. Nothing is sent to a server unless you explicitly enable sync in{" "}
+              <Link href={ROUTES.SETTINGS} style={linkStyle} onClick={onClose}>
+                Settings
+              </Link>
+              . The app works fully offline; install it as a PWA from your browser&rsquo;s menu to keep it one tap away.
+            </p>
+            <p style={bodyStyle}>
+              Want the full story?{" "}
+              <Link href={"/about" as const} style={linkStyle} onClick={onClose}>
+                Read the About page →
+              </Link>
+            </p>
+          </Section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      <h3
+        style={{
+          margin: 0,
+          fontSize: 11,
+          fontWeight: 600,
+          letterSpacing: 0.12,
+          textTransform: "uppercase",
+          color: "var(--ink-3)",
+        }}
+      >
+        {label}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function Concept({ title, accent, children }: { title: string; accent: string; children: React.ReactNode }) {
+  return (
+    <div style={{ display: "flex", gap: 12, alignItems: "flex-start" }}>
+      <span
+        aria-hidden
+        style={{ width: 4, borderRadius: 3, background: accent, alignSelf: "stretch", flexShrink: 0, minHeight: 36 }}
+      />
+      <div>
+        <div className="rd-serif" style={{ fontSize: 18, lineHeight: 1.2, color: "var(--ink)" }}>
+          {title}
+        </div>
+        <p style={{ ...bodyStyle, marginTop: 2 }}>{children}</p>
+      </div>
+    </div>
+  );
+}
+
+function QuadrantLine({
+  rdKey,
+  title,
+  hint,
+}: {
+  rdKey: "q1" | "q2" | "q3" | "q4";
+  title: string;
+  hint: string;
+}) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "12px 1fr",
+        gap: 12,
+        alignItems: "center",
+        padding: "8px 10px",
+        background: `var(--${rdKey}-soft)`,
+        borderRadius: 10,
+      }}
+    >
+      <span
+        style={{
+          width: 10,
+          height: 10,
+          borderRadius: 999,
+          background: `var(--${rdKey})`,
+          display: "inline-block",
+        }}
+      />
+      <div>
+        <div style={{ fontWeight: 600, color: "var(--ink)", fontSize: 13.5 }}>{title}</div>
+        <div style={{ fontSize: 12.5, color: "var(--ink-3)", lineHeight: 1.4 }}>{hint}</div>
+      </div>
+    </div>
+  );
+}
+
+function SyntaxRow({ symbol, meaning }: { symbol: string; meaning: string }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12, fontSize: 13 }}>
+      <code style={{ ...codeStyle, minWidth: 40, textAlign: "center" }}>{symbol}</code>
+      <span style={{ color: "var(--ink-2)" }}>{meaning}</span>
+    </div>
+  );
+}
+
+function ShortcutRow({ keys, action }: { keys: string[]; action: string }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12, fontSize: 13 }}>
+      <div style={{ display: "flex", gap: 4, minWidth: 80 }}>
+        {keys.map((k) => (
+          <kbd key={k}>{k}</kbd>
+        ))}
+      </div>
+      <span style={{ color: "var(--ink-2)" }}>{action}</span>
+    </div>
+  );
+}
+
+const bodyStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: 13.5,
+  lineHeight: 1.55,
+  color: "var(--ink-2)",
+};
+
+const codeStyle: React.CSSProperties = {
+  fontFamily: "var(--font-geist-mono, ui-monospace, monospace)",
+  fontSize: 12,
+  padding: "2px 8px",
+  borderRadius: 6,
+  border: "1px solid var(--line)",
+  background: "var(--bg-inset)",
+  color: "var(--ink)",
+};
+
+const linkStyle: React.CSSProperties = {
+  color: "var(--q2)",
+  textDecoration: "underline",
+  textUnderlineOffset: 2,
+};

--- a/components/redesign/primitives.tsx
+++ b/components/redesign/primitives.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { Calendar, Clock, Flame, Layers, Trash2, Users, AlertCircle } from "lucide-react";
+import type { ReactNode } from "react";
+import { quadrantByRdKey, type QuadrantMeta, type RedesignIconKey, type RedesignQuadrantKey } from "@/lib/quadrants";
+import { formatDueShort, dueBucket } from "@/lib/redesign/due";
+
+export function TagChip({ children }: { children: ReactNode }) {
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-md px-2"
+      style={{
+        height: 20,
+        background: "var(--bg-inset)",
+        color: "var(--ink-3)",
+        fontSize: 11,
+        fontWeight: 500,
+        letterSpacing: 0.02,
+      }}
+    >
+      <span style={{ opacity: 0.55 }}>#</span>
+      {children}
+    </span>
+  );
+}
+
+export function DuePill({ dueDate }: { dueDate: string | undefined }) {
+  const label = formatDueShort(dueDate);
+  if (!label) return null;
+  const bucket = dueBucket(dueDate);
+  const isOverdue = bucket === "overdue";
+  const isToday = bucket === "today";
+  const color = isOverdue ? "var(--q1)" : isToday ? "var(--q2)" : "var(--ink-3)";
+  const bg = isOverdue ? "var(--q1-soft)" : isToday ? "var(--q2-soft)" : "transparent";
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-md px-2"
+      style={{
+        height: 20,
+        background: bg,
+        color,
+        fontSize: 11,
+        fontWeight: 600,
+        border: bg === "transparent" ? "1px solid var(--line)" : "none",
+      }}
+    >
+      {isOverdue ? <AlertCircle size={10} strokeWidth={2.2} /> : <Clock size={10} strokeWidth={2.2} />}
+      {label}
+    </span>
+  );
+}
+
+const ICON_MAP: Record<RedesignIconKey, typeof Flame> = {
+  flame: Flame,
+  calendar: Calendar,
+  users: Users,
+  trash: Trash2,
+};
+
+export function RdQuadrantIcon({ icon, size = 14, strokeWidth = 2 }: { icon: RedesignIconKey; size?: number; strokeWidth?: number }) {
+  const I = ICON_MAP[icon];
+  return <I size={size} strokeWidth={strokeWidth} />;
+}
+
+export function QuadrantBadge({ quadrant, size = "md" }: { quadrant: QuadrantMeta | RedesignQuadrantKey; size?: "sm" | "md" }) {
+  const meta = typeof quadrant === "string" ? quadrantByRdKey(quadrant) : quadrant;
+  const dim = size === "sm" ? 20 : 26;
+  return (
+    <span
+      title={meta.title}
+      className="inline-grid place-items-center"
+      style={{
+        width: dim,
+        height: dim,
+        borderRadius: 7,
+        background: `var(--${meta.rdKey}-tint)`,
+        color: `var(--${meta.rdKey})`,
+      }}
+    >
+      <RdQuadrantIcon icon={meta.rdIcon} size={size === "sm" ? 11 : 14} strokeWidth={2} />
+    </span>
+  );
+}
+
+export interface SegmentedOption<V extends string> {
+  value: V;
+  label: string;
+  icon?: ReactNode;
+}
+
+export function Segmented<V extends string>({
+  options,
+  value,
+  onChange,
+  size = "md",
+  ariaLabel,
+}: {
+  options: SegmentedOption<V>[];
+  value: V;
+  onChange: (v: V) => void;
+  size?: "sm" | "md";
+  ariaLabel?: string;
+}) {
+  const h = size === "sm" ? 28 : 34;
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className="inline-flex gap-[2px] rounded-[10px] p-[3px]"
+      style={{
+        background: "var(--bg-inset)",
+        height: h + 6,
+      }}
+    >
+      {options.map((opt) => {
+        const active = value === opt.value;
+        return (
+          <button
+            key={opt.value}
+            role="tab"
+            aria-selected={active}
+            type="button"
+            onClick={() => onChange(opt.value)}
+            className="inline-flex items-center gap-1.5 rounded-lg"
+            style={{
+              border: 0,
+              background: active ? "var(--paper)" : "transparent",
+              color: active ? "var(--ink)" : "var(--ink-3)",
+              padding: "0 12px",
+              fontWeight: 500,
+              fontSize: 13,
+              height: h,
+              boxShadow: active ? "0 1px 2px rgba(0,0,0,.06)" : "none",
+            }}
+          >
+            {opt.icon}
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function Divider({ className, style }: { className?: string; style?: React.CSSProperties }) {
+  return <div className={className} style={{ height: 1, background: "var(--line-soft)", ...style }} />;
+}
+
+export function SubtaskChip({ done, total }: { done: number; total: number }) {
+  if (total === 0) return null;
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-md px-2"
+      style={{
+        height: 20,
+        border: "1px solid var(--line)",
+        color: "var(--ink-3)",
+        fontSize: 11,
+        fontWeight: 500,
+      }}
+    >
+      <Layers size={10} strokeWidth={2} />
+      {done}/{total}
+    </span>
+  );
+}
+
+export function RdIconButton({
+  children,
+  onClick,
+  title,
+  style,
+  "aria-label": ariaLabel,
+}: {
+  children: ReactNode;
+  onClick?: () => void;
+  title?: string;
+  style?: React.CSSProperties;
+  "aria-label"?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-label={ariaLabel ?? title}
+      className="inline-flex items-center justify-center transition-colors"
+      style={{
+        width: 32,
+        height: 32,
+        borderRadius: 10,
+        border: "1px solid transparent",
+        background: "transparent",
+        color: "var(--ink-3)",
+        cursor: "pointer",
+        ...style,
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.background = "var(--bg-inset)";
+        e.currentTarget.style.color = "var(--ink)";
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.background = (style?.background as string) ?? "transparent";
+        e.currentTarget.style.color = (style?.color as string) ?? "var(--ink-3)";
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function RdButton({
+  children,
+  onClick,
+  variant = "default",
+  type = "button",
+  disabled,
+  style,
+}: {
+  children: ReactNode;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  variant?: "default" | "primary" | "ghost";
+  type?: "button" | "submit";
+  disabled?: boolean;
+  style?: React.CSSProperties;
+}) {
+  const base: React.CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 8,
+    height: 36,
+    padding: "0 14px",
+    borderRadius: 10,
+    fontWeight: 500,
+    fontSize: 13.5,
+    transition: "background .15s, border-color .15s, transform .05s",
+    cursor: disabled ? "not-allowed" : "pointer",
+    opacity: disabled ? 0.5 : 1,
+  };
+  const variants: Record<string, React.CSSProperties> = {
+    default: { border: "1px solid var(--line)", background: "var(--paper)", color: "var(--ink)" },
+    primary: { border: "1px solid var(--ink)", background: "var(--ink)", color: "var(--paper)" },
+    ghost: { border: "1px solid transparent", background: "transparent", color: "var(--ink-2)" },
+  };
+  return (
+    <button type={type} onClick={onClick} disabled={disabled} style={{ ...base, ...variants[variant], ...style }}>
+      {children}
+    </button>
+  );
+}

--- a/components/redesign/quick-add.tsx
+++ b/components/redesign/quick-add.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ArrowRight, Flame, MoreHorizontal, Sparkles } from "lucide-react";
+import { quadrantByRdKey, type RedesignQuadrantKey } from "@/lib/quadrants";
+
+export interface QuickAddSubmit {
+  title: string;
+  urgent: boolean;
+  important: boolean;
+  tags: string[];
+}
+
+export interface QuickAddProps {
+  onSubmit: (draft: QuickAddSubmit) => void;
+  onOpenFull: () => void;
+  presetQuadrant?: RedesignQuadrantKey | null;
+}
+
+export function QuickAdd({ onSubmit, onOpenFull, presetQuadrant }: QuickAddProps) {
+  const [value, setValue] = useState("");
+  const [urgent, setUrgent] = useState(false);
+  const [important, setImportant] = useState(false);
+  const [focused, setFocused] = useState(false);
+
+  useEffect(() => {
+    if (!presetQuadrant) return;
+    const q = quadrantByRdKey(presetQuadrant);
+    setUrgent(q.urgent);
+    setImportant(q.important);
+  }, [presetQuadrant]);
+
+  const parsed = useMemo(() => {
+    const v = value;
+    let u = urgent;
+    let i = important;
+    if (v.includes("!!")) {
+      u = true;
+      i = true;
+    } else if (/(^|\s)!/.test(v)) {
+      u = true;
+    }
+    if (v.includes("*")) i = true;
+    const tags = Array.from(v.matchAll(/#([\w-]+)/g)).map((m) => m[1]);
+    const clean = v
+      .replace(/#[\w-]+/g, "")
+      .replace(/!+|\*+/g, "")
+      .replace(/\s+/g, " ")
+      .trim();
+    return { urgent: u, important: i, tags, clean };
+  }, [value, urgent, important]);
+
+  const inferredKey: RedesignQuadrantKey =
+    parsed.urgent && parsed.important
+      ? "q1"
+      : !parsed.urgent && parsed.important
+        ? "q2"
+        : parsed.urgent
+          ? "q3"
+          : "q4";
+
+  function handleSubmit(e?: React.FormEvent) {
+    e?.preventDefault();
+    if (!parsed.clean) return;
+    onSubmit({
+      title: parsed.clean,
+      urgent: parsed.urgent,
+      important: parsed.important,
+      tags: parsed.tags,
+    });
+    setValue("");
+    setUrgent(false);
+    setImportant(false);
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      style={{
+        position: "relative",
+        background: "var(--paper)",
+        border: `1px solid ${focused ? "var(--ink-2)" : "var(--line)"}`,
+        borderRadius: 14,
+        padding: "4px 4px 4px 14px",
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        transition: "border-color .15s, box-shadow .15s",
+        boxShadow: focused ? "0 0 0 4px rgba(24,24,27,.05)" : "none",
+      }}
+    >
+      <span
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: 999,
+          background: `var(--${inferredKey})`,
+          transition: "background .15s",
+          flexShrink: 0,
+        }}
+      />
+      <input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        placeholder="Tell me what needs doing…   use ! urgent  * important  #tag"
+        style={{
+          flex: 1,
+          border: 0,
+          outline: 0,
+          background: "transparent",
+          fontSize: 14.5,
+          padding: "10px 0",
+          color: "var(--ink)",
+        }}
+      />
+      {focused && (
+        <span className="rd-mono" style={{ fontSize: 11, color: "var(--ink-3)", marginRight: 6 }}>
+          <kbd>⏎</kbd>
+        </span>
+      )}
+      <div style={{ display: "flex", alignItems: "center", gap: 4, flexShrink: 0 }}>
+        <TogglePill
+          active={parsed.urgent}
+          onClick={() => setUrgent((u) => !u)}
+          label="Urgent"
+          activeColor="var(--q1)"
+          icon={<Flame size={12} strokeWidth={2.2} />}
+        />
+        <TogglePill
+          active={parsed.important}
+          onClick={() => setImportant((i) => !i)}
+          label="Important"
+          activeColor="var(--q2)"
+          icon={<Sparkles size={12} strokeWidth={2.2} />}
+        />
+        <button
+          type="button"
+          onClick={onOpenFull}
+          title="Open full composer"
+          aria-label="Open full composer"
+          className="inline-flex items-center justify-center"
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: 10,
+            border: "1px solid transparent",
+            background: "transparent",
+            color: "var(--ink-3)",
+            cursor: "pointer",
+          }}
+        >
+          <MoreHorizontal size={15} />
+        </button>
+        <button
+          type="submit"
+          className="inline-flex items-center gap-1.5"
+          style={{
+            height: 30,
+            padding: "0 12px",
+            borderRadius: 10,
+            border: "1px solid var(--ink)",
+            background: "var(--ink)",
+            color: "var(--paper)",
+            fontSize: 13,
+            fontWeight: 500,
+            cursor: "pointer",
+          }}
+        >
+          Add
+          <ArrowRight size={13} strokeWidth={2.2} />
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function TogglePill({
+  active,
+  onClick,
+  label,
+  activeColor,
+  icon,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  activeColor: string;
+  icon: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={label}
+      className="inline-flex items-center gap-1.5"
+      style={{
+        height: 30,
+        padding: "0 10px",
+        borderRadius: 8,
+        border: "1px solid var(--line)",
+        background: active ? activeColor : "var(--paper)",
+        color: active ? "#fff" : "var(--ink-2)",
+        fontSize: 12,
+        fontWeight: 600,
+        transition: "all .15s",
+        cursor: "pointer",
+      }}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}

--- a/components/redesign/redesign-logo.tsx
+++ b/components/redesign/redesign-logo.tsx
@@ -1,0 +1,51 @@
+/**
+ * Editorial-palette version of the GSD logo for the redesign sidebar.
+ * Uses the redesign's earthy quadrant tokens (q1–q4) so it adapts to
+ * light/dark mode via the `.redesign-scope` CSS variables. Matches the
+ * conceptual structure of the full `GsdLogo` (2×2 grid + checkmark in
+ * the urgent+important quadrant) but tuned for the smaller 30px slot.
+ */
+export function RedesignLogo({ size = 30 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 40 40"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+    >
+      {/* Card background so the logo reads on any sidebar tone */}
+      <rect x="0" y="0" width="40" height="40" rx="8" fill="var(--paper)" />
+
+      {/* 2×2 quadrant grid — top row is the "important" row,
+          matching the Canvas view's axis orientation */}
+      <rect x="4" y="4" width="15.5" height="15.5" rx="3" fill="var(--q2-tint)" />
+      <rect x="20.5" y="4" width="15.5" height="15.5" rx="3" fill="var(--q1-tint)" />
+      <rect x="4" y="20.5" width="15.5" height="15.5" rx="3" fill="var(--q4-tint)" />
+      <rect x="20.5" y="20.5" width="15.5" height="15.5" rx="3" fill="var(--q3-tint)" />
+
+      {/* Check in the Do-First quadrant */}
+      <path
+        d="M23.5 12.25L26 14.75L30.5 10.25"
+        stroke="var(--q1)"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+
+      {/* Subtle outline that sits with the editorial line treatment */}
+      <rect
+        x="0.5"
+        y="0.5"
+        width="39"
+        height="39"
+        rx="7.5"
+        stroke="var(--line)"
+        strokeWidth="1"
+        fill="none"
+      />
+    </svg>
+  );
+}

--- a/components/redesign/redesign-matrix.tsx
+++ b/components/redesign/redesign-matrix.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { DndContext, DragOverlay } from "@dnd-kit/core";
+import { createTask, toggleCompleted, updateTask } from "@/lib/tasks";
+import { useTasks } from "@/lib/use-tasks";
+import type { TaskRecord } from "@/lib/types";
+import type { RedesignQuadrantKey } from "@/lib/quadrants";
+import { quadrantByRdKey } from "@/lib/quadrants";
+import { useToast } from "@/components/ui/toast";
+import { useErrorHandlerWithUndo } from "@/lib/use-error-handler";
+import { useDragAndDrop } from "@/lib/use-drag-and-drop";
+import { useAutoArchive } from "@/lib/use-auto-archive";
+import { useNotificationChecker } from "@/components/matrix-board/use-event-handlers";
+import { TOAST_DURATION } from "@/lib/constants";
+import { RedesignShell, type RedesignView } from "./redesign-shell";
+import { ViewFocus } from "./view-focus";
+import { ViewEditorial } from "./view-editorial";
+import { ViewCanvas } from "./view-canvas";
+import { QuickAdd } from "./quick-add";
+import { ComposerDrawer } from "./composer-drawer";
+import { HelpDrawer } from "./help-drawer";
+import { TaskCard } from "./task-card";
+
+const VIEW_STORAGE_KEY = "gsd:redesign-view";
+
+function isEditable(el: Element | null): boolean {
+  if (!(el instanceof HTMLElement)) return false;
+  const tag = el.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || el.isContentEditable;
+}
+
+function filterTasks(tasks: TaskRecord[], query: string): TaskRecord[] {
+  if (!query.trim()) return tasks;
+  const q = query.trim().toLowerCase();
+  return tasks.filter((t) => {
+    const hay =
+      t.title.toLowerCase() +
+      " " +
+      t.description.toLowerCase() +
+      " " +
+      t.tags.join(" ").toLowerCase() +
+      " " +
+      t.subtasks.map((s) => s.title).join(" ").toLowerCase();
+    return hay.includes(q);
+  });
+}
+
+export function RedesignMatrix() {
+  const { all } = useTasks();
+  const { showToast } = useToast();
+  const { handleError } = useErrorHandlerWithUndo();
+  const { sensors, activeId, handleDragStart, handleDragEnd } = useDragAndDrop(handleError);
+
+  // Background lifecycle hooks preserved from the legacy MatrixBoard —
+  // without these, auto-archive stops running and due-date notifications
+  // stop firing for users who had those features enabled.
+  useAutoArchive();
+  useNotificationChecker();
+
+  const [view, setView] = useState<RedesignView>("focus");
+  const [composerOpen, setComposerOpen] = useState(false);
+  const [presetQuadrant, setPresetQuadrant] = useState<RedesignQuadrantKey | null>(null);
+  const [editingTask, setEditingTask] = useState<TaskRecord | null>(null);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(VIEW_STORAGE_KEY) as RedesignView | null;
+    if (stored === "focus" || stored === "editorial" || stored === "canvas") {
+      setView(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(VIEW_STORAGE_KEY, view);
+  }, [view]);
+
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => {
+      if (isEditable(document.activeElement) || e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key === "n") {
+        e.preventDefault();
+        setPresetQuadrant(null);
+        setEditingTask(null);
+        setComposerOpen(true);
+      } else if (e.key === "/") {
+        e.preventDefault();
+        searchInputRef.current?.focus();
+      } else if (e.key === "?") {
+        e.preventDefault();
+        setHelpOpen(true);
+      } else if (e.key === "1") {
+        setView("focus");
+      } else if (e.key === "2") {
+        setView("editorial");
+      } else if (e.key === "3") {
+        setView("canvas");
+      }
+    };
+    window.addEventListener("keydown", h);
+    return () => window.removeEventListener("keydown", h);
+  }, []);
+
+  // Support PWA manifest shortcut (?action=new-task) and dashboard drill-in URLs.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const action = params.get("action");
+    if (action === "new-task") {
+      setPresetQuadrant(null);
+      setEditingTask(null);
+      setComposerOpen(true);
+      params.delete("action");
+      const next = params.toString();
+      window.history.replaceState({}, "", `${window.location.pathname}${next ? `?${next}` : ""}`);
+    }
+  }, []);
+
+  const visibleTasks = useMemo(() => filterTasks(all, searchQuery), [all, searchQuery]);
+
+  const handleToggle = useCallback(
+    async (task: TaskRecord, completed: boolean) => {
+      try {
+        await toggleCompleted(task.id, completed);
+      } catch {
+        showToast("Failed to update task", undefined, TOAST_DURATION.LONG);
+      }
+    },
+    [showToast]
+  );
+
+  const handleOpenTask = useCallback((task: TaskRecord) => {
+    setEditingTask(task);
+    setPresetQuadrant(null);
+    setComposerOpen(true);
+  }, []);
+
+  const openComposer = useCallback((key?: RedesignQuadrantKey) => {
+    setPresetQuadrant(key ?? null);
+    setEditingTask(null);
+    setComposerOpen(true);
+  }, []);
+
+  const closeComposer = useCallback(() => {
+    setComposerOpen(false);
+    setEditingTask(null);
+  }, []);
+
+  const handleQuickAdd = useCallback(
+    async ({ title, urgent, important, tags }: { title: string; urgent: boolean; important: boolean; tags: string[] }) => {
+      try {
+        await createTask({
+          title,
+          description: "",
+          urgent,
+          important,
+          tags: tags.length > 0 ? tags : undefined,
+        });
+        showToast("Task added", undefined, TOAST_DURATION.SHORT);
+      } catch {
+        showToast("Failed to create task", undefined, TOAST_DURATION.LONG);
+      }
+    },
+    [showToast]
+  );
+
+  const handleComposerSubmit = useCallback(
+    async (
+      draft: { title: string; description: string; urgent: boolean; important: boolean; dueDate?: string; tags: string[] },
+      editingId?: string
+    ) => {
+      try {
+        if (editingId) {
+          await updateTask(editingId, {
+            title: draft.title,
+            description: draft.description,
+            urgent: draft.urgent,
+            important: draft.important,
+            dueDate: draft.dueDate,
+            tags: draft.tags,
+          });
+          showToast("Task updated", undefined, TOAST_DURATION.SHORT);
+        } else {
+          await createTask({
+            title: draft.title,
+            description: draft.description,
+            urgent: draft.urgent,
+            important: draft.important,
+            dueDate: draft.dueDate,
+            tags: draft.tags.length > 0 ? draft.tags : undefined,
+          });
+          const q = quadrantByRdKey(
+            draft.urgent && draft.important ? "q1" : !draft.urgent && draft.important ? "q2" : draft.urgent ? "q3" : "q4"
+          );
+          showToast(`Added to ${q.title}`, undefined, TOAST_DURATION.SHORT);
+        }
+      } catch {
+        showToast(editingId ? "Failed to update task" : "Failed to create task", undefined, TOAST_DURATION.LONG);
+      }
+    },
+    [showToast]
+  );
+
+  const activeDragTask = activeId ? all.find((t) => t.id === activeId) ?? null : null;
+
+  return (
+    <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+      <RedesignShell
+        view={view}
+        onViewChange={setView}
+        onOpenComposer={() => openComposer()}
+        onOpenHelp={() => setHelpOpen(true)}
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        searchInputRef={searchInputRef}
+      >
+        {view !== "canvas" && (
+          <div style={{ marginBottom: 22 }}>
+            <QuickAdd onSubmit={handleQuickAdd} onOpenFull={() => openComposer()} presetQuadrant={presetQuadrant} />
+          </div>
+        )}
+
+        {view === "focus" && (
+          <ViewFocus tasks={visibleTasks} onToggle={handleToggle} onOpen={handleOpenTask} onAdd={openComposer} />
+        )}
+        {view === "editorial" && (
+          <ViewEditorial tasks={visibleTasks} onToggle={handleToggle} onOpen={handleOpenTask} onAdd={openComposer} />
+        )}
+        {view === "canvas" && <ViewCanvas tasks={visibleTasks} onOpen={handleOpenTask} />}
+      </RedesignShell>
+
+      <ComposerDrawer
+        open={composerOpen}
+        onClose={closeComposer}
+        onSubmit={handleComposerSubmit}
+        presetQuadrant={presetQuadrant}
+        editingTask={editingTask}
+      />
+
+      <HelpDrawer open={helpOpen} onClose={() => setHelpOpen(false)} />
+
+      <DragOverlay dropAnimation={null}>
+        {activeDragTask ? (
+          // DragOverlay portals to document.body, so re-apply .redesign-scope
+          // to keep tokens (--paper, --ink, etc.) resolving.
+          <div className="redesign-scope" style={{ cursor: "grabbing" }}>
+            <TaskCard task={activeDragTask} />
+          </div>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
+  );
+}

--- a/components/redesign/redesign-shell.tsx
+++ b/components/redesign/redesign-shell.tsx
@@ -1,0 +1,382 @@
+"use client";
+
+import Link from "next/link";
+import type { Route } from "next";
+import { Focus, Grid2x2, HelpCircle, Info, LineChart, Plus, Search } from "lucide-react";
+import type { ReactNode } from "react";
+import { ROUTES } from "@/lib/routes";
+import { Segmented } from "./primitives";
+import { RedesignSyncButton } from "./sync-button";
+import { RedesignLogo } from "./redesign-logo";
+
+export type RedesignView = "focus" | "editorial" | "canvas";
+
+export interface RedesignShellProps {
+  view: RedesignView;
+  onViewChange: (v: RedesignView) => void;
+  onOpenComposer: () => void;
+  onOpenHelp: () => void;
+  searchQuery: string;
+  onSearchChange: (s: string) => void;
+  searchInputRef?: React.RefObject<HTMLInputElement | null>;
+  children: ReactNode;
+}
+
+const VIEW_LABELS: Record<RedesignView, string> = {
+  focus: "Focus",
+  editorial: "Matrix",
+  canvas: "Canvas",
+};
+
+export function RedesignShell({
+  view,
+  onViewChange,
+  onOpenComposer,
+  onOpenHelp,
+  searchQuery,
+  onSearchChange,
+  searchInputRef,
+  children,
+}: RedesignShellProps) {
+  return (
+    <div className="redesign-scope" style={{ display: "grid", gridTemplateColumns: "232px minmax(0, 1fr)", minHeight: "100vh" }}>
+      <Sidebar view={view} onViewChange={onViewChange} onOpenHelp={onOpenHelp} />
+      <div style={{ display: "flex", flexDirection: "column", minWidth: 0 }}>
+        <TopBar
+          view={view}
+          onViewChange={onViewChange}
+          onOpenComposer={onOpenComposer}
+          searchQuery={searchQuery}
+          onSearchChange={onSearchChange}
+          searchInputRef={searchInputRef}
+        />
+        <main style={{ flex: 1, padding: "22px 36px 48px", maxWidth: 1320, width: "100%", margin: "0 auto" }}>
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function Sidebar({
+  view,
+  onViewChange,
+  onOpenHelp,
+}: {
+  view: RedesignView;
+  onViewChange: (v: RedesignView) => void;
+  onOpenHelp: () => void;
+}) {
+  const items: { id: RedesignView; label: string; icon: ReactNode; hint: string }[] = [
+    { id: "focus", label: "Focus", icon: <Focus size={15} />, hint: "What to do now" },
+    { id: "editorial", label: "Matrix", icon: <Grid2x2 size={15} />, hint: "Four quadrants" },
+    { id: "canvas", label: "Canvas", icon: <LineChart size={15} />, hint: "2D plane" },
+  ];
+  return (
+    <aside
+      style={{
+        background: "var(--bg)",
+        borderRight: "1px solid var(--line-soft)",
+        padding: "20px 16px",
+        display: "flex",
+        flexDirection: "column",
+        position: "sticky",
+        top: 0,
+        height: "100vh",
+      }}
+      className="rd-sidebar"
+    >
+      <div style={{ padding: "4px 10px 20px", display: "flex", alignItems: "center", gap: 10 }}>
+        <RedesignLogo size={30} />
+        <div>
+          <div style={{ fontSize: 13.5, fontWeight: 600, letterSpacing: "-0.01em" }}>GSD</div>
+          <div style={{ fontSize: 11, color: "var(--ink-3)" }}>Focus on what matters</div>
+        </div>
+      </div>
+
+      <nav style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <SectionLabel>Workspace</SectionLabel>
+        {items.map((it) => {
+          const active = view === it.id;
+          return (
+            <button
+              key={it.id}
+              type="button"
+              onClick={() => onViewChange(it.id)}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "8px 10px",
+                border: 0,
+                background: active ? "var(--bg-inset)" : "transparent",
+                color: active ? "var(--ink)" : "var(--ink-2)",
+                borderRadius: 10,
+                cursor: "pointer",
+                fontSize: 13,
+                fontWeight: active ? 600 : 500,
+                textAlign: "left",
+              }}
+            >
+              <span style={{ color: active ? "var(--ink)" : "var(--ink-3)" }}>{it.icon}</span>
+              <span>{it.label}</span>
+              <span style={{ marginLeft: "auto", fontSize: 11, color: "var(--ink-4)" }}>{it.hint}</span>
+            </button>
+          );
+        })}
+
+        <SectionLabel style={{ marginTop: 18 }}>Elsewhere</SectionLabel>
+        <SidebarLink href={ROUTES.DASHBOARD} label="Dashboard" />
+        <SidebarLink href={"/archive" as Route} label="Archive" />
+        <SidebarLink href={"/sync-history" as Route} label="Sync history" />
+        <SidebarLink href={ROUTES.SETTINGS} label="Settings" />
+
+        <SectionLabel style={{ marginTop: 18 }}>Learn</SectionLabel>
+        <SidebarAction icon={<HelpCircle size={14} />} label="Help" hint="?" onClick={onOpenHelp} />
+        <SidebarLink href={ROUTES.ABOUT} label="About" icon={<Info size={14} />} />
+      </nav>
+
+      <SidebarFooter />
+    </aside>
+  );
+}
+
+function SidebarFooter() {
+  const version = process.env.NEXT_PUBLIC_BUILD_NUMBER || "dev";
+  const buildDate = process.env.NEXT_PUBLIC_BUILD_DATE;
+  return (
+    <div
+      style={{
+        marginTop: "auto",
+        fontSize: 11,
+        color: "var(--ink-3)",
+        padding: "0 10px",
+        lineHeight: 1.5,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 4 }}>
+        <span style={{ width: 6, height: 6, borderRadius: 999, background: "var(--q3)" }} />
+        <span style={{ fontWeight: 600, color: "var(--ink-2)" }}>Saved locally</span>
+      </div>
+      <div>No account needed · Works offline</div>
+      <div
+        style={{
+          marginTop: 10,
+          paddingTop: 8,
+          borderTop: "1px solid var(--line-soft)",
+          display: "flex",
+          alignItems: "baseline",
+          gap: 6,
+          fontSize: 10.5,
+          color: "var(--ink-4)",
+        }}
+      >
+        <span className="rd-mono" style={{ color: "var(--ink-3)", fontWeight: 500 }}>
+          v{version}
+        </span>
+        {buildDate && (
+          <>
+            <span aria-hidden>·</span>
+            <span title={`Built ${buildDate}`}>{buildDate}</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SectionLabel({ children, style }: { children: ReactNode; style?: React.CSSProperties }) {
+  return (
+    <div
+      style={{
+        fontSize: 10,
+        letterSpacing: 0.14,
+        textTransform: "uppercase",
+        color: "var(--ink-4)",
+        fontWeight: 600,
+        padding: "0 10px",
+        marginBottom: 6,
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function SidebarLink({ href, label, icon }: { href: Route; label: string; icon?: ReactNode }) {
+  return (
+    <Link
+      href={href}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "7px 10px",
+        color: "var(--ink-2)",
+        borderRadius: 10,
+        fontSize: 13,
+        fontWeight: 500,
+        textDecoration: "none",
+      }}
+    >
+      {icon ? (
+        <span style={{ color: "var(--ink-3)", display: "inline-flex", width: 14, justifyContent: "center" }}>{icon}</span>
+      ) : (
+        <span style={{ width: 5, height: 5, borderRadius: 999, background: "var(--ink-4)" }} />
+      )}
+      {label}
+    </Link>
+  );
+}
+
+function SidebarAction({
+  icon,
+  label,
+  hint,
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  hint?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "7px 10px",
+        border: 0,
+        background: "transparent",
+        color: "var(--ink-2)",
+        borderRadius: 10,
+        cursor: "pointer",
+        fontSize: 13,
+        fontWeight: 500,
+        textAlign: "left",
+      }}
+    >
+      <span style={{ color: "var(--ink-3)", display: "inline-flex", width: 14, justifyContent: "center" }}>{icon}</span>
+      <span>{label}</span>
+      {hint && <span style={{ marginLeft: "auto", fontSize: 11, color: "var(--ink-4)" }}>{hint}</span>}
+    </button>
+  );
+}
+
+function TopBar({
+  view,
+  onViewChange,
+  onOpenComposer,
+  searchQuery,
+  onSearchChange,
+  searchInputRef,
+}: {
+  view: RedesignView;
+  onViewChange: (v: RedesignView) => void;
+  onOpenComposer: () => void;
+  searchQuery: string;
+  onSearchChange: (v: string) => void;
+  searchInputRef?: React.RefObject<HTMLInputElement | null>;
+}) {
+  return (
+    <header
+      className="rd-topbar"
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 30,
+        // Fallback to opaque --bg for browsers without relative color syntax support.
+        background: "var(--bg)",
+        backgroundColor: "color-mix(in srgb, var(--bg) 85%, transparent)",
+        backdropFilter: "blur(12px)",
+        WebkitBackdropFilter: "blur(12px)",
+        borderBottom: "1px solid var(--line-soft)",
+        padding: "12px 36px",
+        display: "flex",
+        alignItems: "center",
+        gap: 14,
+      }}
+    >
+      <Segmented<RedesignView>
+        size="sm"
+        value={view}
+        onChange={onViewChange}
+        ariaLabel="View"
+        options={[
+          { value: "focus", label: "Focus", icon: <Focus size={13} /> },
+          { value: "editorial", label: "Matrix", icon: <Grid2x2 size={13} /> },
+          { value: "canvas", label: "Canvas", icon: <LineChart size={13} /> },
+        ]}
+      />
+
+      <div
+        style={{
+          flex: 1,
+          maxWidth: 440,
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          height: 36,
+          padding: "0 12px",
+          borderRadius: 10,
+          background: "var(--bg-inset)",
+          color: "var(--ink-3)",
+        }}
+      >
+        <Search size={14} />
+        <input
+          ref={searchInputRef}
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder={`Search ${VIEW_LABELS[view]}…`}
+          style={{
+            border: 0,
+            background: "transparent",
+            outline: 0,
+            flex: 1,
+            fontSize: 13,
+            color: "var(--ink)",
+          }}
+        />
+        <kbd>/</kbd>
+      </div>
+
+      <div style={{ flex: 1 }} />
+
+      <RedesignSyncButton />
+
+      <button
+        type="button"
+        onClick={onOpenComposer}
+        className="inline-flex items-center gap-2"
+        style={{
+          height: 36,
+          padding: "0 14px",
+          borderRadius: 10,
+          border: "1px solid var(--ink)",
+          background: "var(--ink)",
+          color: "var(--paper)",
+          fontSize: 13.5,
+          fontWeight: 500,
+          cursor: "pointer",
+        }}
+      >
+        <Plus size={14} /> New task
+        <kbd
+          style={{
+            marginLeft: 2,
+            background: "rgba(255,255,255,.12)",
+            color: "#fff",
+            borderColor: "rgba(255,255,255,.2)",
+          }}
+        >
+          N
+        </kbd>
+      </button>
+    </header>
+  );
+}

--- a/components/redesign/sync-button.tsx
+++ b/components/redesign/sync-button.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState } from "react";
+import { AlertCircle, Check, Cloud, CloudOff, Clock, X as XIcon } from "lucide-react";
+import { useSync } from "@/lib/hooks/use-sync";
+import { useToast } from "@/components/ui/toast";
+import { SyncAuthDialog } from "@/components/sync/sync-auth-dialog";
+import { useSyncHealth } from "@/components/sync/use-sync-health";
+import { useSyncStatus, type IconType } from "@/components/sync/use-sync-status";
+import { SYNC_TOAST_DURATION } from "@/lib/constants/sync";
+
+/**
+ * Compact, editorial-styled sync button for the redesign topbar.
+ * Reuses the same useSync + useSyncStatus + useSyncHealth hooks that
+ * drive the legacy SyncButton — only the rendering differs. Sync lifecycle,
+ * retry logic, and auth flow are unchanged.
+ */
+export function RedesignSyncButton() {
+  const { sync, isSyncing, status, error, isEnabled, nextRetryAt } = useSync();
+  const { showToast } = useToast();
+  const [authDialogOpen, setAuthDialogOpen] = useState(false);
+
+  useSyncHealth({
+    isEnabled,
+    onHealthIssue: showToast,
+    onSync: handleSync,
+  });
+
+  const { iconType, tooltip, pendingCount, hasAuthError, retryCountdown } = useSyncStatus({
+    isEnabled,
+    status,
+    error,
+    nextRetryAt,
+    onAuthError: (message, _action, duration) => {
+      showToast(
+        message,
+        {
+          label: "Re-login",
+          onClick: () => setAuthDialogOpen(true),
+        },
+        duration
+      );
+    },
+  });
+
+  async function handleSync() {
+    if (!isEnabled) {
+      setAuthDialogOpen(true);
+      return;
+    }
+    if (hasAuthError) {
+      showToast("Please re-login to continue syncing", undefined, SYNC_TOAST_DURATION.MEDIUM);
+      setAuthDialogOpen(true);
+      return;
+    }
+    await sync();
+  }
+
+  const icon = getIcon(iconType);
+  const dotColor = getDotColor(iconType, hasAuthError);
+  const badgeText = hasAuthError ? "!" : pendingCount > 0 ? String(pendingCount) : null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleSync}
+        disabled={isSyncing}
+        title={tooltip}
+        aria-label={tooltip}
+        style={{
+          position: "relative",
+          width: 36,
+          height: 36,
+          borderRadius: 10,
+          border: "1px solid var(--line)",
+          background: "var(--paper)",
+          color: "var(--ink-2)",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          cursor: isSyncing ? "default" : "pointer",
+          transition: "background .15s, border-color .15s",
+        }}
+        onMouseEnter={(e) => {
+          if (!isSyncing) e.currentTarget.style.background = "var(--bg-inset)";
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.background = "var(--paper)";
+        }}
+      >
+        {icon}
+
+        {dotColor && (
+          <span
+            aria-hidden
+            style={{
+              position: "absolute",
+              top: 6,
+              right: 6,
+              width: 6,
+              height: 6,
+              borderRadius: 999,
+              background: dotColor,
+              boxShadow: "0 0 0 2px var(--paper)",
+            }}
+          />
+        )}
+
+        {badgeText && (
+          <span
+            aria-hidden
+            style={{
+              position: "absolute",
+              top: -4,
+              right: -4,
+              minWidth: 16,
+              height: 16,
+              padding: "0 4px",
+              borderRadius: 999,
+              background: hasAuthError ? "var(--q1)" : "var(--q2)",
+              color: "#fff",
+              fontSize: 10,
+              fontWeight: 600,
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              lineHeight: 1,
+            }}
+          >
+            {badgeText}
+          </span>
+        )}
+
+        {!hasAuthError && retryCountdown !== null && retryCountdown > 0 && (
+          <span
+            className="rd-mono"
+            aria-hidden
+            style={{
+              position: "absolute",
+              bottom: -14,
+              left: "50%",
+              transform: "translateX(-50%)",
+              fontSize: 10,
+              color: "var(--q4)",
+              fontWeight: 600,
+            }}
+          >
+            {retryCountdown}s
+          </span>
+        )}
+      </button>
+
+      <SyncAuthDialog
+        isOpen={authDialogOpen}
+        onClose={() => setAuthDialogOpen(false)}
+        onSuccess={() => setAuthDialogOpen(false)}
+      />
+    </>
+  );
+}
+
+function getIcon(type: IconType) {
+  const size = 16;
+  switch (type) {
+    case "cloud-off":
+      return <CloudOff size={size} />;
+    case "alert-auth":
+      return <AlertCircle size={size} />;
+    case "clock":
+      return <Clock size={size} />;
+    case "cloud-syncing":
+      return <Cloud size={size} style={{ animation: "rd-fade-in 1.2s ease-in-out infinite alternate" }} />;
+    case "check-success":
+      return <Check size={size} />;
+    case "x-error":
+      return <XIcon size={size} />;
+    case "alert-conflict":
+      return <AlertCircle size={size} />;
+    case "cloud-idle":
+    default:
+      return <Cloud size={size} />;
+  }
+}
+
+function getDotColor(type: IconType, hasAuthError: boolean): string | null {
+  if (hasAuthError) return null; // badge shows "!" instead
+  switch (type) {
+    case "cloud-off":
+      return "var(--ink-4)";
+    case "check-success":
+      return "var(--q3)";
+    case "x-error":
+      return "var(--q1)";
+    case "alert-conflict":
+      return "var(--q4)";
+    case "clock":
+      return "var(--q4)";
+    default:
+      return null;
+  }
+}

--- a/components/redesign/task-card.tsx
+++ b/components/redesign/task-card.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import type { TaskRecord } from "@/lib/types";
+import { quadrantForTask } from "@/lib/quadrants";
+import { isOverdue } from "@/lib/redesign/due";
+import { DuePill, QuadrantBadge, SubtaskChip, TagChip } from "./primitives";
+
+export interface TaskCardProps {
+  task: TaskRecord;
+  onToggle?: (task: TaskRecord, checked: boolean) => void;
+  onOpen?: (task: TaskRecord) => void;
+  compact?: boolean;
+  showQuadrant?: boolean;
+}
+
+export function TaskCard({ task, onToggle, onOpen, compact, showQuadrant }: TaskCardProps) {
+  const quadrant = quadrantForTask(task.urgent, task.important);
+  const [hover, setHover] = useState(false);
+  const overdue = isOverdue(task);
+
+  const doneSubtasks = task.subtasks.filter((s) => s.completed).length;
+  const hasMeta = !compact && (task.tags.length > 0 || task.dueDate || task.subtasks.length > 0);
+
+  return (
+    <div
+      className="rd-task-card rd-fade-in"
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      onClick={() => onOpen?.(task)}
+      style={{
+        position: "relative",
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        padding: 14,
+        background: "var(--paper)",
+        border: "1px solid var(--line)",
+        borderLeft: overdue ? `3px solid var(--${quadrant.rdKey})` : "1px solid var(--line)",
+        borderRadius: "var(--rd-radius)",
+        cursor: onOpen ? "pointer" : "default",
+        boxShadow: hover ? "var(--rd-shadow)" : "var(--rd-shadow-sm)",
+        transform: hover ? "translateY(-1px)" : "none",
+        transition: "background .18s, border-color .18s, transform .18s, box-shadow .18s",
+        opacity: task.completed ? 0.55 : 1,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
+        <input
+          className="rd-checkbox"
+          type="checkbox"
+          checked={task.completed}
+          onClick={(e) => e.stopPropagation()}
+          onChange={(e) => onToggle?.(task, e.target.checked)}
+          aria-label={`Complete ${task.title}`}
+          style={{ marginTop: 1 }}
+        />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              fontSize: 14.5,
+              fontWeight: 550,
+              lineHeight: 1.35,
+              color: "var(--ink)",
+              textDecoration: task.completed ? "line-through" : "none",
+            }}
+          >
+            {task.title}
+          </div>
+          {task.description && !compact && (
+            <div
+              className="rd-task-desc"
+              style={{ marginTop: 4, fontSize: 13, color: "var(--ink-3)", lineHeight: 1.4 }}
+            >
+              {task.description}
+            </div>
+          )}
+        </div>
+        {showQuadrant && <QuadrantBadge quadrant={quadrant} size="sm" />}
+      </div>
+
+      {hasMeta && (
+        <div
+          className="rd-task-meta"
+          style={{ display: "flex", flexWrap: "wrap", gap: 6, alignItems: "center", paddingLeft: 30 }}
+        >
+          {task.dueDate && <DuePill dueDate={task.dueDate} />}
+          <SubtaskChip done={doneSubtasks} total={task.subtasks.length} />
+          {task.tags.slice(0, 4).map((t) => (
+            <TagChip key={t}>{t}</TagChip>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/redesign/view-canvas.tsx
+++ b/components/redesign/view-canvas.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AlertCircle } from "lucide-react";
+import type { TaskRecord } from "@/lib/types";
+import { quadrants, quadrantForTask, type RedesignQuadrantKey } from "@/lib/quadrants";
+import { isOverdue } from "@/lib/redesign/due";
+
+export interface ViewCanvasProps {
+  tasks: TaskRecord[];
+  onOpen: (task: TaskRecord) => void;
+}
+
+function idJitter(id: string): { jx: number; jy: number } {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
+  const jx = ((h % 1000) / 1000) * 0.04 - 0.02;
+  const jy = (((h / 1000) % 1000) / 1000) * 0.02 - 0.01;
+  return { jx, jy };
+}
+
+// Per-quadrant grid layout. Each quadrant occupies a 50% × 50% area of the plane;
+// pills are placed in a 2-column grid that stacks downward from each quadrant's top,
+// with a small deterministic jitter to keep the layout feeling organic.
+function layoutTasks(tasks: TaskRecord[]): { task: TaskRecord; x: number; y: number }[] {
+  const buckets: Record<RedesignQuadrantKey, TaskRecord[]> = { q1: [], q2: [], q3: [], q4: [] };
+  tasks.forEach((t) => {
+    const key: RedesignQuadrantKey =
+      t.urgent && t.important ? "q1" : !t.urgent && t.important ? "q2" : t.urgent ? "q3" : "q4";
+    buckets[key].push(t);
+  });
+
+  const COL_OFFSET = 0.09; // distance from quadrant center to each column (9% of plane width)
+  const ROW_START_TOP = 0.14; // first row y for top quadrants (q1, q2)
+  const ROW_START_BOTTOM = 0.62; // first row y for bottom quadrants (q3, q4)
+  const ROW_GAP = 0.09; // gap between rows (9% of plane height)
+
+  const positioned: { task: TaskRecord; x: number; y: number }[] = [];
+
+  (Object.keys(buckets) as RedesignQuadrantKey[]).forEach((key) => {
+    const quadrantTasks = buckets[key];
+    const centerX = key === "q1" || key === "q3" ? 0.75 : 0.25;
+    const rowStart = key === "q1" || key === "q2" ? ROW_START_TOP : ROW_START_BOTTOM;
+    // If only one task in the quadrant, center it rather than sticking it to column 0.
+    const singleTask = quadrantTasks.length === 1;
+
+    quadrantTasks.forEach((task, i) => {
+      const col = i % 2;
+      const row = Math.floor(i / 2);
+      const { jx, jy } = idJitter(task.id);
+      const x = singleTask ? centerX : centerX + (col === 0 ? -COL_OFFSET : COL_OFFSET);
+      const y = rowStart + row * ROW_GAP;
+      positioned.push({ task, x: x + jx, y: y + jy });
+    });
+  });
+
+  return positioned;
+}
+
+export function ViewCanvas({ tasks, onOpen }: ViewCanvasProps) {
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const active = useMemo(() => tasks.filter((t) => !t.completed), [tasks]);
+  const positioned = useMemo(() => layoutTasks(active), [active]);
+
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          marginBottom: 18,
+          flexWrap: "wrap",
+          gap: 12,
+        }}
+      >
+        <div>
+          <div
+            style={{
+              fontSize: 11,
+              letterSpacing: 0.12,
+              textTransform: "uppercase",
+              color: "var(--ink-3)",
+              fontWeight: 600,
+            }}
+          >
+            Decision canvas
+          </div>
+          <h1 className="rd-serif" style={{ margin: "4px 0 0", fontSize: 32, lineHeight: 1.15 }}>
+            Where does your work actually{" "}
+            <em style={{ fontStyle: "italic", color: "var(--q2)" }}>live</em>?
+          </h1>
+        </div>
+        <div style={{ display: "flex", gap: 16, fontSize: 12, color: "var(--ink-3)", flexWrap: "wrap" }}>
+          {quadrants.map((q) => (
+            <span key={q.rdKey} className="inline-flex items-center gap-1.5">
+              <span
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: 999,
+                  background: `var(--${q.rdKey})`,
+                  display: "inline-block",
+                }}
+              />
+              {q.title}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div
+        style={{
+          position: "relative",
+          background: "var(--paper)",
+          border: "1px solid var(--line)",
+          borderRadius: "var(--rd-radius-lg)",
+          padding: 56,
+          height: 620,
+        }}
+      >
+        <div
+          style={{
+            position: "relative",
+            width: "100%",
+            height: "100%",
+            backgroundImage: `
+              linear-gradient(to right, transparent 49.5%, var(--line) 49.5%, var(--line) 50.5%, transparent 50.5%),
+              linear-gradient(to bottom, transparent 49.5%, var(--line) 49.5%, var(--line) 50.5%, transparent 50.5%)
+            `,
+          }}
+        >
+          {/* Quadrant tints behind the gridlines */}
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gridTemplateRows: "1fr 1fr",
+              opacity: 0.5,
+              zIndex: 0,
+            }}
+          >
+            <div style={{ background: "var(--q2-soft)", margin: "0 2px 2px 0" }} />
+            <div style={{ background: "var(--q1-soft)", margin: "0 0 2px 2px" }} />
+            <div style={{ background: "var(--q4-soft)", margin: "2px 2px 0 0" }} />
+            <div style={{ background: "var(--q3-soft)", margin: "2px 0 0 2px" }} />
+          </div>
+
+          <QLabel pos={{ top: 12, left: 14 }} rdKey="q2" />
+          <QLabel pos={{ top: 12, right: 14 }} rdKey="q1" align="right" />
+          <QLabel pos={{ bottom: 12, left: 14 }} rdKey="q4" />
+          <QLabel pos={{ bottom: 12, right: 14 }} rdKey="q3" align="right" />
+
+          <AxisLabel pos={{ left: "50%", top: -32, transform: "translateX(-50%)" }}>
+            ← Not urgent · <strong>Urgency</strong> · Urgent →
+          </AxisLabel>
+          <AxisLabel
+            pos={{
+              left: -38,
+              top: "50%",
+              transform: "rotate(-90deg) translateX(-50%)",
+              transformOrigin: "left center",
+            }}
+          >
+            ← Not important · <strong>Importance</strong> · Important →
+          </AxisLabel>
+
+          {positioned.map(({ task, x, y }) => {
+            const q = quadrantForTask(task.urgent, task.important);
+            const isHovered = hoveredId === task.id;
+            const overdue = isOverdue(task);
+            return (
+              <div
+                key={task.id}
+                onMouseEnter={() => setHoveredId(task.id)}
+                onMouseLeave={() => setHoveredId(null)}
+                onClick={() => onOpen(task)}
+                style={{
+                  position: "absolute",
+                  left: `${x * 100}%`,
+                  top: `${y * 100}%`,
+                  transform: "translate(-50%, -50%)",
+                  zIndex: isHovered ? 10 : 1,
+                  cursor: "pointer",
+                }}
+              >
+                <div
+                  className="inline-flex items-center gap-1.5"
+                  style={{
+                    padding: isHovered ? "6px 12px 6px 8px" : "5px 10px 5px 8px",
+                    background: "var(--paper)",
+                    border: `1px solid var(--${q.rdKey})`,
+                    borderRadius: 999,
+                    boxShadow: isHovered ? "var(--rd-shadow)" : "var(--rd-shadow-sm)",
+                    transform: isHovered ? "scale(1.04)" : "none",
+                    transition: "all .15s",
+                    maxWidth: isHovered ? 320 : 180,
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 7,
+                      height: 7,
+                      borderRadius: 999,
+                      background: `var(--${q.rdKey})`,
+                      flexShrink: 0,
+                      display: "inline-block",
+                    }}
+                  />
+                  <span
+                    style={{
+                      fontSize: 12.5,
+                      fontWeight: 500,
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      color: "var(--ink)",
+                    }}
+                  >
+                    {task.title}
+                  </span>
+                  {overdue && (
+                    <AlertCircle size={11} strokeWidth={2.4} style={{ color: "var(--q1)", flexShrink: 0 }} />
+                  )}
+                </div>
+                {isHovered && task.description && (
+                  <div
+                    style={{
+                      position: "absolute",
+                      top: "calc(100% + 4px)",
+                      left: 0,
+                      padding: "8px 10px",
+                      background: "var(--ink)",
+                      color: "var(--paper)",
+                      borderRadius: 8,
+                      fontSize: 11.5,
+                      maxWidth: 280,
+                      lineHeight: 1.4,
+                    }}
+                  >
+                    {task.description}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <div
+          style={{
+            marginTop: 14,
+            fontSize: 12,
+            color: "var(--ink-3)",
+            textAlign: "center",
+          }}
+        >
+          Tasks near the axes are borderline. Click a pill to open it.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function QLabel({
+  pos,
+  rdKey,
+  align,
+}: {
+  pos: React.CSSProperties;
+  rdKey: RedesignQuadrantKey;
+  align?: "right";
+}) {
+  const q = quadrants.find((x) => x.rdKey === rdKey)!;
+  return (
+    <div
+      style={{
+        position: "absolute",
+        ...pos,
+        textAlign: align ?? "left",
+        pointerEvents: "none",
+        zIndex: 2,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 10,
+          letterSpacing: 0.14,
+          textTransform: "uppercase",
+          fontWeight: 600,
+          color: `var(--${q.rdKey})`,
+        }}
+      >
+        {q.rdTag}
+      </div>
+      <div className="rd-serif" style={{ fontSize: 22, color: "var(--ink)", lineHeight: 1.05, marginTop: 2 }}>
+        {q.title}
+      </div>
+    </div>
+  );
+}
+
+function AxisLabel({ pos, children }: { pos: React.CSSProperties; children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        ...pos,
+        fontSize: 11,
+        color: "var(--ink-3)",
+        letterSpacing: 0.04,
+        whiteSpace: "nowrap",
+        pointerEvents: "none",
+        zIndex: 2,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/redesign/view-editorial.tsx
+++ b/components/redesign/view-editorial.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useDroppable } from "@dnd-kit/core";
+import { Plus } from "lucide-react";
+import type { TaskRecord } from "@/lib/types";
+import { quadrants, type QuadrantMeta, type RedesignQuadrantKey } from "@/lib/quadrants";
+import { DraggableTaskCard } from "./draggable-task-card";
+import { RdButton, RdIconButton, RdQuadrantIcon } from "./primitives";
+
+export interface ViewEditorialProps {
+  tasks: TaskRecord[];
+  onToggle: (task: TaskRecord, completed: boolean) => void;
+  onOpen: (task: TaskRecord) => void;
+  onAdd: (quadrantKey: RedesignQuadrantKey) => void;
+}
+
+function groupByQuadrant(tasks: TaskRecord[]): Record<RedesignQuadrantKey, TaskRecord[]> {
+  const by: Record<RedesignQuadrantKey, TaskRecord[]> = { q1: [], q2: [], q3: [], q4: [] };
+  tasks.forEach((t) => {
+    const active = !t.completed;
+    if (!active) return;
+    const key: RedesignQuadrantKey =
+      t.urgent && t.important ? "q1" : !t.urgent && t.important ? "q2" : t.urgent ? "q3" : "q4";
+    by[key].push(t);
+  });
+  return by;
+}
+
+export function ViewEditorial({ tasks, onToggle, onOpen, onAdd }: ViewEditorialProps) {
+  const by = groupByQuadrant(tasks);
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 18 }} className="rd-editorial-grid">
+      {quadrants.map((q) => (
+        <EditorialColumn key={q.id} quadrant={q} tasks={by[q.rdKey]} onToggle={onToggle} onOpen={onOpen} onAdd={onAdd} />
+      ))}
+    </div>
+  );
+}
+
+function EditorialColumn({
+  quadrant,
+  tasks,
+  onToggle,
+  onOpen,
+  onAdd,
+}: {
+  quadrant: QuadrantMeta;
+  tasks: TaskRecord[];
+  onToggle: (task: TaskRecord, completed: boolean) => void;
+  onOpen: (task: TaskRecord) => void;
+  onAdd: (quadrantKey: RedesignQuadrantKey) => void;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: quadrant.id });
+  return (
+    <section
+      ref={setNodeRef}
+      style={{
+        background: `var(--${quadrant.rdKey}-soft)`,
+        borderRadius: "var(--rd-radius-lg)",
+        padding: "20px 20px 16px",
+        minHeight: 280,
+        position: "relative",
+        overflow: "hidden",
+        boxShadow: isOver ? `inset 0 0 0 2px var(--${quadrant.rdKey})` : "none",
+        transition: "box-shadow .15s ease",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          marginBottom: 18,
+          gap: 10,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "flex-start", gap: 12, minWidth: 0 }}>
+          <span
+            className="inline-grid place-items-center"
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: 9,
+              background: `var(--${quadrant.rdKey}-tint)`,
+              color: `var(--${quadrant.rdKey})`,
+            }}
+          >
+            <RdQuadrantIcon icon={quadrant.rdIcon} size={16} strokeWidth={2} />
+          </span>
+          <div style={{ minWidth: 0 }}>
+            <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+              <h2 className="rd-serif" style={{ margin: 0, fontSize: 26, lineHeight: 1.15 }}>
+                {quadrant.title}
+              </h2>
+              <span style={{ fontSize: 12, color: `var(--${quadrant.rdKey})`, fontWeight: 600 }}>
+                {tasks.length}
+              </span>
+            </div>
+            <div style={{ marginTop: 4, fontSize: 12, color: "var(--ink-3)", letterSpacing: 0.02 }}>
+              {quadrant.rdHint}
+            </div>
+          </div>
+        </div>
+        <RdIconButton
+          onClick={() => onAdd(quadrant.rdKey)}
+          title="Add task to this quadrant"
+          style={{ color: `var(--${quadrant.rdKey})` }}
+        >
+          <Plus size={16} />
+        </RdIconButton>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {tasks.length === 0 ? (
+          <EmptyState quadrant={quadrant} onAdd={onAdd} />
+        ) : (
+          tasks.map((t) => <DraggableTaskCard key={t.id} task={t} onToggle={onToggle} onOpen={onOpen} />)
+        )}
+      </div>
+    </section>
+  );
+}
+
+function EmptyState({
+  quadrant,
+  onAdd,
+}: {
+  quadrant: QuadrantMeta;
+  onAdd: (quadrantKey: RedesignQuadrantKey) => void;
+}) {
+  return (
+    <div
+      style={{
+        padding: "28px 20px",
+        textAlign: "center",
+        border: "1px dashed var(--line)",
+        borderRadius: 12,
+        color: "var(--ink-3)",
+        fontSize: 13,
+      }}
+    >
+      <div
+        className="rd-serif"
+        style={{ fontSize: 18, color: "var(--ink-2)", marginBottom: 4, fontStyle: "italic" }}
+      >
+        {quadrant.rdEmpty}
+      </div>
+      <RdButton variant="ghost" onClick={() => onAdd(quadrant.rdKey)} style={{ marginTop: 8, height: 30, fontSize: 12.5 }}>
+        <Plus size={13} /> Add task
+      </RdButton>
+    </div>
+  );
+}

--- a/components/redesign/view-focus.tsx
+++ b/components/redesign/view-focus.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useMemo } from "react";
+import { Plus } from "lucide-react";
+import type { TaskRecord } from "@/lib/types";
+import { quadrants, type RedesignQuadrantKey } from "@/lib/quadrants";
+import { dueBucket } from "@/lib/redesign/due";
+import { TaskCard } from "./task-card";
+import { Divider, RdButton } from "./primitives";
+
+export interface ViewFocusProps {
+  tasks: TaskRecord[];
+  onToggle: (task: TaskRecord, completed: boolean) => void;
+  onOpen: (task: TaskRecord) => void;
+  onAdd: (quadrantKey?: RedesignQuadrantKey) => void;
+}
+
+function formatDateCaption(now: Date): string {
+  const weekday = now.toLocaleDateString(undefined, { weekday: "long" });
+  const month = now.toLocaleDateString(undefined, { month: "long" });
+  const day = now.getDate();
+  return `${weekday} · ${month} ${day}`;
+}
+
+export function ViewFocus({ tasks, onToggle, onOpen, onAdd }: ViewFocusProps) {
+  const { now, today, next, later, byQuadrant, total } = useMemo(() => {
+    const active = tasks.filter((t) => !t.completed);
+    const now = active.filter((t) => t.urgent && t.important);
+    const today = active.filter(
+      (t) => !(t.urgent && t.important) && dueBucket(t.dueDate) === "today"
+    );
+    const next = active.filter(
+      (t) => !(t.urgent && t.important) && dueBucket(t.dueDate) !== "today" && t.important
+    );
+    const later = active.filter(
+      (t) => !(t.urgent && t.important) && dueBucket(t.dueDate) !== "today" && !t.important
+    );
+    const byQuadrant: Record<RedesignQuadrantKey, number> = { q1: 0, q2: 0, q3: 0, q4: 0 };
+    active.forEach((t) => {
+      const key: RedesignQuadrantKey =
+        t.urgent && t.important ? "q1" : !t.urgent && t.important ? "q2" : t.urgent ? "q3" : "q4";
+      byQuadrant[key]++;
+    });
+    return { now, today, next, later, byQuadrant, total: active.length };
+  }, [tasks]);
+
+  const caption = formatDateCaption(new Date());
+
+  return (
+    <div className="rd-focus-grid">
+      <div>
+        <div style={{ marginBottom: 28 }}>
+          <div
+            style={{
+              fontSize: 12,
+              letterSpacing: 0.12,
+              textTransform: "uppercase",
+              color: "var(--ink-3)",
+              fontWeight: 600,
+              marginBottom: 6,
+            }}
+          >
+            {caption}
+          </div>
+          <h1
+            className="rd-serif"
+            style={{ margin: 0, fontSize: "clamp(30px, 3.6vw, 42px)", lineHeight: 1.15, letterSpacing: "-0.02em" }}
+          >
+            {now.length > 0 ? (
+              <>
+                You have <em style={{ color: "var(--q1)", fontStyle: "italic" }}>{now.length}</em> thing
+                {now.length === 1 ? "" : "s"} to handle now.
+              </>
+            ) : (
+              <>
+                Nothing urgent. Time for <em style={{ color: "var(--q2)", fontStyle: "italic" }}>meaningful</em> work.
+              </>
+            )}
+          </h1>
+        </div>
+
+        <FocusSection label="Now" sub="Urgent & important — handle first" tone="q1" tasks={now} onToggle={onToggle} onOpen={onOpen} />
+        <FocusSection label="Today" sub="Due today" tone="neutral" tasks={today} onToggle={onToggle} onOpen={onOpen} />
+        <FocusSection label="Next" sub="Important, but not urgent" tone="q2" tasks={next} onToggle={onToggle} onOpen={onOpen} />
+        <FocusSection label="Later" sub="Delegate or drop" tone="muted" tasks={later} onToggle={onToggle} onOpen={onOpen} />
+
+        <div style={{ marginTop: 8 }}>
+          <RdButton onClick={() => onAdd("q1")}>
+            <Plus size={14} /> Add task
+          </RdButton>
+        </div>
+      </div>
+
+      <aside className="rd-compass" style={{ position: "sticky", top: 20 }}>
+        <div
+          style={{
+            fontSize: 11,
+            letterSpacing: 0.12,
+            textTransform: "uppercase",
+            color: "var(--ink-3)",
+            fontWeight: 600,
+            marginBottom: 10,
+          }}
+        >
+          Matrix compass
+        </div>
+        <div
+          style={{
+            background: "var(--paper)",
+            border: "1px solid var(--line)",
+            borderRadius: "var(--rd-radius-lg)",
+            padding: 14,
+          }}
+        >
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6 }}>
+            {quadrants.map((q) => {
+              const count = byQuadrant[q.rdKey];
+              return (
+                <button
+                  key={q.rdKey}
+                  type="button"
+                  onClick={() => onAdd(q.rdKey)}
+                  style={{
+                    background: `var(--${q.rdKey}-tint)`,
+                    borderRadius: 10,
+                    padding: "10px 10px 12px",
+                    minHeight: 78,
+                    position: "relative",
+                    border: 0,
+                    textAlign: "left",
+                    cursor: "pointer",
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: 10.5,
+                      fontWeight: 600,
+                      color: `var(--${q.rdKey})`,
+                      letterSpacing: 0.04,
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    {q.rdShort}
+                  </div>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: "var(--ink)", marginTop: 2 }}>{q.title}</div>
+                  <div
+                    className="rd-serif"
+                    style={{
+                      position: "absolute",
+                      right: 10,
+                      bottom: 6,
+                      fontSize: 26,
+                      color: `var(--${q.rdKey})`,
+                      lineHeight: 1,
+                    }}
+                  >
+                    {count}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <Divider style={{ margin: "12px 0" }} />
+          <div style={{ fontSize: 12, color: "var(--ink-3)", lineHeight: 1.5 }}>
+            <strong style={{ color: "var(--ink)" }}>{total}</strong> active ·{" "}
+            {Math.round((byQuadrant.q2 / Math.max(total, 1)) * 100)}% in the{" "}
+            <em className="rd-serif" style={{ fontStyle: "italic" }}>
+              growth
+            </em>{" "}
+            quadrant
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function FocusSection({
+  label,
+  sub,
+  tone,
+  tasks,
+  onToggle,
+  onOpen,
+}: {
+  label: string;
+  sub: string;
+  tone: "q1" | "q2" | "neutral" | "muted";
+  tasks: TaskRecord[];
+  onToggle: (task: TaskRecord, completed: boolean) => void;
+  onOpen: (task: TaskRecord) => void;
+}) {
+  if (tasks.length === 0 && tone !== "q1") return null;
+  const toneMap = {
+    q1: { dot: "var(--q1)", label: "var(--q1)" },
+    q2: { dot: "var(--q2)", label: "var(--q2)" },
+    neutral: { dot: "var(--ink-2)", label: "var(--ink-2)" },
+    muted: { dot: "var(--ink-4)", label: "var(--ink-3)" },
+  }[tone];
+
+  return (
+    <div style={{ marginBottom: 24 }}>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 10, marginBottom: 10 }}>
+        <span style={{ width: 7, height: 7, borderRadius: 999, background: toneMap.dot }} />
+        <h3
+          style={{
+            margin: 0,
+            fontSize: 13,
+            fontWeight: 600,
+            color: toneMap.label,
+            letterSpacing: 0.02,
+            textTransform: "uppercase",
+          }}
+        >
+          {label}
+        </h3>
+        <span style={{ fontSize: 12, color: "var(--ink-3)" }}>{sub}</span>
+        <span className="rd-mono" style={{ marginLeft: "auto", fontSize: 12, color: "var(--ink-3)" }}>
+          {tasks.length}
+        </span>
+      </div>
+      {tasks.length === 0 ? (
+        <div
+          className="rd-serif"
+          style={{ fontStyle: "italic", fontSize: 18, color: "var(--ink-3)", paddingLeft: 18 }}
+        >
+          Nothing here. Nice.
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          {tasks.map((t) => (
+            <TaskCard key={t.id} task={t} onToggle={onToggle} onOpen={onOpen} showQuadrant />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ const config = [
             "worker/.wrangler/**",
             "packages/mcp-server/dist/**",
             "packages/native/ios.backup/build/**",
+            "design_handoff_gsd_redesign/**",
         ],
     },
     ...nextCoreWebVitals,

--- a/lib/quadrants.ts
+++ b/lib/quadrants.ts
@@ -1,5 +1,8 @@
 import type { QuadrantId } from "@/lib/types";
 
+export type RedesignQuadrantKey = "q1" | "q2" | "q3" | "q4";
+export type RedesignIconKey = "flame" | "calendar" | "users" | "trash";
+
 export interface QuadrantMeta {
   id: QuadrantId;
   title: string;
@@ -13,6 +16,15 @@ export interface QuadrantMeta {
   emptyHeadline: string;
   emptyDescription: string;
   emptyCta: string;
+  // Redesign metadata (prototype port)
+  rdKey: RedesignQuadrantKey;
+  rdShort: string; // "Do", "Plan", "Hand", "Drop"
+  rdTag: string; // "Urgent & important"
+  rdHint: string; // "Crises, deadlines. Handle now."
+  rdIcon: RedesignIconKey;
+  rdEmpty: string;
+  urgent: boolean;
+  important: boolean;
 }
 
 export const quadrants: QuadrantMeta[] = [
@@ -28,7 +40,15 @@ export const quadrants: QuadrantMeta[] = [
     emptyEmoji: "🎯",
     emptyHeadline: "No urgent tasks right now",
     emptyDescription: "Great! You're on top of your critical work. Tasks that need immediate attention will appear here.",
-    emptyCta: "Add urgent task"
+    emptyCta: "Add urgent task",
+    rdKey: "q1",
+    rdShort: "Do",
+    rdTag: "Urgent & important",
+    rdHint: "Crises, deadlines. Handle now.",
+    rdIcon: "flame",
+    rdEmpty: "Clear. Nothing urgent demanding you right now.",
+    urgent: true,
+    important: true,
   },
   {
     id: "not-urgent-important",
@@ -42,7 +62,15 @@ export const quadrants: QuadrantMeta[] = [
     emptyEmoji: "📅",
     emptyHeadline: "Nothing scheduled yet",
     emptyDescription: "Plan important but not urgent tasks here. These are your strategic priorities that build long-term value.",
-    emptyCta: "Schedule a task"
+    emptyCta: "Schedule a task",
+    rdKey: "q2",
+    rdShort: "Plan",
+    rdTag: "Important, not urgent",
+    rdHint: "Strategy, growth. Protect time.",
+    rdIcon: "calendar",
+    rdEmpty: "Plan something meaningful. This is where growth lives.",
+    urgent: false,
+    important: true,
   },
   {
     id: "urgent-not-important",
@@ -56,7 +84,15 @@ export const quadrants: QuadrantMeta[] = [
     emptyEmoji: "🤝",
     emptyHeadline: "No delegated tasks",
     emptyDescription: "Tasks that are urgent but could be handled by others go here. Delegation helps you focus on what matters most.",
-    emptyCta: "Add task to delegate"
+    emptyCta: "Add task to delegate",
+    rdKey: "q3",
+    rdShort: "Hand",
+    rdTag: "Urgent, not important",
+    rdHint: "Interruptions. Hand these off.",
+    rdIcon: "users",
+    rdEmpty: "Nothing to hand off.",
+    urgent: true,
+    important: false,
   },
   {
     id: "not-urgent-not-important",
@@ -70,9 +106,30 @@ export const quadrants: QuadrantMeta[] = [
     emptyEmoji: "🗑️",
     emptyHeadline: "Nothing to eliminate",
     emptyDescription: "Perfect! You're avoiding time-wasters. Tasks here should be minimized or removed entirely.",
-    emptyCta: "Add low-priority task"
+    emptyCta: "Add low-priority task",
+    rdKey: "q4",
+    rdShort: "Drop",
+    rdTag: "Neither",
+    rdHint: "Noise. Stop doing these.",
+    rdIcon: "trash",
+    rdEmpty: "No noise to clear. Good.",
+    urgent: false,
+    important: false,
   }
 ];
+
+export function quadrantByRdKey(key: RedesignQuadrantKey): QuadrantMeta {
+  const found = quadrants.find((q) => q.rdKey === key);
+  if (!found) throw new Error(`Unknown redesign quadrant key: ${key}`);
+  return found;
+}
+
+export function quadrantForTask(urgent: boolean, important: boolean): QuadrantMeta {
+  const id = resolveQuadrantId(urgent, important);
+  const found = quadrants.find((q) => q.id === id);
+  if (!found) throw new Error(`Unknown quadrant id: ${id}`);
+  return found;
+}
 
 export const quadrantOrder: QuadrantId[] = quadrants.map((q) => q.id);
 

--- a/lib/redesign/due.ts
+++ b/lib/redesign/due.ts
@@ -1,0 +1,90 @@
+import type { TaskRecord } from "@/lib/types";
+
+export type DueBucket = "overdue" | "today" | "tomorrow" | "thisweek" | "nextweek" | "later" | "none";
+
+function startOfDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+function addDays(d: Date, n: number): Date {
+  const x = new Date(d);
+  x.setDate(x.getDate() + n);
+  return x;
+}
+
+export function dueBucket(iso: string | undefined, now: Date = new Date()): DueBucket {
+  if (!iso) return "none";
+  const due = new Date(iso);
+  if (Number.isNaN(due.getTime())) return "none";
+  const today = startOfDay(now);
+  const dueDay = startOfDay(due);
+  const diff = Math.round((dueDay.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+  if (diff < 0) return "overdue";
+  if (diff === 0) return "today";
+  if (diff === 1) return "tomorrow";
+  if (diff <= 6) return "thisweek";
+  if (diff <= 13) return "nextweek";
+  return "later";
+}
+
+const SHORT_WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+export function formatDueShort(iso: string | undefined, now: Date = new Date()): string | null {
+  if (!iso) return null;
+  const due = new Date(iso);
+  if (Number.isNaN(due.getTime())) return null;
+  const bucket = dueBucket(iso, now);
+  if (bucket === "overdue") return "Overdue";
+  if (bucket === "today") return "Today";
+  if (bucket === "tomorrow") return "Tomorrow";
+  if (bucket === "thisweek") return SHORT_WEEKDAYS[due.getDay()];
+  if (bucket === "nextweek") return "Next week";
+  return due.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+export function isOverdue(task: Pick<TaskRecord, "dueDate" | "completed">, now: Date = new Date()): boolean {
+  if (task.completed) return false;
+  return dueBucket(task.dueDate, now) === "overdue";
+}
+
+/**
+ * Quick-pick date presets used in the composer.
+ * Returns ISO string for the corresponding day at local end of day, or undefined.
+ */
+export function presetDueDate(
+  key: "none" | "today" | "tomorrow" | "thisfri" | "nextweek",
+  now: Date = new Date()
+): string | undefined {
+  if (key === "none") return undefined;
+  const base = startOfDay(now);
+  let target: Date;
+  if (key === "today") {
+    target = base;
+  } else if (key === "tomorrow") {
+    target = addDays(base, 1);
+  } else if (key === "thisfri") {
+    const daysUntilFri = (5 - base.getDay() + 7) % 7 || 7;
+    target = addDays(base, daysUntilFri);
+  } else {
+    target = addDays(base, 7);
+  }
+  target.setHours(17, 0, 0, 0);
+  return target.toISOString();
+}
+
+export function presetLabel(key: "none" | "today" | "tomorrow" | "thisfri" | "nextweek"): string {
+  if (key === "none") return "No date";
+  if (key === "today") return "Today";
+  if (key === "tomorrow") return "Tomorrow";
+  if (key === "thisfri") return "Friday";
+  return "Next week";
+}
+
+export function isSamePresetDue(iso: string | undefined, key: "none" | "today" | "tomorrow" | "thisfri" | "nextweek"): boolean {
+  if (key === "none") return !iso;
+  const preset = presetDueDate(key);
+  if (!iso || !preset) return false;
+  return startOfDay(new Date(iso)).getTime() === startOfDay(new Date(preset)).getTime();
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.3.2",
+	"version": "8.4.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/data/redesign-due.test.ts
+++ b/tests/data/redesign-due.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { dueBucket, formatDueShort, isOverdue, isSamePresetDue, presetDueDate, presetLabel } from "@/lib/redesign/due";
+
+describe("dueBucket", () => {
+  // Use local-time constructors so tests pass regardless of timezone.
+  const today = new Date(2026, 3, 18, 12, 0, 0); // Apr 18, 2026 local noon
+
+  it("returns 'none' when due date is missing or invalid", () => {
+    expect(dueBucket(undefined, today)).toBe("none");
+    expect(dueBucket("", today)).toBe("none");
+    expect(dueBucket("not-a-date", today)).toBe("none");
+  });
+
+  it("classifies overdue dates", () => {
+    expect(dueBucket(new Date(2026, 3, 17, 12, 0, 0).toISOString(), today)).toBe("overdue");
+    expect(dueBucket(new Date(2020, 0, 1, 0, 0, 0).toISOString(), today)).toBe("overdue");
+  });
+
+  it("classifies today and tomorrow", () => {
+    expect(dueBucket(new Date(2026, 3, 18, 0, 30, 0).toISOString(), today)).toBe("today");
+    expect(dueBucket(new Date(2026, 3, 18, 23, 59, 0).toISOString(), today)).toBe("today");
+    expect(dueBucket(new Date(2026, 3, 19, 8, 0, 0).toISOString(), today)).toBe("tomorrow");
+  });
+
+  it("classifies this-week, next-week, later", () => {
+    expect(dueBucket(new Date(2026, 3, 24, 8).toISOString(), today)).toBe("thisweek"); // +6 days
+    expect(dueBucket(new Date(2026, 3, 25, 8).toISOString(), today)).toBe("nextweek"); // +7
+    expect(dueBucket(new Date(2026, 4, 2, 8).toISOString(), today)).toBe("later"); // +14
+  });
+});
+
+describe("formatDueShort", () => {
+  const today = new Date(2026, 3, 18, 12, 0, 0);
+
+  it("returns null for missing due dates", () => {
+    expect(formatDueShort(undefined, today)).toBeNull();
+  });
+
+  it("returns bucket labels for known buckets", () => {
+    expect(formatDueShort(new Date(2026, 3, 17, 12).toISOString(), today)).toBe("Overdue");
+    expect(formatDueShort(new Date(2026, 3, 18, 20).toISOString(), today)).toBe("Today");
+    expect(formatDueShort(new Date(2026, 3, 19, 10).toISOString(), today)).toBe("Tomorrow");
+    expect(formatDueShort(new Date(2026, 3, 25, 10).toISOString(), today)).toBe("Next week");
+  });
+});
+
+describe("isOverdue", () => {
+  const today = new Date(2026, 3, 18, 12, 0, 0);
+
+  it("is false when the task is completed", () => {
+    expect(
+      isOverdue({ dueDate: new Date(2020, 0, 1).toISOString(), completed: true }, today)
+    ).toBe(false);
+  });
+
+  it("is false when there is no due date", () => {
+    expect(isOverdue({ dueDate: undefined, completed: false }, today)).toBe(false);
+  });
+
+  it("is true when due date falls before today", () => {
+    expect(
+      isOverdue({ dueDate: new Date(2026, 3, 17, 12).toISOString(), completed: false }, today)
+    ).toBe(true);
+  });
+});
+
+describe("presetDueDate", () => {
+  it("returns undefined for 'none'", () => {
+    expect(presetDueDate("none")).toBeUndefined();
+  });
+
+  it("returns a date at 5pm local for today and tomorrow", () => {
+    const today = presetDueDate("today")!;
+    expect(new Date(today).getHours()).toBe(17);
+    const tomorrow = presetDueDate("tomorrow")!;
+    expect(new Date(tomorrow).getDate() - new Date(today).getDate()).toBe(1);
+  });
+
+  it("'thisfri' jumps to NEXT Friday when today is Friday", () => {
+    // 2026-04-17 is a Friday local.
+    const friday = new Date("2026-04-17T12:00:00");
+    const result = presetDueDate("thisfri", friday)!;
+    const diffDays = Math.round(
+      (new Date(result).getTime() - friday.getTime()) / (1000 * 60 * 60 * 24)
+    );
+    expect(diffDays).toBeGreaterThanOrEqual(6);
+    expect(diffDays).toBeLessThanOrEqual(8);
+  });
+
+  it("'thisfri' on Monday returns the coming Friday", () => {
+    const monday = new Date("2026-04-13T12:00:00"); // Monday
+    const result = presetDueDate("thisfri", monday)!;
+    expect(new Date(result).getDay()).toBe(5);
+  });
+});
+
+describe("presetLabel", () => {
+  it("has a unique label for each key", () => {
+    const labels = (["none", "today", "tomorrow", "thisfri", "nextweek"] as const).map(presetLabel);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+});
+
+describe("isSamePresetDue", () => {
+  it("matches 'none' when due is undefined", () => {
+    expect(isSamePresetDue(undefined, "none")).toBe(true);
+    expect(isSamePresetDue("2026-04-18T00:00:00Z", "none")).toBe(false);
+  });
+
+  it("matches same calendar day for preset", () => {
+    const today = presetDueDate("today")!;
+    expect(isSamePresetDue(today, "today")).toBe(true);
+    expect(isSamePresetDue(today, "tomorrow")).toBe(false);
+  });
+});

--- a/tests/ui/app-pages.test.tsx
+++ b/tests/ui/app-pages.test.tsx
@@ -14,6 +14,12 @@ vi.mock('next/font/local', () => ({
   default: () => ({ className: 'mock-font', variable: '--font-mock' }),
 }));
 
+vi.mock('next/font/google', () => ({
+  Geist: () => ({ className: 'mock-geist', variable: '--font-geist' }),
+  Geist_Mono: () => ({ className: 'mock-geist-mono', variable: '--font-geist-mono' }),
+  Instrument_Serif: () => ({ className: 'mock-instrument', variable: '--font-instrument-serif' }),
+}));
+
 vi.mock('@/components/theme-provider', () => ({
   ThemeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));

--- a/tests/ui/matrix-page.test.tsx
+++ b/tests/ui/matrix-page.test.tsx
@@ -9,6 +9,10 @@ vi.mock("@/components/matrix-board", () => ({
   MatrixBoard: () => <div data-testid="matrix-board">MatrixBoard</div>,
 }));
 
+vi.mock("@/components/redesign/redesign-matrix", () => ({
+  RedesignMatrix: () => <div data-testid="matrix-board">RedesignMatrix</div>,
+}));
+
 const mockUseTasks = vi.fn().mockReturnValue({ all: [], isLoading: false });
 vi.mock("@/lib/use-tasks", () => ({
   useTasks: (...args: unknown[]) => mockUseTasks(...args),


### PR DESCRIPTION
## Summary

Ships the GSD redesign from `design_handoff_gsd_redesign/README.md` — a three-view reinterpretation of the matrix built as a thin wrapper over the existing Dexie data layer. All task CRUD, sync, and validation pipelines are reused unchanged; only the rendering + view composition changes.

- **Three lenses on the same data**: Focus (default, editorial feed + matrix compass), Matrix (redesigned quadrant columns), Canvas (2D urgency × importance plane with per-quadrant grid layout)
- **New earthy palette** scoped under `.redesign-scope` in `globals.css` so the legacy dashboard/archive/settings routes are untouched
- **QuickAdd bar** with live smart-syntax parsing (`!`, `!!`, `*`, `#tag`) and a dot that previews the inferred quadrant as you type
- **ComposerDrawer** unifies create and edit with priority toggle tiles and a live mini-matrix; click any card to edit it in place
- **Cross-quadrant drag-and-drop retained** via the existing `useDragAndDrop` hook — 8px activation distance preserves click-to-edit
- **Editorial HelpDrawer** (sidebar link + `?` shortcut) with keyboard reference, smart-syntax guide, quadrant reference, and cloud-sync explainer
- **Compact editorial sync button** in the topbar reusing `useSync` / `useSyncStatus` / `useSyncHealth` — same auth dialog, health monitor, and retry pipeline
- **Sidebar** gains Dashboard / Archive / Sync history / Settings / Help / About links, redesign-palette logo, and a build version + date in the footer
- **Background hooks preserved**: `useAutoArchive` and `useNotificationChecker` still run on the main route so auto-archive and due-date notifications keep firing for users who enabled them
- **Responsive**: focus grid collapses < 900 px, sidebar hides < 720 px; full dark-mode token overrides
- **16 new tests** for `lib/redesign/due.ts` (timezone-safe date-bucket adapter)

Version bumped `8.3.2` → `8.4.0`.

## Quality gates

- `bun typecheck` — passes
- `bun lint` — 0 errors, 5 warnings (pre-existing `react-hooks/set-state-in-effect` configured as `warn`)
- `bun run test` — 2051 passing, 16 baseline failures unchanged from `main`
- `bun run build` — compiles cleanly, all 9 static pages generated

## Known deferrals (not in this PR)

These were flagged during implementation and intentionally deferred. Each is a discrete follow-up:

- **Command palette** (`⌘K` / `Ctrl+K`) — not mounted in the redesign shell
- **Smart views + pinned view shortcuts** — keys `1` / `2` / `3` now switch views; users with pinned smart views bound to `1–9` will lose those bindings on the main route
- **Filter bar** — filter popover and `FilterBar` are not wired in
- **Bulk selection + bulk actions bar** — multi-select is not plumbed into the redesign
- **URL highlight parameter** (`?highlight=taskId`) — dashboard drill-in will no longer scroll to the specific card

Other routes (`/dashboard`, `/archive`, `/settings`, `/sync-history`, `/about`) are unchanged and retain all functionality.

## Test plan

- [ ] Focus view renders with headline, four sections, and matrix compass sidebar
- [ ] Matrix view drag-and-drop: drag a card between quadrants, confirm it persists after reload
- [ ] Matrix view click: click a card (no drag), confirm ComposerDrawer opens in edit mode
- [ ] Canvas view: cards grid cleanly inside each quadrant (no overlap)
- [ ] QuickAdd: type `!! test #work`, confirm dot turns sienna and task lands in Do First
- [ ] Composer drawer: add a task with a due-date preset and tags, confirm it appears in all three views
- [ ] Sync button: click when signed out opens auth dialog; click when signed in triggers a sync
- [ ] Help drawer: press `?`, verify all sections render; Esc closes
- [ ] Sidebar: each link (Dashboard / Archive / Sync history / Settings / About) navigates correctly
- [ ] Footer: version (`v8.4.0`) and build date are visible
- [ ] Dark mode: toggle theme, verify tokens flip cleanly including logo + sync button
- [ ] Mobile: at < 720 px, sidebar hides and topbar wraps; at < 900 px, focus grid single-column
- [ ] PWA shortcut: visit `/?action=new-task` — composer opens immediately
- [ ] Auto-archive + notifications: confirm these still fire after a completion (background hooks)