### PR TITLE
fix(tests): unblock SonarCloud CI by repairing two stale tests

### DIFF
--- a/tests/data/db-coverage.test.ts
+++ b/tests/data/db-coverage.test.ts
@@ -115,9 +115,9 @@ describe('Database - Additional Coverage', () => {
       expect(db2).toBe(db3);
     });
 
-    it('returns a Dexie instance with version 13', () => {
+    it('returns a Dexie instance with version 14', () => {
       const instance = getDb();
-      expect(instance.verno).toBe(13);
+      expect(instance.verno).toBe(14);
     });
   });
 

--- a/tests/ui/edit-drawer.test.tsx
+++ b/tests/ui/edit-drawer.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { EditDrawer } from "@/components/matrix-simplified/edit-drawer";
@@ -23,11 +23,9 @@ const mockTask: TaskRecord = {
 } as TaskRecord;
 
 describe("<EditDrawer>", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-27T12:00:00Z"));
-  });
   afterEach(() => {
+    // Defensive: ensure any per-test fake timers are cleared so they don't bleed
+    // into userEvent-based tests, which hang under fake timers.
     vi.useRealTimers();
   });
 
@@ -82,6 +80,11 @@ describe("<EditDrawer>", () => {
   });
 
   it("pre-selects 'today' preset when task has a full ISO dueDate for today", () => {
+    // Pin the system date so the "today" classification matches the task's dueDate.
+    // Scoped to this test only because fake timers break userEvent in the others.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T12:00:00Z"));
+
     const taskDueToday: TaskRecord = {
       ...mockTask,
       dueDate: "2026-04-27T14:00:00.000Z",


### PR DESCRIPTION
## Summary

Fixes the failing [SonarCloud Analysis run](https://github.com/vscarpenter/gsd-task-manager/actions/runs/25242281840/job/74020201822). The "Run tests with coverage" step exited with 6 failures across two files; both were pre-existing latent bugs unrelated to commit `d2ff906`.

### Root causes

**1. `tests/data/db-coverage.test.ts` — stale version assertion**
- `lib/db.ts` was bumped to schema v14 in #240 (`fix(sync): preserve exhausted queue items as failed`)
- The test still asserted `expect(instance.verno).toBe(13)` and was titled "version 13"
- Updated both the title and the assertion to 14

**2. `tests/ui/edit-drawer.test.tsx` — fake timers + userEvent deadlock**
- A `beforeEach` installed `vi.useFakeTimers()` for the entire describe block, but only one test (`pre-selects 'today' preset…`) actually needs a pinned system date
- `@testing-library/user-event@14.6.1` uses internal `setTimeout` calls between events. When fake timers are installed and never advanced, those timers never fire, and every `userEvent.click/type/keyboard` call hangs until the 5s test timeout
- Tried `userEvent.setup({ advanceTimers, delay: null })` first — still deadlocked, suggesting something in the component's effect chain (`setTimeout(focus, 50)` on open) compounds with the fake-timer install
- Final fix: scope `vi.useFakeTimers()` to the single test that needs it (no userEvent in that one), and let all other tests run on real timers. Added a defensive `afterEach` that restores real timers in case the per-test install isn't reset

### Verification

- `bun run test`: 1788 passed, 1 skipped, 0 failed
- `bun typecheck`: clean
- `bun lint`: 5 pre-existing warnings, 0 errors

## Test plan

- [x] Failing tests now pass locally (`bun run test -- tests/ui/edit-drawer.test.tsx tests/data/db-coverage.test.ts`)
- [x] Full suite still green
- [ ] SonarCloud workflow passes on this PR

https://claude.ai/code/session_01YBb7hkfSVztNdFqLFhDPyU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBb7hkfSVztNdFqLFhDPyU)_