### PR TITLE
fix(ui): token-drift cleanup — chart blue, chevron, truncate, ink-4 text

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -45,6 +45,9 @@
   --gradient-schedule: linear-gradient(135deg, #1d4ed8, #3b82f6);
   --gradient-delegate: linear-gradient(135deg, #15803d, #22c55e);
   --gradient-eliminate: linear-gradient(135deg, #854d0e, #ca8a04);
+
+  /* Chart palette — series 1 uses --accent; series 2+ are tokenized here. */
+  --chart-series-2: 59 130 246;        /* blue-500 */
 }
 
 .dark {
@@ -78,6 +81,8 @@
   --shadow-card-hover: 0 10px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.3);
   --shadow-column: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -2px rgba(0, 0, 0, 0.2);
   --shadow-fab: 0 8px 30px rgba(129, 140, 248, 0.35);
+
+  --chart-series-2: 96 165 250;        /* blue-400 — slightly lighter for dark mode */
 }
 
 body {

--- a/components/dashboard/completion-chart.tsx
+++ b/components/dashboard/completion-chart.tsx
@@ -43,7 +43,7 @@ export function CompletionChart({ data }: CompletionChartProps) {
         <div className="flex items-center gap-2 rounded-full border border-border/70 bg-background-muted/70 px-3 py-1.5">
           <div className="h-2.5 w-2.5 rounded-full bg-[rgb(var(--accent))]" />
           <span className="text-xs font-medium text-foreground-muted">Completed</span>
-          <div className="ml-2 h-2.5 w-2.5 rounded-full bg-blue-500" />
+          <div className="ml-2 h-2.5 w-2.5 rounded-full bg-[rgb(var(--chart-series-2))]" />
           <span className="text-xs font-medium text-foreground-muted">Created</span>
         </div>
       </div>
@@ -55,8 +55,8 @@ export function CompletionChart({ data }: CompletionChartProps) {
               <stop offset="95%" stopColor="rgb(var(--accent))" stopOpacity={0.02} />
             </linearGradient>
             <linearGradient id="gradientCreated" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.22} />
-              <stop offset="95%" stopColor="#3b82f6" stopOpacity={0.02} />
+              <stop offset="0%" stopColor="rgb(var(--chart-series-2))" stopOpacity={0.22} />
+              <stop offset="95%" stopColor="rgb(var(--chart-series-2))" stopOpacity={0.02} />
             </linearGradient>
           </defs>
           <CartesianGrid
@@ -104,11 +104,11 @@ export function CompletionChart({ data }: CompletionChartProps) {
           <Area
             type="monotone"
             dataKey="Created"
-            stroke="#3b82f6"
+            stroke="rgb(var(--chart-series-2))"
             strokeWidth={2}
             fill="url(#gradientCreated)"
             dot={false}
-            activeDot={{ r: 5, fill: "#3b82f6", stroke: "#fff", strokeWidth: 2 }}
+            activeDot={{ r: 5, fill: "rgb(var(--chart-series-2))", stroke: "#fff", strokeWidth: 2 }}
           />
         </AreaChart>
       </ResponsiveContainer>

--- a/components/redesign/matrix-compass.tsx
+++ b/components/redesign/matrix-compass.tsx
@@ -181,7 +181,7 @@ function CompassList({
             <span className="rd-mono" style={{ color: "var(--ink-3)", fontSize: 11.5 }}>
               {count}
             </span>
-            <span style={{ width: 40, textAlign: "right", color: "var(--ink-4)", fontSize: 11 }}>
+            <span style={{ width: 40, textAlign: "right", color: "var(--ink-3)", fontSize: 11 }}>
               {pct}%
             </span>
           </div>

--- a/components/redesign/redesign-shell.tsx
+++ b/components/redesign/redesign-shell.tsx
@@ -120,7 +120,7 @@ function Sidebar({
             >
               <span style={{ color: active ? "var(--ink)" : "var(--ink-3)" }}>{it.icon}</span>
               <span>{it.label}</span>
-              <span style={{ marginLeft: "auto", fontSize: 11, color: "var(--ink-4)" }}>{it.hint}</span>
+              <span style={{ marginLeft: "auto", fontSize: 11, color: "var(--ink-3)" }}>{it.hint}</span>
             </button>
           );
         })}
@@ -165,7 +165,7 @@ function SidebarFooter() {
           alignItems: "baseline",
           gap: 6,
           fontSize: 10.5,
-          color: "var(--ink-4)",
+          color: "var(--ink-3)",
         }}
       >
         <span className="rd-mono" style={{ color: "var(--ink-3)", fontWeight: 500 }}>
@@ -189,7 +189,7 @@ function SectionLabel({ children, style }: { children: ReactNode; style?: React.
         fontSize: 10,
         letterSpacing: 0.14,
         textTransform: "uppercase",
-        color: "var(--ink-4)",
+        color: "var(--ink-3)",
         fontWeight: 600,
         padding: "0 10px",
         marginBottom: 6,
@@ -260,7 +260,7 @@ function SidebarAction({
     >
       <span style={{ color: "var(--ink-3)", display: "inline-flex", width: 14, justifyContent: "center" }}>{icon}</span>
       <span>{label}</span>
-      {hint && <span style={{ marginLeft: "auto", fontSize: 11, color: "var(--ink-4)" }}>{hint}</span>}
+      {hint && <span style={{ marginLeft: "auto", fontSize: 11, color: "var(--ink-3)" }}>{hint}</span>}
     </button>
   );
 }

--- a/components/settings/shared-components.tsx
+++ b/components/settings/shared-components.tsx
@@ -22,7 +22,7 @@ export function SettingsRow({ label, description, children }: SettingsRowProps) 
 			<div className="flex-1 min-w-0">
 				<p className="text-sm font-medium text-foreground">{label}</p>
 				{description && (
-					<p className="text-xs text-foreground-muted mt-0.5 truncate">
+					<p className="text-xs text-foreground-muted mt-0.5">
 						{description}
 					</p>
 				)}
@@ -66,7 +66,7 @@ export function SettingsSelectRow({
 							</option>
 						))}
 					</select>
-					<ChevronRightIcon className="w-4 h-4 text-foreground-muted/50 absolute right-4" />
+					<ChevronRightIcon className="w-4 h-4 text-foreground-muted/70 absolute right-4" />
 				</div>
 			</label>
 		</div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.6.3",
+	"version": "8.6.4",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Bundles four low-risk findings from the UI/UX audit (#5, #6, #10, #12) into a single PR since each is a one-to-six line change and they all share the theme of "inconsistent use of the design tokens."

- **#5 Chart blue tokenized** — `completion-chart.tsx` dropped `#3b82f6` (stroke, gradient stops, legend dot) in favor of a new `--chart-series-2` CSS token declared in `:root` (blue-500) and `.dark` (blue-400). If the chart palette ever shifts, stroke and legend move together.
- **#6 Chevron contrast** — `SettingsSelectRow` trailing chevron went from `text-foreground-muted/50` (~3:1 in dark mode, below WCAG 1.4.11) to `/70` (~4.8:1).
- **#10 Settings description truncate** — `SettingsRow` no longer clips the description. Short strings like "Display finished tasks in the matrix" now wrap instead of disappearing behind an ellipsis on narrow viewports.
- **#12 Small text contrast** — four inline `color: var(--ink-4)` uses promoted to `var(--ink-3)`:
  - Sidebar item hints ("What to do now", "Four quadrants")
  - Sidebar section labels ("Workspace", "Elsewhere", "Learn")
  - Sidebar footer build date line
  - Compass list percentage column
  - Sidebar action hint ("?")
  
  Decorative dots that use `--ink-4` as background (bullet, sync status, focus view muted marker) were left alone — those aren't text contrast issues.

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint` — 0 errors (5 pre-existing warnings unchanged)
- [x] `bun run test` — 2110 passed, 1 skipped
- [ ] Manual: open `/dashboard`, compare "Completed" vs "Created" lines — legend dot, stroke, and area gradient should all share the same blue
- [ ] Manual: open `/settings`, dark mode — chevron on the "Default reminder" dropdown row should be clearly visible
- [ ] Manual: resize browser to ~360px wide on `/settings` — description lines should wrap, not truncate
- [ ] Manual: `/` → sidebar — "What to do now" / "Four quadrants" hints readable in both themes

## Follow-ups

Remaining audit items: #7 `RdButton` default hover, #8 shared serif utility, #9 canvas drag activation, #11 z-index scale. Each is slightly more involved than these token swaps — can be tackled individually or as another small batch.