### PR TITLE
fix(ui): stop canvas pill reflow on hover, align trend arrow with accent

### DIFF
--- a/components/dashboard/stats-card.tsx
+++ b/components/dashboard/stats-card.tsx
@@ -141,7 +141,7 @@ export function StatsCard({
           )}
           {trend && (
             <div className="mt-3 flex items-center gap-1">
-              <span className={`text-xs font-medium ${trend.isPositive ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}`}>
+              <span className={`text-xs font-medium ${trend.isPositive ? "text-emerald-600 dark:text-emerald-400" : "text-red-600 dark:text-red-400"}`}>
                 {trend.isPositive ? "↑" : "↓"} {Math.abs(trend.value)}%
               </span>
               <span className="text-xs text-foreground-muted">from last week</span>

--- a/components/redesign/view-canvas.tsx
+++ b/components/redesign/view-canvas.tsx
@@ -378,14 +378,14 @@ function CanvasPill({
       <div
         className="inline-flex items-center gap-1.5"
         style={{
-          padding: hovered ? "6px 12px 6px 8px" : "5px 10px 5px 8px",
+          padding: "5px 10px 5px 8px",
           background: "var(--paper)",
           border: `1px solid var(--${q.rdKey})`,
           borderRadius: 999,
           boxShadow: hovered ? "var(--rd-shadow)" : "var(--rd-shadow-sm)",
           transform: hovered && !isDragging ? "scale(1.04)" : "none",
-          transition: "transform .15s ease, box-shadow .15s ease, padding .15s ease, max-width .15s ease",
-          maxWidth: hovered ? 320 : 180,
+          transition: "transform .15s ease, box-shadow .15s ease",
+          maxWidth: 180,
         }}
       >
         <span

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.6.2",
+	"version": "8.6.3",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Implements fixes #3 and #4 from the UI/UX Pro Max audit.

- **Canvas pill hover reflow (#3)** — `CanvasPill` was animating `padding` (5/10 → 6/12 px) and `maxWidth` (180 → 320 px) on hover, causing cursor flicker inside the pill and letting the pill overlap neighboring pills in dense quadrants. Removed both animations and pinned the pill at `maxWidth: 180` with ellipsis. The tooltip below the pill already reveals the full description on hover, so the expansion was redundant. Kept `scale(1.04)` + shadow lift for feedback.
- **Trend arrow color drift (#4)** — `StatsCard` was rendering the positive trend indicator with `text-green-600 dark:text-green-400` while the card's icon chip and progress rail use `emerald` via the `accentColor` map. Two visibly different greens were touching each other. Changed the positive case to `text-emerald-600 dark:text-emerald-400` to match the rest of the card.

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint` — 0 errors (5 pre-existing warnings unchanged)
- [x] `bun run test` — 2110 passed, 1 skipped
- [x] Manual: open `/` → Canvas view, hover pills in a crowded quadrant, confirm no overlap with neighbors and no cursor flicker
- [x] Manual: open `/dashboard`, hover "Completed Today" card, confirm positive trend arrow's green matches the emerald chip beside the title