### PR TITLE
test(ui): align tests with editorial redesign

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.5.0",
+	"version": "8.5.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/ui/matrix-board.test.tsx
+++ b/tests/ui/matrix-board.test.tsx
@@ -654,7 +654,7 @@ describe('MatrixBoard Integration Tests', () => {
     it('should enter selection mode when task is selected', async () => {
       await renderWithProviders(<MatrixBoard />);
 
-      const selectionToggle = await screen.findByRole('button', { name: /select tasks/i });
+      const selectionToggle = await screen.findByRole('button', { name: /^select$/i });
       await user.click(selectionToggle);
 
       const taskCheckbox = await screen.findByRole('checkbox', { name: /select bulk task 1/i });
@@ -669,7 +669,7 @@ describe('MatrixBoard Integration Tests', () => {
     it('should select multiple tasks', async () => {
       await renderWithProviders(<MatrixBoard />);
 
-      const selectionToggle = await screen.findByRole('button', { name: /select tasks/i });
+      const selectionToggle = await screen.findByRole('button', { name: /^select$/i });
       await user.click(selectionToggle);
 
       // Select first task
@@ -689,7 +689,7 @@ describe('MatrixBoard Integration Tests', () => {
     it('should bulk delete selected tasks', async () => {
       await renderWithProviders(<MatrixBoard />);
 
-      const selectionToggle = await screen.findByRole('button', { name: /select tasks/i });
+      const selectionToggle = await screen.findByRole('button', { name: /^select$/i });
       await user.click(selectionToggle);
 
       // Select tasks
@@ -718,7 +718,7 @@ describe('MatrixBoard Integration Tests', () => {
     it('should bulk complete selected tasks', async () => {
       await renderWithProviders(<MatrixBoard />);
 
-      const selectionToggle = await screen.findByRole('button', { name: /select tasks/i });
+      const selectionToggle = await screen.findByRole('button', { name: /^select$/i });
       await user.click(selectionToggle);
 
       // Select tasks

--- a/tests/ui/matrix-page.test.tsx
+++ b/tests/ui/matrix-page.test.tsx
@@ -5,8 +5,30 @@ import { render, screen } from "@testing-library/react";
 // Mocks
 // ---------------------------------------------------------------------------
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 vi.mock("@/components/matrix-board", () => ({
   MatrixBoard: () => <div data-testid="matrix-board">MatrixBoard</div>,
+}));
+
+vi.mock("@/components/dashboard/dashboard-shell-header", () => ({
+  DashboardShellHeader: () => <div data-testid="dashboard-shell-header" />,
+}));
+
+vi.mock("@/components/app-header/app-rail", () => ({
+  AppRail: () => <div data-testid="app-rail" />,
+}));
+
+vi.mock("@/components/app-footer", () => ({
+  AppFooter: () => <div data-testid="app-footer" />,
+}));
+
+vi.mock("@/lib/use-keyboard-shortcuts", () => ({
+  useKeyboardShortcuts: () => undefined,
 }));
 
 vi.mock("@/components/redesign/redesign-matrix", () => ({
@@ -118,19 +140,16 @@ describe("DashboardPage", () => {
     render(<DashboardPage />);
 
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
-    expect(
-      screen.getByText("Track your productivity and task completion metrics")
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Track follow-through/i)).toBeInTheDocument();
   });
 
-  it("renders ViewToggle and ThemeToggle in the nav bar", async () => {
+  it("renders the dashboard shell header", async () => {
     const { default: DashboardPage } = await import(
       "@/app/(dashboard)/dashboard/page"
     );
     render(<DashboardPage />);
 
-    expect(screen.getByTestId("view-toggle")).toBeInTheDocument();
-    expect(screen.getByTestId("theme-toggle")).toBeInTheDocument();
+    expect(screen.getByTestId("dashboard-shell-header")).toBeInTheDocument();
   });
 
   it("shows empty state when there are no tasks", async () => {

--- a/tests/ui/misc-components.test.tsx
+++ b/tests/ui/misc-components.test.tsx
@@ -43,6 +43,21 @@ vi.mock('@/components/ui/tooltip', () => ({
   TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode;
+    onSelect?: () => void;
+  }) => <button onClick={onSelect}>{children}</button>,
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
 // --- Imports ---
 
 import { ThemeToggle } from '@/components/theme-toggle';
@@ -168,45 +183,41 @@ describe('PwaRegister', () => {
 
 describe('HeaderActions', () => {
   const defaultProps = {
-    onNewTask: vi.fn(),
     onHelp: vi.fn(),
     onOpenSettings: vi.fn(),
+    onOpenAbout: vi.fn(),
     selectionMode: false,
     selectedCount: 0,
-    isDoFirstEmpty: false,
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('calls onOpenSettings directly when the Settings button is clicked', () => {
+  it('calls onOpenSettings when the Settings menu item is selected', () => {
     const onOpenSettings = vi.fn();
     render(<HeaderActions {...defaultProps} onOpenSettings={onOpenSettings} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /settings/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^settings$/i }));
 
     expect(onOpenSettings).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onNewTask when the New Task button is clicked', () => {
-    const onNewTask = vi.fn();
-    render(<HeaderActions {...defaultProps} onNewTask={onNewTask} />);
-
-    // Both mobile (icon-only) and desktop (labeled) "New Task" buttons are rendered;
-    // getAllByRole avoids ambiguity and either click should wire to onNewTask.
-    const [firstNewTaskButton] = screen.getAllByRole('button', { name: /new task|create task/i });
-    fireEvent.click(firstNewTaskButton);
-
-    expect(onNewTask).toHaveBeenCalledTimes(1);
-  });
-
-  it('calls onHelp when the Help button is clicked', () => {
+  it('calls onHelp when the Help menu item is selected', () => {
     const onHelp = vi.fn();
     render(<HeaderActions {...defaultProps} onHelp={onHelp} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /user guide/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^help$/i }));
 
     expect(onHelp).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onOpenAbout when the About menu item is selected', () => {
+    const onOpenAbout = vi.fn();
+    render(<HeaderActions {...defaultProps} onOpenAbout={onOpenAbout} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^about$/i }));
+
+    expect(onOpenAbout).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/ui/remaining-components.test.tsx
+++ b/tests/ui/remaining-components.test.tsx
@@ -204,7 +204,6 @@ describe('AppHeader', () => {
     render(<AppHeader {...defaultProps} />);
 
     expect(screen.getByText('GSD Task Manager')).toBeInTheDocument();
-    expect(screen.getByTestId('gsd-logo')).toBeInTheDocument();
   });
 
   it('renders view toggle and smart view pills', () => {
@@ -217,19 +216,19 @@ describe('AppHeader', () => {
   it('renders search button when search is collapsed', () => {
     render(<AppHeader {...defaultProps} />);
 
-    expect(screen.getByText('Search')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /search tasks/i })).toBeInTheDocument();
   });
 
-  it('renders Add Filter button', () => {
+  it('renders Filters button', () => {
     render(<AppHeader {...defaultProps} />);
 
-    expect(screen.getByText('Add Filter')).toBeInTheDocument();
+    expect(screen.getByText('Filters')).toBeInTheDocument();
   });
 
-  it('calls onOpenFilters when Add Filter is clicked', () => {
+  it('calls onOpenFilters when Filters is clicked', () => {
     render(<AppHeader {...defaultProps} />);
 
-    fireEvent.click(screen.getByText('Add Filter'));
+    fireEvent.click(screen.getByText('Filters'));
     expect(defaultProps.onOpenFilters).toHaveBeenCalledOnce();
   });
 


### PR DESCRIPTION
## Summary
- Restores 16 failing UI tests after the matrix redesign landed (#215) shifted `HeaderActions`, `AppHeader`, `DashboardPage`, and the selection toggle
- Adds `next/navigation` + sync-related mocks so `DashboardPage` renders without a `SyncProvider`
- Rewrites `HeaderActions` tests for the new dropdown API (removed `onNewTask`, added `onOpenAbout`)
- Bumps version `8.5.0` → `8.5.1`

## Test plan
- [x] `bun run test` → 2102 pass, 1 skipped
- [x] `bun typecheck`
- [x] `bun lint` (pre-existing warnings only, no new errors)