### PR TITLE
feat(redesign): matrix compass, canvas drag-and-drop, healthy sync dot

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
     "esbuild": ">=0.25.0",
     "express-rate-limit": ">=8.2.2",
     "flatted": ">=3.4.2",
-    "hono": ">=4.12.12",
+    "hono": ">=4.12.14",
     "js-yaml": ">=4.1.1",
     "minimatch": ">=3.1.3",
     "path-to-regexp": ">=8.4.0",
@@ -968,7 +968,7 @@
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
-    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
+    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
@@ -1642,8 +1642,6 @@
 
     "tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
-    "vitest/vite": ["vite@8.0.7", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.13", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw=="],
-
     "whatwg-url/@exodus/bytes": ["@exodus/bytes@1.14.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ=="],
 
     "@babel/helper-module-imports/@babel/traverse/@babel/generator": ["@babel/generator@7.28.6", "", { "dependencies": { "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw=="],
@@ -1688,94 +1686,8 @@
 
     "gsd-mcp-server/vitest/tinyrainbow": ["tinyrainbow@3.0.3", "", {}, "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="],
 
-    "gsd-mcp-server/vitest/vite": ["vite@8.0.7", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.13", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw=="],
-
     "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "vitest/vite/rolldown": ["rolldown@1.0.0-rc.13", "", { "dependencies": { "@oxc-project/types": "=0.123.0", "@rolldown/pluginutils": "1.0.0-rc.13" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.13", "@rolldown/binding-darwin-arm64": "1.0.0-rc.13", "@rolldown/binding-darwin-x64": "1.0.0-rc.13", "@rolldown/binding-freebsd-x64": "1.0.0-rc.13", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.13", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.13", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.13", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.13", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.13", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.13", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.13" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw=="],
-
     "@unrs/resolver-binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown": ["rolldown@1.0.0-rc.13", "", { "dependencies": { "@oxc-project/types": "=0.123.0", "@rolldown/pluginutils": "1.0.0-rc.13" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.13", "@rolldown/binding-darwin-arm64": "1.0.0-rc.13", "@rolldown/binding-darwin-x64": "1.0.0-rc.13", "@rolldown/binding-freebsd-x64": "1.0.0-rc.13", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.13", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.13", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.13", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.13", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.13", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.13", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.13" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw=="],
-
-    "vitest/vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.123.0", "", {}, "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.13", "", { "os": "android", "cpu": "arm64" }, "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.13", "", { "os": "darwin", "cpu": "x64" }, "sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.13", "", { "os": "freebsd", "cpu": "x64" }, "sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13", "", { "os": "linux", "cpu": "arm" }, "sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13", "", { "os": "linux", "cpu": "ppc64" }, "sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13", "", { "os": "linux", "cpu": "s390x" }, "sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.13", "", { "os": "linux", "cpu": "x64" }, "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.13", "", { "os": "linux", "cpu": "x64" }, "sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.13", "", { "os": "none", "cpu": "arm64" }, "sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.13", "", { "dependencies": { "@emnapi/core": "1.9.1", "@emnapi/runtime": "1.9.1", "@napi-rs/wasm-runtime": "^1.1.2" }, "cpu": "none" }, "sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13", "", { "os": "win32", "cpu": "arm64" }, "sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.13", "", { "os": "win32", "cpu": "x64" }, "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ=="],
-
-    "vitest/vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.13", "", {}, "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.123.0", "", {}, "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.13", "", { "os": "android", "cpu": "arm64" }, "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.13", "", { "os": "darwin", "cpu": "x64" }, "sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.13", "", { "os": "freebsd", "cpu": "x64" }, "sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13", "", { "os": "linux", "cpu": "arm" }, "sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13", "", { "os": "linux", "cpu": "ppc64" }, "sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13", "", { "os": "linux", "cpu": "s390x" }, "sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.13", "", { "os": "linux", "cpu": "x64" }, "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.13", "", { "os": "linux", "cpu": "x64" }, "sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.13", "", { "os": "none", "cpu": "arm64" }, "sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.13", "", { "dependencies": { "@emnapi/core": "1.9.1", "@emnapi/runtime": "1.9.1", "@napi-rs/wasm-runtime": "^1.1.2" }, "cpu": "none" }, "sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13", "", { "os": "win32", "cpu": "arm64" }, "sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.13", "", { "os": "win32", "cpu": "x64" }, "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.13", "", {}, "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
-
-    "vitest/vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
-
-    "gsd-mcp-server/vitest/vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
   }
 }

--- a/components/redesign/matrix-compass.tsx
+++ b/components/redesign/matrix-compass.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useMemo } from "react";
+import type { TaskRecord } from "@/lib/types";
+import { quadrants, type RedesignQuadrantKey } from "@/lib/quadrants";
+import { Divider } from "./primitives";
+
+export type MatrixCompassVariant = "grid" | "list";
+
+export interface MatrixCompassProps {
+  tasks: TaskRecord[];
+  variant: MatrixCompassVariant;
+  label: string;
+  onAdd?: (quadrantKey: RedesignQuadrantKey) => void;
+}
+
+function computeCounts(tasks: TaskRecord[]) {
+  const byQuadrant: Record<RedesignQuadrantKey, number> = { q1: 0, q2: 0, q3: 0, q4: 0 };
+  let total = 0;
+  tasks.forEach((t) => {
+    if (t.completed) return;
+    total++;
+    const key: RedesignQuadrantKey =
+      t.urgent && t.important ? "q1" : !t.urgent && t.important ? "q2" : t.urgent ? "q3" : "q4";
+    byQuadrant[key]++;
+  });
+  return { byQuadrant, total };
+}
+
+export function MatrixCompass({ tasks, variant, label, onAdd }: MatrixCompassProps) {
+  const { byQuadrant, total } = useMemo(() => computeCounts(tasks), [tasks]);
+  const growthPct = Math.round((byQuadrant.q2 / Math.max(total, 1)) * 100);
+
+  return (
+    <aside className="rd-compass" style={{ position: "sticky", top: 20 }}>
+      <div
+        style={{
+          fontSize: 11,
+          letterSpacing: 0.12,
+          textTransform: "uppercase",
+          color: "var(--ink-3)",
+          fontWeight: 600,
+          marginBottom: 10,
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          background: "var(--paper)",
+          border: "1px solid var(--line)",
+          borderRadius: "var(--rd-radius-lg)",
+          padding: 14,
+        }}
+      >
+        {variant === "grid" ? (
+          <CompassGrid byQuadrant={byQuadrant} onAdd={onAdd} />
+        ) : (
+          <CompassList byQuadrant={byQuadrant} total={total} />
+        )}
+        <Divider style={{ margin: "12px 0" }} />
+        <div style={{ fontSize: 12, color: "var(--ink-3)", lineHeight: 1.5 }}>
+          <strong style={{ color: "var(--ink)" }}>{total}</strong> active · {growthPct}% in the{" "}
+          <em className="rd-serif" style={{ fontStyle: "italic" }}>
+            growth
+          </em>{" "}
+          quadrant
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function CompassGrid({
+  byQuadrant,
+  onAdd,
+}: {
+  byQuadrant: Record<RedesignQuadrantKey, number>;
+  onAdd?: (quadrantKey: RedesignQuadrantKey) => void;
+}) {
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6 }}>
+      {quadrants.map((q) => {
+        const count = byQuadrant[q.rdKey];
+        const interactive = Boolean(onAdd);
+        const content = (
+          <>
+            <div
+              style={{
+                fontSize: 10.5,
+                fontWeight: 600,
+                color: `var(--${q.rdKey})`,
+                letterSpacing: 0.04,
+                textTransform: "uppercase",
+              }}
+            >
+              {q.rdShort}
+            </div>
+            <div style={{ fontSize: 13, fontWeight: 600, color: "var(--ink)", marginTop: 2 }}>{q.title}</div>
+            <div
+              className="rd-serif"
+              style={{
+                position: "absolute",
+                right: 10,
+                bottom: 6,
+                fontSize: 26,
+                color: `var(--${q.rdKey})`,
+                lineHeight: 1,
+              }}
+            >
+              {count}
+            </div>
+          </>
+        );
+        const sharedStyle: React.CSSProperties = {
+          background: `var(--${q.rdKey}-tint)`,
+          borderRadius: 10,
+          padding: "10px 10px 12px",
+          minHeight: 78,
+          position: "relative",
+          border: 0,
+          textAlign: "left",
+        };
+        return interactive ? (
+          <button
+            key={q.rdKey}
+            type="button"
+            onClick={() => onAdd?.(q.rdKey)}
+            style={{ ...sharedStyle, cursor: "pointer" }}
+          >
+            {content}
+          </button>
+        ) : (
+          <div key={q.rdKey} style={sharedStyle}>
+            {content}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function CompassList({
+  byQuadrant,
+  total,
+}: {
+  byQuadrant: Record<RedesignQuadrantKey, number>;
+  total: number;
+}) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {quadrants.map((q) => {
+        const count = byQuadrant[q.rdKey];
+        const pct = total === 0 ? 0 : Math.round((count / total) * 100);
+        return (
+          <div
+            key={q.rdKey}
+            style={{ display: "flex", alignItems: "center", gap: 10, fontSize: 12.5 }}
+          >
+            <span
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: 999,
+                background: `var(--${q.rdKey})`,
+                flexShrink: 0,
+              }}
+            />
+            <span
+              style={{
+                color: "var(--ink-2)",
+                flex: 1,
+                minWidth: 0,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {q.title}
+            </span>
+            <span className="rd-mono" style={{ color: "var(--ink-3)", fontSize: 11.5 }}>
+              {count}
+            </span>
+            <span style={{ width: 40, textAlign: "right", color: "var(--ink-4)", fontSize: 11 }}>
+              {pct}%
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/redesign/redesign-matrix.tsx
+++ b/components/redesign/redesign-matrix.tsx
@@ -16,7 +16,7 @@ import { TOAST_DURATION } from "@/lib/constants";
 import { RedesignShell, type RedesignView } from "./redesign-shell";
 import { ViewFocus } from "./view-focus";
 import { ViewEditorial } from "./view-editorial";
-import { ViewCanvas } from "./view-canvas";
+import { CanvasPillPreview, ViewCanvas } from "./view-canvas";
 import { QuickAdd } from "./quick-add";
 import { ComposerDrawer } from "./composer-drawer";
 import { HelpDrawer } from "./help-drawer";
@@ -245,7 +245,11 @@ export function RedesignMatrix() {
           // DragOverlay portals to document.body, so re-apply .redesign-scope
           // to keep tokens (--paper, --ink, etc.) resolving.
           <div className="redesign-scope" style={{ cursor: "grabbing" }}>
-            <TaskCard task={activeDragTask} />
+            {view === "canvas" ? (
+              <CanvasPillPreview task={activeDragTask} />
+            ) : (
+              <TaskCard task={activeDragTask} />
+            )}
           </div>
         ) : null}
       </DragOverlay>

--- a/components/redesign/redesign-shell.tsx
+++ b/components/redesign/redesign-shell.tsx
@@ -154,10 +154,7 @@ function SidebarFooter() {
         lineHeight: 1.5,
       }}
     >
-      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 4 }}>
-        <span style={{ width: 6, height: 6, borderRadius: 999, background: "var(--q3)" }} />
-        <span style={{ fontWeight: 600, color: "var(--ink-2)" }}>Saved locally</span>
-      </div>
+      <div style={{ fontWeight: 600, color: "var(--ink-2)", marginBottom: 2 }}>Saved locally</div>
       <div>No account needed · Works offline</div>
       <div
         style={{

--- a/components/redesign/sync-button.tsx
+++ b/components/redesign/sync-button.tsx
@@ -7,7 +7,10 @@ import { useToast } from "@/components/ui/toast";
 import { SyncAuthDialog } from "@/components/sync/sync-auth-dialog";
 import { useSyncHealth } from "@/components/sync/use-sync-health";
 import { useSyncStatus, type IconType } from "@/components/sync/use-sync-status";
+import type { SyncState } from "@/lib/sync/sync-provider";
 import { SYNC_TOAST_DURATION } from "@/lib/constants/sync";
+
+type ProviderSyncStatus = SyncState["status"];
 
 /**
  * Compact, editorial-styled sync button for the redesign topbar.
@@ -16,7 +19,7 @@ import { SYNC_TOAST_DURATION } from "@/lib/constants/sync";
  * retry logic, and auth flow are unchanged.
  */
 export function RedesignSyncButton() {
-  const { sync, isSyncing, status, error, isEnabled, nextRetryAt } = useSync();
+  const { sync, isSyncing, status, error, isEnabled, nextRetryAt, lastSuccessfulSyncAt } = useSync();
   const { showToast } = useToast();
   const [authDialogOpen, setAuthDialogOpen] = useState(false);
 
@@ -31,6 +34,7 @@ export function RedesignSyncButton() {
     status,
     error,
     nextRetryAt,
+    lastSuccessfulSyncAt,
     onAuthError: (message, _action, duration) => {
       showToast(
         message,
@@ -57,7 +61,7 @@ export function RedesignSyncButton() {
   }
 
   const icon = getIcon(iconType);
-  const dotColor = getDotColor(iconType, hasAuthError);
+  const dotColor = getDotColor(iconType, hasAuthError, isEnabled, status, lastSuccessfulSyncAt);
   const badgeText = hasAuthError ? "!" : pendingCount > 0 ? String(pendingCount) : null;
 
   return (
@@ -183,7 +187,13 @@ function getIcon(type: IconType) {
   }
 }
 
-function getDotColor(type: IconType, hasAuthError: boolean): string | null {
+function getDotColor(
+  type: IconType,
+  hasAuthError: boolean,
+  isEnabled: boolean,
+  status: ProviderSyncStatus,
+  lastSuccessfulSyncAt: string | null
+): string | null {
   if (hasAuthError) return null; // badge shows "!" instead
   switch (type) {
     case "cloud-off":
@@ -196,6 +206,11 @@ function getDotColor(type: IconType, hasAuthError: boolean): string | null {
       return "var(--q4)";
     case "clock":
       return "var(--q4)";
+    case "cloud-idle":
+      // Healthy steady-state: enabled, idle, and we've synced at least once.
+      // The lastSuccessfulSyncAt gate prevents showing green before the first
+      // successful sync after enabling (e.g. right after OAuth sign-in).
+      return isEnabled && status === "idle" && lastSuccessfulSyncAt ? "var(--q3)" : null;
     default:
       return null;
   }

--- a/components/redesign/view-canvas.tsx
+++ b/components/redesign/view-canvas.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useDraggable, useDroppable } from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
 import { AlertCircle } from "lucide-react";
 import type { TaskRecord } from "@/lib/types";
 import { quadrants, quadrantForTask, type RedesignQuadrantKey } from "@/lib/quadrants";
@@ -246,7 +248,7 @@ export function ViewCanvas({ tasks, onOpen }: ViewCanvasProps) {
             `,
           }}
         >
-          {/* Quadrant tints behind the gridlines */}
+          {/* Quadrant tints behind the gridlines (also drop targets) */}
           <div
             style={{
               position: "absolute",
@@ -258,10 +260,10 @@ export function ViewCanvas({ tasks, onOpen }: ViewCanvasProps) {
               zIndex: 0,
             }}
           >
-            <div style={{ background: "var(--q2-soft)", margin: "0 2px 2px 0" }} />
-            <div style={{ background: "var(--q1-soft)", margin: "0 0 2px 2px" }} />
-            <div style={{ background: "var(--q4-soft)", margin: "2px 2px 0 0" }} />
-            <div style={{ background: "var(--q3-soft)", margin: "2px 0 0 2px" }} />
+            <CanvasDropZone rdKey="q2" margin="0 2px 2px 0" />
+            <CanvasDropZone rdKey="q1" margin="0 0 2px 2px" />
+            <CanvasDropZone rdKey="q4" margin="2px 2px 0 0" />
+            <CanvasDropZone rdKey="q3" margin="2px 0 0 2px" />
           </div>
 
           <QLabel pos={{ top: 12, left: 14 }} rdKey="q2" />
@@ -283,85 +285,17 @@ export function ViewCanvas({ tasks, onOpen }: ViewCanvasProps) {
             ← Not important · <strong>Importance</strong> · Important →
           </AxisLabel>
 
-          {positioned.map(({ task, x, y }) => {
-            const q = quadrantForTask(task.urgent, task.important);
-            const isHovered = hoveredId === task.id;
-            const overdue = isOverdue(task);
-            return (
-              <div
-                key={task.id}
-                onMouseEnter={() => setHoveredId(task.id)}
-                onMouseLeave={() => setHoveredId(null)}
-                onClick={() => onOpen(task)}
-                style={{
-                  position: "absolute",
-                  left: `${x * 100}%`,
-                  top: `${y * 100}%`,
-                  transform: "translate(-50%, -50%)",
-                  zIndex: isHovered ? 10 : 1,
-                  cursor: "pointer",
-                }}
-              >
-                <div
-                  className="inline-flex items-center gap-1.5"
-                  style={{
-                    padding: isHovered ? "6px 12px 6px 8px" : "5px 10px 5px 8px",
-                    background: "var(--paper)",
-                    border: `1px solid var(--${q.rdKey})`,
-                    borderRadius: 999,
-                    boxShadow: isHovered ? "var(--rd-shadow)" : "var(--rd-shadow-sm)",
-                    transform: isHovered ? "scale(1.04)" : "none",
-                    transition: "transform .15s ease, box-shadow .15s ease, padding .15s ease, max-width .15s ease",
-                    maxWidth: isHovered ? 320 : 180,
-                  }}
-                >
-                  <span
-                    style={{
-                      width: 7,
-                      height: 7,
-                      borderRadius: 999,
-                      background: `var(--${q.rdKey})`,
-                      flexShrink: 0,
-                      display: "inline-block",
-                    }}
-                  />
-                  <span
-                    style={{
-                      fontSize: 12.5,
-                      fontWeight: 500,
-                      whiteSpace: "nowrap",
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      color: "var(--ink)",
-                    }}
-                  >
-                    {task.title}
-                  </span>
-                  {overdue && (
-                    <AlertCircle size={11} strokeWidth={2.4} style={{ color: "var(--q1)", flexShrink: 0 }} />
-                  )}
-                </div>
-                {isHovered && task.description && (
-                  <div
-                    style={{
-                      position: "absolute",
-                      top: "calc(100% + 4px)",
-                      left: 0,
-                      padding: "8px 10px",
-                      background: "var(--ink)",
-                      color: "var(--paper)",
-                      borderRadius: 8,
-                      fontSize: 11.5,
-                      maxWidth: 280,
-                      lineHeight: 1.4,
-                    }}
-                  >
-                    {task.description}
-                  </div>
-                )}
-              </div>
-            );
-          })}
+          {positioned.map(({ task, x, y }) => (
+            <CanvasPill
+              key={task.id}
+              task={task}
+              x={x}
+              y={y}
+              hovered={hoveredId === task.id}
+              onHover={setHoveredId}
+              onOpen={onOpen}
+            />
+          ))}
         </div>
 
         <div
@@ -372,9 +306,174 @@ export function ViewCanvas({ tasks, onOpen }: ViewCanvasProps) {
             textAlign: "center",
           }}
         >
-          Tasks near the axes are borderline. Click a pill to open it.
+          Drag a pill to re-quadrant. Click to open.
         </div>
       </div>
+    </div>
+  );
+}
+
+function CanvasDropZone({ rdKey, margin }: { rdKey: RedesignQuadrantKey; margin: string }) {
+  const quadrant = quadrants.find((q) => q.rdKey === rdKey)!;
+  const { setNodeRef, isOver } = useDroppable({ id: quadrant.id });
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        background: `var(--${rdKey}-soft)`,
+        margin,
+        transition: "box-shadow .15s ease, background-color .15s ease",
+        boxShadow: isOver ? `inset 0 0 0 2px var(--${rdKey})` : "none",
+      }}
+    />
+  );
+}
+
+function CanvasPill({
+  task,
+  x,
+  y,
+  hovered,
+  onHover,
+  onOpen,
+}: {
+  task: TaskRecord;
+  x: number;
+  y: number;
+  hovered: boolean;
+  onHover: (id: string | null) => void;
+  onOpen: (task: TaskRecord) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id: task.id });
+  const q = quadrantForTask(task.urgent, task.important);
+  const overdue = isOverdue(task);
+  const pillTransform = transform
+    ? `translate(-50%, -50%) ${CSS.Translate.toString(transform)}`
+    : "translate(-50%, -50%)";
+
+  return (
+    <button
+      ref={setNodeRef}
+      type="button"
+      {...attributes}
+      {...listeners}
+      onMouseEnter={() => onHover(task.id)}
+      onMouseLeave={() => onHover(null)}
+      onClick={() => onOpen(task)}
+      aria-label={`Open task: ${task.title}`}
+      style={{
+        position: "absolute",
+        left: `${x * 100}%`,
+        top: `${y * 100}%`,
+        transform: pillTransform,
+        zIndex: isDragging ? 20 : hovered ? 10 : 1,
+        cursor: isDragging ? "grabbing" : "grab",
+        opacity: isDragging ? 0.4 : 1,
+        touchAction: "manipulation",
+        background: "transparent",
+        border: 0,
+        padding: 0,
+      }}
+    >
+      <div
+        className="inline-flex items-center gap-1.5"
+        style={{
+          padding: hovered ? "6px 12px 6px 8px" : "5px 10px 5px 8px",
+          background: "var(--paper)",
+          border: `1px solid var(--${q.rdKey})`,
+          borderRadius: 999,
+          boxShadow: hovered ? "var(--rd-shadow)" : "var(--rd-shadow-sm)",
+          transform: hovered && !isDragging ? "scale(1.04)" : "none",
+          transition: "transform .15s ease, box-shadow .15s ease, padding .15s ease, max-width .15s ease",
+          maxWidth: hovered ? 320 : 180,
+        }}
+      >
+        <span
+          style={{
+            width: 7,
+            height: 7,
+            borderRadius: 999,
+            background: `var(--${q.rdKey})`,
+            flexShrink: 0,
+            display: "inline-block",
+          }}
+        />
+        <span
+          style={{
+            fontSize: 12.5,
+            fontWeight: 500,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            color: "var(--ink)",
+          }}
+        >
+          {task.title}
+        </span>
+        {overdue && <AlertCircle size={11} strokeWidth={2.4} style={{ color: "var(--q1)", flexShrink: 0 }} />}
+      </div>
+      {hovered && !isDragging && task.description && (
+        <div
+          style={{
+            position: "absolute",
+            top: "calc(100% + 4px)",
+            left: 0,
+            padding: "8px 10px",
+            background: "var(--ink)",
+            color: "var(--paper)",
+            borderRadius: 8,
+            fontSize: 11.5,
+            maxWidth: 280,
+            lineHeight: 1.4,
+            pointerEvents: "none",
+            textAlign: "left",
+          }}
+        >
+          {task.description}
+        </div>
+      )}
+    </button>
+  );
+}
+
+export function CanvasPillPreview({ task }: { task: TaskRecord }) {
+  const q = quadrantForTask(task.urgent, task.important);
+  const overdue = isOverdue(task);
+  return (
+    <div
+      className="inline-flex items-center gap-1.5"
+      style={{
+        padding: "6px 12px 6px 8px",
+        background: "var(--paper)",
+        border: `1px solid var(--${q.rdKey})`,
+        borderRadius: 999,
+        boxShadow: "var(--rd-shadow)",
+        maxWidth: 260,
+      }}
+    >
+      <span
+        style={{
+          width: 7,
+          height: 7,
+          borderRadius: 999,
+          background: `var(--${q.rdKey})`,
+          flexShrink: 0,
+          display: "inline-block",
+        }}
+      />
+      <span
+        style={{
+          fontSize: 12.5,
+          fontWeight: 500,
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          color: "var(--ink)",
+        }}
+      >
+        {task.title}
+      </span>
+      {overdue && <AlertCircle size={11} strokeWidth={2.4} style={{ color: "var(--q1)", flexShrink: 0 }} />}
     </div>
   );
 }

--- a/components/redesign/view-editorial.tsx
+++ b/components/redesign/view-editorial.tsx
@@ -5,6 +5,7 @@ import { Plus } from "lucide-react";
 import type { TaskRecord } from "@/lib/types";
 import { quadrants, type QuadrantMeta, type RedesignQuadrantKey } from "@/lib/quadrants";
 import { DraggableTaskCard } from "./draggable-task-card";
+import { MatrixCompass } from "./matrix-compass";
 import { RdButton, RdIconButton, RdQuadrantIcon } from "./primitives";
 
 export interface ViewEditorialProps {
@@ -29,10 +30,23 @@ function groupByQuadrant(tasks: TaskRecord[]): Record<RedesignQuadrantKey, TaskR
 export function ViewEditorial({ tasks, onToggle, onOpen, onAdd }: ViewEditorialProps) {
   const by = groupByQuadrant(tasks);
   return (
-    <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 18 }} className="rd-editorial-grid">
-      {quadrants.map((q) => (
-        <EditorialColumn key={q.id} quadrant={q} tasks={by[q.rdKey]} onToggle={onToggle} onOpen={onOpen} onAdd={onAdd} />
-      ))}
+    <div className="rd-focus-grid">
+      <div
+        style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 18 }}
+        className="rd-editorial-grid"
+      >
+        {quadrants.map((q) => (
+          <EditorialColumn
+            key={q.id}
+            quadrant={q}
+            tasks={by[q.rdKey]}
+            onToggle={onToggle}
+            onOpen={onOpen}
+            onAdd={onAdd}
+          />
+        ))}
+      </div>
+      <MatrixCompass tasks={tasks} variant="list" label="Balance" onAdd={onAdd} />
     </div>
   );
 }

--- a/components/redesign/view-focus.tsx
+++ b/components/redesign/view-focus.tsx
@@ -3,10 +3,11 @@
 import { useMemo } from "react";
 import { Plus } from "lucide-react";
 import type { TaskRecord } from "@/lib/types";
-import { quadrants, type RedesignQuadrantKey } from "@/lib/quadrants";
+import type { RedesignQuadrantKey } from "@/lib/quadrants";
 import { dueBucket } from "@/lib/redesign/due";
 import { TaskCard } from "./task-card";
-import { Divider, RdButton } from "./primitives";
+import { RdButton } from "./primitives";
+import { MatrixCompass } from "./matrix-compass";
 
 export interface ViewFocusProps {
   tasks: TaskRecord[];
@@ -23,7 +24,7 @@ function formatDateCaption(now: Date): string {
 }
 
 export function ViewFocus({ tasks, onToggle, onOpen, onAdd }: ViewFocusProps) {
-  const { now, today, next, later, byQuadrant, total } = useMemo(() => {
+  const { now, today, next, later } = useMemo(() => {
     const active = tasks.filter((t) => !t.completed);
     const now = active.filter((t) => t.urgent && t.important);
     const today = active.filter(
@@ -35,13 +36,7 @@ export function ViewFocus({ tasks, onToggle, onOpen, onAdd }: ViewFocusProps) {
     const later = active.filter(
       (t) => !(t.urgent && t.important) && dueBucket(t.dueDate) !== "today" && !t.important
     );
-    const byQuadrant: Record<RedesignQuadrantKey, number> = { q1: 0, q2: 0, q3: 0, q4: 0 };
-    active.forEach((t) => {
-      const key: RedesignQuadrantKey =
-        t.urgent && t.important ? "q1" : !t.urgent && t.important ? "q2" : t.urgent ? "q3" : "q4";
-      byQuadrant[key]++;
-    });
-    return { now, today, next, later, byQuadrant, total: active.length };
+    return { now, today, next, later };
   }, [tasks]);
 
   const caption = formatDateCaption(new Date());
@@ -91,86 +86,7 @@ export function ViewFocus({ tasks, onToggle, onOpen, onAdd }: ViewFocusProps) {
         </div>
       </div>
 
-      <aside className="rd-compass" style={{ position: "sticky", top: 20 }}>
-        <div
-          style={{
-            fontSize: 11,
-            letterSpacing: 0.12,
-            textTransform: "uppercase",
-            color: "var(--ink-3)",
-            fontWeight: 600,
-            marginBottom: 10,
-          }}
-        >
-          Matrix compass
-        </div>
-        <div
-          style={{
-            background: "var(--paper)",
-            border: "1px solid var(--line)",
-            borderRadius: "var(--rd-radius-lg)",
-            padding: 14,
-          }}
-        >
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6 }}>
-            {quadrants.map((q) => {
-              const count = byQuadrant[q.rdKey];
-              return (
-                <button
-                  key={q.rdKey}
-                  type="button"
-                  onClick={() => onAdd(q.rdKey)}
-                  style={{
-                    background: `var(--${q.rdKey}-tint)`,
-                    borderRadius: 10,
-                    padding: "10px 10px 12px",
-                    minHeight: 78,
-                    position: "relative",
-                    border: 0,
-                    textAlign: "left",
-                    cursor: "pointer",
-                  }}
-                >
-                  <div
-                    style={{
-                      fontSize: 10.5,
-                      fontWeight: 600,
-                      color: `var(--${q.rdKey})`,
-                      letterSpacing: 0.04,
-                      textTransform: "uppercase",
-                    }}
-                  >
-                    {q.rdShort}
-                  </div>
-                  <div style={{ fontSize: 13, fontWeight: 600, color: "var(--ink)", marginTop: 2 }}>{q.title}</div>
-                  <div
-                    className="rd-serif"
-                    style={{
-                      position: "absolute",
-                      right: 10,
-                      bottom: 6,
-                      fontSize: 26,
-                      color: `var(--${q.rdKey})`,
-                      lineHeight: 1,
-                    }}
-                  >
-                    {count}
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-          <Divider style={{ margin: "12px 0" }} />
-          <div style={{ fontSize: 12, color: "var(--ink-3)", lineHeight: 1.5 }}>
-            <strong style={{ color: "var(--ink)" }}>{total}</strong> active ·{" "}
-            {Math.round((byQuadrant.q2 / Math.max(total, 1)) * 100)}% in the{" "}
-            <em className="rd-serif" style={{ fontStyle: "italic" }}>
-              growth
-            </em>{" "}
-            quadrant
-          </div>
-        </div>
-      </aside>
+      <MatrixCompass tasks={tasks} variant="grid" label="Matrix compass" onAdd={onAdd} />
     </div>
   );
 }

--- a/components/sync/use-sync-status.ts
+++ b/components/sync/use-sync-status.ts
@@ -23,6 +23,12 @@ interface SyncStatusOptions {
   error: string | null;
   nextRetryAt: number | null;
   onAuthError: (message: string, action?: { label: string; onClick: () => void }, duration?: number) => void;
+  /**
+   * Timestamp of the most recent successful sync. When provided alongside
+   * `isEnabled` and idle status, the tooltip communicates the healthy
+   * steady-state so the visual green dot has matching copy.
+   */
+  lastSuccessfulSyncAt?: string | null;
 }
 
 interface SyncStatusResult {
@@ -43,6 +49,7 @@ export function useSyncStatus({
   error,
   nextRetryAt,
   onAuthError,
+  lastSuccessfulSyncAt = null,
 }: SyncStatusOptions): SyncStatusResult {
   const [pendingCount, setPendingCount] = useState(0);
   const [retryCountdown, setRetryCountdown] = useState<number | null>(null);
@@ -110,6 +117,7 @@ export function useSyncStatus({
     status,
     error,
     pendingCount,
+    lastSuccessfulSyncAt,
   });
 
   return {
@@ -158,6 +166,7 @@ interface TooltipOptions {
   status: SyncStatus;
   error: string | null;
   pendingCount: number;
+  lastSuccessfulSyncAt: string | null;
 }
 
 function getTooltip({
@@ -167,10 +176,16 @@ function getTooltip({
   status,
   error,
   pendingCount,
+  lastSuccessfulSyncAt,
 }: TooltipOptions): string {
   if (!isEnabled) return 'Sync not enabled';
   if (hasAuthError) return 'Authentication expired - Click to re-login';
   if (retryCountdown !== null && retryCountdown > 0) return `Retrying in ${retryCountdown}s...`;
+
+  // Healthy steady-state: mirror the green-dot affordance with matching copy.
+  if (status === 'idle' && pendingCount === 0 && lastSuccessfulSyncAt) {
+    return 'Synced · Click to sync now';
+  }
 
   return getStatusTooltip(status, error, pendingCount);
 }

--- a/lib/sync/sync-provider.tsx
+++ b/lib/sync/sync-provider.tsx
@@ -34,6 +34,8 @@ export interface SyncState {
   retryCount: number;
   autoSyncEnabled: boolean;
   autoSyncInterval: number;
+  /** Timestamp of the most recent successful sync, or null if never synced. */
+  lastSuccessfulSyncAt: string | null;
 }
 
 const SyncContext = createContext<SyncState | null>(null);
@@ -57,6 +59,7 @@ export function SyncProvider({ children }: { children: ReactNode }) {
   const [retryCount, setRetryCount] = useState(0);
   const [autoSyncEnabled, setAutoSyncEnabled] = useState(true);
   const [autoSyncInterval, setAutoSyncInterval] = useState(2);
+  const [lastSuccessfulSyncAt, setLastSuccessfulSyncAt] = useState<string | null>(null);
 
   // Single lifecycle owner for health monitor and background sync
   useEffect(() => {
@@ -112,6 +115,7 @@ export function SyncProvider({ children }: { children: ReactNode }) {
       setPendingRequests(coordStatus.pendingRequests);
       setNextRetryAt(coordStatus.nextRetryAt);
       setRetryCount(coordStatus.retryCount);
+      setLastSuccessfulSyncAt(coordStatus.lastSuccessfulSyncAt);
 
       const autoConfig = await getAutoSyncConfig();
       setAutoSyncEnabled(autoConfig.enabled);
@@ -230,6 +234,7 @@ export function SyncProvider({ children }: { children: ReactNode }) {
     retryCount,
     autoSyncEnabled,
     autoSyncInterval,
+    lastSuccessfulSyncAt,
   };
 
   return (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.4.1",
+	"version": "8.5.0",
 	"private": true,
 	"type": "module",
 	"scripts": {
@@ -89,7 +89,7 @@
 		"qs": ">=6.14.2",
 		"minimatch": ">=3.1.3",
 		"rollup": ">=4.59.0",
-		"hono": ">=4.12.12",
+		"hono": ">=4.12.14",
 		"undici": ">=7.24.0",
 		"flatted": ">=3.4.2",
 		"express-rate-limit": ">=8.2.2",

--- a/tests/data/sync/use-sync-status-tooltip.test.ts
+++ b/tests/data/sync/use-sync-status-tooltip.test.ts
@@ -1,0 +1,65 @@
+import { renderHook } from '@testing-library/react';
+
+vi.mock('@/lib/sync/queue', () => ({
+  getSyncQueue: () => ({ getPendingCount: async () => 0 }),
+}));
+
+vi.mock('@/lib/sync/error-categorizer', () => ({
+  isAuthError: () => false,
+}));
+
+vi.mock('@/lib/constants/sync', () => ({
+  SYNC_CONFIG: {
+    PENDING_COUNT_POLL_INTERVAL_MS: 60_000,
+    COUNTDOWN_UPDATE_INTERVAL_MS: 60_000,
+  },
+  SYNC_TOAST_DURATION: { SHORT: 2000, MEDIUM: 4000, LONG: 6000 },
+}));
+
+import { useSyncStatus } from '@/components/sync/use-sync-status';
+
+describe('useSyncStatus tooltip — healthy idle', () => {
+  const onAuthError = vi.fn();
+
+  it('reads "Synced · Click to sync now" when enabled, idle, and we have a successful sync on record', () => {
+    const { result } = renderHook(() =>
+      useSyncStatus({
+        isEnabled: true,
+        status: 'idle',
+        error: null,
+        nextRetryAt: null,
+        onAuthError,
+        lastSuccessfulSyncAt: '2026-04-20T00:00:00.000Z',
+      })
+    );
+    expect(result.current.tooltip).toBe('Synced · Click to sync now');
+  });
+
+  it('falls back to the generic idle tooltip before the first successful sync', () => {
+    const { result } = renderHook(() =>
+      useSyncStatus({
+        isEnabled: true,
+        status: 'idle',
+        error: null,
+        nextRetryAt: null,
+        onAuthError,
+        lastSuccessfulSyncAt: null,
+      })
+    );
+    expect(result.current.tooltip).toBe('Sync with cloud');
+  });
+
+  it('still reports "Sync not enabled" when sync is disabled even with a stale success timestamp', () => {
+    const { result } = renderHook(() =>
+      useSyncStatus({
+        isEnabled: false,
+        status: 'idle',
+        error: null,
+        nextRetryAt: null,
+        onAuthError,
+        lastSuccessfulSyncAt: '2026-04-20T00:00:00.000Z',
+      })
+    );
+    expect(result.current.tooltip).toBe('Sync not enabled');
+  });
+});


### PR DESCRIPTION
## Summary

Round-2 polish for the editorial redesign — three reinforcing changes shipped together because they share information architecture (sidebar balance ↔ canvas interactivity ↔ cleaner sync signaling).

- **P1 — Matrix compass sidebar.** The Matrix view now wraps its 2×2 grid in `.rd-focus-grid` and gains a compass sidecar that mirrors Focus's IA. Extracted `<MatrixCompass variant="grid" | "list">` so the two compasses share `total` / `growthPct` computation and footer copy instead of drifting over time.
- **P2 — Canvas drag-and-drop.** Canvas pills are draggable via `@dnd-kit`; drops route through the existing `useDragAndDrop` → `moveTaskToQuadrant` pipeline, so persistence is identical to the Matrix view. `DragOverlay` branches on `view === "canvas"` and renders a mini-pill (`CanvasPillPreview`) so the overlay doesn't balloon into a full card over a pill-sized source. Pills are `<button type="button">` for keyboard activation. Caption now reads *"Drag a pill to re-quadrant. Click to open."*
- **P3 — Sync healthy indicator.** Added `lastSuccessfulSyncAt` to `SyncState` (sourced from `coordStatus.lastSuccessfulSyncAt`). The sync button lights a green dot only when `isEnabled && status === "idle" && lastSuccessfulSyncAt != null` — guards against the false-positive of showing green right after OAuth sign-in, before a first sync has completed. Tooltip reads *"Synced · Click to sync now"* in that state. The decorative footer dot in the sidebar is removed; the topbar cloud icon is now the single source of truth for sync state.

Also bumps the `hono` override from `>=4.12.12` to `>=4.12.14` to clear `GHSA-458j-xx4x-4375` (hono/jsx SSR HTML injection, transitive via the MCP SDK). `bun audit` now reports clean.

Version: 8.4.1 → 8.5.0.

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun run test` — 16 pre-existing failures unchanged (verified via `git stash`); 3 new tests in `tests/data/sync/use-sync-status-tooltip.test.ts` cover the healthy-idle tooltip branch
- [x] `bun lint` — 0 new errors (5 pre-existing warnings unchanged)
- [x] `bun audit` — no vulnerabilities after override bump
- [ ] **Manual browser verification required before merge:**
  - [ ] Matrix view on a 1440px display shows four quadrants on the left and the Balance card on the right; collapses to single column under 900px.
  - [ ] Drag a pill from top-right quadrant of Canvas into bottom-left — task updates to not-urgent/not-important, pill snaps into new position, reload persists. Verify a short click on a pill still opens the composer (8px activation distance should separate click from drag).
  - [ ] Drag overlay on Canvas renders a mini-pill, not a full task card.
  - [ ] With sync disabled: cloud icon has no dot. Enable sync, trigger one successful sync → green dot appears with "Synced · Click to sync now" tooltip. Right after OAuth sign-in but before first sync: **no** green dot.
  - [ ] Sidebar footer shows "Saved locally" without any dot.
  - [ ] Keyboard: tab to a canvas pill and press Enter — task opens.

Review doc at `design_handoff_gsd_redesign_v2/patches/README.md` was the basis for this work; review fixes (`touch-action` pattern match, drag-overlay mismatch, premature-green dot, accessibility) are folded in.