### PR TITLE
feat(redesign): task card typography + accent checkbox + terracotta overdue (Phase 6)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -645,9 +645,9 @@ main {
 }
 
 .overdue-task {
-  border-left-color: rgb(239 68 68);
+  border-left-color: rgb(var(--terracotta));
 }
 
 .dark .overdue-task {
-  border-left-color: rgb(248 113 113);
+  border-left-color: rgb(var(--terracotta));
 }

--- a/components/task-card/index.tsx
+++ b/components/task-card/index.tsx
@@ -62,7 +62,7 @@ function TaskCardComponent({
         task.completed ? "opacity-60" : "opacity-100 hover:-translate-y-0.5 hover:border-accent/40",
         task.completed && "animate-complete-flash",
         isDragging && "cursor-grabbing",
-        taskIsOverdue ? "overdue-task border-l-4 border-red-200 bg-red-50/40 dark:border-red-800/60 dark:bg-red-950/20" : "border-card-border",
+        taskIsOverdue ? "overdue-task border-l-4 border-terracotta/40 bg-terracotta/5 dark:border-terracotta/50 dark:bg-terracotta/10" : "border-card-border",
         selectionMode && isSelected && "ring-2 ring-accent ring-offset-2",
         isHighlighted && "animate-pulse-highlight ring-4 ring-accent ring-offset-2"
       )}

