### PR TITLE
feat(redesign): elevate capture bar as primary entry point (Phase 3)

### DIFF
--- a/components/matrix-simplified/capture-bar.tsx
+++ b/components/matrix-simplified/capture-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, type FormEvent, type KeyboardEvent } from "react";
-import { ArrowRightIcon } from "lucide-react";
+import { ArrowRightIcon, ZapIcon } from "lucide-react";
 import { parseCapture } from "@/lib/capture-parser";
 import { quadrantByRdKey, type RedesignQuadrantKey } from "@/lib/quadrants";
 import { quadrantAccent } from "@/lib/quadrant-accent";
@@ -127,15 +127,14 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
     <form
       onSubmit={submit}
       className={cn(
-        "flex items-center gap-2.5 rounded-2xl border border-border bg-card px-3.5 py-2.5",
+        "flex items-center gap-3 rounded-2xl border border-border-strong bg-background-muted px-5 py-4",
         "shadow-sm transition-shadow focus-within:border-foreground-muted focus-within:shadow-md"
       )}
     >
-      <span
+      <ZapIcon
         aria-hidden
-        className="h-2.5 w-2.5 shrink-0 rounded-full transition-colors"
-        style={{ backgroundColor: text.trim() ? accent : "rgb(var(--foreground-muted) / 0.5)" }}
-        title={meta.title}
+        className="h-5 w-5 shrink-0 text-accent"
+        strokeWidth={2.5}
       />
       <input
         ref={internalRef}
@@ -144,7 +143,7 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
         onKeyDown={onInputKey}
         placeholder="Capture a task… use ! urgent  * important  #tag"
         aria-label="Capture a task"
