### PR TITLE
fix(security): harden sync, import, and caching against abuse

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -6,6 +6,15 @@ import { createLogger } from "@/lib/logger";
 
 const logger = createLogger("DB");
 
+/**
+ * Legacy task shape used during migrations that reference fields removed
+ * from the current TypeScript schema (e.g. vectorClock from old Cloudflare sync).
+ */
+interface LegacyTaskMigrationRecord {
+  vectorClock?: Record<string, number>;
+  [key: string]: unknown;
+}
+
 class GsdDatabase extends Dexie {
   tasks!: Table<TaskRecord, string>;
   archivedTasks!: Table<TaskRecord, string>;
@@ -135,10 +144,9 @@ class GsdDatabase extends Dexie {
 
         // Migrate existing tasks to have empty vectorClock
         // Dexie's .modify() callback receives a mutable plain object; the typed
-        // schema doesn't include vectorClock (it was removed in v13), so `any` is
-        // required to access this legacy field during migration.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return trans.table("tasks").toCollection().modify((task: any) => {
+        // schema doesn't include vectorClock (it was removed in v13), so a legacy
+        // migration interface is used instead of `any`.
+        return trans.table("tasks").toCollection().modify((task: LegacyTaskMigrationRecord) => {
           if (!task.vectorClock) {
             task.vectorClock = {};
           }
@@ -315,17 +323,13 @@ class GsdDatabase extends Dexie {
         });
 
         // 4. Strip vectorClock from existing tasks
-        // Dexie's .modify() callback receives a mutable plain object; `any` is
-        // required to delete the legacy `vectorClock` field not present in the
-        // current TypeScript schema.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await trans.table("tasks").toCollection().modify((task: any) => {
+        // Uses legacy migration interface for fields not in current TypeScript schema.
+        await trans.table("tasks").toCollection().modify((task: LegacyTaskMigrationRecord) => {
           delete task.vectorClock;
         });
 
-        // Same reason as above: Dexie's .modify() callback is typed any internally.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await trans.table("archivedTasks").toCollection().modify((task: any) => {
+        // Same migration interface for archived tasks.
+        await trans.table("archivedTasks").toCollection().modify((task: LegacyTaskMigrationRecord) => {
           delete task.vectorClock;
         });
 

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -239,12 +239,14 @@ export function createLogger(context: LogContext, minLevel?: LogLevel): Logger {
 }
 
 /**
- * Correlation ID generator for tracking related operations
+ * Correlation ID generator for tracking related operations.
+ * Includes a random suffix to prevent collisions after page reload.
  */
 let correlationCounter = 0;
 
 export function generateCorrelationId(): string {
   const timestamp = Date.now();
   const counter = ++correlationCounter;
-  return `${timestamp}-${counter}`;
+  const random = Math.random().toString(36).slice(2, 6);
+  return `${timestamp}-${counter}-${random}`;
 }

--- a/lib/sync/health-monitor.ts
+++ b/lib/sync/health-monitor.ts
@@ -69,6 +69,10 @@ export class HealthMonitor {
         return { healthy: true, issues: [], timestamp };
       }
 
+      // Prune items that have exceeded max retries to prevent unbounded queue growth
+      const queue = getSyncQueue();
+      await queue.pruneExhaustedRetries();
+
       const issues: HealthIssue[] = [];
 
       const staleIssue = await this.checkStaleOperations();

--- a/lib/sync/pb-pull.ts
+++ b/lib/sync/pb-pull.ts
@@ -9,7 +9,7 @@ import { getPocketBase } from './pocketbase-client';
 import { pocketBaseToTaskRecord } from './task-mapper';
 import { getDb } from '@/lib/db';
 import { createLogger } from '@/lib/logger';
-import { escapeFilterValue, getCurrentUserId, fetchRemoteTaskIndex } from './pb-sync-helpers';
+import { escapeFilterValue, getCurrentUserId, fetchRemoteTaskIndex, assertSafeRecordId } from './pb-sync-helpers';
 import type { RecordModel } from 'pocketbase';
 
 const logger = createLogger('SYNC_ENGINE');
@@ -77,6 +77,8 @@ export async function pullRemoteChanges(lastSyncAt: string | null): Promise<{ pu
     logger.warn('Pull skipped: not authenticated');
     return { pulledCount: 0, authenticated: false, maxObservedTimestamp: null };
   }
+
+  assertSafeRecordId(ownerId, 'ownerId');
 
   let filter = `owner = "${escapeFilterValue(ownerId)}"`;
   if (lastSyncAt) {

--- a/lib/sync/pb-sync-helpers.ts
+++ b/lib/sync/pb-sync-helpers.ts
@@ -16,9 +16,30 @@ export function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/** Maximum allowed length for filter values to prevent query parser issues */
+const MAX_FILTER_VALUE_LENGTH = 500;
+
 /** Escape a string value for safe use in PocketBase filter expressions */
 export function escapeFilterValue(value: string): string {
+  if (value.length > MAX_FILTER_VALUE_LENGTH) {
+    throw new Error(`Filter value exceeds maximum length of ${MAX_FILTER_VALUE_LENGTH}`);
+  }
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/**
+ * Validate that a value matches a safe ID format for use in PocketBase filters.
+ * Accepts PocketBase record IDs (15-char alphanumeric) and common test ID formats.
+ * Rejects values containing filter syntax characters (", ', &&, ||, etc.)
+ */
+export function assertSafeRecordId(value: string, label = 'id'): void {
+  if (value.length === 0 || value.length > 50) {
+    throw new Error(`Invalid ${label} format: unexpected length`);
+  }
+  // Allow alphanumeric, hyphens, and underscores only
+  if (!/^[a-z0-9_-]+$/i.test(value)) {
+    throw new Error(`Invalid ${label} format: contains unsafe characters`);
+  }
 }
 
 /** Get the current device ID from sync config in IndexedDB */
@@ -36,6 +57,7 @@ export { getCurrentUserId };
  * Returns a Map of task_id -> PocketBase record id for efficient lookups.
  */
 export async function fetchRemoteTaskIndex(ownerId: string): Promise<{ index: Map<string, string>; fetchSucceeded: boolean }> {
+  assertSafeRecordId(ownerId, 'ownerId');
   const pb = getPocketBase();
   const index = new Map<string, string>();
 

--- a/lib/sync/queue.ts
+++ b/lib/sync/queue.ts
@@ -7,6 +7,10 @@ import { getDb } from '@/lib/db';
 import type { TaskRecord } from '@/lib/types';
 import type { SyncQueueItem } from './types';
 import { generateId } from '@/lib/id-generator';
+import { SYNC_CONFIG } from '@/lib/constants/sync';
+import { createLogger } from '@/lib/logger';
+
+const logger = createLogger('SYNC_QUEUE');
 
 export class SyncQueue {
   /**
@@ -113,6 +117,31 @@ export class SyncQueue {
     }
 
     return count;
+  }
+
+  /**
+   * Remove items that have exceeded the maximum retry count.
+   * Prevents the queue from growing unboundedly when push operations
+   * repeatedly fail for a specific task (e.g., validation errors).
+   *
+   * @returns Number of pruned items
+   */
+  async pruneExhaustedRetries(): Promise<number> {
+    const db = getDb();
+    const all = await db.syncQueue.toArray();
+    const exhausted = all.filter(item => item.retryCount >= SYNC_CONFIG.MAX_RETRIES);
+
+    if (exhausted.length === 0) return 0;
+
+    const ids = exhausted.map(item => item.id);
+    await db.syncQueue.bulkDelete(ids);
+
+    logger.warn('Pruned exhausted sync queue items', {
+      prunedCount: exhausted.length,
+      taskIds: exhausted.map(item => item.taskId).join(', '),
+    });
+
+    return exhausted.length;
   }
 }
 

--- a/lib/tasks/import-export.ts
+++ b/lib/tasks/import-export.ts
@@ -4,6 +4,12 @@ import { importPayloadSchema, taskRecordSchema } from "@/lib/schema";
 import type { ImportPayload, TaskRecord } from "@/lib/types";
 import { isoNow } from "@/lib/utils";
 
+/** Maximum number of tasks allowed in a single import to prevent storage DoS */
+const MAX_IMPORT_TASKS = 10_000;
+
+/** Maximum raw JSON string size (10 MB) to prevent memory exhaustion */
+const MAX_IMPORT_SIZE_BYTES = 10 * 1024 * 1024;
+
 /**
  * Export all tasks as a structured payload
  */
@@ -95,6 +101,10 @@ export async function importTasks(payload: ImportPayload, mode: "replace" | "mer
     throw new Error(`Invalid import data: ${result.error.issues.map(i => i.message).join(", ")}`);
   }
   const parsed = result.data;
+
+  if (parsed.tasks.length > MAX_IMPORT_TASKS) {
+    throw new Error(`Import exceeds maximum of ${MAX_IMPORT_TASKS.toLocaleString()} tasks. Please split into smaller files.`);
+  }
   let tasksEnqueuedForSync: TaskRecord[] = [];
 
   await db.transaction("rw", db.tasks, async () => {
@@ -132,6 +142,10 @@ export async function importTasks(payload: ImportPayload, mode: "replace" | "mer
  * Import tasks from JSON string with merge or replace mode
  */
 export async function importFromJson(raw: string, mode: "replace" | "merge" = "replace"): Promise<void> {
+  if (raw.length > MAX_IMPORT_SIZE_BYTES) {
+    throw new Error(`Import file is too large (${(raw.length / 1024 / 1024).toFixed(1)} MB). Maximum allowed size is ${MAX_IMPORT_SIZE_BYTES / 1024 / 1024} MB.`);
+  }
+
   try {
     const payload = JSON.parse(raw);
     await importTasks(payload, mode);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev": "next dev",
 		"clean": "rimraf .next out",
 		"prebuild": "rimraf .next out",
-		"build": "node scripts/generate-build-info.cjs && bash -c 'source .build-env.sh && next build 2>&1 | grep -v baseline-browser-mapping'",
+		"build": "node scripts/generate-build-info.cjs && node scripts/update-sw-version.cjs && bash -c 'source .build-env.sh && next build 2>&1 | grep -v baseline-browser-mapping'",
 		"start": "next start",
 		"lint": "eslint .",
 		"test": "vitest run",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,7 @@
-// Use timestamp for cache versioning to ensure iOS devices get updates
-const CACHE_NAME = `gsd-cache-${Date.now()}`;
+// Cache version — updated at build time by scripts/update-sw-version.cjs
+// Using a deterministic version prevents unbounded cache growth from Date.now()
+const CACHE_VERSION = '8.8.0';
+const CACHE_NAME = `gsd-cache-v${CACHE_VERSION}`;
 const OFFLINE_ASSETS = [
 	"/",
 	"/about/",

--- a/scripts/update-sw-version.cjs
+++ b/scripts/update-sw-version.cjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+/**
+ * Updates the service worker cache version to match package.json version.
+ * Called as part of the build process to ensure cache busting on deploys.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const fs = require('fs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require('path');
+
+const PACKAGE_JSON = path.join(__dirname, '..', 'package.json');
+const SW_FILE = path.join(__dirname, '..', 'public', 'sw.js');
+
+const packageJson = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf8'));
+const version = packageJson.version || '0.0.0';
+
+let swContent = fs.readFileSync(SW_FILE, 'utf8');
+
+// Replace the CACHE_VERSION constant value
+const versionPattern = /const CACHE_VERSION = '[^']+';/;
+if (versionPattern.test(swContent)) {
+  swContent = swContent.replace(versionPattern, `const CACHE_VERSION = '${version}';`);
+  fs.writeFileSync(SW_FILE, swContent);
+  console.log(`Service worker cache version updated to ${version}`);
+} else {
+  console.error('Could not find CACHE_VERSION in sw.js');
+  process.exit(1);
+}

--- a/tests/data/logger.test.ts
+++ b/tests/data/logger.test.ts
@@ -602,7 +602,7 @@ describe("Logger module", () => {
 	describe("generateCorrelationId", () => {
 		it("should return a string with timestamp and counter", () => {
 			const correlationId = generateCorrelationId();
-			expect(correlationId).toMatch(/^\d+-\d+$/);
+			expect(correlationId).toMatch(/^\d+-\d+-[a-z0-9]+$/);
 		});
 
 		it("should generate unique IDs on successive calls", () => {

--- a/tests/data/sync/health-monitor.test.ts
+++ b/tests/data/sync/health-monitor.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/lib/logger', () => ({
 // Mock queue
 const mockQueue = {
   getPending: vi.fn().mockResolvedValue([]),
+  pruneExhaustedRetries: vi.fn().mockResolvedValue(0),
 };
 vi.mock('@/lib/sync/queue', () => ({
   getSyncQueue: () => mockQueue,

--- a/tests/sync/health-monitor.test.ts
+++ b/tests/sync/health-monitor.test.ts
@@ -37,6 +37,7 @@ import { isAuthenticated } from '@/lib/sync/pocketbase-client';
 // Create mock instances
 const mockQueue = {
   getPending: vi.fn(async () => []),
+  pruneExhaustedRetries: vi.fn(async () => 0),
 };
 
 // Default: user is authenticated


### PR DESCRIPTION
## Summary

Comprehensive security hardening based on code review audit. All changes are backward-compatible and defensive in nature.

## Changes

### 1. Service Worker Cache Versioning (Medium)
- **Before:** `Date.now()` generated a new cache name on every SW install, causing unbounded cache growth
- **After:** Deterministic version from `package.json`, auto-updated at build time via `scripts/update-sw-version.cjs`

### 2. Import Size Limits (Low-Medium)
- Added `MAX_IMPORT_TASKS = 10,000` count limit
- Added `MAX_IMPORT_SIZE_BYTES = 10 MB` raw JSON size limit
- Prevents storage DoS via maliciously crafted import files

### 3. Sync Queue Pruning (Low)
- New `pruneExhaustedRetries()` method removes items exceeding `MAX_RETRIES` (5)
- Called during each health monitor check cycle
- Prevents unbounded queue growth when push operations fail permanently

### 4. PocketBase Filter Injection Defense (Low)
- `escapeFilterValue()` now rejects values > 500 chars
- New `assertSafeRecordId()` validates ID format before string interpolation
- Rejects values containing filter syntax characters (\", ', &&, ||)

### 5. DB Migration Type Safety (Low)
- Replaced 3 `any` casts with typed `LegacyTaskMigrationRecord` interface
- Removed eslint-disable comments

### 6. Correlation ID Collision Fix (Low)
- Added random suffix to `generateCorrelationId()` to prevent duplicates after page reload

## Testing
- `bun typecheck` ✅
- `bun lint` ✅ (no new warnings)
- `bun run test` — all tests pass (5 pre-existing edit-drawer timeouts unrelated to this PR)