### PR TITLE
fix(audit): remediate coding standards audit findings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
         "react-dom": "19.2.4",
         "recharts": "3.8.1",
         "sonner": "2.0.7",
-        "tailwind-merge": "^3.5.0",
+        "tailwind-merge": "3.5.0",
         "zod": "4.3.6",
       },
       "devDependencies": {

--- a/components/import-dialog.tsx
+++ b/components/import-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { AlertTriangleIcon, PlusCircleIcon, RefreshCwIcon } from "lucide-react";
+import { toast } from "sonner";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { importFromJson } from "@/lib/tasks";
@@ -45,7 +46,7 @@ export function ImportDialog({ open, onOpenChange, fileContents, existingTaskCou
       onOpenChange(false);
     } catch (error) {
       logger.error("Import failed", error instanceof Error ? error : new Error(String(error)));
-      window.alert("Import failed. Ensure you selected a valid export file.");
+      toast.error("Import failed. Ensure you selected a valid export file.");
     } finally {
       setIsImporting(false);
     }

--- a/lib/sync/health-monitor.ts
+++ b/lib/sync/health-monitor.ts
@@ -81,7 +81,8 @@ export class HealthMonitor {
       if (connectivityIssue) issues.push(connectivityIssue);
 
       return { healthy: issues.length === 0, issues, timestamp };
-    } catch {
+    } catch (error) {
+      logger.warn('Health check failed', { error });
       return {
         healthy: false,
         issues: [{
@@ -143,7 +144,8 @@ export class HealthMonitor {
       const pb = getPocketBase();
       await pb.health.check();
       return null;
-    } catch {
+    } catch (error) {
+      logger.debug('PocketBase health check failed', { error });
       return {
         type: 'server_unreachable',
         severity: 'error',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.6.0",
+	"version": "8.6.1",
 	"private": true,
 	"type": "module",
 	"scripts": {
@@ -48,7 +48,7 @@
 		"react-dom": "19.2.4",
 		"recharts": "3.8.1",
 		"sonner": "2.0.7",
-		"tailwind-merge": "^3.5.0",
+		"tailwind-merge": "3.5.0",
 		"zod": "4.3.6"
 	},
 	"devDependencies": {

--- a/tests/data/db-upgrade-paths.test.ts
+++ b/tests/data/db-upgrade-paths.test.ts
@@ -1,0 +1,608 @@
+/**
+ * Tests for lib/db.ts upgrade callbacks (v2 → v13).
+ *
+ * Strategy: seed a raw Dexie database at an older version, then reset the
+ * module cache and re-import `getDb()` to force the full v1→v13 upgrade chain.
+ * fake-indexeddb persists across module resets, so each test deletes the
+ * "GsdTaskManager" IDB first to get a clean slate.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Dexie from 'dexie';
+
+const DB_NAME = 'GsdTaskManager';
+
+async function deleteDb(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(DB_NAME);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+    req.onblocked = () => resolve();
+  });
+}
+
+async function seedAtVersion(version: number, seed: (db: Dexie) => Promise<void>, stores: Record<number, Record<string, string>>): Promise<void> {
+  const legacy = new Dexie(DB_NAME);
+  for (const [v, store] of Object.entries(stores)) {
+    legacy.version(Number(v)).stores(store);
+  }
+  await legacy.open();
+  expect(legacy.verno).toBe(version);
+  await seed(legacy);
+  legacy.close();
+}
+
+async function openCurrentDb() {
+  vi.resetModules();
+  const { getDb } = await import('@/lib/db');
+  return getDb();
+}
+
+describe('db upgrade callbacks', () => {
+  beforeEach(async () => {
+    await deleteDb();
+    vi.resetModules();
+  });
+
+  it('v2 upgrade: should backfill recurrence, tags, and subtasks defaults', async () => {
+    await seedAtVersion(1, async (legacy) => {
+      // v1 task shape — no recurrence/tags/subtasks
+      await legacy.table('tasks').add({
+        id: 'legacy-v1',
+        title: 'Legacy',
+        description: '',
+        urgent: true,
+        important: true,
+        quadrant: 'urgent-important',
+        completed: false,
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      });
+    }, {
+      1: { tasks: 'id, quadrant, completed, dueDate' },
+    });
+
+    const db = await openCurrentDb();
+    const migrated = await db.tasks.get('legacy-v1');
+    expect(migrated).toBeDefined();
+    expect(migrated!.recurrence).toBe('none');
+    expect(migrated!.tags).toEqual([]);
+    expect(migrated!.subtasks).toEqual([]);
+  });
+
+  it('v5 upgrade: should backfill notification defaults', async () => {
+    await seedAtVersion(4, async (legacy) => {
+      await legacy.table('tasks').add({
+        id: 'legacy-v4',
+        title: 'No Notif Fields',
+        description: '',
+        urgent: false,
+        important: true,
+        quadrant: 'not-urgent-important',
+        completed: false,
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+        recurrence: 'none',
+        tags: [],
+        subtasks: [],
+      });
+    }, {
+      1: { tasks: 'id, quadrant, completed, dueDate' },
+      2: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags' },
+      3: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed]' },
+      4: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed]', smartViews: 'id, name, isBuiltIn, createdAt' },
+    });
+
+    const db = await openCurrentDb();
+    const migrated = await db.tasks.get('legacy-v4');
+    expect(migrated).toBeDefined();
+    expect(migrated!.notificationEnabled).toBe(true);
+    expect(migrated!.notificationSent).toBe(false);
+  });
+
+  it('v6 upgrade: should backfill dependencies as empty array', async () => {
+    await seedAtVersion(5, async (legacy) => {
+      await legacy.table('tasks').add({
+        id: 'no-deps',
+        title: 'No Deps',
+        description: '',
+        urgent: false,
+        important: false,
+        quadrant: 'not-urgent-not-important',
+        completed: false,
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+        recurrence: 'none',
+        tags: [],
+        subtasks: [],
+        notificationEnabled: true,
+        notificationSent: false,
+      });
+    }, {
+      1: { tasks: 'id, quadrant, completed, dueDate' },
+      2: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags' },
+      3: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed]' },
+      4: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed]', smartViews: 'id, name, isBuiltIn, createdAt' },
+      5: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+      },
+    });
+
+    const db = await openCurrentDb();
+    const migrated = await db.tasks.get('no-deps');
+    expect(migrated).toBeDefined();
+    expect(migrated!.dependencies).toEqual([]);
+  });
+
+  it('v8 upgrade: should backfill completedAt from updatedAt for completed tasks', async () => {
+    await seedAtVersion(7, async (legacy) => {
+      await legacy.table('tasks').add({
+        id: 'completed-pre-v8',
+        title: 'Done Old',
+        description: '',
+        urgent: false,
+        important: false,
+        quadrant: 'not-urgent-not-important',
+        completed: true,
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-06-01T00:00:00.000Z',
+        recurrence: 'none',
+        tags: [],
+        subtasks: [],
+        dependencies: [],
+        notificationEnabled: false,
+        notificationSent: false,
+      });
+    }, {
+      1: { tasks: 'id, quadrant, completed, dueDate' },
+      2: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags' },
+      3: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed]' },
+      4: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed]', smartViews: 'id, name, isBuiltIn, createdAt' },
+      5: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+      },
+      6: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+      },
+      7: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+        syncQueue: 'id, taskId, operation, timestamp, retryCount',
+        syncMetadata: 'key',
+        deviceInfo: 'key',
+      },
+    });
+
+    const db = await openCurrentDb();
+    const migrated = await db.tasks.get('completed-pre-v8');
+    expect(migrated).toBeDefined();
+    expect(migrated!.completedAt).toBe('2025-06-01T00:00:00.000Z');
+  });
+
+  it('v11 upgrade: should initialise default appPreferences row', async () => {
+    await seedAtVersion(10, async () => {
+      // No seeding needed — migration creates defaults.
+    }, {
+      1: { tasks: 'id, quadrant, completed, dueDate' },
+      2: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags' },
+      3: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed]' },
+      4: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed]', smartViews: 'id, name, isBuiltIn, createdAt' },
+      5: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+      },
+      6: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+      },
+      7: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+        syncQueue: 'id, taskId, operation, timestamp, retryCount',
+        syncMetadata: 'key',
+        deviceInfo: 'key',
+      },
+      8: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies, completedAt',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+        syncQueue: 'id, taskId, operation, timestamp, retryCount',
+        syncMetadata: 'key',
+        deviceInfo: 'key',
+      },
+      9: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies, completedAt',
+        archivedTasks: 'id, quadrant, completed, dueDate, completedAt, archivedAt',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+        syncQueue: 'id, taskId, operation, timestamp, retryCount',
+        syncMetadata: 'key',
+        deviceInfo: 'key',
+        archiveSettings: 'id',
+      },
+      10: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies, completedAt',
+        archivedTasks: 'id, quadrant, completed, dueDate, completedAt, archivedAt',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+        syncQueue: 'id, taskId, operation, timestamp, retryCount',
+        syncMetadata: 'key',
+        deviceInfo: 'key',
+        archiveSettings: 'id',
+        syncHistory: 'id, timestamp, status, deviceId',
+      },
+    });
+
+    const db = await openCurrentDb();
+    const prefs = await db.appPreferences.get('preferences');
+    expect(prefs).toBeDefined();
+    expect(prefs!.pinnedSmartViewIds).toEqual([]);
+    expect(prefs!.maxPinnedViews).toBe(5);
+  });
+
+  it('v12 upgrade: should initialise time-tracking fields and reset corrupt data', async () => {
+    await seedAtVersion(11, async (legacy) => {
+      await legacy.table('tasks').bulkAdd([
+        {
+          id: 'no-time',
+          title: 'No Time Fields',
+          description: '',
+          urgent: false,
+          important: false,
+          quadrant: 'not-urgent-not-important',
+          completed: false,
+          createdAt: '2025-01-01T00:00:00.000Z',
+          updatedAt: '2025-01-01T00:00:00.000Z',
+          recurrence: 'none',
+          tags: [],
+          subtasks: [],
+          dependencies: [],
+          notificationEnabled: false,
+          notificationSent: false,
+        },
+        {
+          id: 'corrupt-time',
+          title: 'Corrupt Time Data',
+          description: '',
+          urgent: false,
+          important: false,
+          quadrant: 'not-urgent-not-important',
+          completed: false,
+          createdAt: '2025-01-01T00:00:00.000Z',
+          updatedAt: '2025-01-01T00:00:00.000Z',
+          recurrence: 'none',
+          tags: [],
+          subtasks: [],
+          dependencies: [],
+          notificationEnabled: false,
+          notificationSent: false,
+          timeEntries: 'not-an-array',
+          timeSpent: -5,
+        },
+        {
+          id: 'mixed-entries',
+          title: 'Mixed valid/invalid time entries',
+          description: '',
+          urgent: false,
+          important: false,
+          quadrant: 'not-urgent-not-important',
+          completed: false,
+          createdAt: '2025-01-01T00:00:00.000Z',
+          updatedAt: '2025-01-01T00:00:00.000Z',
+          recurrence: 'none',
+          tags: [],
+          subtasks: [],
+          dependencies: [],
+          notificationEnabled: false,
+          notificationSent: false,
+          timeEntries: [
+            { id: 'ok', startedAt: '2025-01-01T00:00:00.000Z' },
+            { id: 42, startedAt: 'bad' },
+            null,
+          ],
+          timeSpent: Number.NaN,
+        },
+      ]);
+    }, {
+      1: { tasks: 'id, quadrant, completed, dueDate' },
+      2: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags' },
+      3: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed]' },
+      4: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed]', smartViews: 'id, name, isBuiltIn, createdAt' },
+      5: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+      },
+      6: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+      },
+      7: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+        syncQueue: 'id, taskId, operation, timestamp, retryCount',
+        syncMetadata: 'key',
+        deviceInfo: 'key',
+      },
+      8: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies, completedAt',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+        syncQueue: 'id, taskId, operation, timestamp, retryCount',
+        syncMetadata: 'key',
+        deviceInfo: 'key',
+      },
+      9: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies, completedAt',
+        archivedTasks: 'id, quadrant, completed, dueDate, completedAt, archivedAt',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+        syncQueue: 'id, taskId, operation, timestamp, retryCount',
+        syncMetadata: 'key',
+        deviceInfo: 'key',
+        archiveSettings: 'id',
+      },
+      10: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies, completedAt',
+        archivedTasks: 'id, quadrant, completed, dueDate, completedAt, archivedAt',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+        syncQueue: 'id, taskId, operation, timestamp, retryCount',
+        syncMetadata: 'key',
+        deviceInfo: 'key',
+        archiveSettings: 'id',
+        syncHistory: 'id, timestamp, status, deviceId',
+      },
+      11: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies, completedAt',
+        archivedTasks: 'id, quadrant, completed, dueDate, completedAt, archivedAt',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+        syncQueue: 'id, taskId, operation, timestamp, retryCount',
+        syncMetadata: 'key',
+        deviceInfo: 'key',
+        archiveSettings: 'id',
+        syncHistory: 'id, timestamp, status, deviceId',
+        appPreferences: 'id',
+      },
+    });
+
+    const db = await openCurrentDb();
+
+    const noTime = await db.tasks.get('no-time');
+    expect(noTime!.timeEntries).toEqual([]);
+    expect(noTime!.timeSpent).toBe(0);
+
+    const corrupt = await db.tasks.get('corrupt-time');
+    expect(corrupt!.timeEntries).toEqual([]);
+    expect(corrupt!.timeSpent).toBe(0);
+
+    const mixed = await db.tasks.get('mixed-entries');
+    expect(mixed!.timeEntries).toHaveLength(1);
+    expect(mixed!.timeEntries![0].id).toBe('ok');
+    expect(mixed!.timeSpent).toBe(0);
+  });
+
+  it('v13 upgrade: should reset sync state, strip vectorClock, and remove encryption_salt', async () => {
+    await seedAtVersion(12, async (legacy) => {
+      // Seed a task with the legacy vectorClock field.
+      await legacy.table('tasks').add({
+        id: 'vc-task',
+        title: 'Has Vector Clock',
+        description: '',
+        urgent: false,
+        important: false,
+        quadrant: 'not-urgent-not-important',
+        completed: false,
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+        recurrence: 'none',
+        tags: [],
+        subtasks: [],
+        dependencies: [],
+        notificationEnabled: false,
+        notificationSent: false,
+        timeEntries: [],
+        timeSpent: 0,
+        vectorClock: { 'device-a': 1, 'device-b': 2 },
+      });
+
+      await legacy.table('archivedTasks').add({
+        id: 'archived-vc',
+        title: 'Archived With VC',
+        description: '',
+        urgent: false,
+        important: false,
+        quadrant: 'not-urgent-not-important',
+        completed: true,
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+        completedAt: '2025-01-02T00:00:00.000Z',
+        archivedAt: '2025-01-03T00:00:00.000Z',
+        recurrence: 'none',
+        tags: [],
+        subtasks: [],
+        dependencies: [],
+        notificationEnabled: false,
+        notificationSent: false,
+        timeEntries: [],
+        timeSpent: 0,
+        vectorClock: { 'device-a': 5 },
+      });
+
+      // Seed sync state that should be reset.
+      await legacy.table('syncQueue').add({
+        id: 'queue-1',
+        taskId: 'vc-task',
+        operation: 'update',
+        timestamp: 123,
+        retryCount: 0,
+      });
+
+      await legacy.table('syncMetadata').put({
+        key: 'sync_config',
+        enabled: true,
+        userId: 'legacy-user',
+        deviceId: 'preserved-device-id',
+        deviceName: 'Legacy Device',
+        email: 'legacy@example.com',
+        token: 'legacy-token',
+        tokenExpiresAt: 9999999999,
+        lastSyncAt: 1000,
+        vectorClock: { 'device-a': 1 },
+        conflictStrategy: 'last_write_wins',
+        serverUrl: 'https://old-server.example.com',
+      });
+
+      await legacy.table('syncMetadata').put({
+        key: 'encryption_salt',
+        salt: 'legacy-salt-value',
+      });
+    }, {
+      1: { tasks: 'id, quadrant, completed, dueDate' },
+      2: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags' },
+      3: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed]' },
+      4: { tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed]', smartViews: 'id, name, isBuiltIn, createdAt' },
+      5: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+      },
+      6: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+      },
+      7: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+        syncQueue: 'id, taskId, operation, timestamp, retryCount',
+        syncMetadata: 'key',
+        deviceInfo: 'key',
+      },
+      8: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies, completedAt',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+        syncQueue: 'id, taskId, operation, timestamp, retryCount',
+        syncMetadata: 'key',
+        deviceInfo: 'key',
+      },
+      9: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies, completedAt',
+        archivedTasks: 'id, quadrant, completed, dueDate, completedAt, archivedAt',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+        syncQueue: 'id, taskId, operation, timestamp, retryCount',
+        syncMetadata: 'key',
+        deviceInfo: 'key',
+        archiveSettings: 'id',
+      },
+      10: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies, completedAt',
+        archivedTasks: 'id, quadrant, completed, dueDate, completedAt, archivedAt',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+        syncQueue: 'id, taskId, operation, timestamp, retryCount',
+        syncMetadata: 'key',
+        deviceInfo: 'key',
+        archiveSettings: 'id',
+        syncHistory: 'id, timestamp, status, deviceId',
+      },
+      11: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies, completedAt',
+        archivedTasks: 'id, quadrant, completed, dueDate, completedAt, archivedAt',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+        syncQueue: 'id, taskId, operation, timestamp, retryCount',
+        syncMetadata: 'key',
+        deviceInfo: 'key',
+        archiveSettings: 'id',
+        syncHistory: 'id, timestamp, status, deviceId',
+        appPreferences: 'id',
+      },
+      12: {
+        tasks: 'id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies, completedAt',
+        archivedTasks: 'id, quadrant, completed, dueDate, completedAt, archivedAt',
+        smartViews: 'id, name, isBuiltIn, createdAt',
+        notificationSettings: 'id',
+        syncQueue: 'id, taskId, operation, timestamp, retryCount',
+        syncMetadata: 'key',
+        deviceInfo: 'key',
+        archiveSettings: 'id',
+        syncHistory: 'id, timestamp, status, deviceId',
+        appPreferences: 'id',
+      },
+    });
+
+    const db = await openCurrentDb();
+
+    // vectorClock stripped from both tables.
+    const task = await db.tasks.get('vc-task');
+    expect(task).toBeDefined();
+    expect((task as Record<string, unknown>).vectorClock).toBeUndefined();
+
+    const archived = await db.archivedTasks.get('archived-vc');
+    expect(archived).toBeDefined();
+    expect((archived as Record<string, unknown>).vectorClock).toBeUndefined();
+
+    // syncQueue cleared.
+    const queueSize = await db.syncQueue.count();
+    expect(queueSize).toBe(0);
+
+    // encryption_salt removed.
+    const salt = await db.syncMetadata.get('encryption_salt');
+    expect(salt).toBeUndefined();
+
+    // sync_config reset but deviceId preserved.
+    const config = await db.syncMetadata.get('sync_config') as {
+      enabled: boolean;
+      userId: string | null;
+      deviceId: string;
+      token?: unknown;
+      autoSyncEnabled: boolean;
+      consecutiveFailures: number;
+    };
+    expect(config).toBeDefined();
+    expect(config.enabled).toBe(false);
+    expect(config.userId).toBeNull();
+    expect(config.deviceId).toBe('preserved-device-id');
+    expect(config.autoSyncEnabled).toBe(true);
+    expect(config.consecutiveFailures).toBe(0);
+    expect(config.token).toBeUndefined();
+  });
+});
+
+describe('getDb() environment guard', () => {
+  beforeEach(async () => {
+    await deleteDb();
+    vi.resetModules();
+  });
+
+  it('should throw when indexedDB is not available', async () => {
+    const originalIDB = globalThis.indexedDB;
+    // Simulate a server environment by removing indexedDB before first call.
+    // @ts-expect-error — deliberately removing for the guard path.
+    delete globalThis.indexedDB;
+
+    try {
+      const { getDb } = await import('@/lib/db');
+      expect(() => getDb()).toThrow(/IndexedDB is not available/);
+    } finally {
+      globalThis.indexedDB = originalIDB;
+    }
+  });
+});

--- a/tests/ui/import-dialog.test.tsx
+++ b/tests/ui/import-dialog.test.tsx
@@ -10,6 +10,14 @@ vi.mock("@/lib/tasks", () => ({
   importFromJson: (raw: string, mode: "replace" | "merge") => mockImportFromJson(raw, mode)
 }));
 
+const mockToastError = vi.fn();
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
 describe("ImportDialog", () => {
   const mockOnOpenChange = vi.fn();
   const mockOnImportComplete = vi.fn();
@@ -181,9 +189,8 @@ describe("ImportDialog", () => {
     });
   });
 
-  it("shows alert on import error", async () => {
+  it("shows toast error on import error", async () => {
     const user = userEvent.setup();
-    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
     mockImportFromJson.mockRejectedValue(new Error("Import failed"));
 
     render(<ImportDialog {...defaultProps} />);
@@ -191,15 +198,12 @@ describe("ImportDialog", () => {
     await user.click(screen.getByText("Merge Tasks"));
 
     await waitFor(() => {
-      expect(alertSpy).toHaveBeenCalledWith("Import failed. Ensure you selected a valid export file.");
+      expect(mockToastError).toHaveBeenCalledWith("Import failed. Ensure you selected a valid export file.");
     });
-
-    alertSpy.mockRestore();
   });
 
   it("does not close dialog on import error", async () => {
     const user = userEvent.setup();
-    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
     mockImportFromJson.mockRejectedValue(new Error("Import failed"));
 
     render(<ImportDialog {...defaultProps} />);
@@ -207,17 +211,14 @@ describe("ImportDialog", () => {
     await user.click(screen.getByText("Merge Tasks"));
 
     await waitFor(() => {
-      expect(alertSpy).toHaveBeenCalled();
+      expect(mockToastError).toHaveBeenCalled();
     });
 
     expect(mockOnOpenChange).not.toHaveBeenCalled();
-
-    alertSpy.mockRestore();
   });
 
   it("re-enables buttons after import error", async () => {
     const user = userEvent.setup();
-    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
     mockImportFromJson.mockRejectedValue(new Error("Import failed"));
 
     render(<ImportDialog {...defaultProps} />);
@@ -227,13 +228,11 @@ describe("ImportDialog", () => {
     await user.click(mergeButton!);
 
     await waitFor(() => {
-      expect(alertSpy).toHaveBeenCalled();
+      expect(mockToastError).toHaveBeenCalled();
     });
 
     // Buttons should be re-enabled after error
     expect(mergeButton).not.toBeDisabled();
-
-    alertSpy.mockRestore();
   });
 
   it("handles invalid JSON in fileContents gracefully", () => {


### PR DESCRIPTION
## Summary

Verified the findings in `tasks/coding-standards-audit.md` and applied the four issues that were both real and not already fixed. The audit also contained several false positives (barrel re-export files reported as 0% coverage, plus findings already remediated) — those were skipped. See verification details below.

### Real fixes applied

- **P0-1 (a11y):** `components/import-dialog.tsx` — `window.alert()` → `toast.error()` from sonner
- **P0-2 (deps):** `package.json` — pin `tailwind-merge` to `3.5.0` (was `^3.5.0`)
- **P2-3 (errors):** `lib/sync/health-monitor.ts` — add `logger.warn`/`logger.debug` to two silent catches at L84 and L146
- **P1-7 (tests):** New `tests/data/db-upgrade-paths.test.ts` — exercises v2, v5, v6, v8, v11, v12, v13 migration callbacks plus the `indexedDB` env guard. Brings `lib/db.ts` from **28.37% → 100% lines / 95.23% functions / 76.08% branches**.

### Findings skipped (and why)

- **P1-1 to P1-6:** Audit reported 0% coverage on `lib/tasks.ts`, `components/task-card.tsx`, `components/matrix-board.tsx`, `components/app-header.tsx`, `components/command-palette.tsx`, `components/settings-dialog.tsx`. These are 1–22 line barrel re-export files; the real implementations live in sibling subdirectories (`lib/tasks/crud/*` 95–100%, `components/task-card/` 72.7%, etc.) and dedicated test files exist (`tests/ui/matrix-board.test.tsx`, `tests/ui/task-card.test.tsx`, `tests/ui/command-palette.test.tsx`, `tests/ui/settings-dialog.test.tsx`).
- **P2-2:** `lib/pwa-detection.ts:13` already uses `(window.navigator as { standalone?: boolean }).standalone` — fix was already applied.
- **P3-1:** `.env.example` already exists in the repo root.

## Test plan

- [x] `bun run test` — 2110 pass, 1 skipped (no regressions)
- [x] `bun typecheck` — clean
- [x] `bun lint` — no new errors (5 pre-existing warnings unchanged)
- [x] `bun run test --coverage` — `lib/db.ts` confirmed at 100% lines / 95.23% functions