### PR TITLE
feat(discovery): publish RFC 8288/9727/9728 + MCP/skills surface for agents

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import { Toaster } from "sonner";
 import "./globals.css";
 import { cn } from "@/lib/utils";
 import { PwaRegister } from "@/components/pwa-register";
+import { WebMcpRegister } from "@/components/webmcp-register";
 import { InstallPwaPrompt } from "@/components/install-pwa-prompt";
 import { PwaUpdateToast } from "@/components/pwa-update-toast";
 import { ClientLayout } from "@/components/client-layout";
@@ -111,6 +112,7 @@ export default function RootLayout({
                   </ClientLayout>
                   <FirstTimeRedirect />
                   <PwaRegister />
+                  <WebMcpRegister />
                   <InstallPwaPrompt />
                   <PwaUpdateToast />
                   <Toaster richColors position="top-center" />

--- a/cloudfront-function-response-headers.js
+++ b/cloudfront-function-response-headers.js
@@ -1,0 +1,62 @@
+/**
+ * CloudFront Function: Response headers for agent discovery
+ *
+ * Runs as a viewer-response function so it sees both the request URI and the
+ * upstream response headers.
+ *
+ * Responsibilities:
+ *  1. Emit RFC 8288 `Link` response headers on every HTML response so agents
+ *     can discover the API catalog, MCP server card, agent skills index,
+ *     OAuth protected resource metadata, and OpenAPI document with a single
+ *     `HEAD /` request.
+ *  2. Emit `Vary: Accept` on routes that participate in markdown content
+ *     negotiation so shared caches do not collapse the HTML and markdown
+ *     representations.
+ *  3. Force `Content-Type: text/markdown; charset=utf-8` on `.md` documents
+ *     because S3 may return a generic `binary/octet-stream` for them.
+ *
+ * Security headers (CSP, HSTS, frame options, etc.) are still emitted by the
+ * `gsd-security-headers` Response Headers Policy attached to the same
+ * distribution; this function only adds discovery-related headers.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function handler(event) {
+  var request = event.request;
+  var response = event.response;
+  var headers = response.headers;
+  var uri = request.uri;
+
+  var contentType = headers['content-type'] && headers['content-type'].value;
+  var isHtml = contentType && contentType.indexOf('text/html') === 0;
+  var isMarkdown = uri.endsWith('.md');
+
+  // Force the canonical markdown content type — agents check this byte for byte.
+  if (isMarkdown) {
+    headers['content-type'] = { value: 'text/markdown; charset=utf-8' };
+  }
+
+  // RFC 8288 Link header — emitted on HTML and markdown root documents.
+  // Multiple relations are comma-separated within a single header value.
+  if (isHtml || isMarkdown) {
+    var links = [
+      '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
+      '</.well-known/openapi/pocketbase.json>; rel="service-desc"; type="application/openapi+json"',
+      '</.well-known/oauth-protected-resource>; rel="oauth-protected-resource"; type="application/json"',
+      '</.well-known/mcp/server-card.json>; rel="mcp-server"; type="application/json"',
+      '</.well-known/agent-skills/index.json>; rel="agent-skills"; type="application/json"',
+      '<https://github.com/vscarpenter/gsd-taskmanager>; rel="describedby"; type="text/html"'
+    ];
+    headers['link'] = { value: links.join(', ') };
+  }
+
+  // Mark routes that participate in `Accept` content negotiation. We append
+  // to any existing Vary header to preserve upstream values (e.g. `Cookie`).
+  if (isHtml || isMarkdown) {
+    var existingVary = headers['vary'] && headers['vary'].value;
+    headers['vary'] = {
+      value: existingVary && existingVary.length > 0 ? existingVary + ', Accept' : 'Accept'
+    };
+  }
+
+  return response;
+}

--- a/cloudfront-function-url-rewrite.js
+++ b/cloudfront-function-url-rewrite.js
@@ -1,13 +1,18 @@
 /**
  * CloudFront Function: URL Rewrite for Static Export with Trailing Slashes
  *
- * This function rewrites directory paths to include index.html for Next.js static exports.
- * It handles paths like /dashboard/ → /dashboard/index.html before the request reaches S3.
+ * Two responsibilities:
+ *  1. Rewrite directory paths to include `index.html` for Next.js static
+ *     export (e.g. `/dashboard/` → `/dashboard/index.html`).
+ *  2. Markdown for Agents (RFC-style content negotiation): when the request
+ *     includes `Accept: text/markdown`, rewrite the URI to the `.md` sibling
+ *     so agents receive the markdown rendition while browsers continue to
+ *     receive HTML by default. The companion viewer-response function adds
+ *     `Vary: Accept` so caches do not collapse the two representations.
  *
- * CloudFront Functions run at CloudFront edge locations with sub-millisecond latency.
- *
- * Note: Security headers are handled by a CloudFront Response Headers Policy
- * (gsd-security-headers) which is the AWS-recommended approach.
+ * CloudFront Functions run at CloudFront edge locations with sub-millisecond
+ * latency. Security headers and Link headers are emitted by the
+ * `gsd-response-headers` viewer-response function, not here.
  *
  * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html
  */
@@ -15,14 +20,21 @@
 function handler(event) {
   var request = event.request;
   var uri = request.uri;
+  var headers = request.headers;
 
-  // If URI ends with /, append index.html
+  // 1. Resolve trailing-slash and extensionless paths to their `index.html`.
   if (uri.endsWith('/')) {
     request.uri = uri + 'index.html';
-  }
-  // If URI has no file extension and doesn't end with /, append /index.html
-  else if (!uri.includes('.') && uri !== '/') {
+  } else if (!uri.includes('.') && uri !== '/') {
     request.uri = uri + '/index.html';
+  }
+
+  // 2. Markdown for Agents — content negotiation on `Accept`.
+  //    Only rewrite paths that resolve to an `index.html` (i.e. routes), and
+  //    only when the client *prefers* markdown.
+  var accept = headers['accept'] && headers['accept'].value;
+  if (accept && /text\/markdown/i.test(accept) && request.uri.endsWith('/index.html')) {
+    request.uri = request.uri.replace(/index\.html$/, 'index.md');
   }
 
   return request;

--- a/components/webmcp-register.tsx
+++ b/components/webmcp-register.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect } from "react";
+import { createLogger } from "@/lib/logger";
+
+const logger = createLogger("WEBMCP");
+
+type WebMCPToolInput = {
+	title?: string;
+	description?: string;
+	urgent?: boolean;
+	important?: boolean;
+	dueDate?: string;
+	tags?: string[];
+};
+
+type WebMCPToolDefinition = {
+	name: string;
+	description: string;
+	inputSchema: Record<string, unknown>;
+	execute: (input: WebMCPToolInput) => Promise<unknown>;
+};
+
+type WebMCPProvider = {
+	provideContext: (context: { tools: WebMCPToolDefinition[] }) => Promise<void> | void;
+};
+
+declare global {
+	interface Navigator {
+		modelContext?: WebMCPProvider;
+	}
+}
+
+const TOOLS: WebMCPToolDefinition[] = [
+	{
+		name: "create_task",
+		description:
+			"Create a new task in the user's local GSD Task Manager. The task is saved in IndexedDB on this device and synced if cloud sync is enabled.",
+		inputSchema: {
+			type: "object",
+			required: ["title"],
+			properties: {
+				title: {
+					type: "string",
+					description: "Short, action-oriented title (e.g. 'Review PR #42').",
+					minLength: 1,
+					maxLength: 200,
+				},
+				description: {
+					type: "string",
+					description: "Optional longer notes for the task.",
+					maxLength: 2000,
+				},
+				urgent: {
+					type: "boolean",
+					description: "Whether the task is time-sensitive. Defaults to false.",
+				},
+				important: {
+					type: "boolean",
+					description: "Whether the task contributes to long-term goals. Defaults to true.",
+				},
+				dueDate: {
+					type: "string",
+					format: "date-time",
+					description: "Optional ISO-8601 due date with timezone offset.",
+				},
+				tags: {
+					type: "array",
+					items: { type: "string", minLength: 1, maxLength: 32 },
+					description: "Optional list of lowercase, kebab-case tags.",
+				},
+			},
+		},
+		execute: async (input) => {
+			// Imported lazily so the WebMCP module never blocks the main bundle.
+			const { createTask } = await import("@/lib/tasks");
+			const record = await createTask({
+				title: (input.title ?? "").trim(),
+				description: input.description ?? "",
+				urgent: input.urgent ?? false,
+				important: input.important ?? true,
+				dueDate: input.dueDate,
+				recurrence: "none",
+				tags: input.tags ?? [],
+				subtasks: [],
+				dependencies: [],
+				notificationEnabled: true,
+			});
+			return {
+				id: record.id,
+				quadrant: record.quadrant,
+				createdAt: record.createdAt,
+			};
+		},
+	},
+];
+
+export function WebMcpRegister() {
+	useEffect(() => {
+		if (typeof navigator === "undefined" || !navigator.modelContext?.provideContext) {
+			return;
+		}
+
+		const result = navigator.modelContext.provideContext({ tools: TOOLS });
+		Promise.resolve(result)
+			.then(() => logger.info("WebMCP context registered", { tools: TOOLS.length }))
+			.catch((error: unknown) =>
+				logger.warn("WebMCP context registration failed", {
+					message: error instanceof Error ? error.message : String(error),
+				}),
+			);
+	}, []);
+
+	return null;
+}

--- a/docs/adr/0010-agent-discovery-surface.md
+++ b/docs/adr/0010-agent-discovery-surface.md
@@ -1,0 +1,116 @@
+# 0010: Agent Discovery Surface
+
+**Date:** 2026-04-20
+**Status:** Accepted
+**Deciders:** Vinny Carpenter
+
+## Context
+
+External agent-readiness scanners (e.g. `isitagentready.com`) flagged that
+`https://gsd.vinny.dev` exposes no machine-readable affordances for AI
+agents: no `Link` headers (RFC 8288), no `application/linkset+json` API
+catalog (RFC 9727), no OAuth Protected Resource Metadata (RFC 9728), no MCP
+Server Card, no Agent Skills index, no `Content-Signal` directives in
+`robots.txt`, and no `Accept: text/markdown` content negotiation.
+
+GSD already ships an MCP server (`gsd-mcp-server` on npm) and a PocketBase
+backend at `https://api.vinny.io`. The existing infrastructure can be made
+discoverable cheaply if we expose the right metadata files and response
+headers. Doing so unlocks two practical wins:
+
+1. Agents that crawl with `HEAD /` see one `Link` header and can fetch every
+   discovery document without further guessing.
+2. In-page agents (browser extensions implementing WebMCP) can call the
+   site's `create_task` tool directly, without scraping the DOM.
+
+Because the site is a Next.js static export served from S3 + CloudFront, the
+implementation has constraints: no Next.js middleware, no API routes, no
+runtime content negotiation. All discovery resources must be static files in
+`public/`, and HTTP-level concerns (response headers, content negotiation)
+must be handled at the CDN edge.
+
+## Decision
+
+Expose the following surface, all of it cacheable, all of it static:
+
+### Static files (under `public/`)
+
+| Path | Type | Purpose |
+| --- | --- | --- |
+| `/.well-known/api-catalog` | `application/linkset+json` | RFC 9727 linkset that anchors the PocketBase API and the MCP server |
+| `/.well-known/openapi/pocketbase.json` | `application/openapi+json` | OpenAPI 3.1 description of the GSD-specific PocketBase endpoints |
+| `/.well-known/oauth-protected-resource` | `application/json` | RFC 9728 metadata pointing to PocketBase as the authorization server |
+| `/.well-known/mcp/server-card.json` | `application/json` | SEP-1649-style server card for `gsd-mcp-server` |
+| `/.well-known/agent-skills/index.json` | `application/json` | Agent Skills Discovery v0.2.0 index |
+| `/.well-known/agent-skills/{slug}/SKILL.md` | `text/markdown` | Individual skill documents (`quick-capture`, `triage-inbox`) with SHA-256 digests in the index |
+| `/index.md`, `/about/index.md` | `text/markdown` | Markdown renditions of the homepage and About page for `Accept: text/markdown` clients |
+| `/robots.txt` | `text/plain` | Adds `Content-Signal: search=yes, ai-input=yes, ai-train=no` per the AI Preferences draft |
+
+### CloudFront edge functions
+
+- `gsd-url-rewrite` (viewer-request) gains a second responsibility:
+  when the request includes `Accept: text/markdown`, rewrite the URI from
+  `…/index.html` to `…/index.md` so S3 returns the markdown rendition.
+- `gsd-response-headers` is a new viewer-response function that emits an
+  RFC 8288 `Link` header on every HTML and markdown response, advertises
+  `Vary: Accept`, and forces `Content-Type: text/markdown; charset=utf-8` on
+  `.md` documents (S3 sometimes serves them as `binary/octet-stream`).
+
+### In-browser tooling
+
+- `components/webmcp-register.tsx` calls
+  `navigator.modelContext.provideContext()` on mount when the WebMCP API is
+  available, exposing a single `create_task` tool that writes to the
+  user's local IndexedDB through the existing `lib/tasks/createTask` path.
+
+### Deploy automation
+
+- `scripts/fix-discovery-content-types.sh` patches Content-Type metadata on
+  the well-known files after `aws s3 sync` (S3 cannot infer the right type
+  for `application/linkset+json`, the no-extension `api-catalog` file, or
+  `application/openapi+json`).
+- `scripts/deploy-cloudfront-function.sh` now publishes both edge functions
+  and attaches them to the distribution (viewer-request + viewer-response).
+
+## Consequences
+
+### Easier
+- A single `HEAD /` reveals the entire programmatic surface to any compliant
+  agent crawler.
+- WebMCP-aware browser agents can create tasks without scraping the UI.
+- Markdown renditions reduce token cost when LLMs ingest the homepage.
+- The `Content-Signal` directives publish an explicit AI-training stance
+  alongside the existing `robots.txt` entries.
+
+### Harder
+- Two CloudFront Functions instead of one, both of which must be re-published
+  when their source changes. The deploy script handles this in one command,
+  but engineers need to know the second function exists.
+- Markdown renditions must be hand-maintained until we either generate them
+  from the React tree or accept that they only describe the static landing
+  surfaces (homepage + About).
+- `Vary: Accept` makes shared caches store two representations per route,
+  doubling cache footprint for the homepage and About page.
+
+### Out of scope
+- A site-wide markdown rendition for every authenticated route (the matrix,
+  dashboard, and settings pages are interactive React state and have no
+  meaningful static markdown).
+- Publishing `/.well-known/openid-configuration` here. PocketBase owns the
+  authorization server; that document belongs on `api.vinny.io`, not on the
+  resource server.
+- Server-side WebMCP fallback for browsers without `navigator.modelContext`.
+  The MCP server (`gsd-mcp-server`) covers that case via stdio.
+
+## Alternatives Considered
+
+- **Cloudflare's "Markdown for Agents" feature** — automatically produces
+  markdown from HTML at the edge, but only on Cloudflare's CDN. We use
+  CloudFront, so we ship pre-rendered markdown instead.
+- **A single CloudFront viewer-request function that rewrites and adds
+  response headers via Lambda@Edge** — more powerful but adds cold-start
+  latency and a second deployment surface. Two CloudFront Functions are
+  cheaper and simpler.
+- **Embedding the `Link` header source list in JS at runtime** — would not
+  be visible to crawlers that only inspect HTTP headers, defeating the
+  purpose of RFC 8288.

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -47,7 +47,8 @@ export type LogContext =
   | 'NOTIFICATIONS'
   | 'IMPORT'
   | 'SMART_VIEWS'
-  | 'ERROR_BOUNDARY';
+  | 'ERROR_BOUNDARY'
+  | 'WEBMCP';
 
 export interface LogMetadata {
   [key: string]: unknown;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"test:watch": "vitest",
 		"typecheck": "tsc --noEmit",
 		"export": "next export",
-		"deploy:s3": "bash -c 'aws s3 sync out/ s3://gsd.vinny.dev/ --delete --exclude \"*.html\" --exclude \"sw.js\" --cache-control \"public,max-age=31536000,immutable\" && aws s3 sync out/ s3://gsd.vinny.dev/ --exclude \"*\" --include \"*.html\" --include \"sw.js\" --cache-control \"public,max-age=0,must-revalidate\" && aws s3 cp s3://gsd.vinny.dev/index.html s3://gsd.vinny.dev/index.html --metadata-directive REPLACE --cache-control \"no-cache,no-store,must-revalidate\" --content-type \"text/html\"'",
+		"deploy:s3": "bash -c 'aws s3 sync out/ s3://gsd.vinny.dev/ --delete --exclude \"*.html\" --exclude \"sw.js\" --cache-control \"public,max-age=31536000,immutable\" && aws s3 sync out/ s3://gsd.vinny.dev/ --exclude \"*\" --include \"*.html\" --include \"sw.js\" --cache-control \"public,max-age=0,must-revalidate\" && aws s3 cp s3://gsd.vinny.dev/index.html s3://gsd.vinny.dev/index.html --metadata-directive REPLACE --cache-control \"no-cache,no-store,must-revalidate\" --content-type \"text/html\" && bash scripts/fix-discovery-content-types.sh s3://gsd.vinny.dev'",
 		"deploy:cf": "aws cloudfront create-invalidation --distribution-id E1T6GDX0TQEP94 --paths '/*'",
 		"deploy": "bun run build && bun run deploy:s3 && bun run deploy:cf",
 		"deploy:dev": "bash scripts/deploy-dev.sh"

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://agentskills.io/schemas/v0.2.0/index.schema.json",
+  "version": "0.2.0",
+  "publisher": {
+    "name": "GSD Task Manager",
+    "url": "https://gsd.vinny.dev",
+    "contact": "https://github.com/vscarpenter/gsd-taskmanager/issues"
+  },
+  "skills": [
+    {
+      "name": "quick-capture",
+      "type": "skill.md",
+      "description": "Drop a single new task into GSD Task Manager and place it in the right Eisenhower quadrant.",
+      "url": "https://gsd.vinny.dev/.well-known/agent-skills/quick-capture/SKILL.md",
+      "sha256": "7c3a5503a019d769a54313d3b491e661c616e5b0144cab9185e0da1e2546abd6"
+    },
+    {
+      "name": "triage-inbox",
+      "type": "skill.md",
+      "description": "Walk the user through their open tasks and move them into the correct quadrant.",
+      "url": "https://gsd.vinny.dev/.well-known/agent-skills/triage-inbox/SKILL.md",
+      "sha256": "65c40b09b8cb91549c6f99fec3a9715bf218fd319580048425aa71a5e9417718"
+    }
+  ]
+}

--- a/public/.well-known/agent-skills/quick-capture/SKILL.md
+++ b/public/.well-known/agent-skills/quick-capture/SKILL.md
@@ -1,0 +1,28 @@
+# Skill: Quick Capture
+
+Use this skill to drop a new task into GSD Task Manager from any AI assistant
+that has the `gsd-mcp-server` connected.
+
+## Trigger
+
+Invoke when the user asks to "add a task", "remind me to", "capture", "queue
+up", or similar phrasing that maps to creating a single new task.
+
+## Steps
+
+1. Decide quadrant from the user's wording:
+   - explicit deadline today / blocking → `urgent=true, important=true`
+   - long-term planning, learning, prep → `urgent=false, important=true`
+   - quick favor, low value request → `urgent=true, important=false`
+   - everything else → `urgent=false, important=false`
+2. Call `create_task` with `{ title, urgent, important, tags?, dueAt? }`.
+   Pass `dryRun: true` first when the user is exploring options.
+3. If the user named a project, add it as a tag (lowercase, kebab-case).
+4. Confirm the created quadrant back to the user in one short sentence.
+
+## Anti-goals
+
+- Do not create more than one task per invocation. Use `bulk_update_tasks` for
+  batch work instead.
+- Do not invent due dates the user did not state.
+- Do not modify existing tasks; that belongs in the `triage-inbox` skill.

--- a/public/.well-known/agent-skills/triage-inbox/SKILL.md
+++ b/public/.well-known/agent-skills/triage-inbox/SKILL.md
@@ -1,0 +1,28 @@
+# Skill: Triage Inbox
+
+Use this skill to walk the user through their unfiled or stale tasks and move
+them into the right Eisenhower quadrant.
+
+## Trigger
+
+Invoke when the user asks to "triage", "clean up my inbox", "what should I
+work on", or "review my open tasks".
+
+## Steps
+
+1. Call `list_tasks` with `status: "open"` and sort by `client_updated_at` asc.
+2. Call `get_task_stats` to surface quadrant distribution and stale counts.
+3. For each task older than 7 days with `urgent=false, important=false`,
+   suggest archive or completion. Use `complete_task` or `delete_task` only
+   after the user confirms each action.
+4. For tasks the user reclassifies, call `update_task` with the new
+   `urgent` / `important` flags. Prefer `bulk_update_tasks` when applying the
+   same change to 3+ tasks.
+5. End with a one-line summary of how the quadrants shifted.
+
+## Anti-goals
+
+- Never auto-delete tasks without explicit user confirmation per task or batch.
+- Do not change `dueAt` during triage; the user may need that history.
+- Do not mark recurring tasks complete unless the user asks; completing one
+  silently spawns the next instance.

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,65 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://api.vinny.io/api/",
+      "service-doc": [
+        {
+          "href": "https://pocketbase.io/docs/api-records/",
+          "type": "text/html",
+          "title": "PocketBase Records API documentation"
+        }
+      ],
+      "service-desc": [
+        {
+          "href": "https://gsd.vinny.dev/.well-known/openapi/pocketbase.json",
+          "type": "application/openapi+json",
+          "title": "GSD PocketBase REST API (OpenAPI 3.1)"
+        }
+      ],
+      "status": [
+        {
+          "href": "https://api.vinny.io/api/health",
+          "type": "application/json",
+          "title": "PocketBase health endpoint"
+        }
+      ],
+      "oauth-authorization-server": [
+        {
+          "href": "https://api.vinny.io",
+          "title": "PocketBase OAuth2 issuer"
+        }
+      ],
+      "related": [
+        {
+          "href": "https://github.com/vscarpenter/gsd-taskmanager",
+          "type": "text/html",
+          "title": "GSD Task Manager source repository"
+        }
+      ]
+    },
+    {
+      "anchor": "https://www.npmjs.com/package/gsd-mcp-server",
+      "service-doc": [
+        {
+          "href": "https://github.com/vscarpenter/gsd-taskmanager/blob/main/packages/mcp-server/README.md",
+          "type": "text/markdown",
+          "title": "GSD MCP Server documentation"
+        }
+      ],
+      "service-desc": [
+        {
+          "href": "https://gsd.vinny.dev/.well-known/mcp/server-card.json",
+          "type": "application/json",
+          "title": "GSD MCP Server Card"
+        }
+      ],
+      "related": [
+        {
+          "href": "https://modelcontextprotocol.io/",
+          "type": "text/html",
+          "title": "Model Context Protocol specification"
+        }
+      ]
+    }
+  ]
+}

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/server-card.schema.json",
+  "schemaVersion": "0.1.0",
+  "serverInfo": {
+    "name": "gsd-mcp-server",
+    "version": "0.9.0",
+    "title": "GSD Task Manager MCP Server",
+    "description": "Read, create, update, and analyze tasks in GSD Task Manager from any MCP-aware assistant.",
+    "vendor": "Vinny Carpenter",
+    "homepage": "https://gsd.vinny.dev",
+    "documentation": "https://github.com/vscarpenter/gsd-taskmanager/blob/main/packages/mcp-server/README.md",
+    "license": "MIT",
+    "repository": "https://github.com/vscarpenter/gsd-taskmanager"
+  },
+  "transports": [
+    {
+      "type": "stdio",
+      "package": {
+        "registry": "npm",
+        "name": "gsd-mcp-server",
+        "binary": "gsd-mcp-server"
+      },
+      "install": {
+        "command": "npx",
+        "args": ["-y", "gsd-mcp-server"]
+      },
+      "env": {
+        "GSD_POCKETBASE_URL": {
+          "description": "Base URL of the PocketBase deployment that holds the user's tasks.",
+          "default": "https://api.vinny.io",
+          "required": true
+        },
+        "GSD_AUTH_TOKEN": {
+          "description": "PocketBase auth token for the user (obtain via GSD Task Manager Settings → Sync).",
+          "required": true,
+          "secret": true
+        }
+      }
+    }
+  ],
+  "capabilities": {
+    "tools": { "listChanged": false },
+    "resources": false,
+    "prompts": false,
+    "logging": true
+  },
+  "tools": [
+    { "name": "list_tasks", "category": "read" },
+    { "name": "get_task", "category": "read" },
+    { "name": "search_tasks", "category": "read" },
+    { "name": "get_sync_status", "category": "read" },
+    { "name": "list_devices", "category": "read" },
+    { "name": "get_task_stats", "category": "read" },
+    { "name": "get_token_status", "category": "read" },
+    { "name": "create_task", "category": "write" },
+    { "name": "update_task", "category": "write" },
+    { "name": "complete_task", "category": "write" },
+    { "name": "delete_task", "category": "write" },
+    { "name": "bulk_update_tasks", "category": "write" },
+    { "name": "get_productivity_metrics", "category": "analytics" },
+    { "name": "get_quadrant_analysis", "category": "analytics" },
+    { "name": "get_tag_analytics", "category": "analytics" },
+    { "name": "get_upcoming_deadlines", "category": "analytics" },
+    { "name": "get_task_insights", "category": "analytics" },
+    { "name": "validate_config", "category": "system" },
+    { "name": "get_help", "category": "system" },
+    { "name": "get_cache_stats", "category": "system" }
+  ],
+  "authentication": {
+    "type": "oauth2",
+    "discovery": "https://gsd.vinny.dev/.well-known/oauth-protected-resource"
+  }
+}

