### PR TITLE
[codex] Secure task description links

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,6 +35,21 @@ const instrumentSerif = Instrument_Serif({
   display: "swap",
 });
 
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "img-src 'self' data: blob:",
+  "font-src 'self' data:",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "connect-src 'self' https: wss:",
+  "worker-src 'self' blob:",
+  "manifest-src 'self'",
+].join("; ");
+
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
@@ -85,6 +100,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <meta httpEquiv="Content-Security-Policy" content={contentSecurityPolicy} />
+      </head>
       <body className={cn(geist.variable, geistMono.variable, instrumentSerif.variable, "font-sans bg-background text-foreground antialiased")}>
         <ErrorBoundary>
           <ThemeProvider>

--- a/components/redesign/task-card.tsx
+++ b/components/redesign/task-card.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { TaskRecord } from "@/lib/types";
 import { quadrantForTask } from "@/lib/quadrants";
 import { isOverdue } from "@/lib/redesign/due";
+import { TaskDescription } from "@/components/task-description";
 import { DuePill, QuadrantBadge, SubtaskChip, TagChip } from "./primitives";
 
 export interface TaskCardProps {
@@ -69,24 +70,52 @@ export function TaskCard({ task, onToggle, onOpen, compact, showQuadrant }: Task
           />
         </label>
 
-        {onOpen ? (
-          <button
-            type="button"
-            className="rd-task-card-main"
-            onClick={() => onOpen(task)}
-            onFocus={() => setFocused(true)}
-            onBlur={() => setFocused(false)}
-            style={{
-              flex: 1,
-              minWidth: 0,
-              border: 0,
-              background: "transparent",
-              padding: 0,
-              textAlign: "left",
-              color: "inherit",
-              cursor: "pointer",
-            }}
-          >
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {onOpen ? (
+            <>
+              <button
+                type="button"
+                className="rd-task-card-main"
+                onClick={() => onOpen(task)}
+                onFocus={() => setFocused(true)}
+                onBlur={() => setFocused(false)}
+                style={{
+                  width: "100%",
+                  border: 0,
+                  background: "transparent",
+                  padding: 0,
+                  textAlign: "left",
+                  color: "inherit",
+                  cursor: "pointer",
+                }}
+              >
+                <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div
+                      style={{
+                        fontSize: 14.5,
+                        fontWeight: 550,
+                        lineHeight: 1.35,
+                        color: "var(--ink)",
+                        textDecoration: task.completed ? "line-through" : "none",
+                      }}
+                    >
+                      {task.title}
+                    </div>
+                  </div>
+                  {showQuadrant && <QuadrantBadge quadrant={quadrant} size="sm" />}
+                </div>
+              </button>
+              {task.description && !compact && (
+                <div
+                  className="rd-task-desc"
+                  style={{ marginTop: 4, fontSize: 13, color: "var(--ink-3)", lineHeight: 1.4 }}
+                >
+                  <TaskDescription description={task.description} />
+                </div>
+              )}
+            </>
+          ) : (
             <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
               <div style={{ flex: 1, minWidth: 0 }}>
                 <div
@@ -105,67 +134,27 @@ export function TaskCard({ task, onToggle, onOpen, compact, showQuadrant }: Task
                     className="rd-task-desc"
                     style={{ marginTop: 4, fontSize: 13, color: "var(--ink-3)", lineHeight: 1.4 }}
                   >
-                    {task.description}
+                    <TaskDescription description={task.description} />
                   </div>
                 )}
               </div>
               {showQuadrant && <QuadrantBadge quadrant={quadrant} size="sm" />}
             </div>
+          )}
 
-            {hasMeta && (
-              <div
-                className="rd-task-meta"
-                style={{ display: "flex", flexWrap: "wrap", gap: 6, alignItems: "center", marginTop: 8 }}
-              >
-                {task.dueDate && <DuePill dueDate={task.dueDate} />}
-                <SubtaskChip done={doneSubtasks} total={task.subtasks.length} />
-                {task.tags.slice(0, 4).map((t) => (
-                  <TagChip key={t}>{t}</TagChip>
-                ))}
-              </div>
-            )}
-          </button>
-        ) : (
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <div
-                  style={{
-                    fontSize: 14.5,
-                    fontWeight: 550,
-                    lineHeight: 1.35,
-                    color: "var(--ink)",
-                    textDecoration: task.completed ? "line-through" : "none",
-                  }}
-                >
-                  {task.title}
-                </div>
-                {task.description && !compact && (
-                  <div
-                    className="rd-task-desc"
-                    style={{ marginTop: 4, fontSize: 13, color: "var(--ink-3)", lineHeight: 1.4 }}
-                  >
-                    {task.description}
-                  </div>
-                )}
-              </div>
-              {showQuadrant && <QuadrantBadge quadrant={quadrant} size="sm" />}
+          {hasMeta && (
+            <div
+              className="rd-task-meta"
+              style={{ display: "flex", flexWrap: "wrap", gap: 6, alignItems: "center", marginTop: 8 }}
+            >
+              {task.dueDate && <DuePill dueDate={task.dueDate} />}
+              <SubtaskChip done={doneSubtasks} total={task.subtasks.length} />
+              {task.tags.slice(0, 4).map((t) => (
+                <TagChip key={t}>{t}</TagChip>
+              ))}
             </div>
-
-            {hasMeta && (
-              <div
-                className="rd-task-meta"
-                style={{ display: "flex", flexWrap: "wrap", gap: 6, alignItems: "center", marginTop: 8 }}
-              >
-                {task.dueDate && <DuePill dueDate={task.dueDate} />}
-                <SubtaskChip done={doneSubtasks} total={task.subtasks.length} />
-                {task.tags.slice(0, 4).map((t) => (
-                  <TagChip key={t}>{t}</TagChip>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   );

--- a/components/task-card/task-card-header.tsx
+++ b/components/task-card/task-card-header.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import type { TaskRecord } from "@/lib/types";
 import type { SortableAttributes, SortableListeners } from "./types";
+import { TaskDescription } from "@/components/task-description";
 
 export interface TaskCardHeaderProps {
   task: TaskRecord;
@@ -57,7 +58,9 @@ export function TaskCardHeader({
             {task.title}
           </h3>
           {task.description ? (
-            <p className="mt-0.5 text-xs text-foreground-muted line-clamp-2">{task.description}</p>
+            <p className="mt-0.5 text-xs text-foreground-muted line-clamp-2">
+              <TaskDescription description={task.description} />
+            </p>
           ) : null}
         </div>
       </div>

--- a/components/task-description.tsx
+++ b/components/task-description.tsx
@@ -1,0 +1,34 @@
+import { getDescriptionSegments } from "@/lib/task-links";
+import { cn } from "@/lib/utils";
+
+interface TaskDescriptionProps {
+  description: string;
+  className?: string;
+}
+
+export function TaskDescription({ description, className }: TaskDescriptionProps) {
+  const segments = getDescriptionSegments(description);
+
+  return (
+    <span className={cn("break-words", className)}>
+      {segments.map((segment, index) => {
+        if (segment.type === "text") {
+          return <span key={index}>{segment.text}</span>;
+        }
+
+        return (
+          <a
+            key={index}
+            href={segment.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-accent underline underline-offset-2 hover:text-accent-hover"
+            onClick={(event) => event.stopPropagation()}
+          >
+            {segment.text}
+          </a>
+        );
+      })}
+    </span>
+  );
+}

--- a/lib/task-links.ts
+++ b/lib/task-links.ts
@@ -1,0 +1,78 @@
+export type DescriptionSegment =
+  | { type: "text"; text: string }
+  | { type: "link"; text: string; href: string };
+
+const URL_CANDIDATE_PATTERN = /\bhttps?:\/\/[^\s<>"'`{}|\\^]+/giu;
+const TRAILING_URL_PUNCTUATION_PATTERN = /[),.!?;:]+$/u;
+const MAX_URL_LENGTH = 2048;
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+export function sanitizeHttpUrl(candidate: string): string | null {
+  const value = candidate.trim();
+
+  if (
+    value.length === 0 ||
+    value.length > MAX_URL_LENGTH ||
+    /[\u0000-\u001F\u007F\s]/u.test(value)
+  ) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value);
+
+    if (!ALLOWED_PROTOCOLS.has(url.protocol.toLowerCase())) {
+      return null;
+    }
+
+    if (!url.hostname || url.username || url.password) {
+      return null;
+    }
+
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+export function getDescriptionSegments(description: string): DescriptionSegment[] {
+  const segments: DescriptionSegment[] = [];
+  let lastIndex = 0;
+  const pushText = (text: string) => {
+    if (!text) {
+      return;
+    }
+    const previous = segments.at(-1);
+    if (previous?.type === "text") {
+      previous.text += text;
+      return;
+    }
+    segments.push({ type: "text", text });
+  };
+
+  for (const match of description.matchAll(URL_CANDIDATE_PATTERN)) {
+    const rawMatch = match[0];
+    const matchIndex = match.index ?? 0;
+    const trimmedCandidate = rawMatch.replace(TRAILING_URL_PUNCTUATION_PATTERN, "");
+    const trailingText = rawMatch.slice(trimmedCandidate.length);
+    const href = sanitizeHttpUrl(trimmedCandidate);
+
+    if (!href) {
+      continue;
+    }
+
+    if (matchIndex > lastIndex) {
+      pushText(description.slice(lastIndex, matchIndex));
+    }
+
+    segments.push({ type: "link", text: trimmedCandidate, href });
+    pushText(trailingText);
+    lastIndex = matchIndex + rawMatch.length;
+  }
+
+  if (lastIndex < description.length) {
+    pushText(description.slice(lastIndex));
+  }
+
+  return segments.length > 0 ? segments : [{ type: "text", text: description }];
+}

--- a/tests/data/task-links.test.ts
+++ b/tests/data/task-links.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { getDescriptionSegments, sanitizeHttpUrl } from "@/lib/task-links";
+
+describe("task link sanitization", () => {
+  it("allows http and https URLs", () => {
+    expect(sanitizeHttpUrl("https://example.com/path?q=1")).toBe("https://example.com/path?q=1");
+    expect(sanitizeHttpUrl("http://example.com/")).toBe("http://example.com/");
+  });
+
+  it("blocks scriptable and non-http protocols", () => {
+    expect(sanitizeHttpUrl("javascript:alert(1)")).toBeNull();
+    expect(sanitizeHttpUrl("data:text/html,<script>alert(1)</script>")).toBeNull();
+    expect(sanitizeHttpUrl("vbscript:msgbox(1)")).toBeNull();
+    expect(sanitizeHttpUrl("ftp://example.com/file.txt")).toBeNull();
+  });
+
+  it("blocks whitespace, control characters, credentialed, and malformed URLs", () => {
+    expect(sanitizeHttpUrl("https://exa mple.com")).toBeNull();
+    expect(sanitizeHttpUrl("https://example.com/\nnext")).toBeNull();
+    expect(sanitizeHttpUrl("https://user:pass@example.com")).toBeNull();
+    expect(sanitizeHttpUrl("https://")).toBeNull();
+  });
+
+  it("linkifies only valid explicit http and https URLs", () => {
+    const segments = getDescriptionSegments(
+      "Read https://example.com/docs, not javascript:alert(1) or data:text/html,<svg>."
+    );
+
+    expect(segments).toEqual([
+      { type: "text", text: "Read " },
+      { type: "link", text: "https://example.com/docs", href: "https://example.com/docs" },
+      { type: "text", text: ", not javascript:alert(1) or data:text/html,<svg>." },
+    ]);
+  });
+
+  it("leaves descriptions without valid links as plain text", () => {
+    expect(getDescriptionSegments("<img src=x onerror=alert(1)> javascript:alert(1)")).toEqual([
+      { type: "text", text: "<img src=x onerror=alert(1)> javascript:alert(1)" },
+    ]);
+  });
+});

--- a/tests/ui/app-pages.test.tsx
+++ b/tests/ui/app-pages.test.tsx
@@ -126,6 +126,19 @@ describe('RootLayout', () => {
 
     expect(screen.getByTestId('toaster')).toBeInTheDocument();
   });
+
+  it('renders a CSP that restricts form submissions', () => {
+    render(
+      <RootLayout>
+        <p>content</p>
+      </RootLayout>
+    );
+
+    const csp = document.querySelector('meta[http-equiv="Content-Security-Policy"]');
+    expect(csp).toHaveAttribute('content', expect.stringContaining("form-action 'self'"));
+    expect(csp).toHaveAttribute('content', expect.stringContaining("object-src 'none'"));
+    expect(csp).toHaveAttribute('content', expect.stringContaining("base-uri 'self'"));
+  });
 });
 
 describe('AboutPage', () => {

--- a/tests/ui/task-card.test.tsx
+++ b/tests/ui/task-card.test.tsx
@@ -61,6 +61,32 @@ describe("TaskCard", () => {
     expect(screen.getByText("Test description")).toBeInTheDocument();
   });
 
+  it("renders safe http and https URLs in descriptions as external links", () => {
+    const taskWithUrl = {
+      ...mockTask,
+      description: "Review https://example.com/spec before launch",
+    };
+
+    render(<TaskCard task={taskWithUrl} allTasks={[taskWithUrl]} {...mockHandlers} />);
+
+    const link = screen.getByRole("link", { name: "https://example.com/spec" });
+    expect(link).toHaveAttribute("href", "https://example.com/spec");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("does not link blocked URL protocols in descriptions", () => {
+    const taskWithBlockedUrls = {
+      ...mockTask,
+      description: "Do not run javascript:alert(1) or data:text/html,<svg>",
+    };
+
+    render(<TaskCard task={taskWithBlockedUrls} allTasks={[taskWithBlockedUrls]} {...mockHandlers} />);
+
+    expect(screen.getByText("Do not run javascript:alert(1) or data:text/html,<svg>")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
   it("calls onToggleComplete when checkbox is clicked", async () => {
     const user = userEvent.setup();
     render(<TaskCard task={mockTask} allTasks={[mockTask]} {...mockHandlers} />);


### PR DESCRIPTION
## Summary
- Linkify only sanitized `http` and `https` URLs found in task descriptions.
- Keep blocked protocols such as `javascript:`, `data:`, and `vbscript:` rendered as escaped plain text.
- Add a CSP meta policy with `form-action 'self'` as a backup browser defense.
- Cover URL parsing, rendered task descriptions, and CSP output with regression tests.

## Validation
- `bun run test`
- `bun run typecheck`
- `bun run lint` (passes with existing unrelated warnings)
- `npm run build`