### PR TITLE
fix(composer): repair task drawer positioning on desktop

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -688,3 +688,11 @@ main {
     animation: none !important;
   }
 }
+
+.overdue-task {
+  border-left-color: rgb(239 68 68);
+}
+
+.dark .overdue-task {
+  border-left-color: rgb(248 113 113);
+}

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "react-dom": "19.2.4",
         "recharts": "3.8.1",
         "sonner": "2.0.7",
+        "tailwind-merge": "^3.5.0",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -1394,6 +1395,8 @@
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
     "tailwindcss": ["tailwindcss@4.2.2", "", {}, "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="],
 

--- a/components/redesign/composer-drawer.tsx
+++ b/components/redesign/composer-drawer.tsx
@@ -124,7 +124,7 @@ export function ComposerDrawer({ open, onClose, onSubmit, presetQuadrant, editin
   return (
     <Dialog open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
       <DialogContent
-        className="redesign-scope rd-fade-in border-card-border bg-transparent p-0 md:left-auto md:right-0 md:top-0 md:h-[100dvh] md:w-[460px] md:max-w-[460px] md:translate-x-0 md:translate-y-0 md:rounded-none md:border-l md:border-t-0 md:p-0"
+        className="redesign-scope rd-fade-in border-card-border bg-transparent p-0 md:left-auto md:right-0 md:top-0 md:bottom-auto md:h-[100dvh] md:max-h-none md:w-[460px] md:max-w-[460px] md:translate-x-0 md:translate-y-0 md:rounded-none md:border-l md:border-t-0 md:p-0"
       >
         <div
           style={{

--- a/components/task-card/index.tsx
+++ b/components/task-card/index.tsx
@@ -62,7 +62,7 @@ function TaskCardComponent({
         task.completed ? "opacity-60" : "opacity-100 hover:-translate-y-0.5 hover:border-accent/40",
         task.completed && "animate-complete-flash",
         isDragging && "cursor-grabbing",
-        taskIsOverdue ? "border-l-4 border-l-red-500 border-red-200 bg-red-50/40 dark:border-l-red-400 dark:border-red-800/60 dark:bg-red-950/20" : "border-card-border",
+        taskIsOverdue ? "overdue-task border-l-4 border-red-200 bg-red-50/40 dark:border-red-800/60 dark:bg-red-950/20" : "border-card-border",
         selectionMode && isSelected && "ring-2 ring-accent ring-offset-2",
         isHighlighted && "animate-pulse-highlight ring-4 ring-accent ring-offset-2"
       )}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,8 +1,9 @@
 import { clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
 import { TIME_MS, DATE_CONFIG } from "@/lib/constants";
 
 export function cn(...classNames: Array<string | undefined | false | null>): string {
-  return clsx(classNames);
+  return twMerge(clsx(classNames));
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.4.0",
+	"version": "8.4.1",
 	"private": true,
 	"type": "module",
 	"scripts": {
@@ -48,6 +48,7 @@
 		"react-dom": "19.2.4",
 		"recharts": "3.8.1",
 		"sonner": "2.0.7",
+		"tailwind-merge": "^3.5.0",
 		"zod": "4.3.6"
 	},
 	"devDependencies": {

--- a/tests/ui/task-card.test.tsx
+++ b/tests/ui/task-card.test.tsx
@@ -156,7 +156,7 @@ describe("TaskCard", () => {
     const { container } = render(<TaskCard task={overdueTask} allTasks={[overdueTask]} {...mockHandlers} />);
 
     const article = container.querySelector("article");
-    expect(article).toHaveClass("border-l-4", "border-l-red-500", "border-red-200");
+    expect(article).toHaveClass("overdue-task", "border-l-4", "border-red-200");
   });
 
   it("does not show overdue warning for completed tasks", () => {


### PR DESCRIPTION
## Summary
- Task composer drawer was anchored bottom-right at ~half viewport height instead of rendering as a full-height right-side drawer (see attached bug report on `https://gsd.vinny.dev`).
- Root cause: `cn()` in `lib/utils.ts` used only `clsx` without `tailwind-merge`, so `md:` overrides in `composer-drawer.tsx` lost to the base `DialogContent`'s `md:top-1/2 md:left-1/2 md:max-w-lg`. Tailwind emits conflicting utilities in its own CSS order, not className order.
- Adopting `tailwind-merge` aligns `cn()` with the standard shadcn convention and fixes a class of latent override bugs across the project.

## Changes
- `lib/utils.ts` — `cn()` now runs `twMerge(clsx(...))`; added `tailwind-merge@3.5.0`.
- `components/redesign/composer-drawer.tsx` — added `md:bottom-auto md:max-h-none` so the base dialog's unprefixed `bottom-0` and `max-h-[90vh]` are reset on desktop.
- `components/task-card/index.tsx` + `app/globals.css` — latent side effect: `border-l-red-500` and `border-red-200` conflict under tailwind-merge. Moved the overdue left-border color to a small `.overdue-task` CSS rule so the two concerns don't collide.
- `tests/ui/task-card.test.tsx` — updated class assertion to match.
- Bumped `package.json` to `8.4.1`.

## Test plan
- [x] `bun typecheck` — clean
- [x] `bun lint` — pre-existing warnings only, no new issues
- [x] `bun run test` — 16 failing tests, all present on `main` before this change (verified via `git stash` baseline)
- [x] `tests/ui/task-card.test.tsx` — passes (15/15)
- [ ] Manual browser check: open the composer on desktop (≥768px) — drawer should slide in from the right at 460px wide, full viewport height, with Cancel/Add buttons pinned at the bottom. (Could not verify in this session; Chrome MCP extension was not connected.)
- [ ] Manual browser check: mobile (<768px) bottom-sheet behavior still works.
- [ ] Spot-check overdue task cards — left border should remain a distinct red accent.