### PR TITLE
feat(redesign): γ quadrant header — deep charcoal text + accent dot (Phase 5)

### DIFF
--- a/components/matrix-simplified/quadrant-pane.tsx
+++ b/components/matrix-simplified/quadrant-pane.tsx
@@ -36,35 +36,45 @@ export function QuadrantPane({
     <section
       ref={setNodeRef}
       className={cn(
-        "relative flex min-h-[280px] flex-col rounded-xl border bg-card p-4 transition-all",
+        "relative flex min-h-[280px] flex-col overflow-hidden rounded-xl border bg-card transition-all",
         isOver ? "border-2 shadow-md" : "border-border"
       )}
       style={isOver ? { borderColor: accent } : undefined}
       aria-label={`${meta.title} quadrant`}
     >
-      <header className="mb-3 flex items-center gap-2.5">
-        <span
-          className="rd-mono text-[11px] font-bold uppercase tracking-[0.16em]"
-          style={{ color: accent }}
-        >
-          {meta.title}
-        </span>
-        <span className="text-[12px] text-foreground-muted">{meta.rdHint}</span>
-        <span className="ml-auto rounded bg-background-muted px-1.5 text-[11px] font-medium tabular-nums text-foreground-muted">
-          {tasks.filter((t) => !t.completed).length}
-        </span>
-        <button
-          type="button"
-          onClick={() => onAddInQuadrant(meta.rdKey)}
-          aria-label={`Add to ${meta.title}`}
-          className="inline-flex h-7 w-7 items-center justify-center rounded-md text-foreground-muted hover:bg-background-muted hover:text-foreground"
-        >
-          <PlusIcon className="h-3.5 w-3.5" />
-        </button>
+      <header
+        className="flex items-center justify-between border-b border-border px-4 pb-3 pt-4"
+        style={{ backgroundColor: quadrantAccent(meta.rdKey, 0.05) }}
+      >
+        <div className="flex items-center gap-2">
+          <span
+            aria-hidden
+            className="h-2 w-2 shrink-0 rounded-full"
+            style={{ backgroundColor: accent }}
+          />
+          <h3 className="text-sm font-bold tracking-wide text-foreground">
+            {meta.title}
+          </h3>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="rounded bg-background-muted px-1.5 text-[11px] font-medium tabular-nums text-foreground-muted">
+            {tasks.filter((t) => !t.completed).length}
+          </span>
+          <button
+            type="button"
+            onClick={() => onAddInQuadrant(meta.rdKey)}
+            aria-label={`Add to ${meta.title}`}
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-foreground-muted hover:bg-background hover:text-foreground"
+          >
+            <PlusIcon className="h-3.5 w-3.5" />
+          </button>
+        </div>
       </header>
 
+      <p className="px-4 pt-3 text-xs text-foreground-muted">{meta.rdHint}</p>
+
       <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>
-        <div className="flex flex-1 flex-col gap-2">
+        <div className="flex flex-1 flex-col gap-2 px-4 pb-4 pt-3">
           {tasks.length === 0 ? (
             <p className="my-auto text-center text-sm italic text-foreground-muted">
               {meta.rdEmpty}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.9.2",
+	"version": "8.9.3",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Phase 5 of the redesign per [`tasks/redesign-plan.md`](tasks/redesign-plan.md). **Resolves the WCAG 2.1 AA-normal contrast regression from PR #244** by switching to your chosen γ treatment.

Stacks on [#246 (Phase 4)](https://github.com/vscarpenter/gsd-task-manager/pull/246). After #246 lands I'll retarget this to main.

## Summary — γ treatment

The four quadrant header labels on light mode were measuring 3.00–3.31:1 against the required 4.5:1 (sage / dusty / taupe / slate text on warm canvas at 11px bold). γ resolves this:

- **Tinted header strip:** 5% accent over canvas, extending edge-to-edge inside the rounded pane. Section gets `overflow-hidden` so the strip clips to the parent's rounded corners.
- **Title text:** drop the colored treatment. Now `text-foreground` (deep charcoal) at `text-sm font-bold tracking-wide`, Title Case ("Do First", not "DO FIRST").
- **Identity dot:** 8 × 8 px circle in `quadrantAccent(rdKey)` rendered before the title — quadrant identity preserved in a non-text element where contrast doesn't apply.
- **Hint text** moves from inline-with-title to a dedicated paragraph below the strip.

## Resulting contrast

| Quadrant | Title fg | Effective bg (canvas + 5% tint) | Ratio |
|---|---|---|---|
| Q1 sage | `#18181b` | ~`#f0f0eb` | **~17:1** ✓ AAA (was 3.31:1) |
| Q2 dusty blue | `#18181b` | ~`#f0f1ee` | **~17:1** ✓ AAA (was 3.06:1) |
| Q3 warm taupe | `#18181b` | ~`#f1f0ed` | **~17:1** ✓ AAA (was 3.00:1) |
| Q4 slate gray | `#18181b` | ~`#f0f0ec` | **~17:1** ✓ AAA (was 3.09:1) |

ADR-0012's "Open question for the user" section will be updated in Phase 7 with the resolution; the technical record stays accurate.

## Verification

- `bun typecheck` clean
- `bun run test` on matrix + capture-bar: 16/16 pass (existing snapshot-style assertions still pass — proves rdHint, count, plus-button still rendered correctly)
- Padding restructure: section padding moves from `p-4` to its children (`px-4 pt-4 pb-3` on header strip, `px-4 pt-3` on hint paragraph, `px-4 pb-4 pt-3` on body). Same total spacing, just relocated so the strip can extend edge-to-edge.

Version: → 8.9.3.