--- a/public/.well-known/oauth-protected-resource
+++ b/public/.well-known/oauth-protected-resource
@@ -1,0 +1,12 @@
+{
+  "resource": "https://gsd.vinny.dev",
+  "authorization_servers": [
+    "https://api.vinny.io"
+  ],
+  "bearer_methods_supported": ["header"],
+  "scopes_supported": ["openid", "profile", "email"],
+  "resource_documentation": "https://github.com/vscarpenter/gsd-taskmanager#cloud-sync",
+  "resource_signing_alg_values_supported": ["RS256"],
+  "resource_name": "GSD Task Manager",
+  "resource_policy_uri": "https://gsd.vinny.dev/about"
+}

--- a/public/.well-known/openapi/pocketbase.json
+++ b/public/.well-known/openapi/pocketbase.json
@@ -1,0 +1,187 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "GSD Task Manager — PocketBase API",
+    "version": "1.0.0",
+    "summary": "Optional cloud sync backend for the GSD Task Manager.",
+    "description": "Subset of the self-hosted PocketBase REST API used by GSD Task Manager for multi-device sync. All endpoints require an authenticated user and operate only on records owned by that user. PocketBase exposes its own auto-generated OpenAPI documentation in the admin UI; this document only covers the GSD-specific collections (tasks, devices) and their semantics.",
+    "contact": {
+      "name": "Vinny Carpenter",
+      "url": "https://github.com/vscarpenter/gsd-taskmanager"
+    },
+    "license": {
+      "name": "MIT",
+      "identifier": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://api.vinny.io",
+      "description": "Production PocketBase deployment"
+    }
+  ],
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
+  "paths": {
+    "/api/health": {
+      "get": {
+        "operationId": "getHealth",
+        "summary": "PocketBase health check",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Service is healthy",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Health" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/collections/tasks/records": {
+      "get": {
+        "operationId": "listTasks",
+        "summary": "List tasks owned by the authenticated user",
+        "parameters": [
+          { "name": "page", "in": "query", "schema": { "type": "integer", "minimum": 1 } },
+          { "name": "perPage", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 500 } },
+          { "name": "sort", "in": "query", "schema": { "type": "string" }, "example": "-client_updated_at" },
+          { "name": "filter", "in": "query", "schema": { "type": "string" }, "example": "status = 'open'" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of tasks",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TaskList" }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createTask",
+        "summary": "Create a new task",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/Task" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Created task",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Task" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/collections/tasks/records/{id}": {
+      "parameters": [
+        { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+      ],
+      "get": {
+        "operationId": "getTask",
+        "summary": "Get a single task by id",
+        "responses": {
+          "200": {
+            "description": "Task record",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Task" }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateTask",
+        "summary": "Update a task (last-write-wins by client_updated_at)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/Task" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated task",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Task" }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteTask",
+        "summary": "Delete a task",
+        "responses": { "204": { "description": "Deleted" } }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "PocketBase auth token"
+      }
+    },
+    "schemas": {
+      "Health": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "integer" },
+          "message": { "type": "string" }
+        }
+      },
+      "TaskList": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "integer" },
+          "perPage": { "type": "integer" },
+          "totalItems": { "type": "integer" },
+          "totalPages": { "type": "integer" },
+          "items": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Task" }
+          }
+        }
+      },
+      "Task": {
+        "type": "object",
+        "required": ["id", "owner", "title"],
+        "properties": {
+          "id": { "type": "string", "description": "Task identifier (nanoid)" },
+          "owner": { "type": "string", "description": "Owning user id" },
+          "device_id": { "type": "string", "description": "Originating device for echo filtering" },
+          "title": { "type": "string" },
+          "notes": { "type": "string" },
+          "urgent": { "type": "boolean" },
+          "important": { "type": "boolean" },
+          "status": { "type": "string", "enum": ["open", "completed", "archived"] },
+          "tags": { "type": "array", "items": { "type": "string" } },
+          "due_at": { "type": "string", "format": "date-time", "nullable": true },
+          "client_updated_at": { "type": "string", "format": "date-time" },
+          "created": { "type": "string", "format": "date-time" },
+          "updated": { "type": "string", "format": "date-time" }
+        }
+      }
+    }
+  }
+}

