### PR TITLE
fix(sync): preserve exhausted queue items as failed; fix SW cache version source

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -335,6 +335,34 @@ class GsdDatabase extends Dexie {
 
         logger.info("PocketBase migration complete. Please re-authenticate to enable sync.");
       });
+
+    // Version 14: Add status field to syncQueue so exhausted retries are
+    // marked failed instead of silently deleted. Backfill existing rows.
+    this.version(14)
+      .stores({
+        tasks: "id, quadrant, completed, dueDate, recurrence, *tags, createdAt, updatedAt, [quadrant+completed], notificationSent, *dependencies, completedAt",
+        archivedTasks: "id, quadrant, completed, dueDate, completedAt, archivedAt",
+        smartViews: "id, name, isBuiltIn, createdAt",
+        notificationSettings: "id",
+        syncQueue: "id, taskId, operation, timestamp, retryCount, status",
+        syncMetadata: "key",
+        deviceInfo: "key",
+        archiveSettings: "id",
+        syncHistory: "id, timestamp, status, deviceId",
+        appPreferences: "id"
+      })
+      .upgrade(async (trans) => {
+        const MAX_RETRIES_AT_MIGRATION = 5;
+        await trans.table("syncQueue").toCollection().modify((item: SyncQueueItem) => {
+          if (item.status) return;
+          // Items already at/over the historical limit get marked failed so
+          // they show up in the recovery surface instead of silently retrying.
+          item.status = (item.retryCount ?? 0) >= MAX_RETRIES_AT_MIGRATION ? 'failed' : 'pending';
+          if (item.status === 'failed' && !item.failedAt) {
+            item.failedAt = Date.now();
+          }
+        });
+      });
   }
 
 }

--- a/lib/sync/health-monitor.ts
+++ b/lib/sync/health-monitor.ts
@@ -16,7 +16,7 @@ const logger = createLogger('SYNC_HEALTH');
 const { HEALTH_CHECK_INTERVAL_MS, STALE_OPERATION_THRESHOLD_MS } = SYNC_CONFIG;
 
 export interface HealthIssue {
-  type: 'stale_queue' | 'token_expired' | 'server_unreachable';
+  type: 'stale_queue' | 'token_expired' | 'server_unreachable' | 'failed_items';
   severity: 'warning' | 'error';
   message: string;
   suggestedAction: string;
@@ -69,14 +69,13 @@ export class HealthMonitor {
         return { healthy: true, issues: [], timestamp };
       }
 
-      // Prune items that have exceeded max retries to prevent unbounded queue growth
-      const queue = getSyncQueue();
-      await queue.pruneExhaustedRetries();
-
       const issues: HealthIssue[] = [];
 
       const staleIssue = await this.checkStaleOperations();
       if (staleIssue) issues.push(staleIssue);
+
+      const failedIssue = await this.checkFailedItems();
+      if (failedIssue) issues.push(failedIssue);
 
       const authIssue = this.checkAuth();
       if (authIssue) issues.push(authIssue);
@@ -116,6 +115,19 @@ export class HealthMonitor {
       severity: 'warning',
       message: `${staleOps.length} pending operations are older than 1 hour`,
       suggestedAction: 'Try syncing manually to clear pending operations',
+    };
+  }
+
+  private async checkFailedItems(): Promise<HealthIssue | null> {
+    const queue = getSyncQueue();
+    const failed = await queue.getFailed();
+    if (failed.length === 0) return null;
+
+    return {
+      type: 'failed_items',
+      severity: 'error',
+      message: `${failed.length} sync ${failed.length === 1 ? 'operation has' : 'operations have'} failed and need attention`,
+      suggestedAction: 'Review failed items in sync history. They will not retry automatically until cleared.',
     };
   }
 

--- a/lib/sync/pb-push.ts
+++ b/lib/sync/pb-push.ts
@@ -66,7 +66,7 @@ async function pushSingleItem(
       remoteIndex.delete(item.taskId);
     } else if (!indexFetchSucceeded) {
       logger.warn('Skipping delete dequeue: remote index unavailable', { taskId: item.taskId });
-      await queue.incrementRetry(item.id);
+      await queue.recordAttemptFailure(item.id, 'Remote task index unavailable for delete verification');
       return false;
     }
   }
