### PR TITLE
feat(redesign): unify matrix grid as a cockpit (Phase 4 + Phase 3 backport)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -32,12 +32,6 @@
   --quadrant-delegate: 232 242 236;    /* #e8f2ec */
   --quadrant-eliminate: 245 239 223;   /* #f5efdf */
 
-  /* Quadrant washes — ~5% accent for pane backgrounds (v9 simplified) */
-  --q1-wash: 122 139 126;      /* #7A8B7E sage */
-  --q2-wash: 123 143 163;      /* #7B8FA3 dusty blue */
-  --q3-wash: 157 139 122;      /* #9D8B7A warm taupe */
-  --q4-wash: 138 140 142;      /* #8A8C8E slate gray */
-
   /* Quadrant accent identity — muted earth tones (redesign Phase 2).
    * Single source of truth consumed via lib/quadrant-accent.ts. */
   --quadrant-accent-q1: 122 139 126;   /* #7A8B7E sage — Do First */
@@ -86,12 +80,6 @@
   --quadrant-schedule: 15 26 58;       /* #0f1a3a */
   --quadrant-delegate: 11 36 26;       /* #0b241a */
   --quadrant-eliminate: 44 32 9;       /* #2c2009 */
-
-  /* Wash channels — match new accent identity */
-  --q1-wash: 122 139 126;
-  --q2-wash: 123 143 163;
-  --q3-wash: 157 139 122;
-  --q4-wash: 138 140 142;
 
   /* Quadrant accent identity — first-cut: same triples as light, lifted via
    * --accent-style only if axe surfaces failures. Per redesign-plan.md D1=B. */
@@ -163,18 +151,6 @@ main {
   @apply appearance-none border-0 bg-transparent p-0;
   font: inherit;
   color: inherit;
-}
-
-@layer components {
-  .quadrant-wash-q1 { background-color: rgb(var(--q1-wash) / 0.045); }
-  .quadrant-wash-q2 { background-color: rgb(var(--q2-wash) / 0.045); }
-  .quadrant-wash-q3 { background-color: rgb(var(--q3-wash) / 0.05); }
-  .quadrant-wash-q4 { background-color: rgb(var(--q4-wash) / 0.055); }
-
-  .dark .quadrant-wash-q1 { background-color: rgb(var(--q1-wash) / 0.10); }
-  .dark .quadrant-wash-q2 { background-color: rgb(var(--q2-wash) / 0.10); }
-  .dark .quadrant-wash-q3 { background-color: rgb(var(--q3-wash) / 0.11); }
-  .dark .quadrant-wash-q4 { background-color: rgb(var(--q4-wash) / 0.12); }
 }
 
 /* View Transitions */

--- a/components/matrix-simplified/capture-bar.tsx
+++ b/components/matrix-simplified/capture-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, type FormEvent, type KeyboardEvent } from "react";
-import { ArrowRightIcon } from "lucide-react";
+import { ArrowRightIcon, ZapIcon } from "lucide-react";
 import { parseCapture } from "@/lib/capture-parser";
 import { quadrantByRdKey, type RedesignQuadrantKey } from "@/lib/quadrants";
 import { quadrantAccent } from "@/lib/quadrant-accent";
@@ -127,15 +127,14 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
     <form
       onSubmit={submit}
       className={cn(
-        "flex items-center gap-2.5 rounded-2xl border border-border bg-card px-3.5 py-2.5",
+        "flex items-center gap-3 rounded-2xl border border-border-strong bg-background-muted px-5 py-4",
         "shadow-sm transition-shadow focus-within:border-foreground-muted focus-within:shadow-md"
       )}
     >
-      <span
+      <ZapIcon
         aria-hidden
-        className="h-2.5 w-2.5 shrink-0 rounded-full transition-colors"
-        style={{ backgroundColor: text.trim() ? accent : "rgb(var(--foreground-muted) / 0.5)" }}
-        title={meta.title}
+        className="h-5 w-5 shrink-0 text-accent"
+        strokeWidth={2.5}
       />
       <input
         ref={internalRef}
@@ -144,7 +143,7 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
         onKeyDown={onInputKey}
         placeholder="Capture a task… use ! urgent  * important  #tag"
         aria-label="Capture a task"