--- a/public/about/index.md
+++ b/public/about/index.md
@@ -1,0 +1,50 @@
+# About GSD Task Manager
+
+GSD Task Manager is an open-source, privacy-first task manager built around
+the Eisenhower Matrix. It runs entirely in the browser as a Progressive Web
+App. Optional multi-device sync is available through a self-hosted PocketBase
+backend.
+
+This file is the markdown rendition of <https://gsd.vinny.dev/about>, served
+when a client sends `Accept: text/markdown`.
+
+## What it does
+
+- Classifies every task by **urgency** and **importance** (the four Eisenhower
+  quadrants).
+- Runs offline by default — IndexedDB via Dexie is the source of truth.
+- Ships as an installable PWA with a service worker, push notifications, and
+  badge updates.
+- Adds optional cloud sync (PocketBase + OAuth via Google or GitHub) for
+  users who want their tasks on multiple devices.
+- Exposes an MCP server (`gsd-mcp-server` on npm) so MCP-aware assistants can
+  read and mutate tasks with the user's permission.
+
+## Architecture at a glance
+
+| Layer | Tech | Notes |
+| --- | --- | --- |
+| UI | Next.js 16 App Router, React 19 | Static export — no SSR, no API routes |
+| Storage | IndexedDB via Dexie v13 | Local first; export to JSON for backup |
+| Sync | PocketBase 0.23+ | Last-write-wins; SSE realtime; opt-in |
+| Auth | PocketBase OAuth2 (Google, GitHub) | Tokens persisted in `localStorage` |
+| MCP | `gsd-mcp-server` (stdio) | 20 tools across read, write, analytics |
+| Hosting | S3 + CloudFront | Edge function rewrites paths and adds Link headers |
+
+## Programmatic interfaces for agents
+
+| Resource | URL |
+| --- | --- |
+| API catalog | <https://gsd.vinny.dev/.well-known/api-catalog> |
+| OpenAPI 3.1 (sync backend) | <https://gsd.vinny.dev/.well-known/openapi/pocketbase.json> |
+| OAuth Protected Resource | <https://gsd.vinny.dev/.well-known/oauth-protected-resource> |
+| MCP Server Card | <https://gsd.vinny.dev/.well-known/mcp/server-card.json> |
+| Agent Skills index | <https://gsd.vinny.dev/.well-known/agent-skills/index.json> |
+| WebMCP | Loaded at runtime via `navigator.modelContext.provideContext()` |
+
+## Project links
+
+- **Source:** <https://github.com/vscarpenter/gsd-taskmanager>
+- **MCP package:** <https://www.npmjs.com/package/gsd-mcp-server>
+- **License:** MIT
+- **Maintainer:** Vinny Carpenter