--- a/components/task-card/task-card-actions.tsx
+++ b/components/task-card/task-card-actions.tsx
@@ -32,7 +32,7 @@ export function TaskCardActions({
     <div className="flex items-center justify-between gap-2 text-xs text-foreground-muted">
       <div className="flex items-center gap-2">
         {taskIsOverdue ? (
-          <span className="flex items-center gap-1 rounded-full bg-red-50 dark:bg-red-950/40 px-2 py-0.5 text-red-600 dark:text-red-400 font-medium">
+          <span className="flex items-center gap-1 rounded-full bg-terracotta/10 dark:bg-terracotta/15 px-2 py-0.5 text-terracotta font-medium">
             <AlertCircleIcon className="h-3 w-3" />
             Overdue
           </span>

--- a/components/task-card/task-card-header.tsx
+++ b/components/task-card/task-card-header.tsx
@@ -4,8 +4,17 @@ import { CheckCircle2Icon, CircleIcon, GripVerticalIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import type { TaskRecord } from "@/lib/types";
+import type { RedesignQuadrantKey } from "@/lib/quadrants";
+import { quadrantAccent } from "@/lib/quadrant-accent";
 import type { SortableAttributes, SortableListeners } from "./types";
 import { TaskDescription } from "@/components/task-description";
+
+function rdKeyFor(task: TaskRecord): RedesignQuadrantKey {
+  if (task.urgent && task.important) return "q1";
+  if (!task.urgent && task.important) return "q2";
+  if (task.urgent) return "q3";
+  return "q4";
+}
 
 export interface TaskCardHeaderProps {
   task: TaskRecord;
@@ -27,6 +36,8 @@ export function TaskCardHeader({
   sortableListeners,
 }: TaskCardHeaderProps) {
   const completionLabel = task.completed ? "Mark as incomplete" : "Mark as complete";
+  const accent = quadrantAccent(rdKeyFor(task));
+  const accentSoft = quadrantAccent(rdKeyFor(task), 0.5);
 
   return (
     <div className="flex items-start justify-between gap-2">
@@ -52,7 +63,7 @@ export function TaskCardHeader({
         )}
         <div className="min-w-0 flex-1">
           <h3 className={cn(
-            "text-[15px] font-semibold leading-snug tracking-tight text-foreground truncate",
+            "text-[15px] font-medium leading-snug tracking-tight text-foreground truncate",
             task.completed && "line-through"
           )}>
             {task.title}
@@ -70,11 +81,28 @@ export function TaskCardHeader({
             type="button"
             onClick={() => onToggleComplete(task, !task.completed)}
             className={cn(
-              "button-reset relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border transition-all duration-200 sm:h-9 sm:w-9",
+              "button-reset relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border-2 transition-all duration-200 sm:h-9 sm:w-9",
               task.completed
                 ? "border-emerald-400 bg-emerald-500/15 text-emerald-600 shadow-sm shadow-emerald-500/10 dark:border-emerald-500 dark:text-emerald-400"
-                : "border-border bg-background/90 text-foreground-muted shadow-sm shadow-black/[0.04] hover:border-accent hover:text-accent hover:bg-accent/5 hover:scale-105 hover:shadow-accent/10"
+                : "bg-background/90 text-foreground-muted shadow-sm shadow-black/[0.04] hover:scale-105"
             )}
+            style={
+              task.completed
+                ? undefined
+                : { borderColor: accentSoft }
+            }
+            onMouseEnter={(e) => {
+              if (!task.completed) {
+                e.currentTarget.style.borderColor = accent;
+                e.currentTarget.style.color = accent;
+              }
+            }}
+            onMouseLeave={(e) => {
+              if (!task.completed) {
+                e.currentTarget.style.borderColor = accentSoft;
+                e.currentTarget.style.color = "";
+              }
+            }}
             aria-pressed={task.completed}
             aria-label={completionLabel}
           >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.9.3",
+	"version": "8.9.4",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/ui/task-card.test.tsx
+++ b/tests/ui/task-card.test.tsx
@@ -175,14 +175,17 @@ describe("TaskCard", () => {
     expect(repeatIcon).toBeInTheDocument();
   });
 
-  it("applies red border styling for overdue tasks", () => {
+  it("applies terracotta border styling for overdue tasks", () => {
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
     const overdueTask = { ...mockTask, dueDate: yesterday.toISOString() };
     const { container } = render(<TaskCard task={overdueTask} allTasks={[overdueTask]} {...mockHandlers} />);
 
     const article = container.querySelector("article");
-    expect(article).toHaveClass("overdue-task", "border-l-4", "border-red-200");
+    // Phase 6 redesign: red → terracotta. Border-left color comes from the
+    // .overdue-task CSS rule in globals.css (rgb(var(--terracotta))); the
+    // utility classes here paint the surrounding 4-px border + soft bg tint.
+    expect(article).toHaveClass("overdue-task", "border-l-4", "border-terracotta/40", "bg-terracotta/5");
   });
 
   it("does not show overdue warning for completed tasks", () => {


### PR DESCRIPTION
Phase 6 of the redesign per [`tasks/redesign-plan.md`](tasks/redesign-plan.md). Refines the task card surface: typography weight per spec, quadrant-tinted completion toggle, terracotta family for overdue treatment.

Stacks on [#247 (Phase 5)](https://github.com/vscarpenter/gsd-task-manager/pull/247). Retarget cascade applies on each parent merge.

## Summary

### Task card surface

| What | Before | After |
|---|---|---|
| Title weight | `font-semibold` (600) | `font-medium` (500) — per spec §6 |
| Completion toggle border (rest) | `border-border` | `borderColor: quadrantAccent(rdKey, 0.5)` (per-task quadrant tint) |
| Completion toggle border (hover) | `hover:border-accent` | accent ramps from 0.5 → 1.0 (full quadrant accent on hover) |
| Toggle border width | `border` (1px) | `border-2` (so accent reads at 32–36 px button size) |

### Overdue: red → terracotta

Six call sites across two files + one CSS rule:

- `components/task-card/index.tsx`: `border-red-200 bg-red-50/40 dark:border-red-800/60 dark:bg-red-950/20` → `border-terracotta/40 bg-terracotta/5 dark:border-terracotta/50 dark:bg-terracotta/10`
- `components/task-card/task-card-actions.tsx`: overdue chip `bg-red-50 text-red-600 dark:bg-red-950/40 dark:text-red-400` → `bg-terracotta/10 text-terracotta dark:bg-terracotta/15`
- `app/globals.css`: `.overdue-task` border-left-color `rgb(239 68 68)` → `rgb(var(--terracotta))` (light + dark)

The terracotta token was added in Phase 2; this PR is the first to consume it. Non-overdue red references (destructive buttons, sync errors, Reset / Import dialogs) remain red — those are warning/danger semantics, not quadrant identity.

## Test fix bundled

`tests/ui/task-card.test.tsx` had an assertion `toHaveClass("…border-red-200")`. Renamed the test to "applies terracotta border styling" and updated the assertion to match the new utility classes. Added a comment noting the `.overdue-task` CSS rule paints the actual border *color* via the token; the utility classes paint the 4 px width and bg tint.

## Verification

- `bun typecheck` clean
- `bun lint` clean (5 pre-existing warnings)
- `bun run test`: 17/17 task-card tests pass; full suite 1,790 / 1,797 (6 pre-existing failures unchanged)

## Notes on the hover implementation

Tailwind's `hover:` modifier can't override an inline-style `borderColor`, so the per-task quadrant border uses inline style for the rest state and `onMouseEnter` / `onMouseLeave` handlers to swap to the full accent on hover. Mouse handlers are one per card and run only on actual hover — perf cost is negligible.

Version: → 8.9.4.