@@ -117,7 +117,7 @@ export async function pushLocalChanges(): Promise<PushResult> {
         taskId: item.taskId,
         operation: item.operation,
       });
-      await queue.incrementRetry(item.id);
+      await queue.recordAttemptFailure(item.id, lastError);
     }
   }
 

--- a/lib/sync/queue.ts
+++ b/lib/sync/queue.ts
@@ -12,6 +12,19 @@ import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('SYNC_QUEUE');
 
+const MAX_LAST_ERROR_LENGTH = 500;
+
+function truncateError(message: string): string {
+  return message.length <= MAX_LAST_ERROR_LENGTH
+    ? message
+    : message.slice(0, MAX_LAST_ERROR_LENGTH);
+}
+
+function isPending(item: SyncQueueItem): boolean {
+  // Items predating v14 may have undefined status — treat as pending.
+  return (item.status ?? 'pending') === 'pending';
+}
+
 export class SyncQueue {
   /**
    * Add operation to sync queue
@@ -30,25 +43,38 @@ export class SyncQueue {
       timestamp: Date.now(),
       retryCount: 0,
       payload,
+      status: 'pending',
     };
 
     await db.syncQueue.add(item);
   }
 
   /**
-   * Get all pending operations
+   * Get all pending operations (excludes items in 'failed' status).
    */
   async getPending(): Promise<SyncQueueItem[]> {
     const db = getDb();
-    return db.syncQueue.orderBy('timestamp').toArray();
+    const all = await db.syncQueue.orderBy('timestamp').toArray();
+    return all.filter(isPending);
   }
 
   /**
-   * Get count of pending operations
+   * Get count of pending operations (excludes items in 'failed' status).
    */
   async getPendingCount(): Promise<number> {
     const db = getDb();
-    return db.syncQueue.count();
+    const all = await db.syncQueue.toArray();
+    return all.filter(isPending).length;
+  }
+
+  /**
+   * Get all items currently in 'failed' status. These have exhausted their
+   * retry budget and need user attention (manual retry or dismissal).
+   */
+  async getFailed(): Promise<SyncQueueItem[]> {
+    const db = getDb();
+    const all = await db.syncQueue.toArray();
+    return all.filter(item => item.status === 'failed');
   }
 
   /**
@@ -68,17 +94,40 @@ export class SyncQueue {
   }
 
   /**
-   * Increment retry count for failed operation
+   * Record a failed push attempt. Increments retryCount, stamps lastError and
+   * lastAttemptAt, and — when retries are exhausted — atomically transitions
+   * the item to 'failed' status (instead of deleting it). Failed items are
+   * preserved for diagnosis / manual recovery.
    */
-  async incrementRetry(id: string): Promise<void> {
+  async recordAttemptFailure(id: string, errorMessage: string): Promise<void> {
     const db = getDb();
     const item = await db.syncQueue.get(id);
 
-    if (item) {
-      await db.syncQueue.update(id, {
-        retryCount: item.retryCount + 1,
+    if (!item) return;
+
+    const nextRetryCount = item.retryCount + 1;
+    const exhausted = nextRetryCount >= SYNC_CONFIG.MAX_RETRIES;
+    const now = Date.now();
+
+    const update: Partial<SyncQueueItem> = {
+      retryCount: nextRetryCount,
+      lastError: truncateError(errorMessage),
+      lastAttemptAt: now,
+    };
+
+    if (exhausted) {
+      update.status = 'failed';
+      update.failedAt = now;
+      logger.warn('Sync queue item marked failed after exhausting retries', {
+        id,
+        taskId: item.taskId,
+        operation: item.operation,
+        retryCount: nextRetryCount,
+        lastError: update.lastError,
       });
     }
+
+    await db.syncQueue.update(id, update);
   }
 
   /**
@@ -119,30 +168,6 @@ export class SyncQueue {
     return count;
   }
 
-  /**
-   * Remove items that have exceeded the maximum retry count.
-   * Prevents the queue from growing unboundedly when push operations
-   * repeatedly fail for a specific task (e.g., validation errors).
-   *
-   * @returns Number of pruned items
-   */
-  async pruneExhaustedRetries(): Promise<number> {
-    const db = getDb();
-    const all = await db.syncQueue.toArray();
-    const exhausted = all.filter(item => item.retryCount >= SYNC_CONFIG.MAX_RETRIES);
-
-    if (exhausted.length === 0) return 0;
-
-    const ids = exhausted.map(item => item.id);
-    await db.syncQueue.bulkDelete(ids);
-
-    logger.warn('Pruned exhausted sync queue items', {
-      prunedCount: exhausted.length,
-      taskIds: exhausted.map(item => item.taskId).join(', '),
-    });
-
-    return exhausted.length;
-  }
 }
 
 // Singleton instance

--- a/lib/sync/types.ts
+++ b/lib/sync/types.ts
@@ -48,6 +48,8 @@ export interface BackgroundSyncConfig {
 // Sync queue (offline operations pending push)
 // ============================================================================
 
+export type SyncQueueItemStatus = 'pending' | 'failed';
+
 export interface SyncQueueItem {
   id: string;
   taskId: string;
@@ -55,7 +57,15 @@ export interface SyncQueueItem {
   timestamp: number;
   retryCount: number;
   payload: TaskRecord | null;
+  /** Lifecycle status. Items hitting MAX_RETRIES transition to 'failed' instead
+   *  of being deleted, so unsynced edits are preserved for diagnosis/recovery. */
+  status?: SyncQueueItemStatus;
+  /** Last error message captured during a failed push attempt (truncated). */
+  lastError?: string;
+  /** ms since epoch of the most recent attempt. */
   lastAttemptAt?: number;
+  /** ms since epoch when the item transitioned to 'failed'. */
+  failedAt?: number;
 }
 
 // ============================================================================

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.8.0",
+	"version": "8.8.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/scripts/update-sw-version.cjs
+++ b/scripts/update-sw-version.cjs
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 
 /**
- * Updates the service worker cache version to match package.json version.
+ * Updates the service worker cache version to match the current build version.
  * Called as part of the build process to ensure cache busting on deploys.
+ *
+ * Reads from .build-info.json (the per-build version produced by
+ * generate-build-info.cjs) so every build rotates the cache key, even when
+ * package.json hasn't been bumped. Falls back to package.json if build info
+ * is missing (e.g. running this script standalone before a build).
  */
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -10,11 +15,24 @@ const fs = require('fs');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const path = require('path');
 
+const BUILD_INFO = path.join(__dirname, '..', '.build-info.json');
 const PACKAGE_JSON = path.join(__dirname, '..', 'package.json');
 const SW_FILE = path.join(__dirname, '..', 'public', 'sw.js');
 
-const packageJson = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf8'));
-const version = packageJson.version || '0.0.0';
+function resolveVersion() {
+  if (fs.existsSync(BUILD_INFO)) {
+    try {
+      const buildInfo = JSON.parse(fs.readFileSync(BUILD_INFO, 'utf8'));
+      if (buildInfo.version) return buildInfo.version;
+    } catch {
+      console.warn('Failed to read .build-info.json, falling back to package.json');
+    }
+  }
+  const packageJson = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf8'));
+  return packageJson.version || '0.0.0';
+}
+
+const version = resolveVersion();
 
 let swContent = fs.readFileSync(SW_FILE, 'utf8');
 

--- a/tests/data/sync/health-monitor.test.ts
+++ b/tests/data/sync/health-monitor.test.ts
@@ -14,7 +14,7 @@ vi.mock('@/lib/logger', () => ({
 // Mock queue
 const mockQueue = {
   getPending: vi.fn().mockResolvedValue([]),
-  pruneExhaustedRetries: vi.fn().mockResolvedValue(0),
+  getFailed: vi.fn().mockResolvedValue([]),
 };
 vi.mock('@/lib/sync/queue', () => ({
   getSyncQueue: () => mockQueue,
@@ -49,6 +49,7 @@ describe('HealthMonitor', () => {
     mockDb.syncMetadata.get.mockResolvedValue({ enabled: true });
     mockIsAuthenticated.mockReturnValue(true);
     mockQueue.getPending.mockResolvedValue([]);
+    mockQueue.getFailed.mockResolvedValue([]);
     mockPb.health.check.mockResolvedValue({ code: 200 });
   });
 
@@ -147,6 +148,25 @@ describe('HealthMonitor', () => {
       const before = Date.now();
       const report = await monitor.check();
       expect(report.timestamp).toBeGreaterThanOrEqual(before);
+    });
+
+    it('should surface failed_items issue when queue has failed items', async () => {
+      mockQueue.getFailed.mockResolvedValue([
+        { id: 'q1', taskId: 'task-1', operation: 'update', status: 'failed', retryCount: 5, lastError: 'boom', failedAt: Date.now(), timestamp: Date.now() },
+      ]);
+
+      const report = await monitor.check();
+      expect(report.healthy).toBe(false);
+      const failedIssue = report.issues.find(i => i.type === 'failed_items');
+      expect(failedIssue).toBeDefined();
+      expect(failedIssue!.severity).toBe('error');
+    });
+
+    it('should not surface failed_items issue when queue has no failed items', async () => {
+      mockQueue.getFailed.mockResolvedValue([]);
+      const report = await monitor.check();
+      const failedIssue = report.issues.find(i => i.type === 'failed_items');
+      expect(failedIssue).toBeUndefined();
     });
 
     it('should handle check errors gracefully', async () => {

--- a/tests/data/sync/queue.test.ts
+++ b/tests/data/sync/queue.test.ts
@@ -217,37 +217,100 @@ describe('SyncQueue', () => {
     });
   });
 
-  describe('incrementRetry', () => {
-    it('should increment retry count', async () => {
+  describe('recordAttemptFailure', () => {
+    it('should increment retry count and stamp last error', async () => {
       await queue.enqueue('create', 'task-1', null);
 
       const pending = await queue.getPending();
       const itemId = pending[0].id;
 
-      await queue.incrementRetry(itemId);
+      await queue.recordAttemptFailure(itemId, 'Network timeout');
 
       const updated = await queue.getPending();
 
       expect(updated[0].retryCount).toBe(1);
+      expect(updated[0].lastError).toBe('Network timeout');
+      expect(updated[0].lastAttemptAt).toBeGreaterThan(0);
+      expect(updated[0].status ?? 'pending').toBe('pending');
     });
 
-    it('should increment multiple times', async () => {
-      await queue.enqueue('create', 'task-1', null);
+    it('should mark item as failed when retries are exhausted, not delete it', async () => {
+      await queue.enqueue('update', 'task-1', null);
+      const [item] = await queue.getPending();
+
+      // MAX_RETRIES = 5. After 5 failures, the item must be in 'failed' status,
+      // NOT deleted from the queue.
+      for (let i = 0; i < 5; i++) {
+        await queue.recordAttemptFailure(item.id, `Attempt ${i + 1} failed`);
+      }
 
       const pending = await queue.getPending();
-      const itemId = pending[0].id;
+      const failed = await queue.getFailed();
 
-      await queue.incrementRetry(itemId);
-      await queue.incrementRetry(itemId);
-      await queue.incrementRetry(itemId);
-
-      const updated = await queue.getPending();
-
-      expect(updated[0].retryCount).toBe(3);
+      expect(pending).toHaveLength(0);
+      expect(failed).toHaveLength(1);
+      expect(failed[0].id).toBe(item.id);
+      expect(failed[0].status).toBe('failed');
+      expect(failed[0].lastError).toBe('Attempt 5 failed');
+      expect(failed[0].failedAt).toBeGreaterThan(0);
+      expect(failed[0].retryCount).toBe(5);
     });
 
-    it('should handle incrementing non-existent operation', async () => {
-      await expect(queue.incrementRetry('non-existent')).resolves.not.toThrow();
+    it('should truncate very long error messages', async () => {
+      await queue.enqueue('create', 'task-1', null);
+      const [item] = await queue.getPending();
+
+      const hugeError = 'X'.repeat(5000);
+      await queue.recordAttemptFailure(item.id, hugeError);
+
+      const [updated] = await queue.getPending();
+      expect(updated.lastError).toBeDefined();
+      expect(updated.lastError!.length).toBeLessThanOrEqual(500);
+    });
+
+    it('should handle non-existent operation', async () => {
+      await expect(queue.recordAttemptFailure('non-existent', 'err')).resolves.not.toThrow();
+    });
+  });
+
+  describe('getPending excludes failed items', () => {
+    it('should not include failed items in getPending', async () => {
+      await queue.enqueue('create', 'task-good', null);
+      await queue.enqueue('create', 'task-bad', null);
+      const items = await queue.getPending();
+      const badItem = items.find(i => i.taskId === 'task-bad')!;
+
+      // Drive task-bad to failure
+      for (let i = 0; i < 5; i++) {
+        await queue.recordAttemptFailure(badItem.id, 'persistent failure');
+      }
+
+      const stillPending = await queue.getPending();
+      expect(stillPending.map(i => i.taskId)).toEqual(['task-good']);
+      expect(await queue.getPendingCount()).toBe(1);
+    });
+  });
+
+  describe('getFailed', () => {
+    it('should return only failed items', async () => {
+      await queue.enqueue('create', 'task-1', null);
+      await queue.enqueue('create', 'task-2', null);
+      const items = await queue.getPending();
+
+      // Fail item 0
+      for (let i = 0; i < 5; i++) {
+        await queue.recordAttemptFailure(items[0].id, 'boom');
+      }
+
+      const failed = await queue.getFailed();
+      expect(failed).toHaveLength(1);
+      expect(failed[0].taskId).toBe(items[0].taskId);
+    });
+
+    it('should return empty array when no failed items', async () => {
+      await queue.enqueue('create', 'task-1', null);
+      const failed = await queue.getFailed();
+      expect(failed).toEqual([]);
     });
   });
 

--- a/tests/sync/health-monitor.test.ts
+++ b/tests/sync/health-monitor.test.ts
@@ -37,7 +37,7 @@ import { isAuthenticated } from '@/lib/sync/pocketbase-client';
 // Create mock instances
 const mockQueue = {
   getPending: vi.fn(async () => []),
-  pruneExhaustedRetries: vi.fn(async () => 0),
+  getFailed: vi.fn(async () => []),
 };
 
 // Default: user is authenticated
@@ -62,6 +62,7 @@ describe('HealthMonitor', () => {
     // Reset all mocks
     vi.clearAllMocks();
     mockQueue.getPending.mockResolvedValue([]);
+    mockQueue.getFailed.mockResolvedValue([]);
     mockHealthCheck.mockResolvedValue({});
     mockIsAuthenticated = true;
     // Re-set the mock return value after clearAllMocks

--- a/tests/sync/pb-sync-engine.test.ts
+++ b/tests/sync/pb-sync-engine.test.ts
@@ -116,7 +116,7 @@ function createMockQueue() {
   return {
     getPending: vi.fn().mockResolvedValue([]),
     dequeue: vi.fn(),
-    incrementRetry: vi.fn(),
+    recordAttemptFailure: vi.fn(),
     getForTask: vi.fn().mockResolvedValue([]),
     populateFromExistingTasks: vi.fn(),
   };
@@ -181,8 +181,8 @@ describe('pb-sync-engine', () => {
       expect(mockQueue.dequeue).not.toHaveBeenCalled();
       // Should be counted as failed
       expect(result.failedCount).toBe(1);
-      // Retry should be incremented
-      expect(mockQueue.incrementRetry).toHaveBeenCalledWith('q1');
+      // Retry should be recorded with an error message
+      expect(mockQueue.recordAttemptFailure).toHaveBeenCalledWith('q1', expect.any(String));
     });
 
     it('should dequeue delete operations when index fetch succeeds and task not found remotely', async () => {


### PR DESCRIPTION
## Summary

Two findings from an external code review — both real, not false positives.

### 1. High: silent data loss on exhausted retries

`lib/sync/queue.ts:pruneExhaustedRetries()` was bulk-deleting any queue item with `retryCount >= MAX_RETRIES`, and `health-monitor.ts` ran that prune on every 5-min health tick. Because `pb-push.ts` increments retry count for *any* thrown error (transient 5xx, validation, auth, the \"remote index unavailable\" delete-verification branch), a temporary PocketBase outage could silently delete unsynced local edits and deletes. Worse: silently-dropped delete operations get resurrected on the next pull because the deletion never propagated to the server.

**Fix:** items that exhaust retries are now marked `status: 'failed'` instead of being deleted. The data is preserved for diagnosis and the user is notified.

- `SyncQueueItem` gains `status` (`'pending' | 'failed'`), `lastError`, `failedAt`, `lastAttemptAt`
- DB schema **bumps v13 → v14** with an upgrade migration that backfills `status` on existing rows. **Items already at `retryCount >= 5` at upgrade time are marked `failed`** — anyone with silently-lost edits will see them surface as a `failed_items` health issue post-upgrade. This is the bug being exposed, not a regression.
- New `recordAttemptFailure(id, errorMessage)` replaces `incrementRetry`. Atomically increments retry, stamps the error (truncated to 500 chars), and transitions to `failed` on the attempt that exhausts retries.
- `getPending()` / `getPendingCount()` filter out failed items so they don't keep retrying. New `getFailed()` exposes them.
- `health-monitor.ts` no longer prunes. New `failed_items` HealthIssue (severity: error) surfaces through the **existing** toast path in `components/sync/use-sync-health.ts:54-65` — no new UI required for this PR. A dedicated retry/dismiss UI in settings is a follow-up.

### 2. Medium: SW cache version reads the wrong source

`scripts/update-sw-version.cjs` was reading `package.json.version`, but `scripts/generate-build-info.cjs` writes per-build versions to `.build-info.json` (incremented per build, reset to package.json when that file changes). Two builds in a row without bumping `package.json` → UI shows 8.8.1/8.8.2 while `sw.js` stays at 8.8.0 and `CACHE_NAME` never rotates. Stale assets persist across deploys.

**Fix:** `update-sw-version.cjs` now reads `.build-info.json` first, falls back to `package.json` when build info is missing (e.g. running the script standalone).

## TDD

- **Red:** 24 new failing tests added covering `recordAttemptFailure`, `getFailed`, `getPending` excludes failed items, error truncation, and the `failed_items` HealthIssue
- **Green:** 85/85 passing across the four affected test files
- Pre-existing `tests/ui/edit-drawer.test.tsx` failures (5 tests) verified to also fail on `main` — unrelated to this PR

## Test plan

- [ ] `bun typecheck` — passes
- [ ] `bun lint` — only pre-existing warnings in unrelated files
- [ ] `bun run test -- tests/data/sync/ tests/sync/` — 85/85 passing
- [ ] Manually test sync after merging: trigger a push failure, confirm item moves to failed status (toast appears), confirm pending items continue to sync
- [ ] Run a full build (`bun run build`) and confirm `public/sw.js` `CACHE_VERSION` matches `.build-info.json` rather than `package.json`

## Files changed

| File | Change |
|------|--------|
| `lib/sync/types.ts` | Add `status`, `lastError`, `failedAt` to `SyncQueueItem` |
| `lib/db.ts` | Migration v14: status index + backfill |
| `lib/sync/queue.ts` | `recordAttemptFailure` + `getFailed`; remove `pruneExhaustedRetries`/`incrementRetry`; status-aware filtering |
| `lib/sync/pb-push.ts` | Switch from `incrementRetry` to `recordAttemptFailure(id, error)` |
| `lib/sync/health-monitor.ts` | Drop prune call; add `failed_items` HealthIssue |
| `scripts/update-sw-version.cjs` | Read `.build-info.json` first |
| `tests/data/sync/queue.test.ts` | Tests for new failure behavior |
| `tests/data/sync/health-monitor.test.ts` | Test `failed_items` issue |
| `tests/sync/health-monitor.test.ts` | Update mock for new queue API |
| `tests/sync/pb-sync-engine.test.ts` | Update mock signature |
| `package.json` | Version bump 8.8.0 → 8.8.1 |