--- a/public/index.md
+++ b/public/index.md
@@ -1,0 +1,64 @@
+# GSD Task Manager
+
+> Prioritize what matters with a privacy-first Eisenhower matrix.
+
+GSD ("get stuff done") is a browser-native task manager that classifies work
+into the four Eisenhower quadrants — urgent/important, important-only,
+urgent-only, and neither. All data lives locally in IndexedDB. A self-hosted
+PocketBase deployment is available for opt-in cloud sync across devices.
+
+This file is the markdown rendition of <https://gsd.vinny.dev>, served when a
+client sends `Accept: text/markdown`.
+
+## Quadrants
+
+| Quadrant | Label | Action |
+| --- | --- | --- |
+| Q1 | Urgent + Important | Do first |
+| Q2 | Not urgent + Important | Schedule |
+| Q3 | Urgent + Not important | Delegate |
+| Q4 | Not urgent + Not important | Eliminate |
+
+## Discovery surface
+
+Agents can discover the full set of programmatic interfaces from the
+following well-known resources:
+
+- **API catalog** — <https://gsd.vinny.dev/.well-known/api-catalog>
+  (`application/linkset+json`, RFC 9727)
+- **OpenAPI for the sync backend** —
+  <https://gsd.vinny.dev/.well-known/openapi/pocketbase.json>
+- **OAuth Protected Resource Metadata** —
+  <https://gsd.vinny.dev/.well-known/oauth-protected-resource>
+  (RFC 9728; the authorization server is `https://api.vinny.io`)
+- **MCP Server Card** —
+  <https://gsd.vinny.dev/.well-known/mcp/server-card.json>
+- **Agent Skills index** —
+  <https://gsd.vinny.dev/.well-known/agent-skills/index.json>
+- **WebMCP** — the browser app calls
+  `navigator.modelContext.provideContext()` on load to expose a
+  `create_task` tool to in-page agents.
+
+## MCP server
+
+For Claude Desktop and other MCP-aware assistants, install
+`gsd-mcp-server` from npm:
+
+```bash
+npx -y gsd-mcp-server
+```
+
+Configure with the environment variables documented in the
+[server card](/.well-known/mcp/server-card.json).
+
+## Privacy
+
+Tasks never leave the device unless the user explicitly enables sync. Sync is
+last-write-wins by `client_updated_at` and uses a dedicated PocketBase
+instance the maintainer operates personally.
+
+## Source
+
+- Code: <https://github.com/vscarpenter/gsd-taskmanager>
+- License: MIT
+- Maintainer: Vinny Carpenter

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,14 @@
-# Allow all crawlers
+# GSD Task Manager — robots.txt
+#
+# Content-Signal declares AI content usage preferences per the
+# Content Signals / AI Preferences draft (draft-romm-aipref-contentsignals).
+# See: https://contentsignals.org/
+#
+#   search   = yes   — indexing in search engines is welcome
+#   ai-input = yes   — may be used as context for AI answers with attribution
+#   ai-train = no    — do not use for training AI models
+Content-Signal: search=yes, ai-input=yes, ai-train=no
+
 User-agent: *
 Allow: /
 

