### PR TITLE
fix(ui): RdButton hover, shared serif utility, z-index scale

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -156,10 +156,7 @@ export default function DashboardPage() {
               <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-foreground-muted">
                 Workspace Insights
               </p>
-              <h1
-                className="mt-2 text-3xl tracking-tight text-foreground sm:text-4xl"
-                style={{ fontFamily: "var(--font-instrument-serif, ui-serif, Georgia, serif)" }}
-              >
+              <h1 className="rd-serif mt-2 text-3xl tracking-tight text-foreground sm:text-4xl">
                 Dashboard
               </h1>
               <p className="mt-3 max-w-2xl text-sm leading-relaxed text-foreground-muted sm:text-base">

--- a/app/globals.css
+++ b/app/globals.css
@@ -445,7 +445,10 @@ main {
   --q4-soft: #2c2009; --q4-tint: #3a2a0d;
 }
 
-.redesign-scope .rd-serif {
+/* Editorial serif utility — global so dashboard and settings pages can use
+ * the same display typography as the redesign scope without duplicating
+ * the font-family fallback chain inline. */
+.rd-serif {
   font-family: var(--font-instrument-serif, ui-serif, Georgia, serif);
   font-weight: 400;
   letter-spacing: -0.01em;
@@ -636,6 +639,36 @@ main {
   .redesign-scope .rd-fade-in {
     animation: none !important;
   }
+}
+
+/* RdButton variants — split out of inline styles so :hover rules can attach
+ * and so `prefers-reduced-motion` gating works consistently. */
+.redesign-scope .rd-button-default {
+  border: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--ink);
+}
+.redesign-scope .rd-button-default:hover:not(:disabled) {
+  background: var(--bg-inset);
+  border-color: var(--ink-3);
+}
+.redesign-scope .rd-button-primary {
+  border: 1px solid var(--ink);
+  background: var(--ink);
+  color: var(--paper);
+}
+.redesign-scope .rd-button-primary:hover:not(:disabled) {
+  background: var(--ink-2);
+  border-color: var(--ink-2);
+}
+.redesign-scope .rd-button-ghost {
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--ink-2);
+}
+.redesign-scope .rd-button-ghost:hover:not(:disabled) {
+  background: var(--bg-inset);
+  color: var(--ink);
 }
 
 /* Touch target minimums (WCAG 2.5.5) — enforced only on coarse pointers so

--- a/components/about/feature-card.tsx
+++ b/components/about/feature-card.tsx
@@ -16,10 +16,7 @@ export function FeatureCard({ icon: Icon, title, description, className }: Featu
       className
     )}>
       <Icon className="mb-4 h-5 w-5 text-accent" aria-hidden="true" />
-      <h3
-        className="mb-2 text-xl tracking-tight text-foreground"
-        style={{ fontFamily: "var(--font-instrument-serif, ui-serif, Georgia, serif)" }}
-      >
+      <h3 className="rd-serif mb-2 text-xl tracking-tight text-foreground">
         {title}
       </h3>
       <p className="text-sm text-foreground-muted leading-relaxed">{description}</p>

--- a/components/about/footer-cta.tsx
+++ b/components/about/footer-cta.tsx
@@ -13,10 +13,7 @@ export function FooterCta({ version }: FooterCtaProps) {
           <p className="mb-4 text-[11px] font-semibold uppercase tracking-[0.18em] text-foreground-muted">
             Ready When You Are
           </p>
-          <h2
-            className="mb-4 text-3xl tracking-tight text-foreground sm:text-4xl"
-            style={{ fontFamily: "var(--font-instrument-serif, ui-serif, Georgia, serif)" }}
-          >
+          <h2 className="rd-serif mb-4 text-3xl tracking-tight text-foreground sm:text-4xl">
             Ready to get stuff done?
           </h2>
           <p className="mb-8 text-foreground-muted">

--- a/components/about/hero-section.tsx
+++ b/components/about/hero-section.tsx
@@ -16,10 +16,7 @@ export function HeroSection() {
             Productivity Framework
           </p>
 
-          <h1
-            className="mb-6 text-4xl tracking-tight text-foreground sm:text-6xl lg:text-7xl"
-            style={{ fontFamily: "var(--font-instrument-serif, ui-serif, Georgia, serif)" }}
-          >
+          <h1 className="rd-serif mb-6 text-4xl tracking-tight text-foreground sm:text-6xl lg:text-7xl">
             Stop juggling.
             <br />
             Start finishing.

--- a/components/redesign/primitives.tsx
+++ b/components/redesign/primitives.tsx
@@ -250,22 +250,17 @@ export function RdButton({
     borderRadius: 10,
     fontWeight: 500,
     fontSize: 13.5,
-    transition: "background .15s, border-color .15s, transform .05s",
+    transition: "background .15s, border-color .15s, color .15s, transform .05s",
     cursor: disabled ? "not-allowed" : "pointer",
     opacity: disabled ? 0.5 : 1,
-  };
-  const variants: Record<string, React.CSSProperties> = {
-    default: { border: "1px solid var(--line)", background: "var(--paper)", color: "var(--ink)" },
-    primary: { border: "1px solid var(--ink)", background: "var(--ink)", color: "var(--paper)" },
-    ghost: { border: "1px solid transparent", background: "transparent", color: "var(--ink-2)" },
   };
   return (
     <button
       type={type}
       onClick={onClick}
       disabled={disabled}
-      className="rd-button"
-      style={{ ...base, ...variants[variant], ...style }}
+      className={`rd-button rd-button-${variant}`}
+      style={{ ...base, ...style }}
     >
       {children}
     </button>

--- a/components/redesign/redesign-shell.tsx
+++ b/components/redesign/redesign-shell.tsx
@@ -5,6 +5,7 @@ import type { Route } from "next";
 import { Focus, Grid2x2, HelpCircle, Info, LineChart, Plus, Search } from "lucide-react";
 import type { ReactNode } from "react";
 import { ROUTES } from "@/lib/routes";
+import { Z } from "@/lib/z-index";
 import { Segmented } from "./primitives";
 import { RedesignSyncButton } from "./sync-button";
 import { RedesignLogo } from "./redesign-logo";
@@ -286,7 +287,7 @@ function TopBar({
       style={{
         position: "sticky",
         top: 0,
-        zIndex: 30,
+        zIndex: Z.sticky,
         // Fallback to opaque --bg for browsers without relative color syntax support.
         background: "var(--bg)",
         backgroundColor: "color-mix(in srgb, var(--bg) 85%, transparent)",

--- a/components/redesign/view-canvas.tsx
+++ b/components/redesign/view-canvas.tsx
@@ -7,6 +7,7 @@ import { AlertCircle } from "lucide-react";
 import type { TaskRecord } from "@/lib/types";
 import { quadrants, quadrantForTask, type RedesignQuadrantKey } from "@/lib/quadrants";
 import { isOverdue } from "@/lib/redesign/due";
+import { Z } from "@/lib/z-index";
 
 export interface ViewCanvasProps {
   tasks: TaskRecord[];
@@ -366,7 +367,7 @@ function CanvasPill({
         left: `${x * 100}%`,
         top: `${y * 100}%`,
         transform: pillTransform,
-        zIndex: isDragging ? 20 : hovered ? 10 : 1,
+        zIndex: isDragging ? Z.dragging : hovered ? Z.hover : Z.base,
         cursor: isDragging ? "grabbing" : "grab",
         opacity: isDragging ? 0.4 : 1,
         touchAction: "manipulation",
@@ -495,7 +496,7 @@ function QLabel({
         ...pos,
         textAlign: align ?? "left",
         pointerEvents: "none",
-        zIndex: 2,
+        zIndex: Z.canvasLabel,
       }}
     >
       <div
@@ -527,7 +528,7 @@ function AxisLabel({ pos, children }: { pos: React.CSSProperties; children: Reac
         letterSpacing: 0.04,
         whiteSpace: "nowrap",
         pointerEvents: "none",
-        zIndex: 2,
+        zIndex: Z.canvasLabel,
       }}
     >
       {children}

--- a/components/settings-page/index.tsx
+++ b/components/settings-page/index.tsx
@@ -245,10 +245,7 @@ export function SettingsPage() {
             <p className="mt-5 text-[11px] font-semibold uppercase tracking-[0.16em] text-foreground-muted">
               Preferences & Data
             </p>
-            <h1
-              className="mt-2 text-4xl tracking-tight text-foreground sm:text-5xl"
-              style={{ fontFamily: "var(--font-instrument-serif, ui-serif, Georgia, serif)" }}
-            >
+            <h1 className="rd-serif mt-2 text-4xl tracking-tight text-foreground sm:text-5xl">
               Settings
             </h1>
             <p className="mt-3 max-w-2xl text-base leading-relaxed text-foreground-muted">

--- a/components/settings-page/section-card.tsx
+++ b/components/settings-page/section-card.tsx
@@ -32,8 +32,7 @@ export function SectionCard({ eyebrow, title, description, icon: Icon, children 
           </p>
           <h2
             id={`section-${title.toLowerCase().replace(/\s+/g, "-")}`}
-            className="mt-2 text-[2rem] tracking-tight text-foreground"
-            style={{ fontFamily: "var(--font-instrument-serif, ui-serif, Georgia, serif)" }}
+            className="rd-serif mt-2 text-[2rem] tracking-tight text-foreground"
           >
             {title}
           </h2>

--- a/lib/z-index.ts
+++ b/lib/z-index.ts
@@ -1,0 +1,18 @@
+/**
+ * Layering scale for the entire UI.
+ *
+ * Use these constants instead of raw numbers so the stacking order is
+ * discoverable in one place and stays consistent as new layers are added.
+ * Tailwind utilities (`z-30`, etc.) used in JSX should match these values.
+ */
+export const Z = {
+  base: 1,
+  canvasLabel: 2,
+  hover: 10,
+  dragging: 20,
+  sticky: 30,
+  overlay: 40,
+  modal: 50,
+} as const;
+
+export type ZLayer = keyof typeof Z;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.6.4",
+	"version": "8.6.5",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Closes out the remaining audit items (#7, #8, #11). Audit item #9 (canvas drag activation) verified already-correct in `lib/use-drag-and-drop.ts` — no change needed.

- **#7 RdButton default hover** — Variant styles moved out of inline into `.rd-button-default/primary/ghost` classes in `globals.css` so `:hover` rules can attach without `!important` gymnastics. Default hover now swaps background to `--bg-inset` and tightens the border; primary shifts to `--ink-2`; ghost gets the same inset background. Previously only the cursor changed on hover for default.
- **#8 Shared serif utility** — `.rd-serif` promoted from a `.redesign-scope` selector to a global class. Six callsites that duplicated the `var(--font-instrument-serif, ui-serif, Georgia, serif)` fallback chain inline now use `className="rd-serif"` (dashboard h1, settings h1, settings SectionCard h2, about hero h1, about feature card h3, about footer CTA h2).
- **#11 Z-index scale** — New `lib/z-index.ts` exports a `Z` constant documenting the full scale: `base 1 / canvasLabel 2 / hover 10 / dragging 20 / sticky 30 / overlay 40 / modal 50`. CanvasPill, QLabel, AxisLabel, and the redesign topbar migrated to named constants. Tailwind `z-30` usages on dashboard and settings sticky headers already match the sticky layer so they're left alone.

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint` — 0 errors (5 pre-existing warnings unchanged)
- [x] `bun run test` — 2110 passed, 1 skipped
- [x] `bun run build` — static export succeeds for all 9 routes
- [ ] Manual: `/` → hover the three sidebar view-switcher Segmented tabs and any `RdButton` (default variant) in composer — background should shift subtly to `--bg-inset`
- [ ] Manual: `/dashboard`, `/settings`, `/about`, `/` — confirm all editorial serif headings still render in Instrument Serif with the same letter-spacing
- [ ] Manual: `/` → Canvas view — hover a pill; confirm hovered pill floats above neighbors (z=10) and a dragged pill floats above everything (z=20)

## Audit status

All 12 findings from the original UI audit are now addressed across four PRs: #219 (touch targets, reduced motion), #220 (canvas pill reflow, trend colors), #221 (token drift cleanup), and this one.