### PR TITLE
feat(ui): unified cockpit design for v9 matrix shell

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -230,6 +230,16 @@ main {
   .dark .quadrant-wash-q2 { background-color: rgb(var(--q2-wash) / 0.10); }
   .dark .quadrant-wash-q3 { background-color: rgb(var(--q3-wash) / 0.11); }
   .dark .quadrant-wash-q4 { background-color: rgb(var(--q4-wash) / 0.12); }
+
+  .quadrant-header-q1 { background-color: rgb(var(--q1-wash) / 0.07); }
+  .quadrant-header-q2 { background-color: rgb(var(--q2-wash) / 0.07); }
+  .quadrant-header-q3 { background-color: rgb(var(--q3-wash) / 0.075); }
+  .quadrant-header-q4 { background-color: rgb(var(--q4-wash) / 0.08); }
+
+  .dark .quadrant-header-q1 { background-color: rgb(var(--q1-wash) / 0.16); }
+  .dark .quadrant-header-q2 { background-color: rgb(var(--q2-wash) / 0.16); }
+  .dark .quadrant-header-q3 { background-color: rgb(var(--q3-wash) / 0.17); }
+  .dark .quadrant-header-q4 { background-color: rgb(var(--q4-wash) / 0.18); }
 }
 
 /* View Transitions */

--- a/components/matrix-simplified/capture-bar.tsx
+++ b/components/matrix-simplified/capture-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, type FormEvent, type KeyboardEvent } from "react";
-import { ArrowRightIcon } from "lucide-react";
+import { ArrowRightIcon, ZapIcon } from "lucide-react";
 import { parseCapture } from "@/lib/capture-parser";
 import { quadrantByRdKey, type RedesignQuadrantKey } from "@/lib/quadrants";
 import { cn } from "@/lib/utils";
@@ -132,15 +132,14 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
     <form
       onSubmit={submit}
       className={cn(
-        "flex items-center gap-2.5 rounded-2xl border border-border bg-card px-3.5 py-2.5",
-        "shadow-sm transition-shadow focus-within:border-foreground-muted focus-within:shadow-md"
+        "flex items-center gap-3 rounded-2xl border border-border bg-card px-4 py-3.5",
+        "shadow-md transition-shadow focus-within:border-foreground-muted focus-within:shadow-lg"
       )}
     >
-      <span
+      <ZapIcon
         aria-hidden
-        className="h-2.5 w-2.5 shrink-0 rounded-full transition-colors"
-        style={{ backgroundColor: text.trim() ? accent : "rgb(var(--foreground-muted) / 0.5)" }}
-        title={meta.title}
+        className="h-4 w-4 shrink-0 transition-colors"
+        style={{ color: text.trim() ? accent : "rgb(var(--foreground-muted) / 0.7)" }}
       />
       <input
         ref={internalRef}
@@ -149,7 +148,7 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
         onKeyDown={onInputKey}
         placeholder="Capture a task… use ! urgent  * important  #tag"
         aria-label="Capture a task"