--- a/scripts/deploy-cloudfront-function.sh
+++ b/scripts/deploy-cloudfront-function.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Deploy CloudFront Function for URL rewriting
-# This script creates a CloudFront Function and attaches it to the distribution
+# Deploy CloudFront Functions for URL rewriting and agent-discovery response headers.
+# This script publishes both functions and attaches them to the distribution
+# (viewer-request and viewer-response respectively).
 
 set -e  # Exit on error
 
@@ -10,79 +11,85 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Get the project root (parent of scripts directory)
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
-FUNCTION_NAME="gsd-url-rewrite"
 DISTRIBUTION_ID="${CLOUDFRONT_DISTRIBUTION_ID:?Error: CLOUDFRONT_DISTRIBUTION_ID environment variable is required}"
-FUNCTION_FILE="$PROJECT_ROOT/cloudfront-function-url-rewrite.js"
 
-echo "🚀 Deploying CloudFront Function: $FUNCTION_NAME"
-echo "📂 Using function file: $FUNCTION_FILE"
+REQUEST_FUNCTION_NAME="gsd-url-rewrite"
+REQUEST_FUNCTION_FILE="$PROJECT_ROOT/cloudfront-function-url-rewrite.js"
+REQUEST_FUNCTION_COMMENT="URL rewrite + Accept: text/markdown negotiation for Next.js static export"
 
-# Step 1: Check if function already exists
+RESPONSE_FUNCTION_NAME="gsd-response-headers"
+RESPONSE_FUNCTION_FILE="$PROJECT_ROOT/cloudfront-function-response-headers.js"
+RESPONSE_FUNCTION_COMMENT="Agent discovery: Link headers + Vary: Accept + markdown content-type"
+
+publish_function() {
+  local name="$1"
+  local file="$2"
+  local comment="$3"
+
+  echo ""
+  echo "🚀 Publishing CloudFront Function: $name"
+  echo "📂 Source: $file"
+
+  local exists
+  exists=$(aws cloudfront list-functions --query "FunctionList.Items[?Name=='$name'].Name" --output text)
+
+  if [ -z "$exists" ]; then
+    echo "✨ Creating new function..."
+    aws cloudfront create-function \
+      --name "$name" \
+      --function-config "{\"Comment\":\"$comment\",\"Runtime\":\"cloudfront-js-2.0\"}" \
+      --function-code fileb://"$file" \
+      --query 'FunctionSummary.FunctionMetadata.FunctionARN' \
+      --output text
+  else
+    echo "📝 Function exists, updating code..."
+    local etag
+    etag=$(aws cloudfront describe-function --name "$name" --query 'ETag' --output text)
+    aws cloudfront update-function \
+      --name "$name" \
+      --if-match "$etag" \
+      --function-config "{\"Comment\":\"$comment\",\"Runtime\":\"cloudfront-js-2.0\"}" \
+      --function-code fileb://"$file" \
+      --query 'FunctionSummary.FunctionMetadata.FunctionARN' \
+      --output text
+  fi
+
+  local etag
+  etag=$(aws cloudfront describe-function --name "$name" --query 'ETag' --output text)
+  aws cloudfront publish-function --name "$name" --if-match "$etag" > /dev/null
+  echo "✅ Function published: $name"
+}
+
+# Step 1: Publish both functions, then resolve their LIVE-stage ARNs (the
+# published stage is what the distribution must reference).
+publish_function "$REQUEST_FUNCTION_NAME" "$REQUEST_FUNCTION_FILE" "$REQUEST_FUNCTION_COMMENT"
+publish_function "$RESPONSE_FUNCTION_NAME" "$RESPONSE_FUNCTION_FILE" "$RESPONSE_FUNCTION_COMMENT"
+
+REQUEST_FUNCTION_ARN=$(aws cloudfront describe-function --name "$REQUEST_FUNCTION_NAME" --stage LIVE --query 'FunctionSummary.FunctionMetadata.FunctionARN' --output text)
+RESPONSE_FUNCTION_ARN=$(aws cloudfront describe-function --name "$RESPONSE_FUNCTION_NAME" --stage LIVE --query 'FunctionSummary.FunctionMetadata.FunctionARN' --output text)
+
 echo ""
-echo "📋 Checking if function exists..."
-FUNCTION_EXISTS=$(aws cloudfront list-functions --query "FunctionList.Items[?Name=='$FUNCTION_NAME'].Name" --output text)
+echo "📋 Live function ARNs:"
+echo "  viewer-request:  $REQUEST_FUNCTION_ARN"
+echo "  viewer-response: $RESPONSE_FUNCTION_ARN"
 
