### PR TITLE
fix(a11y): enforce 44px touch targets and universal reduced-motion reset

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -356,38 +356,21 @@ main {
   }
 }
 
-/* Respect reduced motion preference */
+/* Respect reduced motion preference.
+ * Universal reset covers both class-based animations and inline `transition:`
+ * declarations on components (stylesheet !important beats non-!important inline styles). */
 @media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
   ::view-transition-old(root),
   ::view-transition-new(root) {
-    animation: none !important;
-  }
-
-  .animate-slide-in-card {
-    animation: none !important;
-  }
-
-  .animate-complete-flash {
-    animation: none !important;
-  }
-
-  .animate-new-task-glow {
-    animation: none !important;
-  }
-
-  .animate-stagger-in {
-    animation: none !important;
-  }
-
-  .animate-drag-lift {
-    animation: none !important;
-  }
-
-  .animate-drop-zone-pulse {
-    animation: none !important;
-  }
-
-  .animate-bulk-bar-in {
     animation: none !important;
   }
 }
@@ -647,6 +630,36 @@ main {
 @media (prefers-reduced-motion: reduce) {
   .redesign-scope .rd-fade-in {
     animation: none !important;
+  }
+}
+
+/* Touch target minimums (WCAG 2.5.5) — enforced only on coarse pointers so
+ * desktop/mouse UIs keep their compact density. !important is needed because
+ * the redesign primitives set explicit inline width/height. */
+@media (pointer: coarse) {
+  .redesign-scope .rd-icon-button,
+  .redesign-scope [role="tab"] {
+    min-width: 44px !important;
+    min-height: 44px !important;
+    width: auto !important;
+    height: auto !important;
+    padding: 8px !important;
+  }
+
+  .redesign-scope .rd-button,
+  .redesign-scope .rd-toggle-pill,
+  .redesign-scope .rd-quick-add-submit,
+  .redesign-scope .rd-primary-action {
+    min-height: 44px !important;
+  }
+
+  .redesign-scope [role="tablist"] {
+    height: auto !important;
+  }
+
+  .redesign-scope .rd-checkbox {
+    width: 26px;
+    height: 26px;
   }
 }
 

--- a/components/app-header/header-actions.tsx
+++ b/components/app-header/header-actions.tsx
@@ -39,7 +39,7 @@ export function HeaderActions({
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"
-          className="h-10 w-10 p-0 md:h-11 md:w-11"
+          className="h-11 w-11 p-0"
           aria-label="More options"
         >
           <EllipsisIcon className="h-5 w-5" />

--- a/components/dashboard/dashboard-shell-header.tsx
+++ b/components/dashboard/dashboard-shell-header.tsx
@@ -57,7 +57,7 @@ export function DashboardShellHeader({
                   <TooltipTrigger asChild>
                     <Button
                       variant={searchExpanded ? "subtle" : "ghost"}
-                      className="h-10 w-10 p-0"
+                      className="h-11 w-11 p-0"
                       onClick={() => {
                         if (searchExpanded) {
                           setSearchExpanded(false);
@@ -122,7 +122,7 @@ export function DashboardShellHeader({
 
               <Button
                 onClick={onNewTask}
-                className="h-10 w-10 p-0 md:hidden"
+                className="h-11 w-11 p-0 md:hidden"
                 aria-label="Create task"
               >
                 <PlusIcon className="h-4 w-4" />

--- a/components/redesign/primitives.tsx
+++ b/components/redesign/primitives.tsx
@@ -201,7 +201,7 @@ export function RdIconButton({
       onClick={onClick}
       title={title}
       aria-label={ariaLabel ?? title}
-      className="inline-flex items-center justify-center transition-colors"
+      className="rd-icon-button inline-flex items-center justify-center transition-colors"
       style={{
         width: 32,
         height: 32,
@@ -260,7 +260,13 @@ export function RdButton({
     ghost: { border: "1px solid transparent", background: "transparent", color: "var(--ink-2)" },
   };
   return (
-    <button type={type} onClick={onClick} disabled={disabled} style={{ ...base, ...variants[variant], ...style }}>
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      className="rd-button"
+      style={{ ...base, ...variants[variant], ...style }}
+    >
       {children}
     </button>
   );

--- a/components/redesign/quick-add.tsx
+++ b/components/redesign/quick-add.tsx
@@ -143,7 +143,7 @@ export function QuickAdd({ onSubmit, onOpenFull, presetQuadrant }: QuickAddProps
           onClick={onOpenFull}
           title="Open full composer"
           aria-label="Open full composer"
-          className="inline-flex items-center justify-center"
+          className="rd-icon-button inline-flex items-center justify-center"
           style={{
             width: 32,
             height: 32,
@@ -200,7 +200,7 @@ function TogglePill({
       type="button"
       onClick={onClick}
       title={label}
-      className="inline-flex items-center gap-1.5"
+      className="rd-toggle-pill inline-flex items-center gap-1.5"
       aria-pressed={active}
       style={{
         minHeight: 30,

--- a/components/redesign/redesign-shell.tsx
+++ b/components/redesign/redesign-shell.tsx
@@ -353,7 +353,7 @@ function TopBar({
         <button
           type="button"
           onClick={onOpenComposer}
-          className="inline-flex items-center gap-2"
+          className="rd-primary-action inline-flex items-center gap-2"
           style={{
             minHeight: 36,
             padding: "0 14px",

--- a/components/settings-page/settings-sidebar.tsx
+++ b/components/settings-page/settings-sidebar.tsx
@@ -72,6 +72,7 @@ export function SettingsSidebar({ activeId, onSelect, visibleSections }: Setting
               onClick={() => onSelect(section.id)}
               className={cn(
                 "inline-flex shrink-0 items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-all",
+                "min-h-11",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
                 isActive
                   ? "border-accent/40 bg-accent/10 text-accent"

--- a/components/settings/appearance-settings.tsx
+++ b/components/settings/appearance-settings.tsx
@@ -82,6 +82,7 @@ function ThemeOption({
 			className={`
 				relative flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium
 				transition-all duration-200
+				pointer-coarse:min-h-11 pointer-coarse:px-4
 				${isActive
 					? "bg-card text-foreground shadow-sm"
 					: "text-foreground-muted hover:text-foreground"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.6.1",
+	"version": "8.6.2",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Implements fixes #1 (touch targets) and #2 (reduced motion) from the UI/UX Pro Max audit against the Pre-Delivery Checklist.

- **Touch targets (WCAG 2.5.5):** Redesign primitives (`RdIconButton` 32×32, `Segmented` tabs 28–34px, `TogglePill` 30px, Quick Add submit 30px) and mobile header buttons (40px) were below the 44×44 minimum. Added `@media (pointer: coarse)` rules in `globals.css` gated by new class hooks (`.rd-icon-button`, `.rd-button`, `.rd-toggle-pill`, `.rd-primary-action`) — compact desktop density is preserved; only coarse pointers get the enforcement. Tailwind surfaces (dashboard search/new-task/hamburger buttons, settings mobile pill nav, appearance theme toggles) bumped directly.
- **Reduced motion:** Inline `transition:` declarations on `TaskCard`, `CanvasPill`, `RdButton`, `QuickAdd`, and `TogglePill` were escaping the existing per-class `@media (prefers-reduced-motion: reduce)` rules. Replaced with a universal `*, *::before, *::after` reset that zeroes `transition-duration` and `animation-duration` via `!important` — stylesheet `!important` beats non-`!important` inline styles per CSS spec, so no component refactor is required.

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint` — 0 errors (5 pre-existing warnings unrelated to this change)
- [x] `bun run test` — 2110 passed, 1 skipped
- [x] `bun run build` — static export succeeds for all 9 routes
- [x] Manual: Chrome DevTools → Rendering → emulate `prefers-reduced-motion: reduce` — verify task-card hover lift, canvas pill scale, and quick-add focus ring all snap instantly with no animation
- [x] Manual: Chrome DevTools → Rendering → emulate `pointer: coarse` — verify all icon buttons, segmented tabs, toggle pills, and "New task" primary button meet 44×44 on matrix/dashboard/settings
- [x] Manual on a real phone: open matrix, dashboard, and settings; confirm tap targets feel comfortable

## Follow-ups (not in this PR)

The audit also flagged #3 canvas pill hover reflow, #4 trend arrow colors, #5 hard-coded chart blue, and others. Planned as separate PRs per the remediation order in the audit.