-        className="min-w-0 flex-1 border-0 bg-transparent text-[14.5px] leading-snug text-foreground outline-none placeholder:text-foreground-muted"
+        className="min-w-0 flex-1 border-0 bg-transparent text-[15px] leading-snug text-foreground outline-none placeholder:text-foreground-muted"
       />
       {text.trim() ? (
         <>
@@ -192,13 +191,13 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
         type="submit"
         disabled={!parsed.title}
         className={cn(
-          "inline-flex h-8 items-center gap-1 rounded-lg px-3 text-[13px] font-medium",
+          "inline-flex h-9 items-center gap-1.5 rounded-lg px-4 text-[14px] font-semibold",
           "bg-foreground text-background hover:bg-foreground/90",
           "disabled:cursor-not-allowed disabled:opacity-40"
         )}
       >
         Add
-        <ArrowRightIcon className="h-3.5 w-3.5" />
+        <ArrowRightIcon className="h-4 w-4" />
       </button>
     </form>
   );

--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -227,7 +227,7 @@ export function MatrixSimplified() {
         onSearchChange={setSearchQuery}
         searchInputRef={searchInputRef}
       >
-        <div className="sticky top-[60px] z-10 mb-4 -mx-4 bg-background px-4 py-2 sm:static sm:m-0 sm:bg-transparent sm:p-0 sm:pb-4">
+        <div className="sticky top-[60px] z-10 -mx-4 mb-10 bg-background/85 px-4 py-3 backdrop-blur-xl backdrop-saturate-150 sm:-mx-9 sm:mb-12 sm:px-9 sm:py-4">
           <CaptureBar onSubmit={handleCapture} onMoreOptions={handleOpenCreateDrawer} inputRef={captureInputRef} />
         </div>
         <MatrixGrid

--- a/components/matrix-simplified/matrix-grid.tsx
+++ b/components/matrix-simplified/matrix-grid.tsx
@@ -41,11 +41,12 @@ export function MatrixGrid({
   }, [tasks]);
 
   return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:grid-rows-2">
-      {quadrants.map((meta) => (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:grid-rows-2 md:gap-0 md:overflow-hidden md:rounded-2xl md:border md:border-border md:bg-card md:shadow-sm">
+      {quadrants.map((meta, index) => (
         <QuadrantPane
           key={meta.id}
           meta={meta}
+          position={POSITIONS[index]}
           tasks={grouped[meta.rdKey]}
           allTasks={tasks}
           onEdit={onEdit}
@@ -57,3 +58,5 @@ export function MatrixGrid({
     </div>
   );
 }
+
+const POSITIONS = ["tl", "tr", "bl", "br"] as const;

--- a/components/matrix-simplified/quadrant-pane.tsx
+++ b/components/matrix-simplified/quadrant-pane.tsx
@@ -15,6 +15,13 @@ const WASH_CLASS: Record<RedesignQuadrantKey, string> = {
   q4: "quadrant-wash-q4",
 };
 
+const HEADER_CLASS: Record<RedesignQuadrantKey, string> = {
+  q1: "quadrant-header-q1",
+  q2: "quadrant-header-q2",
+  q3: "quadrant-header-q3",
+  q4: "quadrant-header-q4",
+};
+
 const ACCENT: Record<RedesignQuadrantKey, string> = {
   q1: "#c2410c",
   q2: "#1d4ed8",
@@ -22,8 +29,21 @@ const ACCENT: Record<RedesignQuadrantKey, string> = {
   q4: "#854d0e",
 };
 
+export type QuadrantPosition = "tl" | "tr" | "bl" | "br";
+
+// On md+, the outer container in <MatrixGrid> owns the perimeter border + radius.
+// Each pane only contributes the rules between cells: a left rule for right-column
+// panes and a top rule for bottom-row panes.
+const POSITION_RULES: Record<QuadrantPosition, string> = {
+  tl: "",
+  tr: "md:border-l md:border-border",
+  bl: "md:border-t md:border-border",
+  br: "md:border-l md:border-t md:border-border",
+};
+
 interface QuadrantPaneProps {
   meta: QuadrantMeta;
+  position: QuadrantPosition;
   tasks: TaskRecord[];
   allTasks: TaskRecord[];
   onEdit: (task: TaskRecord) => void;
@@ -34,6 +54,7 @@ interface QuadrantPaneProps {
 
 export function QuadrantPane({
   meta,
+  position,
   tasks,
   allTasks,
   onEdit,
@@ -49,21 +70,28 @@ export function QuadrantPane({
     <section
       ref={setNodeRef}
       className={cn(
-        "relative flex min-h-[280px] flex-col rounded-2xl border p-4 transition-all",
+        "relative flex min-h-[280px] flex-col rounded-2xl border border-border p-5 transition-colors",
         WASH_CLASS[meta.rdKey],
-        isOver ? "border-2 shadow-md" : "border-border"
+        "md:rounded-none md:border-0",
+        POSITION_RULES[position],
+        isOver && "ring-2 ring-inset"
       )}
-      style={isOver ? { borderColor: accent } : undefined}
+      style={isOver ? { ["--tw-ring-color" as string]: accent } : undefined}
       aria-label={`${meta.title} quadrant`}
     >
-      <header className="mb-3 flex items-center gap-2.5">
+      <header
+        className={cn(
+          "-mx-5 -mt-5 mb-4 flex items-center gap-2.5 border-b border-border-muted px-5 py-3",
+          HEADER_CLASS[meta.rdKey]
+        )}
+      >
         <span
-          className="rd-mono text-[11px] font-bold uppercase tracking-[0.16em]"
-          style={{ color: accent }}
+          className="rd-serif text-[15px] font-semibold leading-none"
+          style={{ color: accent, letterSpacing: "-0.005em" }}
         >
           {meta.title}
         </span>
-        <span className="text-[12px] text-foreground-muted">{meta.rdHint}</span>
+        <span className="text-[12.5px] text-foreground-muted">{meta.rdHint}</span>
         <span className="ml-auto rounded bg-background-muted px-1.5 text-[11px] font-medium tabular-nums text-foreground-muted">
           {tasks.filter((t) => !t.completed).length}
         </span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.8.2",
+	"version": "8.9.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '8.8.3';
+const CACHE_VERSION = '8.9.0';
 const CACHE_NAME = `gsd-cache-v${CACHE_VERSION}`;
 const OFFLINE_ASSETS = [
 	"/",


### PR DESCRIPTION
## Summary
- Reframes the v9 single-matrix view as one cohesive cockpit. Four quadrants render as cells of a single bordered grid on `md+` (mobile keeps the stacked-card treatment).
- Capture bar is now an always-visible command strip: leading `Zap` icon, larger padding, stronger shadow, heavier Add button, sticky with backdrop-blur on every breakpoint at `top-[60px]`.
- Quadrant headers get tinted bands (new `.quadrant-header-q1..q4` classes mirroring the wash scale) with Title-Case `rd-serif` labels replacing the uppercase mono treatment.
- Drag-over highlight switched to `ring-2 ring-inset` so positional pane borders don't jitter on hover.
- Whitespace rebalanced: ~40-48px between capture bar and matrix; pane internals nudged from `p-4` to `p-5`.

Bump `8.8.2` → `8.9.0`.

## Test plan
- [x] `bun typecheck` clean
- [x] `bun run test tests/ui/capture-bar.test.tsx` — 9/9 passing
- [x] `bun run test tests/ui/matrix-simplified.test.tsx` — 6/6 passing
- [x] `bun run build` — production build succeeds, all 9 routes prerender
- [x] Manual visual QA at desktop width (light + dark, drag-and-drop)
- [ ] Reviewer: confirm mobile (<md) still renders each pane as a self-contained card with full border + radius
- [ ] Reviewer: spot-check inter-quadrant rule color against the warm-paper background — bump from `border-border` to a darker token if it disappears
- [ ] Reviewer: confirm sticky capture bar doesn't overlap topbar on tall-content pages

## Notes
- Pre-existing `tests/ui/edit-drawer.test.tsx` failures (5 tests) confirmed present on `main` baseline — not caused by this change.
- No changes to capture parsing, quadrant routing, drag-and-drop, edit drawer, icon rail, or accessibility semantics.