-if [ -z "$FUNCTION_EXISTS" ]; then
-  echo "✨ Creating new CloudFront Function..."
-
-  # Create the function
-  FUNCTION_ARN=$(aws cloudfront create-function \
-    --name "$FUNCTION_NAME" \
-    --function-config '{"Comment":"URL rewrite for Next.js static export with trailing slashes","Runtime":"cloudfront-js-2.0"}' \
-    --function-code fileb://"$FUNCTION_FILE" \
-    --query 'FunctionSummary.FunctionMetadata.FunctionARN' \
-    --output text)
-
-  echo "✅ Function created: $FUNCTION_ARN"
-else
-  echo "📝 Function exists, updating code..."
-
-  # Get current ETag
-  ETAG=$(aws cloudfront describe-function --name "$FUNCTION_NAME" --query 'ETag' --output text)
-
-  # Update the function
-  FUNCTION_ARN=$(aws cloudfront update-function \
-    --name "$FUNCTION_NAME" \
-    --if-match "$ETAG" \
-    --function-config '{"Comment":"URL rewrite for Next.js static export with trailing slashes","Runtime":"cloudfront-js-2.0"}' \
-    --function-code fileb://"$FUNCTION_FILE" \
-    --query 'FunctionSummary.FunctionMetadata.FunctionARN' \
-    --output text)
-
-  echo "✅ Function updated: $FUNCTION_ARN"
-fi
-
-# Step 2: Publish the function
-echo ""
-echo "📤 Publishing function..."
-ETAG=$(aws cloudfront describe-function --name "$FUNCTION_NAME" --query 'ETag' --output text)
-aws cloudfront publish-function --name "$FUNCTION_NAME" --if-match "$ETAG" > /dev/null
-echo "✅ Function published"
-
-# Step 3: Get the distribution config
+# Step 2: Get the distribution config
 echo ""
 echo "📋 Getting CloudFront distribution config..."
 aws cloudfront get-distribution-config --id "$DISTRIBUTION_ID" > /tmp/dist-config.json
 DIST_ETAG=$(jq -r '.ETag' /tmp/dist-config.json)
-
-# Step 4: Update the distribution config to attach the function
-echo ""
-echo "🔗 Attaching function to distribution..."
-
-# Extract just the DistributionConfig
 jq '.DistributionConfig' /tmp/dist-config.json > /tmp/dist-config-only.json
 
-# Add the function association to DefaultCacheBehavior
-jq --arg arn "$FUNCTION_ARN" \
-  '.DefaultCacheBehavior.FunctionAssociations.Quantity = 1 |
+# Step 3: Attach both functions to DefaultCacheBehavior
+echo ""
+echo "🔗 Attaching functions to distribution..."
+jq --arg req "$REQUEST_FUNCTION_ARN" --arg res "$RESPONSE_FUNCTION_ARN" \
+  '.DefaultCacheBehavior.FunctionAssociations.Quantity = 2 |
    .DefaultCacheBehavior.FunctionAssociations.Items = [
-     {
-       "FunctionARN": $arn,
-       "EventType": "viewer-request"
-     }
+     { "FunctionARN": $req, "EventType": "viewer-request" },
+     { "FunctionARN": $res, "EventType": "viewer-response" }
    ]' /tmp/dist-config-only.json > /tmp/dist-config-updated.json
 
-# Update the distribution
 aws cloudfront update-distribution \
   --id "$DISTRIBUTION_ID" \
   --if-match "$DIST_ETAG" \
@@ -90,7 +97,7 @@ aws cloudfront update-distribution \
 
 echo "✅ Distribution updated"
 
