### PR TITLE
feat(redesign): muted earth-tone palette identity (Phase 2)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,21 +6,25 @@
 
   /* Surfaces — warm paper */
   --background: 246 245 241;           /* #f6f5f1 */
-  --background-muted: 239 237 231;     /* #efede7 */
+  --background-muted: 239 237 231;     /* #efede7 — also serves as capture-bar bg */
   --background-accent: 235 232 224;    /* #ebe8e0 */
 
   /* Text */
   --foreground: 24 24 27;              /* #18181b */
-  --foreground-muted: 113 113 122;     /* #71717a — AA on paper 4.8:1 */
+  --foreground-muted: 107 104 101;     /* #6B6865 — warm gray (redesign Phase 2) */
 
   /* Borders — warm */
   --border: 230 227 219;               /* #e6e3db */
   --border-muted: 239 237 231;         /* #efede7 */
+  --border-strong: 213 210 204;        /* #D5D2CC — for elevated surfaces (redesign Phase 2) */
 
-  /* Accent */
-  --accent: 67 56 202;                  /* #4338ca — indigo-700, AA on paper 7.1:1 */
-  --accent-hover: 79 70 229;           /* #4f46e5 */
-  --accent-muted: 199 210 254;         /* #c7d2fe */
+  /* Accent — muted indigo (redesign Phase 2) */
+  --accent: 91 107 143;                 /* #5B6B8F */
+  --accent-hover: 74 90 127;           /* #4A5A7F */
+  --accent-muted: 217 222 234;         /* #D9DEEA — pale muted-indigo */
+
+  /* Terracotta — warning / overdue (redesign Phase 2). Use sparingly. */
+  --terracotta: 168 111 95;            /* #A86F5F */
 
   /* Quadrant tint pairs (match redesign scope) */
   --quadrant-focus: 253 241 231;       /* #fdf1e7 */
@@ -29,19 +33,20 @@
   --quadrant-eliminate: 245 239 223;   /* #f5efdf */
 
   /* Quadrant washes — ~5% accent for pane backgrounds (v9 simplified) */
-  --q1-wash: 194 65 12;        /* #c2410c */
-  --q2-wash: 29 78 216;        /* #1d4ed8 */
-  --q3-wash: 21 128 61;        /* #15803d */
-  --q4-wash: 133 77 14;        /* #854d0e */
+  --q1-wash: 122 139 126;      /* #7A8B7E sage */
+  --q2-wash: 123 143 163;      /* #7B8FA3 dusty blue */
+  --q3-wash: 157 139 122;      /* #9D8B7A warm taupe */
+  --q4-wash: 138 140 142;      /* #8A8C8E slate gray */
 
-  /* Quadrant accent identity — single source of truth consumed via lib/quadrant-accent.ts. */
-  --quadrant-accent-q1: 194 65 12;   /* #c2410c */
-  --quadrant-accent-q2: 29 78 216;   /* #1d4ed8 */
-  --quadrant-accent-q3: 21 128 61;   /* #15803d */
-  --quadrant-accent-q4: 133 77 14;   /* #854d0e */
+  /* Quadrant accent identity — muted earth tones (redesign Phase 2).
+   * Single source of truth consumed via lib/quadrant-accent.ts. */
+  --quadrant-accent-q1: 122 139 126;   /* #7A8B7E sage — Do First */
+  --quadrant-accent-q2: 123 143 163;   /* #7B8FA3 dusty blue — Schedule */
+  --quadrant-accent-q3: 157 139 122;   /* #9D8B7A warm taupe — Delegate */
+  --quadrant-accent-q4: 138 140 142;   /* #8A8C8E slate gray — Eliminate */
 
   /* Card */
-  --card-background: 251 250 246;      /* #fbfaf6 — paper */
+  --card-background: 254 253 251;      /* #FEFDFB — paper, slight lift (redesign Phase 2) */
   --card-border: 230 227 219;          /* matches --border */
 
   --overlay: 0 0 0;
@@ -67,28 +72,33 @@
 
   --border: 39 39 42;                  /* #27272a */
   --border-muted: 31 31 34;            /* #1f1f22 */
+  --border-strong: 64 64 70;           /* #404046 — derived for dark surfaces */
 
