### PR TITLE
fix(confetti): wrap getConfettiInstance in try-catch and raise z-index

### DIFF
--- a/lib/confetti.ts
+++ b/lib/confetti.ts
@@ -36,6 +36,9 @@ function canRenderCanvas(): boolean {
 /**
  * Lazily create a fullscreen confetti canvas attached to document.body
  * with the worker disabled (CSP-safe). Reused across calls.
+ *
+ * z-index 1000000 keeps confetti above Sonner's default z-index (999999)
+ * and all other UI layers.
  */
 function getConfettiInstance(): CreateTypes | null {
   if (fireConfetti) return fireConfetti;
@@ -47,7 +50,7 @@ function getConfettiInstance(): CreateTypes | null {
   canvas.style.width = "100%";
   canvas.style.height = "100%";
   canvas.style.pointerEvents = "none";
-  canvas.style.zIndex = "9999";
+  canvas.style.zIndex = "1000000";
   document.body.appendChild(canvas);
 
   fireConfetti = confetti.create(canvas, { resize: true, useWorker: false });
@@ -59,10 +62,10 @@ export function celebrateCompletion(): void {
   if (prefersReducedMotion()) return;
   if (!canRenderCanvas()) return;
 
-  const fire = getConfettiInstance();
-  if (!fire) return;
-
   try {
+    const fire = getConfettiInstance();
+    if (!fire) return;
+
     // Big center burst.
     fire({
       particleCount: 120,

--- a/tests/data/coverage-boost.test.ts
+++ b/tests/data/coverage-boost.test.ts
@@ -279,9 +279,42 @@ describe("smart-views", () => {
 
 describe("confetti", () => {
   it("celebrateCompletion does not throw in jsdom (no canvas support)", async () => {
+    vi.resetModules();
     const { celebrateCompletion } = await import("@/lib/confetti");
     // jsdom canvas getContext returns null, so canRenderCanvas = false => early return
     expect(() => celebrateCompletion()).not.toThrow();
+  });
+
+  it("celebrateCompletion does not throw when prefersReducedMotion is true", async () => {
+    vi.resetModules();
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() } as unknown as MediaQueryList);
+    const { celebrateCompletion } = await import("@/lib/confetti");
+    expect(() => celebrateCompletion()).not.toThrow();
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it("celebrateCompletion swallows errors from confetti initialization", async () => {
+    vi.resetModules();
+    // Mock confetti module to make .create throw, simulating a CSP block
+    vi.doMock("canvas-confetti", () => ({
+      default: Object.assign(vi.fn(), {
+        create: vi.fn().mockImplementation(() => { throw new Error("CSP blocked"); })
+      })
+    }));
+    // Make canRenderCanvas() return true by having all canvas elements return a context.
+    // Double-cast is needed because jsdom's getContext return type is a broad union.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+      {} as unknown as CanvasRenderingContext2D
+    );
+
+    const { celebrateCompletion } = await import("@/lib/confetti");
+    // Should not throw even when getConfettiInstance() fails internally
+    expect(() => celebrateCompletion()).not.toThrow();
+
+    vi.restoreAllMocks();
+    vi.doUnmock("canvas-confetti");
   });
 });
 


### PR DESCRIPTION
Fixes two bugs that prevented confetti from firing on task completion.

**Bug 1:** `getConfettiInstance()` was called outside the try-catch in `celebrateCompletion()`. If `confetti.create()` threw for any reason, the error propagated to `handleComplete()` and was treated as a task operation failure, silently preventing confetti from firing. Fixed by moving `getConfettiInstance()` inside the try-catch.

**Bug 2:** Confetti canvas z-index (9999) was below Sonner's default z-index (999999). Raised to 1000000 to keep confetti above all UI layers.

Also adds three targeted tests for confetti behavior, including a regression test for Bug 1.

Closes #224

Generated with [Claude Code](https://claude.ai/code)