-# Step 5: Create invalidation to clear cache
+# Step 4: Invalidate so changes take effect immediately
 echo ""
 echo "🗑️  Creating cache invalidation..."
 INVALIDATION_ID=$(aws cloudfront create-invalidation \
@@ -98,7 +105,6 @@ INVALIDATION_ID=$(aws cloudfront create-invalidation \
   --paths "/*" \
   --query 'Invalidation.Id' \
   --output text)
-
 echo "✅ Cache invalidation created: $INVALIDATION_ID"
 
 # Cleanup
@@ -107,9 +113,4 @@ rm -f /tmp/dist-config.json /tmp/dist-config-only.json /tmp/dist-config-updated.
 echo ""
 echo "🎉 Deployment complete!"
 echo ""
-echo "The CloudFront Function is now deployed and will rewrite:"
-echo "  /dashboard/ → /dashboard/index.html"
-echo "  /install/ → /install/index.html"
-echo ""
-echo "Cache invalidation is in progress. Changes may take a few minutes to propagate."
-echo "You can check the status at: https://console.aws.amazon.com/cloudfront/v3/home#/distributions/$DISTRIBUTION_ID"
+echo "Distribution: https://console.aws.amazon.com/cloudfront/v3/home#/distributions/$DISTRIBUTION_ID"

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -62,6 +62,11 @@ aws s3 cp "$S3_BUCKET/index.html" "$S3_BUCKET/index.html" \
   --cache-control "no-cache,no-store,must-revalidate" \
   --content-type "text/html"
 
+# Fix Content-Type on /.well-known/* and markdown renditions used for
+# agent discovery (RFC 8288 / 9727 / 9728 + Markdown for Agents).
+echo "  → Fixing Content-Type on agent-discovery files..."
+"$(dirname "$0")/fix-discovery-content-types.sh" "$S3_BUCKET"
+
 echo -e "${GREEN}✓${NC} Synced to S3"
 echo ""
 

--- a/scripts/fix-discovery-content-types.sh
+++ b/scripts/fix-discovery-content-types.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Fix Content-Type metadata on agent-discovery files in S3.
+#
+# Next.js static export ships these files unchanged from `public/`, but S3
+# infers Content-Type from the extension. Some discovery files have no
+# extension (e.g. `/.well-known/api-catalog`) or need a non-default media
+# type (e.g. `application/linkset+json`, `application/openapi+json`,
+# `text/markdown`). This script copies them in place with the correct
+# Content-Type so agents and validators see the canonical type.
+#
+# Usage: scripts/fix-discovery-content-types.sh s3://bucket-name
+
+set -e
+
+BUCKET="${1:?Usage: $0 s3://bucket-name}"
+
+# Helper that runs `aws s3 cp <key> <key>` with a content-type override.
+fix_type() {
+  local key="$1"
+  local ctype="$2"
+  local cache="${3:-public,max-age=300,must-revalidate}"
+  echo "  → $key  ($ctype)"
+  aws s3 cp "$BUCKET/$key" "$BUCKET/$key" \
+    --metadata-directive REPLACE \
+    --content-type "$ctype" \
+    --cache-control "$cache" \
+    >/dev/null
+}
+
+echo "Fixing Content-Type on discovery files in $BUCKET ..."
+
+# RFC 9727 — application/linkset+json (no file extension on disk).
+fix_type ".well-known/api-catalog" "application/linkset+json"
+
+# RFC 9728 — Protected Resource Metadata.
+fix_type ".well-known/oauth-protected-resource" "application/json"
+
+# OpenAPI 3.1 description for the sync backend.
+fix_type ".well-known/openapi/pocketbase.json" "application/openapi+json"
+
+# MCP Server Card and Agent Skills index — registered as application/json.
+fix_type ".well-known/mcp/server-card.json" "application/json"
+fix_type ".well-known/agent-skills/index.json" "application/json"
+
+# SKILL.md files served as markdown for agent consumption.
+for skill in quick-capture triage-inbox; do
+  fix_type ".well-known/agent-skills/$skill/SKILL.md" "text/markdown; charset=utf-8"
+done
+
+# Markdown renditions of HTML pages (consumed via Accept: text/markdown).
+for md in index.md about/index.md; do
+  fix_type "$md" "text/markdown; charset=utf-8" "public,max-age=0,must-revalidate"
+done
+
+echo "Done."

--- a/tests/data/agent-discovery-files.test.ts
+++ b/tests/data/agent-discovery-files.test.ts
@@ -1,0 +1,137 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = resolve(__dirname, '../../public');
+
+const readJson = <T,>(relativePath: string): T => {
+	const raw = readFileSync(resolve(root, relativePath), 'utf-8');
+	return JSON.parse(raw) as T;
+};
+
+describe('robots.txt content signals', () => {
+	it('declares Content-Signal preferences before the User-agent block', () => {
+		const robots = readFileSync(resolve(root, 'robots.txt'), 'utf-8');
+		const signalIndex = robots.search(/^Content-Signal:/m);
+		const userAgentIndex = robots.search(/^User-agent:/m);
+		expect(signalIndex).toBeGreaterThanOrEqual(0);
+		expect(userAgentIndex).toBeGreaterThan(signalIndex);
+		expect(robots).toMatch(/Content-Signal:[^\n]*ai-train=no/);
+		expect(robots).toMatch(/Content-Signal:[^\n]*search=yes/);
+	});
+});
+
+describe('/.well-known/api-catalog (RFC 9727)', () => {
+	type Linkset = { linkset: Array<Record<string, unknown>> };
+	const catalog = readJson<Linkset>('.well-known/api-catalog');
+
+	it('is a non-empty linkset', () => {
+		expect(Array.isArray(catalog.linkset)).toBe(true);
+		expect(catalog.linkset.length).toBeGreaterThan(0);
+	});
+
+	it('every entry has an anchor URL', () => {
+		for (const entry of catalog.linkset) {
+			expect(typeof entry.anchor).toBe('string');
+			expect(entry.anchor as string).toMatch(/^https?:\/\//);
+		}
+	});
+
+	it('first entry advertises service-doc, service-desc, and status', () => {
+		const first = catalog.linkset[0]!;
+		expect(first['service-doc']).toBeDefined();
+		expect(first['service-desc']).toBeDefined();
+		expect(first['status']).toBeDefined();
+	});
+});
+
+describe('/.well-known/oauth-protected-resource (RFC 9728)', () => {
+	type Resource = {
+		resource: string;
+		authorization_servers: string[];
+		bearer_methods_supported: string[];
+		scopes_supported: string[];
+	};
+	const meta = readJson<Resource>('.well-known/oauth-protected-resource');
+
+	it('points to the GSD origin as the resource', () => {
+		expect(meta.resource).toBe('https://gsd.vinny.dev');
+	});
+
+	it('lists at least one authorization server', () => {
+		expect(meta.authorization_servers.length).toBeGreaterThan(0);
+		expect(meta.authorization_servers[0]).toMatch(/^https:\/\//);
+	});
+
+	it('declares header-based bearer tokens and at least one scope', () => {
+		expect(meta.bearer_methods_supported).toContain('header');
+		expect(meta.scopes_supported.length).toBeGreaterThan(0);
+	});
+});
+
+describe('/.well-known/mcp/server-card.json', () => {
+	type ServerCard = {
+		serverInfo: { name: string; version: string };
+		transports: Array<{ type: string; install?: { command: string } }>;
+		tools: Array<{ name: string; category: string }>;
+	};
+	const card = readJson<ServerCard>('.well-known/mcp/server-card.json');
+
+	it('matches the published npm package name', () => {
+		expect(card.serverInfo.name).toBe('gsd-mcp-server');
+		expect(card.serverInfo.version).toMatch(/^\d+\.\d+\.\d+/);
+	});
+
+	it('declares a stdio transport with an install command', () => {
+		const stdio = card.transports.find((t) => t.type === 'stdio');
+		expect(stdio).toBeDefined();
+		expect(stdio?.install?.command).toBeDefined();
+	});
+
+	it('lists the 20 documented MCP tools', () => {
+		expect(card.tools).toHaveLength(20);
+		const names = new Set(card.tools.map((t) => t.name));
+		for (const required of ['list_tasks', 'create_task', 'get_productivity_metrics']) {
+			expect(names.has(required)).toBe(true);
+		}
+	});
+});
+
+describe('/.well-known/agent-skills/index.json', () => {
+	type SkillsIndex = {
+		version: string;
+		skills: Array<{ name: string; url: string; sha256: string }>;
+	};
+	const index = readJson<SkillsIndex>('.well-known/agent-skills/index.json');
+
+	it('uses the v0.2.0 schema', () => {
+		expect(index.version).toBe('0.2.0');
+	});
+
+	it('digest matches the actual SKILL.md bytes for every skill', () => {
+		for (const skill of index.skills) {
+			const path = resolve(root, '.well-known/agent-skills', skill.name, 'SKILL.md');
+			const bytes = readFileSync(path);
+			const digest = createHash('sha256').update(bytes).digest('hex');
+			expect(digest).toBe(skill.sha256);
+		}
+	});
+});
+
+describe('/.well-known/openapi/pocketbase.json', () => {
+	type OpenApi = {
+		openapi: string;
+		info: { title: string; version: string };
+		paths: Record<string, unknown>;
+	};
+	const spec = readJson<OpenApi>('.well-known/openapi/pocketbase.json');
+
+	it('is OpenAPI 3.1+', () => {
+		expect(spec.openapi).toMatch(/^3\.[1-9]/);
+	});
+
+	it('describes the tasks collection endpoints', () => {
+		expect(Object.keys(spec.paths)).toContain('/api/collections/tasks/records');
+	});
+});

--- a/tests/data/cloudfront-functions.test.ts
+++ b/tests/data/cloudfront-functions.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+type CFHeader = { value: string };
+type CFRequest = { uri: string; headers: Record<string, CFHeader> };
+type CFResponse = { headers: Record<string, CFHeader> };
+type CFEvent = { request: CFRequest; response?: CFResponse };
+type Handler = (event: CFEvent) => CFRequest | CFResponse;
+
+const root = resolve(__dirname, '../..');
+
+const loadHandler = (file: string): Handler => {
+	const source = readFileSync(resolve(root, file), 'utf-8');
+	// CloudFront Functions are bare scripts that declare `function handler(event)`.
+	// Wrap them so the `Function` constructor returns the handler reference.
+	const factory = new Function(`${source}; return handler;`);
+	return factory() as Handler;
+};
+
+const urlRewrite = loadHandler('cloudfront-function-url-rewrite.js');
+const responseHeaders = loadHandler('cloudfront-function-response-headers.js');
+
+const makeRequest = (uri: string, headers: Record<string, string> = {}): CFRequest => ({
+	uri,
+	headers: Object.fromEntries(
+		Object.entries(headers).map(([k, v]) => [k.toLowerCase(), { value: v }]),
+	),
+});
+
+const makeResponse = (headers: Record<string, string>): CFResponse => ({
+	headers: Object.fromEntries(
+		Object.entries(headers).map(([k, v]) => [k.toLowerCase(), { value: v }]),
+	),
+});
+
+describe('cloudfront-function-url-rewrite (viewer-request)', () => {
+	it('appends index.html for trailing-slash URIs', () => {
+		const req = makeRequest('/dashboard/');
+		const out = urlRewrite({ request: req }) as CFRequest;
+		expect(out.uri).toBe('/dashboard/index.html');
+	});
+
+	it('appends /index.html for extensionless paths', () => {
+		const req = makeRequest('/about');
+		const out = urlRewrite({ request: req }) as CFRequest;
+		expect(out.uri).toBe('/about/index.html');
+	});
+
+	it('passes through asset paths with extensions unchanged', () => {
+		const req = makeRequest('/_next/static/chunks/main.js');
+		const out = urlRewrite({ request: req }) as CFRequest;
+		expect(out.uri).toBe('/_next/static/chunks/main.js');
+	});
+
+	it('rewrites to .md when the client sends Accept: text/markdown', () => {
+		const req = makeRequest('/about/', { accept: 'text/markdown, text/html;q=0.9' });
+		const out = urlRewrite({ request: req }) as CFRequest;
+		expect(out.uri).toBe('/about/index.md');
+	});
+
+	it('keeps .html when Accept does not include text/markdown', () => {
+		const req = makeRequest('/about/', { accept: 'text/html' });
+		const out = urlRewrite({ request: req }) as CFRequest;
+		expect(out.uri).toBe('/about/index.html');
+	});
+});
+
+describe('cloudfront-function-response-headers (viewer-response)', () => {
+	it('emits a Link header with all discovery relations on HTML responses', () => {
+		const event: CFEvent = {
+			request: makeRequest('/index.html'),
+			response: makeResponse({ 'content-type': 'text/html; charset=utf-8' }),
+		};
+		const out = responseHeaders(event) as CFResponse;
+		const link = out.headers['link']?.value ?? '';
+		expect(link).toContain('rel="api-catalog"');
+		expect(link).toContain('rel="service-desc"');
+		expect(link).toContain('rel="oauth-protected-resource"');
+		expect(link).toContain('rel="mcp-server"');
+		expect(link).toContain('rel="agent-skills"');
+	});
+
+	it('forces text/markdown content type on .md responses', () => {
+		const event: CFEvent = {
+			request: makeRequest('/index.md'),
+			response: makeResponse({ 'content-type': 'binary/octet-stream' }),
+		};
+		const out = responseHeaders(event) as CFResponse;
+		expect(out.headers['content-type']?.value).toBe('text/markdown; charset=utf-8');
+	});
+
+	it('appends Accept to an existing Vary header', () => {
+		const event: CFEvent = {
+			request: makeRequest('/index.html'),
+			response: makeResponse({
+				'content-type': 'text/html',
+				vary: 'Cookie',
+			}),
+		};
+		const out = responseHeaders(event) as CFResponse;
+		expect(out.headers['vary']?.value).toBe('Cookie, Accept');
+	});
+
+	it('does not emit a Link header on non-HTML, non-markdown assets', () => {
+		const event: CFEvent = {
+			request: makeRequest('/_next/static/chunks/main.js'),
+			response: makeResponse({ 'content-type': 'application/javascript' }),
+		};
+		const out = responseHeaders(event) as CFResponse;
+		expect(out.headers['link']).toBeUndefined();
+	});
+});

--- a/tests/ui/webmcp-register.test.tsx
+++ b/tests/ui/webmcp-register.test.tsx
@@ -1,0 +1,104 @@
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WebMcpRegister } from '@/components/webmcp-register';
+
+const createTaskMock = vi.fn();
+
+vi.mock('@/lib/tasks', () => ({
+	createTask: (...args: unknown[]) => createTaskMock(...args),
+}));
+
+type Tool = {
+	name: string;
+	description: string;
+	inputSchema: Record<string, unknown>;
+	execute: (input: Record<string, unknown>) => Promise<unknown>;
+};
+
+type ProvideContextArg = { tools: Tool[] };
+
+describe('WebMcpRegister', () => {
+	const provideContext = vi.fn<(arg: ProvideContextArg) => Promise<void>>();
+	const originalDescriptor = Object.getOwnPropertyDescriptor(navigator, 'modelContext');
+
+	beforeEach(() => {
+		provideContext.mockReset();
+		provideContext.mockResolvedValue(undefined);
+		createTaskMock.mockReset();
+		Object.defineProperty(navigator, 'modelContext', {
+			value: { provideContext },
+			writable: true,
+			configurable: true,
+		});
+	});
+
+	afterEach(() => {
+		if (originalDescriptor) {
+			Object.defineProperty(navigator, 'modelContext', originalDescriptor);
+		} else {
+			Reflect.deleteProperty(navigator as unknown as Record<string, unknown>, 'modelContext');
+		}
+	});
+
+	it('registers a create_task tool with navigator.modelContext on mount', async () => {
+		render(<WebMcpRegister />);
+
+		await waitFor(() => expect(provideContext).toHaveBeenCalledTimes(1));
+
+		const arg = provideContext.mock.calls[0]?.[0];
+		expect(arg).toBeDefined();
+		expect(arg?.tools).toHaveLength(1);
+		expect(arg?.tools[0]?.name).toBe('create_task');
+		expect(arg?.tools[0]?.inputSchema).toMatchObject({
+			type: 'object',
+			required: ['title'],
+		});
+	});
+
+	it('execute() forwards normalized fields to lib/tasks createTask', async () => {
+		createTaskMock.mockResolvedValue({
+			id: 'task-1',
+			quadrant: 'not-urgent-important',
+			createdAt: '2026-04-20T00:00:00.000Z',
+		});
+
+		render(<WebMcpRegister />);
+		await waitFor(() => expect(provideContext).toHaveBeenCalledTimes(1));
+
+		const tool = provideContext.mock.calls[0]?.[0]?.tools[0];
+		expect(tool).toBeDefined();
+		const result = await tool!.execute({
+			title: '  Write spec  ',
+			urgent: true,
+			important: true,
+			tags: ['triage'],
+		});
+
+		expect(createTaskMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				title: 'Write spec',
+				urgent: true,
+				important: true,
+				tags: ['triage'],
+				recurrence: 'none',
+				notificationEnabled: true,
+			}),
+		);
+		expect(result).toEqual({
+			id: 'task-1',
+			quadrant: 'not-urgent-important',
+			createdAt: '2026-04-20T00:00:00.000Z',
+		});
+	});
+
+	it('is a no-op when navigator.modelContext is unavailable', async () => {
+		Reflect.deleteProperty(navigator as unknown as Record<string, unknown>, 'modelContext');
+
+		render(<WebMcpRegister />);
+
+		// Give the effect a chance to run; if it tried to call provideContext it would throw.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(provideContext).not.toHaveBeenCalled();
+		expect(createTaskMock).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

Closes the agent-readiness gaps flagged by `isitagentready.com`. From a
single `HEAD https://gsd.vinny.dev/` an agent can now discover:

- **Link header (RFC 8288)** — emitted by a new CloudFront viewer-response
  function, listing the api-catalog, OpenAPI, OAuth Protected Resource
  Metadata, MCP Server Card, and Agent Skills index.
- **API catalog (RFC 9727)** — `/.well-known/api-catalog` as
  `application/linkset+json` anchoring the PocketBase backend and the MCP
  server, plus an OpenAPI 3.1 doc at `/.well-known/openapi/pocketbase.json`.
- **OAuth Protected Resource Metadata (RFC 9728)** —
  `/.well-known/oauth-protected-resource` pointing to
  `https://api.vinny.io` as the authorization server.
- **MCP Server Card** — `/.well-known/mcp/server-card.json` describing
  `gsd-mcp-server`, its 20 tools, env vars, and `npx` install command.
- **Agent Skills index (v0.2.0)** —
  `/.well-known/agent-skills/index.json` plus `quick-capture/SKILL.md`
  and `triage-inbox/SKILL.md` with SHA-256 digests.
- **Content Signals** — `Content-Signal: search=yes, ai-input=yes,
  ai-train=no` in `robots.txt`.
- **Markdown for Agents** — pre-rendered `/index.md` and `/about/index.md`
  served when the request includes `Accept: text/markdown`. The existing
  viewer-request CloudFront Function rewrites `index.html` → `index.md`,
  and the new viewer-response function adds `Vary: Accept` and forces
  `text/markdown; charset=utf-8`.
- **WebMCP** — `WebMcpRegister` calls
  `navigator.modelContext.provideContext()` on mount, exposing a
  `create_task` tool that writes through the existing
  `lib/tasks/createTask` path.

Deploy plumbing keeps everything reproducible:

- `scripts/fix-discovery-content-types.sh` patches Content-Type on the
  well-known files after `aws s3 sync` (S3 cannot infer
  `application/linkset+json`, `application/openapi+json`, or the
  no-extension `api-catalog`). Wired into both `deploy:s3` and
  `deploy-dev.sh`.
- `scripts/deploy-cloudfront-function.sh` now publishes both edge
  functions and attaches viewer-request + viewer-response.

Architecture decision recorded in
`docs/adr/0010-agent-discovery-surface.md`.

## Test plan

- [x] `bun typecheck` — clean.
- [x] `bun lint` — only pre-existing warnings in `components/redesign/*`
      (not touched here).
- [x] `bun run test` for the new tests — 26/26 passing across
      `tests/data/agent-discovery-files.test.ts`,
      `tests/data/cloudfront-functions.test.ts`, and
      `tests/ui/webmcp-register.test.tsx`. Full-suite failures are
      pre-existing (matrix redesign / coverage tests) and reproduce on
      `main` without these changes.
- [x] `bun run build` — static export succeeds; verified all
      `out/.well-known/*`, `out/index.md`, and `out/about/index.md` are
      emitted.
- [ ] After merge: run `CLOUDFRONT_DISTRIBUTION_ID=… ./scripts/deploy-cloudfront-function.sh`
      to publish the new viewer-response function and confirm the `Link`
      header is visible via `curl -I https://gsd.vinny.dev/`.
- [ ] After deploy: `curl -H 'Accept: text/markdown' https://gsd.vinny.dev/`
      should return the markdown rendition with
      `Content-Type: text/markdown; charset=utf-8` and `Vary: Accept`.
- [ ] After deploy: re-run `isitagentready.com` against
      `https://gsd.vinny.dev` and verify the Link, api-catalog,
      content-signals, oauth-protected-resource, mcp-server-card, and
      agent-skills checks pass.

https://claude.ai/code/session_01Qz3oa5t5yw1VDY5wkJ2JAD