-        className="min-w-0 flex-1 border-0 bg-transparent text-[14.5px] leading-snug text-foreground outline-none placeholder:text-foreground-muted"
+        className="min-w-0 flex-1 border-0 bg-transparent text-[15px] font-medium leading-snug text-foreground outline-none placeholder:font-normal placeholder:text-foreground-muted"
       />
       {text.trim() ? (
         <>
@@ -187,8 +186,8 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
         type="submit"
         disabled={!parsed.title}
         className={cn(
-          "inline-flex h-8 items-center gap-1 rounded-lg px-3 text-[13px] font-medium",
-          "bg-foreground text-background hover:bg-foreground/90",
+          "inline-flex h-9 items-center gap-1 rounded-lg px-4 text-sm font-semibold",
+          "bg-accent text-white hover:bg-accent-hover",
           "disabled:cursor-not-allowed disabled:opacity-40"
         )}
       >

--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -227,7 +227,7 @@ export function MatrixSimplified() {
         onSearchChange={setSearchQuery}
         searchInputRef={searchInputRef}
       >
-        <div className="sticky top-[60px] z-10 mb-4 -mx-4 bg-background px-4 py-2 sm:static sm:m-0 sm:bg-transparent sm:p-0 sm:pb-4">
+        <div className="sticky top-[60px] z-10 mb-12 -mx-4 bg-background px-4 py-2 sm:mx-0 sm:px-0 sm:pb-2 sm:pt-3">
           <CaptureBar onSubmit={handleCapture} onMoreOptions={handleOpenCreateDrawer} inputRef={captureInputRef} />
         </div>
         <MatrixGrid

--- a/components/matrix-simplified/matrix-grid.tsx
+++ b/components/matrix-simplified/matrix-grid.tsx
@@ -41,19 +41,37 @@ export function MatrixGrid({
   }, [tasks]);
 
   return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:grid-rows-2">
-      {quadrants.map((meta) => (
-        <QuadrantPane
-          key={meta.id}
-          meta={meta}
-          tasks={grouped[meta.rdKey]}
-          allTasks={tasks}
-          onEdit={onEdit}
-          onToggleComplete={onToggleComplete}
-          onDelete={onDelete}
-          onAddInQuadrant={onAddInQuadrant}
+    <div className="rounded-2xl border border-border-strong bg-background/40 p-3 backdrop-blur-sm sm:p-6">
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 md:grid-rows-[auto_1px_auto]">
+        {quadrants.slice(0, 2).map((meta) => (
+          <QuadrantPane
+            key={meta.id}
+            meta={meta}
+            tasks={grouped[meta.rdKey]}
+            allTasks={tasks}
+            onEdit={onEdit}
+            onToggleComplete={onToggleComplete}
+            onDelete={onDelete}
+            onAddInQuadrant={onAddInQuadrant}
+          />
+        ))}
+        <div
+          aria-hidden
+          className="hidden bg-border-strong/60 md:col-span-2 md:block"
         />
-      ))}
+        {quadrants.slice(2, 4).map((meta) => (
+          <QuadrantPane
+            key={meta.id}
+            meta={meta}
+            tasks={grouped[meta.rdKey]}
+            allTasks={tasks}
+            onEdit={onEdit}
+            onToggleComplete={onToggleComplete}
+            onDelete={onDelete}
+            onAddInQuadrant={onAddInQuadrant}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/components/matrix-simplified/quadrant-pane.tsx
+++ b/components/matrix-simplified/quadrant-pane.tsx
@@ -9,13 +9,6 @@ import type { QuadrantMeta, RedesignQuadrantKey } from "@/lib/quadrants";
 import { quadrantAccent } from "@/lib/quadrant-accent";
 import { cn } from "@/lib/utils";
 
-const WASH_CLASS: Record<RedesignQuadrantKey, string> = {
-  q1: "quadrant-wash-q1",
-  q2: "quadrant-wash-q2",
-  q3: "quadrant-wash-q3",
-  q4: "quadrant-wash-q4",
-};
-
 interface QuadrantPaneProps {
   meta: QuadrantMeta;
   tasks: TaskRecord[];
@@ -43,8 +36,7 @@ export function QuadrantPane({
     <section
       ref={setNodeRef}
       className={cn(
-        "relative flex min-h-[280px] flex-col rounded-2xl border p-4 transition-all",
-        WASH_CLASS[meta.rdKey],
+        "relative flex min-h-[280px] flex-col rounded-xl border bg-card p-4 transition-all",
         isOver ? "border-2 shadow-md" : "border-border"
       )}
       style={isOver ? { borderColor: accent } : undefined}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.9.0",
+	"version": "8.9.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.9.1",
+	"version": "8.9.2",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -27,8 +27,10 @@ const config = {
         },
         border: {
           DEFAULT: "rgb(var(--border) / <alpha-value>)",
-          muted: "rgb(var(--border-muted) / <alpha-value>)"
+          muted: "rgb(var(--border-muted) / <alpha-value>)",
+          strong: "rgb(var(--border-strong) / <alpha-value>)"
         },
+        terracotta: "rgb(var(--terracotta) / <alpha-value>)",
         accent: {
           DEFAULT: "rgb(var(--accent) / <alpha-value>)",
           hover: "rgb(var(--accent-hover) / <alpha-value>)",

--- a/tests/ui/capture-bar.test.tsx
+++ b/tests/ui/capture-bar.test.tsx
@@ -87,4 +87,24 @@ describe("<CaptureBar>", () => {
     fireEvent.keyDown(window, { key: "N", shiftKey: true });
     expect(onMoreOptions).toHaveBeenCalledWith({ title: "", urgent: false, important: false, tags: [] });
   });
+
+  it("renders the lifted Phase-3 surface — Zap icon, lifted bg, strong border, accent Add button", () => {
+    const { container } = render(<CaptureBar onSubmit={vi.fn()} />);
+
+    // Zap icon is rendered as the persistent prefix mark (regression guard for the elevated capture bar).
+    const zap = container.querySelector('svg.lucide-zap');
+    expect(zap, "expected ZapIcon to render in the capture bar").not.toBeNull();
+
+    // Form wrapper carries the lifted-surface classes introduced in Phase 3.
+    const form = container.querySelector('form');
+    expect(form?.className).toContain('bg-background-muted');
+    expect(form?.className).toContain('border-border-strong');
+    expect(form?.className).toContain('px-5');
+    expect(form?.className).toContain('py-4');
+
+    // Add button uses the new solid muted-indigo treatment, not the old foreground/background swap.
+    const addBtn = screen.getByRole('button', { name: /^Add$/i });
+    expect(addBtn.className).toContain('bg-accent');
+    expect(addBtn.className).toContain('text-white');
+  });
 });


### PR DESCRIPTION
Phase 4 of the redesign per [`tasks/redesign-plan.md`](tasks/redesign-plan.md). **Also includes Phase 3 (capture bar elevation, originally PR #245)** which never propagated to main due to a stacked-PR merge sequencing — see "Phase 3 backport" note below.

## Summary

### Phase 3 backport (commits `92636ce`)

When PR #244 (Phase 2) was squash-merged first, it closed #244's path to main. Then #245 merged into the now-stale `claude/redesign-phase-2` branch, so its changes never reached main. This PR carries those changes forward:

- Capture bar lifted surface: `bg-card` → `bg-background-muted`, `border-border` → `border-border-strong`, padding `px-3.5 py-2.5` → `px-5 py-4`
- Persistent `<ZapIcon>` prefix replacing the empty-state quadrant dot
- Solid muted-indigo Add button (`bg-accent text-white`)
- Sticky on desktop too (`sm:static` removed)
- 48 px gap before matrix (`mb-4` → `mb-12`)
- Tailwind config: `border.strong` + top-level `terracotta` color mappings

### Phase 4 — Unified matrix container (commit `3f422fe`)

- Wrap the four quadrant panes in a single rounded container: `rounded-2xl border-border-strong bg-background/40 backdrop-blur-sm`, padding `p-3 sm:p-6`. Reads as one cockpit instead of four separate cards.
- Internal grid gap `gap-4` → `gap-3` (visual unity per spec §9).
- Horizontal divider between top (Q1+Q2) and bottom (Q3+Q4) rows on `md:` breakpoint via `grid-template-rows: auto 1px auto`.
- Per-pane `quadrant-wash-q*` class dropped — the unified container now provides the surface. Per-pane `bg-card` added so each pane reads as a distinct card inside.
- Pane corner radius `rounded-2xl` → `rounded-xl` (smaller radius nested inside the parent's larger radius).
- Globals cleanup: `.quadrant-wash-q*` classes + `--q1..q4-wash` tokens deleted (zero consumers).

## Verification

- `bun typecheck` clean
- `bun lint` clean (5 pre-existing warnings)
- `bun run test`: 1,790 / 1,797 pass; 6 pre-existing failures unchanged from main
- Visual: matrix reads as one cockpit, divider visible on md+, capture bar still pins to top under topbar on scroll

## What's still pending

This PR doesn't fix the light-mode quadrant label AA contrast regression from #244 — that's Phase 5's job (γ treatment). Phase 5/6/7 are stacked on this branch and will follow as separate PRs once this lands.

Version: → 8.9.2.