### PR TITLE
feat(capture): extract URLs from task title into description field

### DIFF
--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DndContext, DragOverlay } from "@dnd-kit/core";
 import { createTask, toggleCompleted, updateTask, deleteTask } from "@/lib/tasks";
+import { extractUrlsFromTitle } from "@/lib/capture-parser";
 import { useTasks } from "@/lib/use-tasks";
 import { useToast } from "@/components/ui/toast";
 import { useErrorHandlerWithUndo } from "@/lib/use-error-handler";
@@ -42,6 +43,13 @@ function filterTasks(tasks: TaskRecord[], query: string): TaskRecord[] {
       .toLowerCase();
     return hay.includes(q);
   });
+}
+
+/** Merges extracted URLs into an existing description, separated by newlines. */
+function buildDescription(existing: string, urls: string[]): string {
+  if (urls.length === 0) return existing;
+  const urlBlock = urls.join("\n");
+  return existing.trim() ? `${existing.trim()}\n${urlBlock}` : urlBlock;
 }
 
 export function MatrixSimplified() {
@@ -112,9 +120,10 @@ export function MatrixSimplified() {
   const handleCapture = useCallback(
     async ({ title, urgent, important, tags }: CapturePayload) => {
       try {
+        const { cleanTitle, urls } = extractUrlsFromTitle(title);
         await createTask({
-          title,
-          description: "",
+          title: cleanTitle,
+          description: buildDescription("", urls),
           urgent,
           important,
           tags: tags.length > 0 ? tags : undefined,
@@ -157,11 +166,18 @@ export function MatrixSimplified() {
   const handleEditClose = useCallback(() => setEditingTask(null), []);
 
   const handleOpenCreateDrawer = useCallback((payload?: CapturePayload) => {
-    setCreateInitial(
-      payload
-        ? { title: payload.title, urgent: payload.urgent, important: payload.important, tags: payload.tags }
-        : undefined
-    );
+    if (payload) {
+      const { cleanTitle, urls } = extractUrlsFromTitle(payload.title);
+      setCreateInitial({
+        title: cleanTitle,
+        description: buildDescription("", urls),
+        urgent: payload.urgent,
+        important: payload.important,
+        tags: payload.tags,
+      });
+    } else {
+      setCreateInitial(undefined);
+    }
     setCreateDrawerOpen(true);
   }, []);
 
@@ -178,9 +194,10 @@ export function MatrixSimplified() {
           showToast("Task updated", undefined, TOAST_DURATION.SHORT);
           setEditingTask(null);
         } else {
+          const { cleanTitle, urls } = extractUrlsFromTitle(draft.title);
           await createTask({
-            title: draft.title,
-            description: draft.description,
+            title: cleanTitle,
+            description: buildDescription(draft.description, urls),
             urgent: draft.urgent,
             important: draft.important,
             dueDate: draft.dueDate,

--- a/lib/capture-parser.ts
+++ b/lib/capture-parser.ts
@@ -5,6 +5,65 @@ export interface ParsedCapture {
   tags: string[];
 }
 
+export interface ExtractedUrls {
+  cleanTitle: string;
+  urls: string[];
+}
+
+const FALLBACK_TITLE_FOR_URL_ONLY = "Review link below";
+
+// Matches http/https URLs; reuses the same pattern as lib/task-links.ts
+const TITLE_URL_PATTERN = /\bhttps?:\/\/[^\s<>"'`{}|\\^]+/giu;
+const TRAILING_PUNCTUATION = /[),.!?;:]+$/u;
+const MAX_URL_LENGTH = 2048;
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+function sanitizeTitleUrl(candidate: string): string | null {
+  const value = candidate.trim();
+  if (value.length === 0 || value.length > MAX_URL_LENGTH || /[\u0000-\u001F\u007F\s]/u.test(value)) {
+    return null;
+  }
+  try {
+    const url = new URL(value);
+    if (!ALLOWED_PROTOCOLS.has(url.protocol.toLowerCase())) return null;
+    if (!url.hostname || url.username || url.password) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Scans `title` for http/https URLs, removes them, and returns the sanitized
+ * URL list alongside the cleaned title text.
+ *
+ * Rules:
+ * - All valid URLs are extracted and sanitized (XSS-safe: http/https only, no credentials).
+ * - Invalid or unsafe URL candidates are left in the title unchanged.
+ * - If the title collapses to empty after extraction, `cleanTitle` is set to
+ *   FALLBACK_TITLE_FOR_URL_ONLY ("Review link below").
+ */
+export function extractUrlsFromTitle(title: string): ExtractedUrls {
+  const urls: string[] = [];
+  let working = title;
+
+  // We build the cleaned title by iterating matches and replacing valid URLs.
+  // Using a replacer lets us handle invalid candidates gracefully (leave them in place).
+  working = working.replace(TITLE_URL_PATTERN, (raw) => {
+    const trimmed = raw.replace(TRAILING_PUNCTUATION, "");
+    const safe = sanitizeTitleUrl(trimmed);
+    if (!safe) return raw; // leave invalid/unsafe candidates untouched
+    urls.push(safe);
+    // Trailing punctuation (e.g. a period at the end of a sentence) is dropped
+    // along with the URL — it was sentence-level punctuation around the link.
+    return "";
+  });
+
+  const cleanTitle = working.replace(/\s+/g, " ").trim() || (urls.length > 0 ? FALLBACK_TITLE_FOR_URL_ONLY : "");
+
+  return { cleanTitle, urls };
+}
+
 const TAG_PATTERN = /(^|\s)#([a-z0-9_-]+)/gi;
 const DOUBLE_BANG = /(^|\s)!!(\s|$)/g;
 const SINGLE_BANG = /(^|\s)!(\s|$)/g;

--- a/tests/data/capture-parser.test.ts
+++ b/tests/data/capture-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseCapture } from "@/lib/capture-parser";
+import { parseCapture, extractUrlsFromTitle } from "@/lib/capture-parser";
 
 describe("parseCapture", () => {
   it("returns plain title with no flags when input has no markers", () => {
@@ -81,5 +81,80 @@ describe("parseCapture", () => {
       important: false,
       tags: [],
     });
+  });
+});
+
+describe("extractUrlsFromTitle", () => {
+  it("returns unchanged title and empty urls when no URL present", () => {
+    expect(extractUrlsFromTitle("buy milk")).toEqual({
+      cleanTitle: "buy milk",
+      urls: [],
+    });
+  });
+
+  it("extracts a single URL from the end of a title", () => {
+    expect(extractUrlsFromTitle("Review this https://example.com")).toEqual({
+      cleanTitle: "Review this",
+      urls: ["https://example.com/"],
+    });
+  });
+
+  it("extracts a single URL from the middle of a title", () => {
+    expect(extractUrlsFromTitle("Check https://example.com for details")).toEqual({
+      cleanTitle: "Check for details",
+      urls: ["https://example.com/"],
+    });
+  });
+
+  it("extracts all URLs when multiple are present", () => {
+    const result = extractUrlsFromTitle("Compare https://foo.com and https://bar.com");
+    expect(result.cleanTitle).toBe("Compare and");
+    expect(result.urls).toEqual(["https://foo.com/", "https://bar.com/"]);
+  });
+
+  it("returns 'Review link below' as cleanTitle when title is only a URL", () => {
+    expect(extractUrlsFromTitle("https://example.com")).toEqual({
+      cleanTitle: "Review link below",
+      urls: ["https://example.com/"],
+    });
+  });
+
+  it("returns 'Review link below' when title is only whitespace + URL", () => {
+    expect(extractUrlsFromTitle("  https://example.com  ")).toEqual({
+      cleanTitle: "Review link below",
+      urls: ["https://example.com/"],
+    });
+  });
+
+  it("blocks javascript: protocol URLs", () => {
+    expect(extractUrlsFromTitle("Do task javascript:alert(1)")).toEqual({
+      cleanTitle: "Do task javascript:alert(1)",
+      urls: [],
+    });
+  });
+
+  it("blocks URLs with credentials", () => {
+    expect(extractUrlsFromTitle("Visit https://user:pass@evil.com")).toEqual({
+      cleanTitle: "Visit https://user:pass@evil.com",
+      urls: [],
+    });
+  });
+
+  it("trims trailing punctuation from URLs before validating", () => {
+    const result = extractUrlsFromTitle("See https://example.com/path.");
+    expect(result.urls).toEqual(["https://example.com/path"]);
+    expect(result.cleanTitle).toBe("See");
+  });
+
+  it("collapses extra whitespace in cleanTitle after URL removal", () => {
+    const result = extractUrlsFromTitle("foo   https://example.com   bar");
+    expect(result.cleanTitle).toBe("foo bar");
+    expect(result.urls).toEqual(["https://example.com/"]);
+  });
+
+  it("preserves capture markers (! * #tag) alongside URL extraction", () => {
+    const result = extractUrlsFromTitle("Review https://example.com ! #work");
+    expect(result.cleanTitle).toBe("Review ! #work");
+    expect(result.urls).toEqual(["https://example.com/"]);
   });
 });


### PR DESCRIPTION
## Summary

- When a new task is created with a URL in the title, all valid `http`/`https` URLs are automatically extracted from the title and moved to the description field
- If the title becomes empty after extraction (i.e. the title was URL-only), the title defaults to `Review link below`
- Multiple URLs are extracted and joined with newlines in the description
- Existing description content is preserved — URLs are appended on a new line

### XSS protection
Each extracted URL is validated through an allow-list sanitizer before being stored:
- Only `http:` and `https:` protocols are allowed
- URLs with embedded credentials (`user:pass@host`) are rejected
- Malformed URLs are left in the title unchanged (not silently dropped)

### Affected creation paths
All three task-creation entry points apply URL extraction:
1. **Quick-capture** (type + Enter in the capture bar)
2. **Full drawer submit** (create via the edit drawer form)
3. **Details ↗ pre-fill** (opening the drawer from the capture bar carries the extracted title/description into the form)

### Files changed
| File | Change |
|---|---|
| `lib/capture-parser.ts` | New `extractUrlsFromTitle()` export |
| `components/matrix-simplified/index.tsx` | Apply extraction in all three creation paths |
| `tests/data/capture-parser.test.ts` | 11 new unit tests |

#### Test plan
- [x] `bun run test` — all 1793 tests pass (1 pre-existing parse-error failure in `edit-drawer.test.tsx` unrelated to this PR)
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean (pre-existing merge conflict marker in `edit-drawer.test.tsx` only)
- [x] Unit tests cover: single URL, multiple URLs, URL-only title fallback, trailing punctuation trimming, `javascript:` XSS vector, credentials rejection, whitespace collapsing, capture-marker coexistence

Generated with Devin (https://cli.devin.ai/docs)