### PR TITLE
fix(edit-drawer): convert date-only dueDate to full ISO datetime on submit

### DIFF
--- a/components/matrix-simplified/edit-drawer.tsx
+++ b/components/matrix-simplified/edit-drawer.tsx
@@ -33,8 +33,10 @@ const ACCENT: Record<RedesignQuadrantKey, string> = {
 function classifyExistingDate(iso: string | undefined): DuePreset {
   if (!iso) return "none";
   const todayIso = new Date().toISOString().slice(0, 10);
-  if (iso === todayIso) return "today";
-  const target = new Date(`${iso}T00:00:00`);
+  // Support both date-only ("2026-04-27") and full datetime ("2026-04-27T14:00:00Z")
+  const dateOnly = iso.slice(0, 10);
+  if (dateOnly === todayIso) return "today";
+  const target = new Date(`${dateOnly}T00:00:00`);
   const today = new Date(`${todayIso}T00:00:00`);
   const diff = (target.getTime() - today.getTime()) / (1000 * 60 * 60 * 24);
   if (diff > 0 && diff <= 7) return "this-week";
@@ -81,13 +83,16 @@ export function EditDrawer({ open, task, onClose, onSubmit }: EditDrawerProps) {
   const submit = (e?: FormEvent) => {
     e?.preventDefault();
     if (!title.trim()) return;
+    const rawDate = resolveDuePreset(duePreset);
+    // Convert date-only "YYYY-MM-DD" to full ISO datetime required by taskDraftSchema
+    const dueDate = rawDate ? new Date(`${rawDate}T00:00:00`).toISOString() : undefined;
     void onSubmit(
       {
         title: title.trim(),
         description: description.trim(),
         urgent,
         important,
-        dueDate: resolveDuePreset(duePreset),
+        dueDate,
         tags,
       },
       task.id

--- a/tests/ui/edit-drawer.test.tsx
+++ b/tests/ui/edit-drawer.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { EditDrawer } from "@/components/matrix-simplified/edit-drawer";
@@ -23,6 +23,14 @@ const mockTask: TaskRecord = {
 } as TaskRecord;
 
 describe("<EditDrawer>", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T12:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("submits updated title and disables save when title is empty", async () => {
     const onSubmit = vi.fn();
     render(<EditDrawer open task={mockTask} onClose={vi.fn()} onSubmit={onSubmit} />);
@@ -58,5 +66,28 @@ describe("<EditDrawer>", () => {
       expect.objectContaining({ urgent: false, important: true }),
       "t1"
     );
+  });
+
+  it("submits dueDate as a full ISO datetime string, not a date-only string", async () => {
+    const onSubmit = vi.fn();
+    render(<EditDrawer open task={mockTask} onClose={vi.fn()} onSubmit={onSubmit} />);
+    await userEvent.click(screen.getByRole("button", { name: /^today$/i }));
+    await userEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const [draft] = onSubmit.mock.calls[0] as [{ dueDate?: string }];
+    expect(draft.dueDate).toBeDefined();
+    // Must be a full ISO datetime (contains 'T'), not a date-only string
+    expect(draft.dueDate).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("pre-selects 'today' preset when task has a full ISO dueDate for today", () => {
+    const taskDueToday: TaskRecord = {
+      ...mockTask,
+      dueDate: "2026-04-27T14:00:00.000Z",
+    };
+    render(<EditDrawer open task={taskDueToday} onClose={vi.fn()} onSubmit={vi.fn()} />);
+    const todayBtn = screen.getByRole("button", { name: /^today$/i });
+    expect(todayBtn.getAttribute("aria-pressed")).toBe("true");
   });
 });


### PR DESCRIPTION
Fixes #231

**Root cause:** `resolveDuePreset()` returns date-only strings like `"2026-04-27"`, but `taskDraftSchema` validates `dueDate` with `z.string().datetime({ offset: true })`, which requires a full ISO 8601 datetime. This caused a Zod validation failure inside `updateTask()` whenever a due date preset was selected, logged as `[TASK_CRUD] Object` in the console.

**Changes:**
- `submit()` now converts date-only result from `resolveDuePreset()` to a full ISO datetime before submitting
- `classifyExistingDate()` now extracts the date portion from full ISO datetime strings before comparing, so presets are correctly pre-populated
- Two new tests added covering both fixes

Generated with [Claude Code](https://claude.ai/code)