### PR TITLE
feat: quick capture + full detail drawer for new tasks

### DIFF
--- a/components/matrix-simplified/capture-bar.tsx
+++ b/components/matrix-simplified/capture-bar.tsx
@@ -15,6 +15,8 @@ export interface CapturePayload {
 
 interface CaptureBarProps {
   onSubmit: (payload: CapturePayload) => void | Promise<void>;
+  /** Called when the user wants to open the full new-task drawer (Shift+N or "Details" button). */
+  onMoreOptions?: (payload: CapturePayload) => void;
   inputRef?: React.MutableRefObject<HTMLInputElement | null>;
 }
 
@@ -41,10 +43,18 @@ function isEditable(el: Element | null): boolean {
   return t === "INPUT" || t === "TEXTAREA" || el.isContentEditable;
 }
 
-export function CaptureBar({ onSubmit, inputRef: externalRef }: CaptureBarProps) {
+export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: CaptureBarProps) {
   const [text, setText] = useState("");
   const [override, setOverride] = useState<RedesignQuadrantKey | null>(null);
   const internalRef = useRef<HTMLInputElement | null>(null);
+
+  // Stable refs so the keydown handler never needs to re-register on every keystroke.
+  const textRef = useRef(text);
+  textRef.current = text;
+  const overrideRef = useRef(override);
+  overrideRef.current = override;
+  const onMoreOptionsRef = useRef(onMoreOptions);
+  onMoreOptionsRef.current = onMoreOptions;
 
   useEffect(() => {
     if (externalRef) externalRef.current = internalRef.current;
@@ -56,6 +66,23 @@ export function CaptureBar({ onSubmit, inputRef: externalRef }: CaptureBarProps)
       if (e.key === "n") {
         e.preventDefault();
         internalRef.current?.focus();
+      } else if (e.key === "N" && e.shiftKey) {
+        e.preventDefault();
+        const currentParsed = parseCapture(textRef.current);
+        const ov = overrideRef.current;
+        const flags = ov
+          ? { urgent: quadrantByRdKey(ov).urgent, important: quadrantByRdKey(ov).important }
+          : { urgent: currentParsed.urgent, important: currentParsed.important };
+        onMoreOptionsRef.current?.({
+          title: currentParsed.title || "",
+          urgent: flags.urgent,
+          important: flags.important,
+          tags: currentParsed.tags,
+        });
+        if (textRef.current.trim()) {
+          setText("");
+          setOverride(null);
+        }
       }
     };
     window.addEventListener("keydown", handler);
@@ -125,17 +152,37 @@ export function CaptureBar({ onSubmit, inputRef: externalRef }: CaptureBarProps)
         className="min-w-0 flex-1 border-0 bg-transparent text-[14.5px] leading-snug text-foreground outline-none placeholder:text-foreground-muted"
       />
       {text.trim() ? (
-        <button
-          type="button"
-          onClick={cycleQuadrant}
-          title="Tab to cycle quadrant"
-          className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide"
-          style={{ backgroundColor: `${accent}1a`, color: accent }}
-        >
-          <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: accent }} />
-          {meta.rdShort}
-          {override ? <span className="ml-1 font-normal normal-case opacity-60">·fixed</span> : null}
-        </button>
+        <>
+          <button
+            type="button"
+            onClick={cycleQuadrant}
+            title="Tab to cycle quadrant"
+            className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide"
+            style={{ backgroundColor: `${accent}1a`, color: accent }}
+          >
+            <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: accent }} />
+            {meta.rdShort}
+            {override ? <span className="ml-1 font-normal normal-case opacity-60">·fixed</span> : null}
+          </button>
+          {onMoreOptions ? (
+            <button
+              type="button"
+              onClick={() => {
+                const flags = override
+                  ? { urgent: quadrantByRdKey(override).urgent, important: quadrantByRdKey(override).important }
+                  : { urgent: parsed.urgent, important: parsed.important };
+                onMoreOptions({ title: parsed.title || "", urgent: flags.urgent, important: flags.important, tags: parsed.tags });
+                setText("");
+                setOverride(null);
+              }}
+              title="Open full form (Shift+N)"
+              aria-label="Open full task form"
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-foreground-muted hover:bg-background-muted hover:text-foreground"
+            >
+              Details ↗
+            </button>
+          ) : null}
+        </>
       ) : (
         <span className="rounded border border-border px-1.5 py-0.5 font-mono text-[11px] text-foreground-muted">
           n

--- a/components/matrix-simplified/edit-drawer.tsx
+++ b/components/matrix-simplified/edit-drawer.tsx
@@ -18,9 +18,11 @@ export interface EditDraft {
 
 interface EditDrawerProps {
   open: boolean;
-  task: TaskRecord | null;
+  task?: TaskRecord | null;
+  /** Pre-fill fields when opening in create mode (task is null/absent). */
+  initialDraft?: Partial<EditDraft>;
   onClose: () => void;
-  onSubmit: (draft: EditDraft, taskId: string) => void | Promise<void>;
+  onSubmit: (draft: EditDraft, taskId?: string) => void | Promise<void>;
 }
 
 const ACCENT: Record<RedesignQuadrantKey, string> = {
@@ -44,7 +46,7 @@ function classifyExistingDate(iso: string | undefined): DuePreset {
   return "none";
 }
 
-export function EditDrawer({ open, task, onClose, onSubmit }: EditDrawerProps) {
+export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: EditDrawerProps) {
   const titleRef = useRef<HTMLInputElement>(null);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -55,16 +57,25 @@ export function EditDrawer({ open, task, onClose, onSubmit }: EditDrawerProps) {
   const [tagInput, setTagInput] = useState("");
 
   useEffect(() => {
-    if (!open || !task) return;
-    setTitle(task.title);
-    setDescription(task.description ?? "");
-    setUrgent(task.urgent);
-    setImportant(task.important);
-    setDuePreset(classifyExistingDate(task.dueDate));
-    setTags(task.tags ?? []);
+    if (!open) return;
+    if (task) {
+      setTitle(task.title);
+      setDescription(task.description ?? "");
+      setUrgent(task.urgent);
+      setImportant(task.important);
+      setDuePreset(classifyExistingDate(task.dueDate));
+      setTags(task.tags ?? []);
+    } else {
+      setTitle(initialDraft?.title ?? "");
+      setDescription(initialDraft?.description ?? "");
+      setUrgent(initialDraft?.urgent ?? false);
+      setImportant(initialDraft?.important ?? false);
+      setDuePreset("none");
+      setTags(initialDraft?.tags ?? []);
+    }
     setTagInput("");
     setTimeout(() => titleRef.current?.focus(), 50);
-  }, [open, task]);
+  }, [open, task, initialDraft]);
 
   useEffect(() => {
     if (!open) return;
@@ -75,7 +86,8 @@ export function EditDrawer({ open, task, onClose, onSubmit }: EditDrawerProps) {
     return () => window.removeEventListener("keydown", onKey);
   }, [open, onClose]);
 
-  if (!open || !task) return null;
+  if (!open) return null;
+  const isCreateMode = !task;
 
   const activeQuadrant = quadrants.find((q) => q.urgent === urgent && q.important === important);
   const accent = activeQuadrant ? ACCENT[activeQuadrant.rdKey] : "#c2410c";
@@ -95,7 +107,7 @@ export function EditDrawer({ open, task, onClose, onSubmit }: EditDrawerProps) {
         dueDate,
         tags,
       },
-      task.id
+      task?.id
     );
   };
 
@@ -115,11 +127,11 @@ export function EditDrawer({ open, task, onClose, onSubmit }: EditDrawerProps) {
         onClick={(e) => e.stopPropagation()}
         onSubmit={submit}
         className="flex h-full w-full max-w-[520px] flex-col border-l border-border bg-card shadow-2xl"
-        aria-label="Edit task"
+        aria-label={isCreateMode ? "New task" : "Edit task"}
       >
         <header className="flex items-center gap-2.5 border-b border-border/60 px-5 py-4">
           <span aria-hidden className="h-2 w-2 rounded-full" style={{ backgroundColor: accent }} />
-          <h2 className="rd-serif text-[22px] text-foreground">Edit task</h2>
+          <h2 className="rd-serif text-[22px] text-foreground">{isCreateMode ? "New task" : "Edit task"}</h2>
           {activeQuadrant ? (
             <span
               className="ml-1 text-[11px] font-semibold uppercase tracking-wider"
@@ -269,7 +281,7 @@ export function EditDrawer({ open, task, onClose, onSubmit }: EditDrawerProps) {
             )}
           >
             <CheckIcon className="h-3.5 w-3.5" />
-            Save changes
+            {isCreateMode ? "Create task" : "Save changes"}
           </button>
         </footer>
       </form>

--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -59,6 +59,8 @@ export function MatrixSimplified() {
   const captureInputRef = useRef<HTMLInputElement | null>(null);
 
   const [editingTask, setEditingTask] = useState<TaskRecord | null>(null);
+  const [createDrawerOpen, setCreateDrawerOpen] = useState(false);
+  const [createInitial, setCreateInitial] = useState<Partial<EditDraft> | undefined>(undefined);
   const [showCompleted, setShowCompleted] = useState<boolean>(readShowCompleted);
 
   useEffect(() => {
@@ -155,14 +157,42 @@ export function MatrixSimplified() {
   const handleEditOpen = useCallback((task: TaskRecord) => setEditingTask(task), []);
   const handleEditClose = useCallback(() => setEditingTask(null), []);
 
+  const handleOpenCreateDrawer = useCallback((payload?: CapturePayload) => {
+    setCreateInitial(
+      payload
+        ? { title: payload.title, urgent: payload.urgent, important: payload.important, tags: payload.tags }
+        : undefined
+    );
+    setCreateDrawerOpen(true);
+  }, []);
+
+  const handleCreateClose = useCallback(() => {
+    setCreateDrawerOpen(false);
+    setCreateInitial(undefined);
+  }, []);
+
   const handleEditSubmit = useCallback(
-    async (draft: EditDraft, taskId: string) => {
+    async (draft: EditDraft, taskId?: string) => {
       try {
-        await updateTask(taskId, draft);
-        showToast("Task updated", undefined, TOAST_DURATION.SHORT);
-        setEditingTask(null);
+        if (taskId) {
+          await updateTask(taskId, draft);
+          showToast("Task updated", undefined, TOAST_DURATION.SHORT);
+          setEditingTask(null);
+        } else {
+          await createTask({
+            title: draft.title,
+            description: draft.description,
+            urgent: draft.urgent,
+            important: draft.important,
+            dueDate: draft.dueDate,
+            tags: draft.tags.length > 0 ? draft.tags : undefined,
+          });
+          showToast("Task added", undefined, TOAST_DURATION.SHORT);
+          setCreateDrawerOpen(false);
+          setCreateInitial(undefined);
+        }
       } catch {
-        showToast("Failed to update task", undefined, TOAST_DURATION.LONG);
+        showToast("Failed to save task", undefined, TOAST_DURATION.LONG);
       }
     },
     [showToast]
@@ -198,7 +228,7 @@ export function MatrixSimplified() {
         searchInputRef={searchInputRef}
       >
         <div className="sticky top-[60px] z-10 mb-4 -mx-4 bg-background px-4 py-2 sm:static sm:m-0 sm:bg-transparent sm:p-0 sm:pb-4">
-          <CaptureBar onSubmit={handleCapture} inputRef={captureInputRef} />
+          <CaptureBar onSubmit={handleCapture} onMoreOptions={handleOpenCreateDrawer} inputRef={captureInputRef} />
         </div>
         <MatrixGrid
           tasks={visibleTasks}
@@ -213,6 +243,13 @@ export function MatrixSimplified() {
         open={Boolean(editingTask)}
         task={editingTask}
         onClose={handleEditClose}
+        onSubmit={handleEditSubmit}
+      />
+      <EditDrawer
+        open={createDrawerOpen}
+        task={null}
+        initialDraft={createInitial}
+        onClose={handleCreateClose}
         onSubmit={handleEditSubmit}
       />
 

--- a/tests/ui/capture-bar.test.tsx
+++ b/tests/ui/capture-bar.test.tsx
@@ -53,4 +53,38 @@ describe("<CaptureBar>", () => {
     fireEvent.keyDown(window, { key: "n" });
     expect(document.activeElement).toBe(input);
   });
+
+  it("Details button appears when text is entered and onMoreOptions is provided", async () => {
+    render(<CaptureBar onSubmit={vi.fn()} onMoreOptions={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: /open full task form/i })).toBeNull();
+    const input = screen.getByLabelText("Capture a task");
+    await userEvent.type(input, "my task");
+    expect(screen.getByRole("button", { name: /open full task form/i })).toBeInTheDocument();
+  });
+
+  it("Details button is not rendered when onMoreOptions is not provided", async () => {
+    render(<CaptureBar onSubmit={vi.fn()} />);
+    const input = screen.getByLabelText("Capture a task");
+    await userEvent.type(input, "my task");
+    expect(screen.queryByRole("button", { name: /open full task form/i })).toBeNull();
+  });
+
+  it("Details button calls onMoreOptions with parsed payload and clears the input", async () => {
+    const onMoreOptions = vi.fn();
+    render(<CaptureBar onSubmit={vi.fn()} onMoreOptions={onMoreOptions} />);
+    const input = screen.getByLabelText("Capture a task") as HTMLInputElement;
+    await userEvent.type(input, "ship release ! #launch");
+    await userEvent.click(screen.getByRole("button", { name: /open full task form/i }));
+    expect(onMoreOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "ship release", urgent: true, tags: ["launch"] })
+    );
+    expect(input.value).toBe("");
+  });
+
+  it("global Shift+N calls onMoreOptions (empty payload) when capture bar has no text", () => {
+    const onMoreOptions = vi.fn();
+    render(<CaptureBar onSubmit={vi.fn()} onMoreOptions={onMoreOptions} />);
+    fireEvent.keyDown(window, { key: "N", shiftKey: true });
+    expect(onMoreOptions).toHaveBeenCalledWith({ title: "", urgent: false, important: false, tags: [] });
+  });
 });

--- a/tests/ui/edit-drawer.test.tsx
+++ b/tests/ui/edit-drawer.test.tsx
@@ -90,4 +90,43 @@ describe("<EditDrawer>", () => {
     const todayBtn = screen.getByRole("button", { name: /^today$/i });
     expect(todayBtn.getAttribute("aria-pressed")).toBe("true");
   });
+
+  describe("create mode (task is null)", () => {
+    it("shows 'New task' header and 'Create task' button", () => {
+      render(<EditDrawer open task={null} onClose={vi.fn()} onSubmit={vi.fn()} />);
+      expect(screen.getByRole("heading", { name: /new task/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /create task/i })).toBeInTheDocument();
+    });
+
+    it("pre-fills title from initialDraft", () => {
+      render(
+        <EditDrawer
+          open
+          task={null}
+          initialDraft={{ title: "Pre-filled title", urgent: true }}
+          onClose={vi.fn()}
+          onSubmit={vi.fn()}
+        />
+      );
+      const titleInput = screen.getByLabelText(/title/i) as HTMLInputElement;
+      expect(titleInput.value).toBe("Pre-filled title");
+    });
+
+    it("calls onSubmit without a taskId in create mode", async () => {
+      const onSubmit = vi.fn();
+      render(<EditDrawer open task={null} onClose={vi.fn()} onSubmit={onSubmit} />);
+      const titleInput = screen.getByLabelText(/title/i);
+      await userEvent.type(titleInput, "Brand new task");
+      await userEvent.click(screen.getByRole("button", { name: /create task/i }));
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Brand new task" }),
+        undefined
+      );
+    });
+
+    it("disables Create task button when title is empty", () => {
+      render(<EditDrawer open task={null} onClose={vi.fn()} onSubmit={vi.fn()} />);
+      expect(screen.getByRole("button", { name: /create task/i })).toBeDisabled();
+    });
+  });
 });


### PR DESCRIPTION
Closes #235

Adds two new ways to open the full task detail drawer when creating a task:

- `Shift+N` global keyboard shortcut (transfers any CaptureBar text)
- "Details ↗" inline button that appears in the CaptureBar when text is typed

The `n` key quick-capture flow is unchanged.

Generated with [Claude Code](https://claude.ai/code)