-        className="min-w-0 flex-1 border-0 bg-transparent text-[14.5px] leading-snug text-foreground outline-none placeholder:text-foreground-muted"
+        className="min-w-0 flex-1 border-0 bg-transparent text-[15px] font-medium leading-snug text-foreground outline-none placeholder:font-normal placeholder:text-foreground-muted"
       />
       {text.trim() ? (
         <>
@@ -187,8 +186,8 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
         type="submit"
         disabled={!parsed.title}
         className={cn(
-          "inline-flex h-8 items-center gap-1 rounded-lg px-3 text-[13px] font-medium",
-          "bg-foreground text-background hover:bg-foreground/90",
+          "inline-flex h-9 items-center gap-1 rounded-lg px-4 text-sm font-semibold",
+          "bg-accent text-white hover:bg-accent-hover",
           "disabled:cursor-not-allowed disabled:opacity-40"
         )}
       >

--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -227,7 +227,7 @@ export function MatrixSimplified() {
         onSearchChange={setSearchQuery}
         searchInputRef={searchInputRef}
       >
-        <div className="sticky top-[60px] z-10 mb-4 -mx-4 bg-background px-4 py-2 sm:static sm:m-0 sm:bg-transparent sm:p-0 sm:pb-4">
+        <div className="sticky top-[60px] z-10 mb-12 -mx-4 bg-background px-4 py-2 sm:mx-0 sm:px-0 sm:pb-2 sm:pt-3">
           <CaptureBar onSubmit={handleCapture} onMoreOptions={handleOpenCreateDrawer} inputRef={captureInputRef} />
         </div>
         <MatrixGrid

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.9.0",
+	"version": "8.9.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -27,8 +27,10 @@ const config = {
         },
         border: {
           DEFAULT: "rgb(var(--border) / <alpha-value>)",
-          muted: "rgb(var(--border-muted) / <alpha-value>)"
+          muted: "rgb(var(--border-muted) / <alpha-value>)",
+          strong: "rgb(var(--border-strong) / <alpha-value>)"
         },
+        terracotta: "rgb(var(--terracotta) / <alpha-value>)",
         accent: {
           DEFAULT: "rgb(var(--accent) / <alpha-value>)",
           hover: "rgb(var(--accent-hover) / <alpha-value>)",

--- a/tests/ui/capture-bar.test.tsx
+++ b/tests/ui/capture-bar.test.tsx
@@ -87,4 +87,24 @@ describe("<CaptureBar>", () => {
     fireEvent.keyDown(window, { key: "N", shiftKey: true });
     expect(onMoreOptions).toHaveBeenCalledWith({ title: "", urgent: false, important: false, tags: [] });
   });
+
+  it("renders the lifted Phase-3 surface — Zap icon, lifted bg, strong border, accent Add button", () => {
+    const { container } = render(<CaptureBar onSubmit={vi.fn()} />);
+
+    // Zap icon is rendered as the persistent prefix mark (regression guard for the elevated capture bar).
+    const zap = container.querySelector('svg.lucide-zap');
+    expect(zap, "expected ZapIcon to render in the capture bar").not.toBeNull();
+
+    // Form wrapper carries the lifted-surface classes introduced in Phase 3.
+    const form = container.querySelector('form');
+    expect(form?.className).toContain('bg-background-muted');
+    expect(form?.className).toContain('border-border-strong');
+    expect(form?.className).toContain('px-5');
+    expect(form?.className).toContain('py-4');
+
+    // Add button uses the new solid muted-indigo treatment, not the old foreground/background swap.
+    const addBtn = screen.getByRole('button', { name: /^Add$/i });
+    expect(addBtn.className).toContain('bg-accent');
+    expect(addBtn.className).toContain('text-white');
+  });
 });


### PR DESCRIPTION
Phase 3 of the redesign per [`tasks/redesign-plan.md`](tasks/redesign-plan.md). Stacks on top of [#244 (Phase 2)](https://github.com/vscarpenter/gsd-task-manager/pull/244) — base branch is `claude/redesign-phase-2`. After #244 lands I'll rebase this onto main.

> **Capture bar is now the visual anchor.** Lifted surface, persistent Zap icon, solid muted-indigo Add button, sticky on desktop too — this is the spec's "primary entry point" treatment.

## Changes

### Capture bar markup ([`components/matrix-simplified/capture-bar.tsx`](components/matrix-simplified/capture-bar.tsx))

| What | Before | After |
|---|---|---|
| Form bg | `bg-card` (#FEFDFB) | `bg-background-muted` (#EFEEE9 — the spec's `--color-capture-bar-bg`) |
| Form border | `border-border` | `border-border-strong` (#D5D2CC — new in Phase 2) |
| Form padding | `px-3.5 py-2.5` | `px-5 py-4` |
| Prefix indicator | quadrant-tinted `<span>` dot | persistent `<ZapIcon>` (h-5 w-5, `text-accent`, `strokeWidth=2.5`) |
| Input text | `text-[14.5px]` | `text-[15px] font-medium` (placeholder kept `font-normal`) |
| Add button | `bg-foreground text-background h-8 px-3 text-[13px] font-medium` | `bg-accent text-white h-9 px-4 text-sm font-semibold` |

The `ArrowRightIcon` trailing arrow is preserved per your earlier call.

### Sticky wrapper ([`components/matrix-simplified/index.tsx`](components/matrix-simplified/index.tsx))

```diff
- <div className="sticky top-[60px] z-10 mb-4 -mx-4 bg-background px-4 py-2 sm:static sm:m-0 sm:bg-transparent sm:p-0 sm:pb-4">
+ <div className="sticky top-[60px] z-10 mb-12 -mx-4 bg-background px-4 py-2 sm:mx-0 sm:px-0 sm:pb-2 sm:pt-3">
```

- Removed `sm:static` — capture bar is now sticky on desktop too.
- `mb-4` → `mb-12` (48px gap to matrix per spec §9).
- Bg + padding adjusted so the lifted form sits cleanly in the main column on desktop and edge-to-edge on mobile.

### Tailwind config ([`tailwind.config.ts`](tailwind.config.ts))

Added two foundational mappings ahead of where they're needed:
- `border.strong` → `--border-strong` (used by this PR; will be reused by Phase 4 matrix container).
- `terracotta` → `--terracotta` (added now so Phase 6's overdue work has a clean utility surface).

## Quadrant feedback during typing — preserved

The empty-state quadrant dot is gone, but functional information is not lost:
- Empty state: just the Zap icon (no quadrant decided yet).
- Typing: the override pill renders next to the Add button with its own colored dot, so users still see which quadrant they're targeting.

## Verification

- `bun typecheck` clean
- `bun lint` clean (0 errors; 5 pre-existing warnings unchanged)
- `bun run test` — 10/10 capture-bar tests pass (one new regression-guard test added). Full suite: 1,790 / 1,797 pass; 6 pre-existing failures unchanged from main.
- Dev server smoke (light mode):
  - Capture bar visibly elevated above canvas; Zap icon renders in muted indigo.
  - Sticky on desktop scroll: bar pinned under topbar, matrix scrolls underneath.
  - Override pill still renders with the Phase 2 sage/dusty-blue/taupe/slate accents on typing.
  - 48px gap between capture bar and matrix is visibly more generous.

The known light-mode quadrant label contrast issue from [#244](https://github.com/vscarpenter/gsd-task-manager/pull/244) is unchanged — that's Phase 5's job (γ treatment: deep-charcoal text + accent dot prefix).

## Test plan

- [x] Typecheck / lint / vitest — clean
- [x] Dev-server visual: empty state, typed state with override, scroll-to-stick
- [ ] *Local verification:* `git checkout claude/redesign-phase-3 && bun dev`. Eyeball the elevated capture bar, scroll to confirm sticky behavior on desktop, type a task and confirm the override pill still renders correctly.

## Follow-up

- Phase 4: unified matrix container (one outer border, gap-3, divider) — foundation already partly done since `border.strong` is now wired.
- Phase 5: quadrant header redesign — deep-charcoal text + accent-colored dot prefix per γ. Resolves the light-mode label contrast issue from #244.
- Phase 6: task card typography + accent checkboxes + terracotta overdue (terracotta utility now available).
- Phase 7: icon stroke weights + final spacing pass + WCAG sweep.

Version: 8.9.0 → 8.9.1.