### PR TITLE
fix(shell): full-height help drawer and restore app footer

### DIFF
--- a/components/app-footer.tsx
+++ b/components/app-footer.tsx
@@ -5,7 +5,10 @@ export function AppFooter() {
   const buildDate = process.env.NEXT_PUBLIC_BUILD_DATE || "unknown";
 
   return (
-    <footer className="mt-10 border-t border-border px-6 py-6 text-xs text-foreground-muted">
+    <footer
+      className="border-t border-border/70 bg-background px-4 py-3 text-xs text-foreground-muted sm:px-9"
+      role="contentinfo"
+    >
       <p className="text-center">
         Created by{" "}
         <a
@@ -16,9 +19,9 @@ export function AppFooter() {
         >
           Vinny Carpenter
         </a>
-        {" · "}
+        <span aria-hidden="true">{" · "}</span>
         <span className="text-foreground-muted/70">
-          Build {buildNumber} · {buildDate}
+          v{buildNumber} · {buildDate}
         </span>
       </p>
     </footer>

--- a/components/matrix-simplified/app-shell.tsx
+++ b/components/matrix-simplified/app-shell.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, type ReactNode, type RefObject } from "react";
 import { IconRail } from "./icon-rail";
 import { SimplifiedTopbar } from "./topbar";
 import { HelpDrawer } from "@/components/matrix-simplified/help-drawer";
+import { AppFooter } from "@/components/app-footer";
 
 interface AppShellProps {
   title: string;
@@ -47,6 +48,7 @@ export function AppShell({
         <main className="mx-auto w-full max-w-[1320px] flex-1 px-4 py-5 pb-20 sm:px-9 sm:py-6 md:pb-6">
           {children}
         </main>
+        <AppFooter />
       </div>
       <HelpDrawer open={helpOpen} onClose={() => setHelpOpen(false)} />
     </div>

--- a/components/matrix-simplified/help-drawer.tsx
+++ b/components/matrix-simplified/help-drawer.tsx
@@ -15,12 +15,14 @@ export function HelpDrawer({ open, onClose }: HelpDrawerProps) {
   return (
     <Dialog open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
       <DialogContent
-        className="redesign-scope rd-fade-in border-card-border bg-transparent p-0 md:left-auto md:right-0 md:top-0 md:h-[100dvh] md:w-[520px] md:max-w-[520px] md:translate-x-0 md:translate-y-0 md:rounded-none md:border-l md:border-t-0 md:p-0"
+        className="redesign-scope rd-fade-in border-card-border bg-transparent p-0 md:left-auto md:right-0 md:top-0 md:h-[100dvh] md:max-h-[100dvh] md:w-[520px] md:max-w-[520px] md:translate-x-0 md:translate-y-0 md:rounded-none md:border-l md:border-t-0 md:overflow-hidden md:p-0"
+        style={{ paddingBottom: 0 }}
       >
         <div
           style={{
             background: "var(--paper)",
             display: "flex",
+            height: "100%",
             minHeight: "inherit",
             flexDirection: "column",
             boxShadow: "var(--rd-shadow-lg)",

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,8 @@
 import type { NextConfig } from "next";
+import pkg from "./package.json" with { type: "json" };
+
+const buildDate = process.env.NEXT_PUBLIC_BUILD_DATE ?? new Date().toISOString().slice(0, 10);
+const buildNumber = process.env.NEXT_PUBLIC_BUILD_NUMBER ?? pkg.version;
 
 const nextConfig: NextConfig = {
   output: "export",
@@ -7,7 +11,11 @@ const nextConfig: NextConfig = {
     unoptimized: true
   },
   typedRoutes: true,
-  reactCompiler: true
+  reactCompiler: true,
+  env: {
+    NEXT_PUBLIC_BUILD_NUMBER: buildNumber,
+    NEXT_PUBLIC_BUILD_DATE: buildDate,
+  }
 
   // IMPORTANT: Security headers cannot be set here for static exports
   // They must be configured at the CDN/hosting level (CloudFront, Netlify, Vercel, etc.)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.7.21",
+	"version": "8.7.22",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary
- **Help drawer cut off**: `HelpDrawer` was reusing the shared `DialogContent` primitive, which hard-caps height at `max-h-[90vh]` and applies a safe-area-aware `paddingBottom` inline style. Both fight a flush, full-height side drawer. Fixed with `md:max-h-[100dvh]`, `md:overflow-hidden`, an inline `paddingBottom: 0` override, and `height: 100%` on the inner panel so it fills its parent.
- **Footer missing after the v9 refactor**: re-mounted `<AppFooter />` inside `AppShell` after `<main>`. It sits at the bottom of the viewport when content is short (parent has `min-h-screen`, main has `flex-1`).
- **Version/date wiring**: `NEXT_PUBLIC_BUILD_NUMBER` / `NEXT_PUBLIC_BUILD_DATE` were consumed in three places but never populated outside production builds. Added defaults in `next.config.ts` (sourced from `package.json`) so `bun dev` shows real values.
- Bumped version `8.7.21` → `8.7.22`.

## Test plan
- [x] `bun typecheck` passes
- [x] `bun run test` — only pre-existing `tests/ui/edit-drawer.test.tsx` failures (already failing on `main`)
- [x] Verified in browser at `http://localhost:3000`:
  - Help drawer rect: `top:0, bottom:1091, left:1166, right:1686` (full viewport height, flush right edge), `maxHeight: 1091px`, `paddingBottom: 0px`
  - Footer renders: `Created by Vinny Carpenter · v8.7.22 · 2026-04-28`