### PR TITLE
chore(ci): cap workflow runtimes to prevent runaway jobs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,6 +19,7 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -16,6 +16,7 @@ jobs:
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.8.1",
+	"version": "8.8.2",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Adds job-level `timeout-minutes` to every GitHub Actions workflow so a hung or runaway job can't burn unbounded compute (or, for the Claude actions, unbounded API spend).

**Motivation:** The Claude Code Review action recently ran for 3h 47m on a large PR before crashing with a context-window thrashing error, costing ~\$200. GitHub's default job timeout is 360 minutes — there is no implicit cost ceiling, you have to opt in.

## Changes

| File | Job | Timeout | Rationale |
|---|---|---|---|
| `.github/workflows/claude-code-review.yml` | `claude-review` | **30m** | The job that triggered the incident |
| `.github/workflows/claude.yml` | `claude` | **30m** | Same `anthropics/claude-code-action@v1` runtime, same failure mode; triggered by `@claude` mentions in user-controlled comment/issue bodies |
| `.github/workflows/security-audit.yml` | `audit` | **15m** | `bun audit` typically finishes in <5m; 15m catches a hung registry fetch |
| `.github/workflows/sonarcloud.yml` | `sonarcloud` | **15m** | Install + tests + scanner upload typically <8m; 15m catches a stuck SonarCloud upload |

Also bumps `package.json` from 8.8.1 → 8.8.2.

## Notes

- `timeout-minutes` is set at the **job** level, sibling to `runs-on:` and `permissions:`. This bounds the entire job (all steps), not just one step — the right scope for runaway-prevention.
- These caps are floors on safety, not targets. If a job legitimately grows past its cap (e.g., test suite expansion pushes SonarCloud past 15m), raise the cap rather than removing it.
- `timeout-minutes` doesn't roll back partial side effects (uploaded SonarCloud reports, partially-posted PR comments). All four jobs here are idempotent, so this is fine.

## Test plan

- [ ] Confirm `gh workflow view` shows the timeout on each job once merged
- [ ] On the next Claude review run, verify the job page shows "Job will be cancelled in N minutes" countdown
- [ ] Watch for any legitimate jobs that get cut off — adjust caps upward if so