### PR TITLE
fix(matrix): respect "show completed" preference in v9 matrix view

### DIFF
--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -10,6 +10,11 @@ import { useDragAndDrop } from "@/lib/use-drag-and-drop";
 import { useAutoArchive } from "@/lib/use-auto-archive";
 import { useNotificationChecker } from "@/lib/use-notification-checker";
 import { TOAST_DURATION } from "@/lib/constants";
+import {
+  SHOW_COMPLETED_EVENT,
+  type ShowCompletedEventDetail,
+  readShowCompleted,
+} from "@/lib/preferences/show-completed";
 import type { RedesignQuadrantKey } from "@/lib/quadrants";
 import type { TaskRecord } from "@/lib/types";
 import { TaskCard } from "@/components/task-card";
@@ -54,6 +59,16 @@ export function MatrixSimplified() {
   const captureInputRef = useRef<HTMLInputElement | null>(null);
 
   const [editingTask, setEditingTask] = useState<TaskRecord | null>(null);
+  const [showCompleted, setShowCompleted] = useState<boolean>(readShowCompleted);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<ShowCompletedEventDetail>).detail;
+      setShowCompleted(Boolean(detail?.show));
+    };
+    window.addEventListener(SHOW_COMPLETED_EVENT, handler);
+    return () => window.removeEventListener(SHOW_COMPLETED_EVENT, handler);
+  }, []);
 
   // PWA shortcut: ?action=new-task → focus capture bar (not drawer)
   useEffect(() => {
@@ -82,7 +97,10 @@ export function MatrixSimplified() {
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
-  const visibleTasks = useMemo(() => filterTasks(all, searchQuery), [all, searchQuery]);
+  const visibleTasks = useMemo(() => {
+    const base = showCompleted ? all : all.filter((t) => !t.completed);
+    return filterTasks(base, searchQuery);
+  }, [all, searchQuery, showCompleted]);
   const total = all.length;
   const completed = all.filter((t) => t.completed).length;
   const overdue = all.filter((t) => {

--- a/components/settings-page/index.tsx
+++ b/components/settings-page/index.tsx
@@ -16,6 +16,10 @@ import type { NotificationSettings } from "@/lib/types";
 import { getSyncStatus } from "@/lib/sync/config";
 import { exportToJson } from "@/lib/tasks";
 import { createLogger } from "@/lib/logger";
+import {
+  SHOW_COMPLETED_EVENT,
+  SHOW_COMPLETED_KEY,
+} from "@/lib/preferences/show-completed";
 
 import { AppearanceSettings } from "@/components/settings/appearance-settings";
 import { NotificationSettingsSection } from "@/components/settings/notification-settings";
@@ -36,7 +40,6 @@ const ImportDialog = lazy(() =>
   import("@/components/import-dialog").then((m) => ({ default: m.ImportDialog }))
 );
 
-const SHOW_COMPLETED_KEY = "gsd:show-completed";
 const DEFAULT_SECTION: SettingsSectionId = "appearance";
 const logger = createLogger("UI");
 
@@ -110,7 +113,7 @@ export function SettingsPage() {
       if (typeof window !== "undefined") {
         localStorage.setItem(SHOW_COMPLETED_KEY, String(next));
         window.dispatchEvent(
-          new CustomEvent("toggle-completed", { detail: { show: next } }),
+          new CustomEvent(SHOW_COMPLETED_EVENT, { detail: { show: next } }),
         );
       }
       return next;

--- a/lib/preferences/show-completed.ts
+++ b/lib/preferences/show-completed.ts
@@ -1,0 +1,11 @@
+export const SHOW_COMPLETED_KEY = "gsd:show-completed";
+export const SHOW_COMPLETED_EVENT = "toggle-completed";
+
+export interface ShowCompletedEventDetail {
+  show: boolean;
+}
+
+export function readShowCompleted(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(SHOW_COMPLETED_KEY) === "true";
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.7.20",
+	"version": "8.7.21",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/ui/matrix-simplified.test.tsx
+++ b/tests/ui/matrix-simplified.test.tsx
@@ -1,10 +1,13 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { TaskRecord } from "@/lib/types";
+
+const tasksFixture = vi.hoisted(() => ({ current: [] as TaskRecord[] }));
 
 vi.mock("@/lib/use-tasks", () => ({
   useTasks: () => ({
-    all: [],
+    all: tasksFixture.current,
     byQuadrant: {
       "urgent-important": [],
       "not-urgent-important": [],
@@ -14,6 +17,27 @@ vi.mock("@/lib/use-tasks", () => ({
     isLoading: false,
   }),
 }));
+
+function makeTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    id: overrides.id ?? `task-${Math.random().toString(36).slice(2)}`,
+    title: "Test task",
+    description: "",
+    urgent: false,
+    important: false,
+    quadrant: "not-urgent-not-important",
+    completed: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    recurrence: "none",
+    tags: [],
+    subtasks: [],
+    dependencies: [],
+    notificationEnabled: false,
+    notificationSent: false,
+    ...overrides,
+  };
+}
 
 vi.mock("@/lib/tasks", () => ({
   createTask: vi.fn().mockResolvedValue(undefined),
@@ -74,6 +98,11 @@ import { MatrixSimplified } from "@/components/matrix-simplified";
 import { createTask } from "@/lib/tasks";
 
 describe("<MatrixSimplified>", () => {
+  beforeEach(() => {
+    tasksFixture.current = [];
+    localStorage.removeItem("gsd:show-completed");
+  });
+
   it("submitting capture bar calls createTask with parsed payload", async () => {
     render(<MatrixSimplified />);
     await userEvent.type(
@@ -103,5 +132,48 @@ describe("<MatrixSimplified>", () => {
     expect(screen.getByRole("region", { name: /schedule quadrant/i })).toBeInTheDocument();
     expect(screen.getByRole("region", { name: /delegate quadrant/i })).toBeInTheDocument();
     expect(screen.getByRole("region", { name: /eliminate quadrant/i })).toBeInTheDocument();
+  });
+
+  describe("show-completed preference", () => {
+    it("hides completed tasks when 'gsd:show-completed' is unset", () => {
+      tasksFixture.current = [
+        makeTask({ id: "a", title: "Active alpha", completed: false }),
+        makeTask({ id: "b", title: "Done bravo", completed: true }),
+      ];
+      render(<MatrixSimplified />);
+      expect(screen.getByText("Active alpha")).toBeInTheDocument();
+      expect(screen.queryByText("Done bravo")).not.toBeInTheDocument();
+    });
+
+    it("shows completed tasks when 'gsd:show-completed' is true", () => {
+      localStorage.setItem("gsd:show-completed", "true");
+      tasksFixture.current = [
+        makeTask({ id: "a", title: "Active alpha", completed: false }),
+        makeTask({ id: "b", title: "Done bravo", completed: true }),
+      ];
+      render(<MatrixSimplified />);
+      expect(screen.getByText("Active alpha")).toBeInTheDocument();
+      expect(screen.getByText("Done bravo")).toBeInTheDocument();
+    });
+
+    it("re-renders when 'toggle-completed' event fires", async () => {
+      tasksFixture.current = [
+        makeTask({ id: "a", title: "Active alpha", completed: false }),
+        makeTask({ id: "b", title: "Done bravo", completed: true }),
+      ];
+      render(<MatrixSimplified />);
+      expect(screen.queryByText("Done bravo")).not.toBeInTheDocument();
+
+      act(() => {
+        localStorage.setItem("gsd:show-completed", "true");
+        window.dispatchEvent(
+          new CustomEvent("toggle-completed", { detail: { show: true } }),
+        );
+      });
+
+      await waitFor(() =>
+        expect(screen.getByText("Done bravo")).toBeInTheDocument(),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

The v9 simplified matrix view (shipped in #229) replaced `matrix-board` but never wired up the **Show completed items** setting. The toggle in Settings writes `gsd:show-completed` to localStorage and dispatches a `toggle-completed` custom event — but no component listened for it. Completed tasks rendered regardless of the toggle state, making the setting silently dead.

## Root cause

- `components/matrix-simplified/index.tsx` only filtered by search query, never by completion.
- `useTasks().all` returns every row from IndexedDB unfiltered.
- `MatrixGrid` sorted completed tasks to the bottom but never excluded them.
- A grep across the codebase confirmed `gsd:show-completed` and `toggle-completed` only appeared in `settings-page/index.tsx` (the writer).

## Fix

- Extract `SHOW_COMPLETED_KEY`, `SHOW_COMPLETED_EVENT`, and `readShowCompleted()` into `lib/preferences/show-completed.ts` so producer and consumer reference one source of truth.
- `MatrixSimplified` now reads the initial value from localStorage, listens for `toggle-completed`, and filters `all` before passing to `MatrixGrid`.
- The header caption (`X done`) intentionally still reflects total counts — the setting only hides cards from the matrix.
- 3 TDD-first tests cover the unset, true, and live-toggle paths (red confirmed before green).

## Test plan

- [x] `bun run test` — 2083 passed, 1 skipped
- [x] `bun typecheck` — clean
- [x] `bun lint` — no new warnings
- [ ] In the deployed build: toggle "Show completed items" in Settings → matrix updates instantly
- [ ] Refresh the page with the toggle off → completed tasks stay hidden
- [ ] Toggle back on → completed tasks reappear (sorted to the bottom of each quadrant)