### PR TITLE
fix(help-drawer): align shortcuts and view copy with v9 layout

### DIFF
--- a/components/matrix-simplified/help-drawer.tsx
+++ b/components/matrix-simplified/help-drawer.tsx
@@ -55,25 +55,22 @@ export function HelpDrawer({ open, onClose }: HelpDrawerProps) {
               </h2>
             </DialogTitle>
             <DialogDescription className="sr-only">
-              Overview of the focus, matrix, and canvas views plus shortcuts and sync guidance.
+              Overview of the Eisenhower matrix, capture bar syntax, keyboard shortcuts, and sync guidance.
             </DialogDescription>
           </div>
         </header>
 
         <div style={{ flex: 1, overflowY: "auto", padding: "22px 24px 40px", display: "flex", flexDirection: "column", gap: 28 }}>
-          <Section label="Three lenses on one list">
-            <Concept title="Focus" accent="var(--q2)">
-              Default view. An editorial feed grouped{" "}
-              <em className="rd-serif" style={{ fontStyle: "italic" }}>Now → Today → Next → Later</em>. Answers{" "}
-              <strong>&ldquo;what should I do next?&rdquo;</strong> A small compass shows how many tasks live in each quadrant.
+          <Section label="One board, one capture bar">
+            <Concept title="The matrix" accent="var(--q1)">
+              The classic 2×2 Eisenhower board is your home view. Drag a task between quadrants to reclassify it; hover a
+              quadrant while dragging to see the drop target highlight.
             </Concept>
-            <Concept title="Matrix" accent="var(--q1)">
-              The classic 2×2 Eisenhower board. Drag a task between quadrants to reclassify it. Hover a quadrant while dragging to
-              see the drop target highlight.
-            </Concept>
-            <Concept title="Canvas" accent="var(--q3)">
-              Tasks plotted on a real urgency × importance plane. Useful when you want to see distribution at a glance. Click any
-              pill to open its editor.
+            <Concept title="The capture bar" accent="var(--q2)">
+              Every task starts in the bar at the top. Type your task, hit{" "}
+              <kbd>Enter</kbd>, and the parser routes it to the right quadrant based on{" "}
+              <code style={codeStyle}>!</code> / <code style={codeStyle}>*</code> markers — or press{" "}
+              <kbd>Tab</kbd> to cycle the destination manually.
             </Concept>
           </Section>
 
@@ -100,15 +97,16 @@ export function HelpDrawer({ open, onClose }: HelpDrawerProps) {
           </Section>
 
           <Section label="Keyboard shortcuts">
-            <ShortcutRow keys={["N"]} action="Open the full composer" />
+            <ShortcutRow keys={["n"]} action="Jump to the capture bar" />
+            <ShortcutRow keys={["Shift", "N"]} action="Open the full composer" />
             <ShortcutRow keys={["/"]} action="Focus the search field" />
-            <ShortcutRow keys={["1"]} action="Switch to Focus view" />
-            <ShortcutRow keys={["2"]} action="Switch to Matrix view" />
-            <ShortcutRow keys={["3"]} action="Switch to Canvas view" />
+            <ShortcutRow keys={["Tab"]} action="Cycle quadrant override (in the capture bar)" />
+            <ShortcutRow keys={["Enter"]} action="Submit the task (in the capture bar)" />
             <ShortcutRow keys={["?"]} action="Open this help drawer" />
             <ShortcutRow keys={["Esc"]} action="Close any open drawer" />
             <p style={{ ...bodyStyle, color: "var(--ink-3)", fontSize: 12 }}>
-              Shortcuts are suppressed while a text field is focused.
+              Global shortcuts are suppressed while a text field is focused, so typing in the capture bar or composer
+              won&rsquo;t hijack keys.
             </p>
           </Section>
 
@@ -121,8 +119,8 @@ export function HelpDrawer({ open, onClose }: HelpDrawerProps) {
               task&rsquo;s details. Save to update, close without saving to cancel.
             </p>
             <p style={bodyStyle}>
-              <strong>Drag to reclassify</strong> — in the Matrix view, drag a task onto any other quadrant. An 8-pixel activation
-              distance means plain clicks still open the editor.
+              <strong>Drag to reclassify</strong> — drag a task onto any other quadrant. An 8-pixel activation distance
+              means plain clicks still open the editor.
             </p>
           </Section>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.7.22",
+	"version": "8.7.23",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary
- Removes Focus/Canvas view copy and the `1` / `2` / `3` view-switching shortcuts that were eliminated in the v9 single-matrix consolidation (commit `cc5c85e`) but still appeared in the help drawer.
- Splits the ambiguous `N` shortcut into `n` (jump to capture bar) and `Shift+N` (open the full composer) to match what's actually wired up in `capture-bar.tsx:66-86`.
- Surfaces previously undocumented capture-bar keys: `Tab` (cycle quadrant override) and `Enter` (submit).
- Reframes the "Three lenses" section as "One board, one capture bar" to describe the surfaces that actually exist.
- Updates the screen-reader `DialogDescription` to drop the obsolete view-list phrasing.
- Bumps version to `8.7.23`.

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` shows no new warnings in `help-drawer.tsx`
- [ ] Open the help drawer (`?` key) and confirm the keyboard-shortcut list matches the keys that actually fire
- [ ] Confirm `n`, `Shift+N`, `/`, `Tab` (in capture), `Enter` (in capture), `?`, and `Esc` all behave as documented