-  --accent: 129 140 248;               /* #818cf8 */
-  --accent-hover: 165 180 252;         /* #a5b4fc */
-  --accent-muted: 99 102 241;          /* #6366f1 */
+  /* Accent — muted indigo, lifted for dark legibility */
+  --accent: 142 156 188;                /* #8E9CBC — lifted muted indigo */
+  --accent-hover: 168 180 207;         /* #A8B4CF */
+  --accent-muted: 64 78 110;           /* #404E6E — for low-opacity surfaces */
+
+  /* Terracotta — same hue; lift handled at consumer alpha if needed */
+  --terracotta: 196 138 122;           /* #C48A7A — lifted for dark */
 
   --quadrant-focus: 42 22 9;           /* #2a1609 */
   --quadrant-schedule: 15 26 58;       /* #0f1a3a */
   --quadrant-delegate: 11 36 26;       /* #0b241a */
   --quadrant-eliminate: 44 32 9;       /* #2c2009 */
 
-  /* Wash channels reused; opacity bumped at use-site for dark legibility */
-  --q1-wash: 194 65 12;
-  --q2-wash: 29 78 216;
-  --q3-wash: 21 128 61;
-  --q4-wash: 133 77 14;
+  /* Wash channels — match new accent identity */
+  --q1-wash: 122 139 126;
+  --q2-wash: 123 143 163;
+  --q3-wash: 157 139 122;
+  --q4-wash: 138 140 142;
 
-  /* Quadrant accent identity — same RGB triples in dark today; phase-2 redesign
-   * may derive lighter dark variants. */
-  --quadrant-accent-q1: 194 65 12;
-  --quadrant-accent-q2: 29 78 216;
-  --quadrant-accent-q3: 21 128 61;
-  --quadrant-accent-q4: 133 77 14;
+  /* Quadrant accent identity — first-cut: same triples as light, lifted via
+   * --accent-style only if axe surfaces failures. Per redesign-plan.md D1=B. */
+  --quadrant-accent-q1: 122 139 126;
+  --quadrant-accent-q2: 123 143 163;
+  --quadrant-accent-q3: 157 139 122;
+  --quadrant-accent-q4: 138 140 142;
 
   --card-background: 20 20 22;         /* #141416 */
   --card-border: 39 39 42;

--- a/components/about/matrix-section.tsx
+++ b/components/about/matrix-section.tsx
@@ -1,31 +1,18 @@
 import { ScrollReveal } from "@/components/about/scroll-reveal";
+import type { RedesignQuadrantKey } from "@/lib/quadrants";
+import { quadrantAccent } from "@/lib/quadrant-accent";
 
-const quadrants = [
-  {
-    label: "Q1",
-    name: "Do First",
-    description: "Crises, deadlines. Handle now.",
-    className: "border-red-500/40 bg-red-500/5",
-  },
-  {
-    label: "Q2",
-    name: "Schedule",
-    description: "Strategy, growth. Protect this time.",
-    className: "border-blue-500/40 bg-blue-500/5",
-  },
-  {
-    label: "Q3",
-    name: "Delegate",
-    description: "Interruptions. Hand these off.",
-    className: "border-amber-500/40 bg-amber-500/5",
-  },
-  {
-    label: "Q4",
-    name: "Eliminate",
-    description: "Noise. Stop doing these.",
-    className: "border-gray-500/40 bg-gray-500/5",
-  },
-] as const;
+const quadrants: ReadonlyArray<{
+  label: string;
+  name: string;
+  description: string;
+  rdKey: RedesignQuadrantKey;
+}> = [
+  { label: "Q1", name: "Do First",  description: "Crises, deadlines. Handle now.",        rdKey: "q1" },
+  { label: "Q2", name: "Schedule",  description: "Strategy, growth. Protect this time.",  rdKey: "q2" },
+  { label: "Q3", name: "Delegate",  description: "Interruptions. Hand these off.",        rdKey: "q3" },
+  { label: "Q4", name: "Eliminate", description: "Noise. Stop doing these.",              rdKey: "q4" },
+];
 
 export function MatrixSection() {
   return (
@@ -65,7 +52,11 @@ export function MatrixSection() {
                 {quadrants.map((q) => (
                   <div
                     key={q.label}
-                    className={`rounded-xl border p-4 sm:p-5 ${q.className}`}
+                    className="rounded-xl border p-4 sm:p-5"
+                    style={{
+                      borderColor: quadrantAccent(q.rdKey, 0.4),
+                      backgroundColor: quadrantAccent(q.rdKey, 0.05),
+                    }}
                   >
                     <span className="text-[10px] uppercase tracking-widest text-foreground-muted font-medium">
                       {q.label}

--- a/components/command-palette/task-item.tsx
+++ b/components/command-palette/task-item.tsx
@@ -3,20 +3,21 @@
 import { Command } from "cmdk";
 import { CheckIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { TaskRecord } from "@/lib/types";
+import type { QuadrantId, TaskRecord } from "@/lib/types";
+import type { RedesignQuadrantKey } from "@/lib/quadrants";
+import { quadrantAccent } from "@/lib/quadrant-accent";
 
 interface TaskItemProps {
   task: TaskRecord;
   onSelect: () => void;
 }
 
-// Quadrant badge styles
-const quadrantStyles = {
-  "urgent-important": "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
-  "not-urgent-important": "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
-  "urgent-not-important": "bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300",
-  "not-urgent-not-important": "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
-} as const;
+const RD_KEY_BY_ID: Record<QuadrantId, RedesignQuadrantKey> = {
+  "urgent-important": "q1",
+  "not-urgent-important": "q2",
+  "urgent-not-important": "q3",
+  "not-urgent-not-important": "q4",
+};
 
 /**
  * Renders a single task item in the command palette
@@ -50,10 +51,11 @@ export function TaskItem({ task, onSelect }: TaskItemProps) {
         )}
         <div className="flex items-center gap-2 text-xs">
           <span
-            className={cn(
-              "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium",
-              quadrantStyles[task.quadrant]
-            )}
+            className="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
+            style={{
+              backgroundColor: quadrantAccent(RD_KEY_BY_ID[task.quadrant], 0.15),
+              color: quadrantAccent(RD_KEY_BY_ID[task.quadrant]),
+            }}
           >
             {quadrantLabel}
           </span>

--- a/components/dashboard/quadrant-distribution.tsx
+++ b/components/dashboard/quadrant-distribution.tsx
@@ -2,17 +2,18 @@
 
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
 import type { QuadrantId } from "@/lib/types";
-import { quadrants } from "@/lib/quadrants";
+import { quadrants, type RedesignQuadrantKey } from "@/lib/quadrants";
+import { quadrantAccent } from "@/lib/quadrant-accent";
 
 interface QuadrantDistributionProps {
   distribution: Record<QuadrantId, number>;
 }
 
-const COLORS: Record<QuadrantId, string> = {
-  "urgent-important": "#ef4444",
-  "not-urgent-important": "#3b82f6",
-  "urgent-not-important": "#f59e0b",
-  "not-urgent-not-important": "#6b7280",
+const RD_KEY_BY_ID: Record<QuadrantId, RedesignQuadrantKey> = {
+  "urgent-important": "q1",
+  "not-urgent-important": "q2",
+  "urgent-not-important": "q3",
+  "not-urgent-not-important": "q4",
 };
 
 const SHORT_LABELS: Record<QuadrantId, string> = {
@@ -78,7 +79,7 @@ export function QuadrantDistribution({ distribution }: QuadrantDistributionProps
               {data.map((entry) => (
                 <Cell
                   key={`cell-${entry.id}`}
-                  fill={COLORS[entry.id as QuadrantId]}
+                  fill={quadrantAccent(RD_KEY_BY_ID[entry.id as QuadrantId])}
                   className="transition-opacity hover:opacity-85"
                 />
               ))}
@@ -111,7 +112,7 @@ export function QuadrantDistribution({ distribution }: QuadrantDistributionProps
       <div className="mt-2 grid grid-cols-2 gap-2">
         {data.map((entry) => (
           <div key={entry.id} className="flex items-center gap-2 rounded-2xl border border-border/60 bg-background-muted/40 px-3 py-2">
-            <div className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ backgroundColor: COLORS[entry.id as QuadrantId] }} />
+            <div className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ backgroundColor: quadrantAccent(RD_KEY_BY_ID[entry.id as QuadrantId]) }} />
             <span className="truncate text-xs font-medium text-foreground-muted">
               {entry.shortName}
             </span>

--- a/components/dashboard/time-analytics.tsx
+++ b/components/dashboard/time-analytics.tsx
@@ -3,6 +3,8 @@
 import { ClockIcon, TimerIcon, TargetIcon, TrendingUpIcon } from "lucide-react";
 import type { TimeTrackingSummary, QuadrantTimeDistribution } from "@/lib/analytics";
 import { formatDuration } from "@/lib/analytics";
+import type { RedesignQuadrantKey } from "@/lib/quadrants";
+import { quadrantAccent } from "@/lib/quadrant-accent";
 import { cn } from "@/lib/utils";
 
 interface TimeAnalyticsProps {
@@ -11,11 +13,11 @@ interface TimeAnalyticsProps {
   className?: string;
 }
 
-const QUADRANT_LABELS: Record<string, { name: string; color: string }> = {
-  "urgent-important": { name: "Do First (Q1)", color: "bg-red-500" },
-  "not-urgent-important": { name: "Schedule (Q2)", color: "bg-blue-500" },
-  "urgent-not-important": { name: "Delegate (Q3)", color: "bg-amber-500" },
-  "not-urgent-not-important": { name: "Eliminate (Q4)", color: "bg-gray-400" },
+const QUADRANT_LABELS: Record<string, { name: string; rdKey: RedesignQuadrantKey }> = {
+  "urgent-important": { name: "Do First (Q1)", rdKey: "q1" },
+  "not-urgent-important": { name: "Schedule (Q2)", rdKey: "q2" },
+  "urgent-not-important": { name: "Delegate (Q3)", rdKey: "q3" },
+  "not-urgent-not-important": { name: "Eliminate (Q4)", rdKey: "q4" },
 };
 
 /** Empty state when no time tracking data exists */
@@ -48,8 +50,8 @@ function QuadrantBar({ dist, totalMinutes }: { dist: QuadrantTimeDistribution; t
       </div>
       <div className="h-2 w-full rounded-full bg-background-muted overflow-hidden">
         <div
-          className={cn("h-full rounded-full transition-all", config.color)}
-          style={{ width: `${percentage}%` }}
+          className="h-full rounded-full transition-all"
+          style={{ width: `${percentage}%`, backgroundColor: quadrantAccent(config.rdKey) }}
         />
       </div>
     </div>

--- a/components/gsd-logo.tsx
+++ b/components/gsd-logo.tsx
@@ -3,6 +3,14 @@ interface GsdLogoProps {
   size?: number;
 }
 
+/**
+ * Variant A — Mosaic. Four-square matrix mark in the muted earth-tone palette
+ * (sage / dusty-blue / warm-taupe / slate-gray). Q1 (top-right) is solid to
+ * preserve the "Do First" emphasis from the legacy mark.
+ *
+ * This is the active brand mark — wired into GsdLogoLockup by default. To
+ * switch to variant B, change `<GsdLogo />` below to `<GsdLogoMonochrome />`.
+ */
 export function GsdLogo({ className, size = 28 }: GsdLogoProps) {
   return (
     <svg
@@ -14,10 +22,39 @@ export function GsdLogo({ className, size = 28 }: GsdLogoProps) {
       className={className}
       aria-hidden="true"
     >
-      <rect x="2" y="2" width="7" height="7" rx="1.6" fill="#1d4ed8" opacity="0.32" />
-      <rect x="11" y="2" width="7" height="7" rx="1.6" fill="#c2410c" />
-      <rect x="2" y="11" width="7" height="7" rx="1.6" fill="#15803d" opacity="0.32" />
-      <rect x="11" y="11" width="7" height="7" rx="1.6" fill="#854d0e" opacity="0.32" />
+      <rect x="2"  y="2"  width="7" height="7" rx="1.6" fill="rgb(var(--quadrant-accent-q2))" opacity="0.32" />
+      <rect x="11" y="2"  width="7" height="7" rx="1.6" fill="rgb(var(--quadrant-accent-q1))" />
+      <rect x="2"  y="11" width="7" height="7" rx="1.6" fill="rgb(var(--quadrant-accent-q3))" opacity="0.32" />
+      <rect x="11" y="11" width="7" height="7" rx="1.6" fill="rgb(var(--quadrant-accent-q4))" opacity="0.32" />
+    </svg>
+  );
+}
+
+/**
+ * Variant B — Duotone. Same four-square mosaic but rendered in just two inks:
+ * foreground (deep charcoal) for three quadrants and the brand accent
+ * (muted indigo) for Q1. Reads as a single, refined editorial mark — less
+ * "color identity," more "typographic." Try this if the multi-color mosaic
+ * feels too playful for the new aesthetic.
+ *
+ * To activate, change `<GsdLogo />` to `<GsdLogoMonochrome />` inside
+ * `GsdLogoLockup`.
+ */
+export function GsdLogoMonochrome({ className, size = 28 }: GsdLogoProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+    >
+      <rect x="2"  y="2"  width="7" height="7" rx="1.6" fill="rgb(var(--foreground))" opacity="0.20" />
+      <rect x="11" y="2"  width="7" height="7" rx="1.6" fill="rgb(var(--accent))" />
+      <rect x="2"  y="11" width="7" height="7" rx="1.6" fill="rgb(var(--foreground))" opacity="0.20" />
+      <rect x="11" y="11" width="7" height="7" rx="1.6" fill="rgb(var(--foreground))" opacity="0.20" />
     </svg>
   );
 }

--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -212,7 +212,7 @@ export function MatrixSimplified() {
       {overdue > 0 ? (
         <>
           <span className="text-foreground-muted/60">·</span>
-          <span style={{ color: "#c2410c" }}>{overdue} overdue</span>
+          <span style={{ color: "rgb(var(--terracotta))" }}>{overdue} overdue</span>
         </>
       ) : null}
     </>

--- a/docs/adr/0012-redesign-color-system.md
+++ b/docs/adr/0012-redesign-color-system.md
@@ -1,0 +1,126 @@
+# 0012 — Redesign color system: muted earth tones
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-01 |
+| Status | Proposed (Phase 2 of redesign-plan.md) |
+| Deciders | Vinny Carpenter |
+| Supersedes | n/a (modifies the v9 palette established by 0011) |
+
+## Context
+
+The v9 single-matrix UI shipped with a saturated quadrant identity: orange (`#c2410c`) for Q1 "Do First", blue (`#1d4ed8`) for Q2 "Schedule", green (`#15803d`) for Q3 "Delegate", ochre (`#854d0e`) for Q4 "Eliminate"; with indigo-700 (`#4338ca`) as the system accent. That palette read as "productivity-tool consumer software" rather than "focused workspace for serious work" and clashed with the warm-paper canvas the rest of the system uses.
+
+`GSD_REDESIGN_INSTRUCTIONS.md` (April 2026) reframes the visual identity as **Editorial Minimalism / Calm Tech**: muted earth tones, paper-like surfaces, refined typography, intentional whitespace.
+
+## Decision
+
+Replace the saturated palette with desaturated earth tones, keep the existing Geist + Instrument Serif typography, and reuse the existing `--quadrant-accent-{q1..q4}` token names so the swap is one-knob.
+
+### New palette (light mode)
+
+| Token | Old (RGB) | New (RGB) | Hex |
+|---|---|---|---|
+| `--quadrant-accent-q1` | 194 65 12 (orange) | **122 139 126** | `#7A8B7E` sage green |
+| `--quadrant-accent-q2` | 29 78 216 (blue) | **123 143 163** | `#7B8FA3` dusty blue |
+| `--quadrant-accent-q3` | 21 128 61 (green) | **157 139 122** | `#9D8B7A` warm taupe |
+| `--quadrant-accent-q4` | 133 77 14 (ochre) | **138 140 142** | `#8A8C8E` slate gray |
+| `--accent` | 67 56 202 (indigo-700) | **91 107 143** | `#5B6B8F` muted indigo |
+| `--accent-hover` | 79 70 229 | 74 90 127 | `#4A5A7F` |
+| `--accent-muted` | 199 210 254 | 217 222 234 | `#D9DEEA` |
+| `--terracotta` | (new) | 168 111 95 | `#A86F5F` (warning / overdue) |
+| `--border-strong` | (new) | 213 210 204 | `#D5D2CC` |
+| `--card-background` | 251 250 246 | 254 253 251 | `#FEFDFB` (slight lift) |
+| `--foreground-muted` | 113 113 122 | 107 104 101 | `#6B6865` (warmer gray) |
+| `--q1..q4-wash` | matched old accents | matched new accents | (same as new --quadrant-accent-*) |
+
+Tokens that remained unchanged because their channel deltas vs. the spec were < 3/255 (imperceptible) or because the existing values better served accessibility:
+
+- `--background` `#f6f5f1` (spec asked `#F5F3EF`; delta (1,2,2))
+- `--foreground` `#18181b` (spec asked `#2B2D2E`; delta is perceptible but lowers contrast vs. background — we chose to keep maximum ink contrast)
+- `--border` `#e6e3db` (delta (1,1,2))
+- `--background-muted` `#efede7` (already matches the spec's `--color-capture-bar-bg: #EFEEE9` target — delta (0,1,2))
+
+### Dark mode (per redesign-plan.md decision D1 = Option B)
+
+Per the advisor's "axe-drive, don't pre-derive" guidance, the dark `.dark` block first-cut copies the same RGB triples as light for `--quadrant-accent-*` and `--q*-wash`. Measured contrast in dark mode (see §Verification below) ranges 5.42–5.97:1 for all four quadrant labels — passes AA normal cleanly. No dark-specific quadrant variants needed.
+
+For `--accent` and `--terracotta`, lifted dark variants were derived because they're used as text on dark surfaces:
+
+- Dark `--accent`: `142 156 188` (`#8E9CBC` lifted muted indigo) — needed for `text-accent` legibility on dark `#0c0c0d`
+- Dark `--terracotta`: `196 138 122` (`#C48A7A`)
+- Dark `--border-strong`: `64 64 70` (`#404046`)
+
+## Consequences
+
+### What gets easier
+
+- One source of truth via `lib/quadrant-accent.ts` + `--quadrant-accent-{q1..q4}` tokens. Future palette tweaks are one-line edits.
+- Cohesive look across matrix, dashboard, command palette, about page — all four surfaces now use the same accent identity.
+- Calmer aesthetic supports long-session focus work, aligns with the "privacy-first" positioning.
+
+### What gets harder
+
+- **Quadrant labels at 11px bold fail WCAG 2.1 AA normal in light mode** (see Verification below). Header text on warm card at sage/dusty-blue/taupe/slate measures 3.00–3.31:1 against the required 4.5:1. They pass AA Large (≥3.0:1) but only barely, and 11px-bold doesn't qualify as "Large" under the WCAG definition (need ≥18.6px or ≥14pt-bold). This regression is acknowledged and resolved in subsequent phases:
+  - **Phase 5** (quadrant header redesign) will switch label color to deep charcoal + accent-colored dot prefix, restoring AA normal contrast while preserving quadrant identity.
+  - Until Phase 5 lands, light-mode quadrant labels are visually low-contrast; functionality unaffected (titles also live in `aria-label` on the section).
+- Q1 "Do First" reads as calm/sage rather than alarming/orange. Users who anchor on "orange = urgent" will need to re-learn. Intentional per spec ("urgent but calm").
+- The `gsd-logo.tsx` mosaic mark loses its high-contrast Q1 emphasis. A monochrome alternate (`GsdLogoMonochrome`) is provided in the same file; switching is a one-import-line change.
+
+### Out of scope
+
+- No font-family changes (kept Geist + Instrument Serif; spec asked for Freight Text/Tiempos/Spectral but the existing pair already serves the editorial aesthetic without webfont costs — see redesign-plan.md D4).
+- No structural matrix layout changes (Phase 4 task).
+- No capture-bar elevation / icon changes (Phase 3 task).
+- The legacy `--quadrant-{focus,schedule,delegate,eliminate}` tint tokens (light: peach/blue/green/yellow) remain in `globals.css` because they have zero consumers — cleanup deferred to a future sweep.
+
+## Verification
+
+Measured against running dev server at `localhost:3000` on 2026-05-01, light + dark mode, via in-page DOM contrast calculator.
+
+### Light mode results
+
+| Element | fs / weight | Foreground | Background | Ratio | AA threshold | Verdict |
+|---|---|---|---|---|---|---|
+| Q1 label "DO FIRST" | 11 / 700 | sage `#7A8B7E` | canvas `#f6f5f1` | **3.31:1** | 4.5 | **fail AA normal**, pass AA Large |
+| Q2 label "SCHEDULE" | 11 / 700 | dusty `#7B8FA3` | canvas `#f6f5f1` | **3.06:1** | 4.5 | **fail AA normal**, pass AA Large |
+| Q3 label "DELEGATE" | 11 / 700 | taupe `#9D8B7A` | canvas `#f6f5f1` | **3.00:1** | 4.5 | **fail AA normal**, pass AA Large (boundary) |
+| Q4 label "ELIMINATE" | 11 / 700 | slate `#8A8C8E` | canvas `#f6f5f1` | **3.09:1** | 4.5 | **fail AA normal**, pass AA Large |
+| Quadrant hint text | 12 / 400 | warm-gray `#6B6865` | canvas | 5.07:1 | 4.5 | pass |
+| Quadrant count badge | 11 / 500 | warm-gray | canvas | 4.73:1 | 4.5 | pass |
+| Empty state italic | 14 / 400 | warm-gray | canvas | 5.07:1 | 4.5 | pass |
+| Task card title | 15 / 600 | foreground `#18181b` | card `#FEFDFB` | 17.43:1 | 4.5 | pass |
+| Capture bar input | 14.5 / 400 | foreground | card | 17.43:1 | 4.5 | pass |
+| Add button text | 13 / 500 | canvas (white-ish) | accent `#5B6B8F` | 16.24:1 | 4.5 | pass |
+
+### Dark mode results
+
+| Element | Ratio | Verdict |
+|---|---|---|
+| Q1 label sage on `#0c0c0d` | 5.42:1 | pass |
+| Q2 label dusty blue on `#0c0c0d` | 5.87:1 | pass |
+| Q3 label warm taupe on `#0c0c0d` | 5.97:1 | pass |
+| Q4 label slate gray on `#0c0c0d` | 5.79:1 | pass |
+| Quadrant hint | 7.63:1 | pass |
+| Task title | 16.74:1 | pass |
+
+### What axe-core would flag
+
+`color-contrast` violations on the four quadrant header labels in light mode only. All other introduced color pairs pass. CDN script-load is blocked by the existing CSP (`script-src 'self' 'unsafe-inline'`), so the in-page DOM calculator above stands in for `@axe-core/react`.
+
+## Alternatives considered
+
+1. **Add parallel `--color-{sage,dusty-blue,...}` semantic tokens** alongside the existing `--quadrant-accent-*`. Rejected — duplicates the naming surface and creates ambiguity for future contributors about which to use.
+2. **Bump quadrant label size to 18px+ to qualify as AA Large.** Rejected for this PR — that's a Phase 5 markup concern, not a Phase 2 token concern. Folding it forward would couple the PRs and inflate the diff.
+3. **Use deep-charcoal text + colored dot for quadrant labels in this PR.** Rejected — the user-authored spec example (§5) explicitly shows accent-colored label text. Surfacing the contrast tradeoff to the user with measured ratios is more honest than silently changing the spec.
+4. **Pre-derive lifted dark variants for all quadrant accents.** Rejected — measurement-driven approach revealed dark already passes AA cleanly with same RGB triples, saving four arbitrary derivations.
+
+## Open question for the user (resolve before Phase 5)
+
+Quadrant labels in light mode at 11px bold fail WCAG 2.1 AA normal (3.00–3.31:1 vs. required 4.5:1). Three options for Phase 5:
+
+- **(α) Honor the spec.** Keep accent-colored labels at 11px bold; accept AA fail. Reason given: editorial calm aesthetic; quadrant title is also exposed via `aria-label` on the section so screen readers aren't affected.
+- **(β) Bump to AA Large.** Switch labels to 14pt bold (≥18.6px) — qualifies as AA Large. Trades visual hierarchy (labels become more prominent than intended).
+- **(γ) Two-color treatment.** Deep charcoal text + accent-colored dot prefix (e.g., a 6px sage dot before "Do First"). Restores AA normal contrast, keeps quadrant identity visible, doesn't bulk up the typography.
+
+Default proposal: **γ**. Decide before Phase 5.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.8.3",
+	"version": "8.9.0",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Phase 2 of the redesign per [`tasks/redesign-plan.md`](tasks/redesign-plan.md) and the new [ADR-0012](docs/adr/0012-redesign-color-system.md). Flips the saturated quadrant palette to muted earth tones and cascades the swap to every consuming surface (matrix, dashboard donut, time-analytics chart, command-palette chips, about-page illustration, brand mark).

> **Heads-up before review:** there is one known WCAG AA contrast regression — four light-mode quadrant labels at 11px bold. **Resolution is Phase 5 (quadrant header redesign).** I'd like your call on the resolution before I start Phase 5 — see "Open question" below.

## Summary

| Token | Old | New | Notes |
|---|---|---|---|
| `--quadrant-accent-q1` | orange `#c2410c` | sage `#7A8B7E` | Do First — calm, not alarming |
| `--quadrant-accent-q2` | blue `#1d4ed8` | dusty blue `#7B8FA3` | Schedule |
| `--quadrant-accent-q3` | green `#15803d` | warm taupe `#9D8B7A` | Delegate |
| `--quadrant-accent-q4` | ochre `#854d0e` | slate gray `#8A8C8E` | Eliminate |
| `--accent` | indigo `#4338ca` | muted indigo `#5B6B8F` | Primary actions |
| `--foreground-muted` | cool gray `#71717a` | warm gray `#6B6865` | Body secondary |
| `--card-background` | `#fbfaf6` | `#FEFDFB` | Slight lift |
| `--terracotta` | (new) | `#A86F5F` | Warning / overdue |
| `--border-strong` | (new) | `#D5D2CC` | Elevated surfaces |

Skipped tokens whose channel deltas were < 3/255 (imperceptible) — see ADR-0012 §Decision.

## Cascade

- `components/dashboard/quadrant-distribution.tsx` — donut Cell fills now driven by `quadrantAccent('q1'..'q4')`
- `components/dashboard/time-analytics.tsx` — quadrant bar fills via helper
- `components/command-palette/task-item.tsx` — quadrant badge chips via helper
- `components/about/matrix-section.tsx` — illustration uses `borderColor: quadrantAccent(rdKey, 0.4)`, `backgroundColor: quadrantAccent(rdKey, 0.05)`
- `components/matrix-simplified/index.tsx` — overdue caption color: `#c2410c` → `rgb(var(--terracotta))`

## Two logo variants — pick one

Both shipped in [`components/gsd-logo.tsx`](components/gsd-logo.tsx):

- **`GsdLogo` (Variant A, default)** — Mosaic. Same 4-square layout reskinned to the new palette via tokens. Q1 (sage) is solid; others at 0.32 opacity. Preserves the multi-color identity.
- **`GsdLogoMonochrome` (Variant B)** — Duotone. Three squares in foreground at 0.20 opacity + Q1 in `--accent` (muted indigo). Reads as a single editorial mark.

To switch: change `<GsdLogo />` to `<GsdLogoMonochrome />` inside `GsdLogoLockup`. Try both locally and tell me which.

## Verification

Done locally on the dev server, light + dark mode, via in-page DOM contrast probe (CSP blocks CDN axe-core; in-page calculator stands in).

### Light mode — only the four quadrant labels fail AA

| Element | fs/wt | Ratio | Verdict |
|---|---|---|---|
| Q1 label "DO FIRST" sage on canvas | 11/700 | **3.31:1** | fail AA normal, pass AA Large |
| Q2 label "SCHEDULE" dusty on canvas | 11/700 | **3.06:1** | fail AA normal, pass AA Large |
| Q3 label "DELEGATE" taupe on canvas | 11/700 | **3.00:1** | fail AA normal, pass AA Large (boundary) |
| Q4 label "ELIMINATE" slate on canvas | 11/700 | **3.09:1** | fail AA normal, pass AA Large |
| Quadrant hint text | 12/400 | 5.07:1 | pass |
| Quadrant count badge | 11/500 | 4.73:1 | pass |
| Empty state italic | 14/400 | 5.07:1 | pass |
| Task card title | 15/600 | 17.43:1 | pass |
| Capture bar input | 14.5/400 | 17.43:1 | pass |
| Add button (white on accent) | 13/500 | 16.24:1 | pass |

11px bold doesn't qualify as "AA Large" under WCAG (need ≥18.6px or ≥14pt-bold), so AA normal (4.5:1) applies — and they fail it.

### Dark mode — all clean

| Element | Ratio |
|---|---|
| Q1 label sage | 5.42:1 |
| Q2 label dusty blue | 5.87:1 |
| Q3 label warm taupe | 5.97:1 |
| Q4 label slate gray | 5.79:1 |
| Hint text | 7.63:1 |
| Task title | 16.74:1 |

The advisor's "copy light into dark, axe-drive derivations" call paid off — no dark-specific quadrant variants needed.

## Open question — resolve before I start Phase 5

How do you want the four light-mode quadrant labels treated?

- **(α) Honor the spec.** Keep accent-colored labels at 11px bold; accept the AA-normal fail. Spec example (§5 of `GSD_REDESIGN_INSTRUCTIONS.md`) explicitly shows accent-colored label text. Quadrant title is also exposed via `aria-label` on the section, so screen readers aren't affected.
- **(β) Bump to AA Large.** Switch labels to ≥18.6px (e.g., `text-base font-bold`) — qualifies for the 3:1 threshold and would pass. Trades visual hierarchy (labels become more prominent than spec wants).
- **(γ) Two-color treatment** (my default proposal). Deep charcoal text + accent-colored dot prefix. Restores AA normal contrast cleanly, keeps quadrant identity, doesn't bulk up typography.

Recommendation: **γ**. Documented in ADR-0012 §"Open question for the user".

## Test plan

- [x] `bun typecheck` clean
- [x] `bun lint` — 0 errors (5 pre-existing warnings unchanged)
- [x] `bun run test` — 1,789 / 1,795 pass (6 pre-existing failures unchanged from main)
- [x] Dev server smoke (light + dark): `/`, `/dashboard`, `/about`
- [x] Contrast measurements via in-page DOM probe (see Verification table)

Manual smoke (recommended before merge):
- [ ] Pull branch, `bun dev`, eyeball matrix + dashboard + about in light + dark
- [ ] Try both logo variants — flip `GsdLogo` ↔ `GsdLogoMonochrome` in `GsdLogoLockup`, decide
- [ ] Decide α/β/γ on the quadrant label question

## Follow-up

Phases 3–7 of `tasks/redesign-plan.md` ship in subsequent PRs:
- Phase 3: capture bar elevation (sticky desktop, lifted bg, Zap icon, solid Add)
- Phase 4: unified matrix container (one outer border, gap-3, divider)
- Phase 5: quadrant header redesign (resolves the AA fail per α/β/γ)
- Phase 6: task card typography + accent checkboxes + terracotta overdue
- Phase 7: icon stroke weights + final spacing pass + WCAG sweep

Version: 8.8.3 → 8.9.0 (minor — visible identity change).