### PR TITLE
feat(mcp): URL extraction parity with webapp capture flow

### DIFF
--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DndContext, DragOverlay } from "@dnd-kit/core";
 import { createTask, toggleCompleted, updateTask, deleteTask } from "@/lib/tasks";
-import { extractUrlsFromTitle } from "@/lib/capture-parser";
+import { extractUrlsFromTitle, buildDescription } from "@/lib/capture-parser";
 import { useTasks } from "@/lib/use-tasks";
 import { useToast } from "@/components/ui/toast";
 import { useErrorHandlerWithUndo } from "@/lib/use-error-handler";
@@ -43,13 +43,6 @@ function filterTasks(tasks: TaskRecord[], query: string): TaskRecord[] {
       .toLowerCase();
     return hay.includes(q);
   });
-}
-
-/** Merges extracted URLs into an existing description, separated by newlines. */
-function buildDescription(existing: string, urls: string[]): string {
-  if (urls.length === 0) return existing;
-  const urlBlock = urls.join("\n");
-  return existing.trim() ? `${existing.trim()}\n${urlBlock}` : urlBlock;
 }
 
 export function MatrixSimplified() {

--- a/docs/superpowers/plans/2026-05-02-mcp-url-extraction-parity.md
+++ b/docs/superpowers/plans/2026-05-02-mcp-url-extraction-parity.md
@@ -1,0 +1,818 @@
+# MCP URL Extraction Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make MCP `create_task` apply the same URL-extraction behavior the webapp's capture-bar / create-drawer applies, so a task created via Claude Desktop with a URL in its title is normalized identically to one created in the UI.
+
+**Architecture:** Vendor `extractUrlsFromTitle` + `buildDescription` from the canonical `lib/capture-parser.ts` into the MCP package as a one-file mirror at `packages/mcp-server/src/text/capture-parser.ts`. Wire MCP `createTask` to call them. Protect against drift with a parity test that asserts both behavioral and source-text equivalence between the two files.
+
+**Tech Stack:** TypeScript (strict), Vitest, the existing webapp + MCP workspace setup. No new dependencies, no bundler.
+
+**Spec:** `docs/superpowers/specs/2026-05-02-mcp-url-extraction-parity-design.md`
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `lib/capture-parser.ts` | Modify | Canonical source. Adds `buildDescription` next to `extractUrlsFromTitle`. |
+| `tests/data/capture-parser.test.ts` | Modify | Adds 5 unit tests for `buildDescription`. |
+| `components/matrix-simplified/index.tsx` | Modify | Removes local `buildDescription`, imports it from the canonical module. |
+| `packages/mcp-server/src/text/capture-parser.ts` | Create | Verbatim mirror of the canonical exports + private helpers. |
+| `packages/mcp-server/src/__tests__/text/capture-parser-parity.test.ts` | Create | Behavioral + source-text parity assertions. |
+| `packages/mcp-server/src/write-ops/task-operations.ts` | Modify | `createTask` calls `extractUrlsFromTitle` + `buildDescription` before constructing `newTask`. |
+| `packages/mcp-server/src/__tests__/write-ops/task-operations-create.test.ts` | Create | End-to-end tests for the create path with URL extraction. |
+
+---
+
+## Task 1: Promote `buildDescription` into the canonical module (TDD)
+
+**Files:**
+- Modify: `lib/capture-parser.ts` (append a new exported function)
+- Test: `tests/data/capture-parser.test.ts` (append a new `describe` block)
+
+- [ ] **Step 1.1: Write the failing tests for `buildDescription`**
+
+In `tests/data/capture-parser.test.ts`, update the existing import line at the top from:
+
+```typescript
+import { parseCapture, extractUrlsFromTitle } from "@/lib/capture-parser";
+```
+
+to:
+
+```typescript
+import { parseCapture, extractUrlsFromTitle, buildDescription } from "@/lib/capture-parser";
+```
+
+Then append this `describe` block at the end of the file (after the existing `describe("extractUrlsFromTitle", ...)` block):
+
+```typescript
+describe("buildDescription", () => {
+  it("returns existing unchanged when there are no urls", () => {
+    expect(buildDescription("Notes here", [])).toBe("Notes here");
+  });
+
+  it("returns urls joined by newline when existing is empty", () => {
+    expect(buildDescription("", ["https://a.test/", "https://b.test/"])).toBe(
+      "https://a.test/\nhttps://b.test/"
+    );
+  });
+
+  it("returns urls joined by newline when existing is whitespace only", () => {
+    expect(buildDescription("   \n  ", ["https://a.test/"])).toBe("https://a.test/");
+  });
+
+  it("appends urls below trimmed existing text separated by a single newline", () => {
+    expect(buildDescription("  Plan trip  ", ["https://a.test/"])).toBe(
+      "Plan trip\nhttps://a.test/"
+    );
+  });
+
+  it("preserves multi-line existing text and appends urls below", () => {
+    expect(
+      buildDescription("Line one\nLine two", ["https://a.test/", "https://b.test/"])
+    ).toBe("Line one\nLine two\nhttps://a.test/\nhttps://b.test/");
+  });
+});
+```
+
+- [ ] **Step 1.2: Run tests, confirm they fail for the right reason**
+
+Run:
+```bash
+bun run test -- tests/data/capture-parser.test.ts
+```
+Expected: 5 new tests fail with a TypeScript / module-resolution error along the lines of `"buildDescription" is not exported by "lib/capture-parser.ts"`. The 12 existing tests in the file must still pass.
+
+- [ ] **Step 1.3: Implement `buildDescription` in `lib/capture-parser.ts`**
+
+Append this function at the end of `lib/capture-parser.ts` (after `extractUrlsFromTitle`, keeping the two together):
+
+```typescript
+/**
+ * Merges extracted URLs into an existing description, separated by newlines.
+ * - If `urls` is empty, returns `existing` unchanged.
+ * - If `existing` is empty/whitespace, returns the URL block alone.
+ * - Otherwise returns `existing.trim() + "\n" + urls.join("\n")`.
+ */
+export function buildDescription(existing: string, urls: string[]): string {
+  if (urls.length === 0) return existing;
+  const urlBlock = urls.join("\n");
+  return existing.trim() ? `${existing.trim()}\n${urlBlock}` : urlBlock;
+}
+```
+
+- [ ] **Step 1.4: Run tests, confirm they pass**
+
+Run:
+```bash
+bun run test -- tests/data/capture-parser.test.ts
+```
+Expected: all 17 tests pass (12 existing + 5 new).
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add lib/capture-parser.ts tests/data/capture-parser.test.ts
+git commit -m "refactor(capture-parser): promote buildDescription into shared module"
+```
+
+---
+
+## Task 2: Switch `matrix-simplified` to import the promoted helper
+
+**Files:**
+- Modify: `components/matrix-simplified/index.tsx` (lines 6 and 48-53)
+
+- [ ] **Step 2.1: Update the import line**
+
+Change the existing import at line 6 from:
+
+```typescript
+import { extractUrlsFromTitle } from "@/lib/capture-parser";
+```
+
+to:
+
+```typescript
+import { extractUrlsFromTitle, buildDescription } from "@/lib/capture-parser";
+```
+
+- [ ] **Step 2.2: Delete the local `buildDescription` helper**
+
+Delete lines 48-53 of `components/matrix-simplified/index.tsx`:
+
+```typescript
+/** Merges extracted URLs into an existing description, separated by newlines. */
+function buildDescription(existing: string, urls: string[]): string {
+  if (urls.length === 0) return existing;
+  const urlBlock = urls.join("\n");
+  return existing.trim() ? `${existing.trim()}\n${urlBlock}` : urlBlock;
+}
+```
+
+The three call sites further down (`handleCapture`, `handleOpenCreateDrawer`, `handleEditSubmit`) already invoke `buildDescription(...)` with the right arguments and now resolve to the imported version automatically.
+
+- [ ] **Step 2.3: Run typecheck and webapp tests**
+
+Run:
+```bash
+bun typecheck && bun run test
+```
+Expected: typecheck clean; full Vitest suite green.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add components/matrix-simplified/index.tsx
+git commit -m "refactor(matrix-simplified): consume buildDescription from shared module"
+```
+
+---
+
+## Task 3: Vendor the mirror into the MCP package
+
+**Files:**
+- Create: `packages/mcp-server/src/text/capture-parser.ts`
+
+- [ ] **Step 3.1: Create the directory**
+
+Run:
+```bash
+mkdir -p packages/mcp-server/src/text
+```
+
+- [ ] **Step 3.2: Create the mirror file**
+
+Write `packages/mcp-server/src/text/capture-parser.ts` with this exact content:
+
+```typescript
+// MIRROR OF lib/capture-parser.ts (extractUrlsFromTitle + buildDescription only).
+// Keep this file in sync with the canonical webapp module. Drift is detected by
+// packages/mcp-server/src/__tests__/text/capture-parser-parity.test.ts.
+//
+// The MCP server is published as a standalone npm package built with plain `tsc`.
+// It cannot import from the webapp's lib/ tree because tsconfig.rootDir = "./src".
+// Vendoring + parity test was chosen over introducing a bundler or a separate
+// shared workspace package — see
+// docs/superpowers/specs/2026-05-02-mcp-url-extraction-parity-design.md.
+
+export interface ExtractedUrls {
+  cleanTitle: string;
+  urls: string[];
+}
+
+const FALLBACK_TITLE_FOR_URL_ONLY = "Review link below";
+
+// Matches http/https URLs; reuses the same pattern as lib/task-links.ts
+const TITLE_URL_PATTERN = /\bhttps?:\/\/[^\s<>"'`{}|\\^]+/giu;
+const TRAILING_PUNCTUATION = /[),.!?;:]+$/u;
+const MAX_URL_LENGTH = 2048;
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+function sanitizeTitleUrl(candidate: string): string | null {
+  const value = candidate.trim();
+  if (value.length === 0 || value.length > MAX_URL_LENGTH || /[ -\s]/u.test(value)) {
+    return null;
+  }
+  try {
+    const url = new URL(value);
+    if (!ALLOWED_PROTOCOLS.has(url.protocol.toLowerCase())) return null;
+    if (!url.hostname || url.username || url.password) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Scans `title` for http/https URLs, removes them, and returns the sanitized
+ * URL list alongside the cleaned title text.
+ *
+ * Rules:
+ * - All valid URLs are extracted and sanitized (XSS-safe: http/https only, no credentials).
+ * - Invalid or unsafe URL candidates are left in the title unchanged.
+ * - If the title collapses to empty after extraction, `cleanTitle` is set to
+ *   FALLBACK_TITLE_FOR_URL_ONLY ("Review link below").
+ */
+export function extractUrlsFromTitle(title: string): ExtractedUrls {
+  const urls: string[] = [];
+  let working = title;
+
+  // We build the cleaned title by iterating matches and replacing valid URLs.
+  // Using a replacer lets us handle invalid candidates gracefully (leave them in place).
+  working = working.replace(TITLE_URL_PATTERN, (raw) => {
+    const trimmed = raw.replace(TRAILING_PUNCTUATION, "");
+    const safe = sanitizeTitleUrl(trimmed);
+    if (!safe) return raw; // leave invalid/unsafe candidates untouched
+    urls.push(safe);
+    // Trailing punctuation (e.g. a period at the end of a sentence) is dropped
+    // along with the URL — it was sentence-level punctuation around the link.
+    return "";
+  });
+
+  const cleanTitle = working.replace(/\s+/g, " ").trim() || (urls.length > 0 ? FALLBACK_TITLE_FOR_URL_ONLY : "");
+
+  return { cleanTitle, urls };
+}
+
+/**
+ * Merges extracted URLs into an existing description, separated by newlines.
+ * - If `urls` is empty, returns `existing` unchanged.
+ * - If `existing` is empty/whitespace, returns the URL block alone.
+ * - Otherwise returns `existing.trim() + "\n" + urls.join("\n")`.
+ */
+export function buildDescription(existing: string, urls: string[]): string {
+  if (urls.length === 0) return existing;
+  const urlBlock = urls.join("\n");
+  return existing.trim() ? `${existing.trim()}\n${urlBlock}` : urlBlock;
+}
+```
+
+> **Important:** The function bodies of `extractUrlsFromTitle`, `buildDescription`, and `sanitizeTitleUrl` MUST match `lib/capture-parser.ts` byte-for-byte (after whitespace normalization). The parity test in Task 4 enforces this.
+
+- [ ] **Step 3.3: Verify it typechecks in the MCP package**
+
+Run:
+```bash
+cd packages/mcp-server && npx tsc --noEmit && cd -
+```
+Expected: no errors.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add packages/mcp-server/src/text/capture-parser.ts
+git commit -m "feat(mcp): vendor extractUrlsFromTitle + buildDescription from webapp"
+```
+
+---
+
+## Task 4: Add the parity test (write the test, watch it pass against the verbatim copy, then PROVE it detects drift)
+
+**Files:**
+- Create: `packages/mcp-server/src/__tests__/text/capture-parser-parity.test.ts`
+
+- [ ] **Step 4.1: Create the test file**
+
+Write `packages/mcp-server/src/__tests__/text/capture-parser-parity.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import {
+  extractUrlsFromTitle as mcpExtract,
+  buildDescription as mcpBuild,
+} from '../../text/capture-parser.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../../../..');
+const CANONICAL_PATH = resolve(REPO_ROOT, 'lib/capture-parser.ts');
+const MIRROR_PATH = resolve(__dirname, '../../text/capture-parser.ts');
+
+interface Fixture {
+  name: string;
+  input: string;
+  expected: { cleanTitle: string; urls: string[] };
+}
+
+const FIXTURES: Fixture[] = [
+  {
+    name: 'single url in title',
+    input: 'Read https://example.com later',
+    expected: { cleanTitle: 'Read later', urls: ['https://example.com/'] },
+  },
+  {
+    name: 'multiple urls',
+    input: 'See https://a.test and https://b.test',
+    expected: { cleanTitle: 'See and', urls: ['https://a.test/', 'https://b.test/'] },
+  },
+  {
+    name: 'url-only title falls back',
+    input: 'https://example.com',
+    expected: { cleanTitle: 'Review link below', urls: ['https://example.com/'] },
+  },
+  {
+    name: 'trailing punctuation stripped',
+    input: 'Check https://example.com.',
+    expected: { cleanTitle: 'Check', urls: ['https://example.com/'] },
+  },
+  {
+    name: 'javascript protocol url left in place',
+    input: 'Bad javascript:alert(1) link',
+    expected: { cleanTitle: 'Bad javascript:alert(1) link', urls: [] },
+  },
+  {
+    name: 'data protocol url left in place',
+    input: 'data:text/html,<script>',
+    expected: { cleanTitle: 'data:text/html,<script>', urls: [] },
+  },
+  {
+    name: 'credentialed url left in place',
+    input: 'Login https://user:pass@example.com',
+    expected: { cleanTitle: 'Login https://user:pass@example.com', urls: [] },
+  },
+  {
+    name: 'no url passthrough',
+    input: 'just a regular task',
+    expected: { cleanTitle: 'just a regular task', urls: [] },
+  },
+  {
+    name: 'empty string',
+    input: '',
+    expected: { cleanTitle: '', urls: [] },
+  },
+  {
+    name: 'oversized url rejected',
+    input: `huge https://example.com/${'a'.repeat(2050)}`,
+    expected: {
+      cleanTitle: `huge https://example.com/${'a'.repeat(2050)}`,
+      urls: [],
+    },
+  },
+];
+
+describe('capture-parser parity: behavior', () => {
+  for (const fixture of FIXTURES) {
+    it(`mcp mirror produces expected output for: ${fixture.name}`, () => {
+      const result = mcpExtract(fixture.input);
+      expect(result).toEqual(fixture.expected);
+    });
+  }
+
+  it('mcp buildDescription empty urls returns existing unchanged', () => {
+    expect(mcpBuild('Notes', [])).toBe('Notes');
+  });
+
+  it('mcp buildDescription empty existing returns urls joined', () => {
+    expect(mcpBuild('', ['https://a.test/', 'https://b.test/'])).toBe(
+      'https://a.test/\nhttps://b.test/'
+    );
+  });
+
+  it('mcp buildDescription appends urls below trimmed existing', () => {
+    expect(mcpBuild('  Plan trip  ', ['https://a.test/'])).toBe('Plan trip\nhttps://a.test/');
+  });
+});
+
+/**
+ * Extracts the body of a top-level named function declaration from TS source.
+ * Handles single-line and multi-line bodies. Whitespace inside the body is
+ * collapsed to single spaces for comparison.
+ */
+function extractFunctionBody(source: string, name: string): string {
+  // Match `export function name(...)` or `function name(...)` followed by an opening brace.
+  const signature = new RegExp(`function\\s+${name}\\s*\\([^)]*\\)\\s*(?::[^{]+)?\\{`);
+  const match = source.match(signature);
+  if (!match || match.index === undefined) {
+    throw new Error(`Function "${name}" not found in source`);
+  }
+  const start = match.index + match[0].length;
+  let depth = 1;
+  let i = start;
+  while (i < source.length && depth > 0) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') depth--;
+    i++;
+  }
+  if (depth !== 0) {
+    throw new Error(`Unbalanced braces while reading body of "${name}"`);
+  }
+  // body is between `start` and `i - 1` (i is now one past the closing brace).
+  return source.slice(start, i - 1).replace(/\s+/g, ' ').trim();
+}
+
+describe('capture-parser parity: source text', () => {
+  const canonical = readFileSync(CANONICAL_PATH, 'utf8');
+  const mirror = readFileSync(MIRROR_PATH, 'utf8');
+
+  it('extractUrlsFromTitle body matches canonical', () => {
+    expect(extractFunctionBody(mirror, 'extractUrlsFromTitle')).toBe(
+      extractFunctionBody(canonical, 'extractUrlsFromTitle')
+    );
+  });
+
+  it('buildDescription body matches canonical', () => {
+    expect(extractFunctionBody(mirror, 'buildDescription')).toBe(
+      extractFunctionBody(canonical, 'buildDescription')
+    );
+  });
+
+  it('sanitizeTitleUrl body matches canonical', () => {
+    expect(extractFunctionBody(mirror, 'sanitizeTitleUrl')).toBe(
+      extractFunctionBody(canonical, 'sanitizeTitleUrl')
+    );
+  });
+});
+```
+
+- [ ] **Step 4.2: Run the parity test, confirm all assertions pass**
+
+Run:
+```bash
+cd packages/mcp-server && npm run test -- capture-parser-parity && cd -
+```
+Expected: all behavioral fixtures + 3 source-text assertions pass. If a behavioral fixture fails, the mirror file in Task 3 has a bug — fix the mirror, not the test fixture.
+
+- [ ] **Step 4.3: Drift detection sanity check (manual, do NOT commit the edit)**
+
+Temporarily edit the mirror's `extractUrlsFromTitle` — change `const urls: string[] = [];` to `const urls: string[] = []; // drift`. Re-run:
+
+```bash
+cd packages/mcp-server && npm run test -- capture-parser-parity && cd -
+```
+Expected: the `extractUrlsFromTitle body matches canonical` assertion FAILS. Revert the change and re-run; expected: green again.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add packages/mcp-server/src/__tests__/text/capture-parser-parity.test.ts
+git commit -m "test(mcp): add behavioral + source parity tests for vendored capture-parser"
+```
+
+---
+
+## Task 5: Wire `extractUrlsFromTitle` + `buildDescription` into MCP `createTask` (TDD)
+
+**Files:**
+- Create: `packages/mcp-server/src/__tests__/write-ops/task-operations-create.test.ts`
+- Modify: `packages/mcp-server/src/write-ops/task-operations.ts` (imports + `createTask` body around lines 35-93)
+
+- [ ] **Step 5.1: Write the failing tests**
+
+Create `packages/mcp-server/src/__tests__/write-ops/task-operations-create.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { GsdConfig } from '../../types.js';
+
+// Mock the helpers so we never touch real PocketBase.
+vi.mock('../../write-ops/helpers.js', async () => {
+  const actual = await vi.importActual<typeof import('../../write-ops/helpers.js')>(
+    '../../write-ops/helpers.js'
+  );
+  return {
+    ...actual,
+    createTaskInPB: vi.fn().mockResolvedValue(undefined),
+    getAuthInfo: vi.fn().mockResolvedValue({ ownerId: 'owner-1', deviceId: 'device-1' }),
+  };
+});
+
+vi.mock('../../tools/list-tasks.js', () => ({
+  listTasks: vi.fn().mockResolvedValue([]),
+}));
+
+import { createTask } from '../../write-ops/task-operations.js';
+
+const config: GsdConfig = {
+  pocketbaseUrl: 'http://example.invalid',
+  authToken: 'fake',
+} as GsdConfig;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createTask URL extraction', () => {
+  it('extracts a single url from the title into the description', async () => {
+    const result = await createTask(config, {
+      title: 'Read https://example.com later',
+      urgent: false,
+      important: false,
+      dryRun: true,
+    });
+
+    expect(result.task.title).toBe('Read later');
+    expect(result.task.description).toBe('https://example.com/');
+  });
+
+  it('uses the fallback title when the title is url-only', async () => {
+    const result = await createTask(config, {
+      title: 'https://example.com',
+      urgent: false,
+      important: false,
+      dryRun: true,
+    });
+
+    expect(result.task.title).toBe('Review link below');
+    expect(result.task.description).toBe('https://example.com/');
+  });
+
+  it('appends the url below an existing description', async () => {
+    const result = await createTask(config, {
+      title: 'Read https://example.com later',
+      description: 'Notes here',
+      urgent: false,
+      important: false,
+      dryRun: true,
+    });
+
+    expect(result.task.title).toBe('Read later');
+    expect(result.task.description).toBe('Notes here\nhttps://example.com/');
+  });
+
+  it('does not extract javascript protocol urls', async () => {
+    const result = await createTask(config, {
+      title: 'Bad javascript:alert(1) link',
+      urgent: false,
+      important: false,
+      dryRun: true,
+    });
+
+    expect(result.task.title).toBe('Bad javascript:alert(1) link');
+    expect(result.task.description).toBe('');
+  });
+
+  it('leaves a no-url title unchanged', async () => {
+    const result = await createTask(config, {
+      title: 'Plain task',
+      description: 'Some notes',
+      urgent: true,
+      important: true,
+      dryRun: true,
+    });
+
+    expect(result.task.title).toBe('Plain task');
+    expect(result.task.description).toBe('Some notes');
+    expect(result.task.urgent).toBe(true);
+    expect(result.task.important).toBe(true);
+  });
+
+  it('returns the transformed task on dry run without persisting', async () => {
+    const helpers = await import('../../write-ops/helpers.js');
+    const result = await createTask(config, {
+      title: 'Read https://example.com later',
+      urgent: false,
+      important: false,
+      dryRun: true,
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.task.title).toBe('Read later');
+    expect(helpers.createTaskInPB).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 5.2: Run the tests, confirm they fail**
+
+Run:
+```bash
+cd packages/mcp-server && npm run test -- task-operations-create && cd -
+```
+Expected: tests fail. The first assertion fails with `expected 'Read https://example.com later' to be 'Read later'` — `createTask` is not extracting URLs yet.
+
+- [ ] **Step 5.3: Wire extraction into `createTask`**
+
+Edit `packages/mcp-server/src/write-ops/task-operations.ts`.
+
+After the existing import block (around line 22, after the `dependencies` import), add:
+
+```typescript
+import { extractUrlsFromTitle, buildDescription } from '../text/capture-parser.js';
+```
+
+Inside `createTask` (currently lines 35-111), insert the extraction call right after the `allTasks` line. Change this block:
+
+```typescript
+export async function createTask(
+  config: GsdConfig,
+  input: CreateTaskInput
+): Promise<CreateTaskResult> {
+  const warnings: string[] = [];
+  const allTasks = input.dependencies?.length ? await listTasks(config) : [];
+```
+
+to:
+
+```typescript
+export async function createTask(
+  config: GsdConfig,
+  input: CreateTaskInput
+): Promise<CreateTaskResult> {
+  const warnings: string[] = [];
+  const allTasks = input.dependencies?.length ? await listTasks(config) : [];
+
+  // Mirror the webapp capture flow: pull http(s) URLs out of the title and
+  // append them to the description. See lib/capture-parser.ts (canonical) and
+  // packages/mcp-server/src/text/capture-parser.ts (vendored mirror).
+  const { cleanTitle, urls } = extractUrlsFromTitle(input.title);
+  const mergedDescription = buildDescription(input.description ?? '', urls);
+```
+
+Then, in the same function, replace the `newTask` literal. Change this:
+
+```typescript
+  const newTask: Task = {
+    id: taskId,
+    title: input.title,
+    description: input.description || '',
+```
+
+to:
+
+```typescript
+  const newTask: Task = {
+    id: taskId,
+    title: cleanTitle,
+    description: mergedDescription,
+```
+
+Leave the rest of `createTask` (and all of `updateTask`, `completeTask`, `deleteTask`) untouched.
+
+- [ ] **Step 5.4: Run the new tests, confirm they pass**
+
+Run:
+```bash
+cd packages/mcp-server && npm run test -- task-operations-create && cd -
+```
+Expected: all 6 tests pass.
+
+- [ ] **Step 5.5: Run the full MCP suite**
+
+Run:
+```bash
+cd packages/mcp-server && npm run test && cd -
+```
+Expected: full suite green (existing tests + new parity test + new create test).
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add packages/mcp-server/src/write-ops/task-operations.ts packages/mcp-server/src/__tests__/write-ops/task-operations-create.test.ts
+git commit -m "feat(mcp): apply URL extraction in create_task to match webapp"
+```
+
+---
+
+## Task 6: Full verification + version bump
+
+**Files:**
+- Modify: `package.json` (root version bump — patch)
+- Modify: `packages/mcp-server/package.json` (MCP version bump — minor, since MCP gains a behavioral change)
+
+- [ ] **Step 6.1: Run the full test suite (root)**
+
+Run:
+```bash
+bun run test
+```
+Expected: all tests green.
+
+- [ ] **Step 6.2: Run typecheck (root)**
+
+Run:
+```bash
+bun typecheck
+```
+Expected: no errors.
+
+- [ ] **Step 6.3: Run lint (root)**
+
+Run:
+```bash
+bun lint
+```
+Expected: clean.
+
+- [ ] **Step 6.4: Run the full MCP test suite + typecheck**
+
+Run:
+```bash
+cd packages/mcp-server && npm run test && npx tsc --noEmit && cd -
+```
+Expected: green + clean.
+
+- [ ] **Step 6.5: Bump versions**
+
+Read root `package.json` to find the current version, then bump the patch number (e.g. `1.4.2` → `1.4.3`).
+
+Read `packages/mcp-server/package.json` (currently `1.0.0`) and bump the minor number (e.g. `1.0.0` → `1.1.0`) since MCP `create_task` gains observable new behavior.
+
+- [ ] **Step 6.6: Commit the bumps**
+
+```bash
+git add package.json packages/mcp-server/package.json
+git commit -m "chore: bump versions for MCP URL extraction parity"
+```
+
+---
+
+## Task 7: Branch, push, PR
+
+- [ ] **Step 7.1: Confirm we're on a feature branch (not `main`)**
+
+Run:
+```bash
+git status -sb
+```
+
+If currently on `main`, create a branch and move the new commits to it:
+
+```bash
+git switch -c feat/mcp-url-extraction-parity
+```
+
+(If a worktree was created up-front by the brainstorming flow, you should already be on a feature branch — skip this step.)
+
+- [ ] **Step 7.2: Push the branch**
+
+```bash
+git push -u origin feat/mcp-url-extraction-parity
+```
+
+- [ ] **Step 7.3: Open the PR**
+
+```bash
+gh pr create --title "feat(mcp): URL extraction parity with webapp capture flow" --body "$(cat <<'EOF'
+## Summary
+- Vendor `extractUrlsFromTitle` + `buildDescription` from `lib/capture-parser.ts` into the MCP server at `packages/mcp-server/src/text/capture-parser.ts`
+- Wire MCP `create_task` to apply the same URL-extraction the webapp's capture-bar / create-drawer applies (title to description merge, URL-only fallback, XSS-safe sanitizer)
+- Add a parity test (`__tests__/text/capture-parser-parity.test.ts`) that asserts both behavioral and source-text equivalence between the canonical webapp module and the vendored mirror, so drift fails CI
+- Promote `buildDescription` out of `components/matrix-simplified/index.tsx` into the canonical module so both consumers share one implementation
+
+`update_task` is intentionally unchanged — mirrors the webapp, which only extracts on creation.
+
+## Spec
+`docs/superpowers/specs/2026-05-02-mcp-url-extraction-parity-design.md`
+
+## Test plan
+- [ ] `bun run test` passes (root)
+- [ ] `bun typecheck` clean
+- [ ] `bun lint` clean
+- [ ] `npm run test` passes inside `packages/mcp-server/`
+- [ ] `npx tsc --noEmit` clean inside `packages/mcp-server/`
+- [ ] Manual: invoke MCP `create_task` with `{ title: "Read https://example.com later" }`; resulting task in webapp shows title `"Read later"` and description containing `https://example.com/`
+- [ ] Manual: invoke MCP `update_task` with a URL in the title; URL stays in the title (parity confirmed)
+- [ ] Drift sanity check: temporarily edit the mirror, confirm parity test fails, revert
+EOF
+)"
+```
+
+Expected: a PR URL is printed. Report it back.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- AC #1 (single URL extracted) → Task 5 Step 5.1 first test + Task 4 fixture `single url in title`. Covered.
+- AC #2 (URL-only fallback) → Task 5 Step 5.1 second test + Task 4 fixture `url-only title falls back`. Covered.
+- AC #3 (no-URL passthrough) → Task 5 Step 5.1 fifth test + Task 4 fixture `no url passthrough`. Covered.
+- AC #4 (`javascript:` / `data:` rejected) → Task 5 Step 5.1 fourth test + Task 4 fixtures for both. Covered.
+- AC #5 (existing description preserved, URLs appended) → Task 5 Step 5.1 third test + Task 1 Step 1.1 test 4. Covered.
+- AC #6 (`dryRun` returns transformed task) → Task 5 Step 5.1 sixth test. Covered.
+- AC #7 (`update_task` unchanged) → Task 5 explicitly leaves `updateTask` untouched; PR description calls this out. No regression test for "doesn't extract on update", but it's implicit in the unchanged code path. Acceptable.
+- AC #8 (webapp paths unchanged) → Task 2 Step 2.3 runs full webapp suite; Task 6 reruns it. Covered.
+- AC #9 (drift causes test failure) → Task 4 Step 4.3 manual drift sanity check; CI runs Task 4's test on every push. Covered.
+
+**Placeholder scan:** Searched for "TBD", "TODO", "fill in", "appropriate". None present. Every code/edit step shows the actual code or the actual lines being changed.
+
+**Type consistency:** `extractUrlsFromTitle` returns `{ cleanTitle, urls }` consistently across the canonical module, the mirror, the parity test fixtures, and the `createTask` consumer. `buildDescription(existing: string, urls: string[]): string` — same signature in canonical and mirror. `CreateTaskInput.title: string` and `CreateTaskInput.description?: string` are unchanged from `packages/mcp-server/src/write-ops/types.ts`.
+
+**Gap fix:** None required. Plan is complete.

--- a/docs/superpowers/specs/2026-05-02-mcp-url-extraction-parity-design.md
+++ b/docs/superpowers/specs/2026-05-02-mcp-url-extraction-parity-design.md
@@ -1,0 +1,119 @@
+# MCP URL Extraction Parity — Design Spec
+
+- **Date:** 2026-05-02
+- **Status:** Proposed
+- **Author:** Vinny Carpenter (with Claude)
+- **Related:** PR #253 (`feat(capture): extract URLs from task title into description field`), commit `db31a1f`
+
+## Goal
+
+Make MCP `create_task` apply the same URL-extraction behavior the webapp's capture-bar / create-drawer applies, so a task created via Claude Desktop with a URL in its title is normalized identically to one created in the UI.
+
+## Background
+
+PR #253 added `extractUrlsFromTitle()` to `lib/capture-parser.ts` and wired it into all three webapp creation paths:
+1. Quick-capture Enter (`components/matrix-simplified/index.tsx:120-137`)
+2. Full create-drawer submit (`index.tsx:189-215`)
+3. Drawer pre-fill from capture-bar "more options" (`index.tsx:168-182`)
+
+The MCP server (`packages/mcp-server/src/write-ops/task-operations.ts`, `createTask`) was not updated and writes `input.title` to PocketBase as-is. This produces inconsistent task shapes depending on which client created the task.
+
+## Constraint that shapes the solution
+
+The MCP package builds with plain `tsc` and is published as a standalone npm package (`gsd-mcp-server`). Its `tsconfig.json` sets `rootDir: "./src"`, which prevents importing webapp `lib/` files directly. Switching MCP to a bundler (tsup/esbuild) to inline a workspace dep was considered (Approach B in brainstorming) and rejected — adding bundler infra for ~50 lines of pure code violates "boring tech" / YAGNI for the current scope.
+
+**Chosen approach: vendor the module with a parity test.** A copy lives in `packages/mcp-server/src/text/capture-parser.ts`. A test asserts behavioral and source-text parity with the canonical `lib/capture-parser.ts` so any drift fails CI.
+
+## Inputs / Outputs
+
+### MCP `create_task` (changed behavior)
+
+| Field | Before | After |
+| --- | --- | --- |
+| `input.title` | written to PB as-is | passed through `extractUrlsFromTitle`; `cleanTitle` is what gets stored |
+| `input.description` | written to PB as-is | merged with extracted URLs via `buildDescription(input.description ?? '', urls)` |
+| All other fields | unchanged | unchanged |
+
+### MCP `update_task` and `bulk_update_tasks`
+
+Unchanged. The webapp does NOT apply extraction on updates; we mirror that exactly.
+
+## Acceptance Criteria
+
+1. Calling MCP `create_task` with `{ title: "Read https://example.com later" }` produces a task with `title === "Read later"` and `description === "https://example.com/"`.
+2. Calling MCP `create_task` with `{ title: "https://example.com" }` (URL-only title) produces `title === "Review link below"` and `description === "https://example.com/"`.
+3. Calling MCP `create_task` with `{ title: "Plan trip", description: "Notes here" }` produces an unchanged title and an unchanged description.
+4. Calling MCP `create_task` with a `javascript:` or `data:` URL in the title leaves the URL in the title (sanitizer rejects) and does NOT add it to the description.
+5. Calling MCP `create_task` with both an existing description AND a URL in the title produces a description with the existing text on the first line(s) and the extracted URL(s) appended below, separated by `\n`.
+6. Calling MCP `create_task` with `dryRun: true` returns the same transformed task shape (no PocketBase write).
+7. Calling MCP `update_task` with a title containing a URL leaves the URL in the title (no extraction).
+8. The webapp's three creation paths (capture-bar, drawer submit, drawer pre-fill) continue to behave exactly as they do today; no UX regression.
+9. Editing only `lib/capture-parser.ts` (or only the MCP mirror) causes the parity test to fail.
+
+## Test Stubs
+
+### Webapp (`tests/data/capture-parser.test.ts`)
+- `buildDescription_returns_existing_when_no_urls`
+- `buildDescription_returns_urls_only_when_existing_is_empty`
+- `buildDescription_appends_urls_below_existing_text_with_newline`
+- `buildDescription_trims_existing_before_appending`
+- `buildDescription_joins_multiple_urls_with_newlines`
+
+### MCP (`packages/mcp-server/src/__tests__/capture-parser-parity.test.ts`)
+- `parity_behavioral_single_url_in_title`
+- `parity_behavioral_multiple_urls`
+- `parity_behavioral_url_only_title_falls_back`
+- `parity_behavioral_trailing_punctuation_stripped`
+- `parity_behavioral_javascript_url_left_in_place`
+- `parity_behavioral_data_url_left_in_place`
+- `parity_behavioral_credentialed_url_left_in_place`
+- `parity_behavioral_no_url_passthrough`
+- `parity_behavioral_empty_title`
+- `parity_behavioral_oversized_url_rejected`
+- `parity_source_text_extractUrlsFromTitle_matches_canonical`
+- `parity_source_text_buildDescription_matches_canonical`
+
+### MCP (`packages/mcp-server/src/__tests__/task-operations-create.test.ts`)
+- `createTask_extracts_url_from_title_into_description`
+- `createTask_url_only_title_uses_fallback`
+- `createTask_appends_url_below_existing_description`
+- `createTask_javascript_url_not_extracted`
+- `createTask_no_url_unchanged`
+- `createTask_dry_run_returns_transformed_task`
+
+## Out of Scope
+
+- Sharing `parseCapture` (`!`/`*`/`#tag` shortcuts). UI-only.
+- Applying extraction to MCP `update_task` or `bulk_update_tasks`.
+- Migrating MCP to a bundler (tsup/esbuild) or creating a `packages/shared-*` workspace.
+- Backfilling extraction for tasks that already exist in PocketBase with URLs in titles.
+- Changing the URL sanitizer rules (allowed protocols, max length, credential rejection).
+- Restoring extraction on the webapp's edit-drawer (Edit a task and add a URL → not extracted today; out of scope).
+
+## Implementation Plan (high level — full plan via writing-plans skill)
+
+1. **Promote `buildDescription` into `lib/capture-parser.ts`.** Move the 6-line helper from `components/matrix-simplified/index.tsx`. Update the import. Verify the three webapp call sites still work via the existing tests + adding tests for the helper.
+2. **Vendor the mirror at `packages/mcp-server/src/text/capture-parser.ts`.** Verbatim copy of the canonical exports + private helpers. Top-of-file `MIRROR OF` comment naming the canonical file and the parity test.
+3. **Wire MCP `createTask`.** Apply `extractUrlsFromTitle` + `buildDescription` at the top of `createTask` before validation. Use `cleanTitle` and the merged description when constructing `newTask`.
+4. **Add the parity test.** Behavioral assertions over the shared fixture array. Source-text comparison via `readFileSync` of both files; normalize whitespace; assert the function bodies of `extractUrlsFromTitle` and `buildDescription` match.
+5. **Add MCP create-tests** for the URL-extraction behavior end-to-end.
+6. **Run the full suite** in both root and `packages/mcp-server/` plus typecheck and lint.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Two source files drift | Source-text parity assertion fails the build. |
+| Source-text comparison is brittle to formatting | Normalize whitespace (collapse runs, trim) before comparing. Compare bodies of named functions, not whole-file text. |
+| MCP create signature changes silently break callers | The transformation happens inside `createTask`; the public `CreateTaskInput` interface is unchanged. |
+| Extraction surprises an LLM that intentionally put a URL in the title | Webapp parity is the explicit goal; if surprising, future ADR can revisit (e.g., add an opt-out flag). |
+| Description merging order | Existing description first, extracted URLs appended — matches `buildDescription(draft.description, urls)` at `components/matrix-simplified/index.tsx:200`. |
+
+## Verification Method
+
+- `bun run test` (root) — must pass; coverage of `lib/capture-parser.ts` stays ≥80%.
+- `npm run test` in `packages/mcp-server/` — must pass; new tests cover parity + create.
+- `bun typecheck` and MCP `tsc --noEmit` — both clean.
+- `bun lint` — clean.
+- Manual smoke via Claude Desktop: invoke `create_task` with a URL-bearing title; verify the resulting task in the webapp matches what the capture-bar would have produced.
+- Drift check: edit one of the two `capture-parser.ts` files (e.g., add a comment inside a function body); confirm the parity test fails.

--- a/lib/capture-parser.ts
+++ b/lib/capture-parser.ts
@@ -64,6 +64,18 @@ export function extractUrlsFromTitle(title: string): ExtractedUrls {
   return { cleanTitle, urls };
 }
 
+/**
+ * Merges extracted URLs into an existing description, separated by newlines.
+ * - If `urls` is empty, returns `existing` unchanged.
+ * - If `existing` is empty/whitespace, returns the URL block alone.
+ * - Otherwise returns `existing.trim() + "\n" + urls.join("\n")`.
+ */
+export function buildDescription(existing: string, urls: string[]): string {
+  if (urls.length === 0) return existing;
+  const urlBlock = urls.join("\n");
+  return existing.trim() ? `${existing.trim()}\n${urlBlock}` : urlBlock;
+}
+
 const TAG_PATTERN = /(^|\s)#([a-z0-9_-]+)/gi;
 const DOUBLE_BANG = /(^|\s)!!(\s|$)/g;
 const SINGLE_BANG = /(^|\s)!(\s|$)/g;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.9.0",
+	"version": "8.9.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-mcp-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "MCP server for GSD Task Manager — 20 tools for task CRUD, analytics, and diagnostics over PocketBase. Validated inputs, dry-run support, JWT-aware token health, and dependency-safe deletes.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/src/__tests__/text/capture-parser-parity.test.ts
+++ b/packages/mcp-server/src/__tests__/text/capture-parser-parity.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import {
+  extractUrlsFromTitle as mcpExtract,
+  buildDescription as mcpBuild,
+} from '../../text/capture-parser.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../../../..');
+const CANONICAL_PATH = resolve(REPO_ROOT, 'lib/capture-parser.ts');
+const MIRROR_PATH = resolve(__dirname, '../../text/capture-parser.ts');
+
+interface Fixture {
+  name: string;
+  input: string;
+  expected: { cleanTitle: string; urls: string[] };
+}
+
+const FIXTURES: Fixture[] = [
+  {
+    name: 'single url in title',
+    input: 'Read https://example.com later',
+    expected: { cleanTitle: 'Read later', urls: ['https://example.com/'] },
+  },
+  {
+    name: 'multiple urls',
+    input: 'See https://a.test and https://b.test',
+    expected: { cleanTitle: 'See and', urls: ['https://a.test/', 'https://b.test/'] },
+  },
+  {
+    name: 'url-only title falls back',
+    input: 'https://example.com',
+    expected: { cleanTitle: 'Review link below', urls: ['https://example.com/'] },
+  },
+  {
+    name: 'trailing punctuation stripped',
+    input: 'Check https://example.com.',
+    expected: { cleanTitle: 'Check', urls: ['https://example.com/'] },
+  },
+  {
+    name: 'javascript protocol url left in place',
+    input: 'Bad javascript:alert(1) link',
+    expected: { cleanTitle: 'Bad javascript:alert(1) link', urls: [] },
+  },
+  {
+    name: 'data protocol url left in place',
+    input: 'data:text/html,<script>',
+    expected: { cleanTitle: 'data:text/html,<script>', urls: [] },
+  },
+  {
+    name: 'credentialed url left in place',
+    input: 'Login https://user:pass@example.com',
+    expected: { cleanTitle: 'Login https://user:pass@example.com', urls: [] },
+  },
+  {
+    name: 'no url passthrough',
+    input: 'just a regular task',
+    expected: { cleanTitle: 'just a regular task', urls: [] },
+  },
+  {
+    name: 'empty string',
+    input: '',
+    expected: { cleanTitle: '', urls: [] },
+  },
+  {
+    name: 'oversized url rejected',
+    input: `huge https://example.com/${'a'.repeat(2050)}`,
+    expected: {
+      cleanTitle: `huge https://example.com/${'a'.repeat(2050)}`,
+      urls: [],
+    },
+  },
+];
+
+describe('capture-parser parity: behavior', () => {
+  for (const fixture of FIXTURES) {
+    it(`mcp mirror produces expected output for: ${fixture.name}`, () => {
+      const result = mcpExtract(fixture.input);
+      expect(result).toEqual(fixture.expected);
+    });
+  }
+
+  it('mcp buildDescription empty urls returns existing unchanged', () => {
+    expect(mcpBuild('Notes', [])).toBe('Notes');
+  });
+
+  it('mcp buildDescription empty existing returns urls joined', () => {
+    expect(mcpBuild('', ['https://a.test/', 'https://b.test/'])).toBe(
+      'https://a.test/\nhttps://b.test/'
+    );
+  });
+
+  it('mcp buildDescription appends urls below trimmed existing', () => {
+    expect(mcpBuild('  Plan trip  ', ['https://a.test/'])).toBe('Plan trip\nhttps://a.test/');
+  });
+});
+
+/**
+ * Extracts the body of a top-level named function declaration from TS source.
+ * Handles single-line and multi-line bodies. Whitespace inside the body is
+ * collapsed to single spaces for comparison.
+ */
+function extractFunctionBody(source: string, name: string): string {
+  // Match `export function name(...)` or `function name(...)` followed by an opening brace.
+  const signature = new RegExp(`function\\s+${name}\\s*\\([^)]*\\)\\s*(?::[^{]+)?\\{`);
+  const match = source.match(signature);
+  if (!match || match.index === undefined) {
+    throw new Error(`Function "${name}" not found in source`);
+  }
+  const start = match.index + match[0].length;
+  let depth = 1;
+  let i = start;
+  while (i < source.length && depth > 0) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') depth--;
+    i++;
+  }
+  if (depth !== 0) {
+    throw new Error(`Unbalanced braces while reading body of "${name}"`);
+  }
+  // body is between `start` and `i - 1` (i is now one past the closing brace).
+  return source.slice(start, i - 1).replace(/\s+/g, ' ').trim();
+}
+
+describe('capture-parser parity: source text', () => {
+  const canonical = readFileSync(CANONICAL_PATH, 'utf8');
+  const mirror = readFileSync(MIRROR_PATH, 'utf8');
+
+  it('extractUrlsFromTitle body matches canonical', () => {
+    expect(extractFunctionBody(mirror, 'extractUrlsFromTitle')).toBe(
+      extractFunctionBody(canonical, 'extractUrlsFromTitle')
+    );
+  });
+
+  it('buildDescription body matches canonical', () => {
+    expect(extractFunctionBody(mirror, 'buildDescription')).toBe(
+      extractFunctionBody(canonical, 'buildDescription')
+    );
+  });
+
+  it('sanitizeTitleUrl body matches canonical', () => {
+    expect(extractFunctionBody(mirror, 'sanitizeTitleUrl')).toBe(
+      extractFunctionBody(canonical, 'sanitizeTitleUrl')
+    );
+  });
+});

--- a/packages/mcp-server/src/__tests__/text/capture-parser-parity.test.ts
+++ b/packages/mcp-server/src/__tests__/text/capture-parser-parity.test.ts
@@ -99,8 +99,19 @@ describe('capture-parser parity: behavior', () => {
 
 /**
  * Extracts the body of a top-level named function declaration from TS source.
- * Handles single-line and multi-line bodies. Whitespace inside the body is
- * collapsed to single spaces for comparison.
+ * Whitespace inside the body is collapsed to single spaces for comparison.
+ *
+ * Assumptions (violating either silently produces wrong output):
+ *  1. Return type is a named alias (e.g. `: ExtractedUrls`), not an inline object
+ *     literal (`: { foo: string }`). Inline literals contain `{` which the signature
+ *     regex would match instead of the function body's opening brace.
+ *  2. The function body contains no string/regex literal with unbalanced `{` or `}`
+ *     (e.g. `/\d{1,3}/`). The brace counter is naive and would miscount.
+ *
+ * Today's three protected functions (sanitizeTitleUrl, extractUrlsFromTitle,
+ * buildDescription) satisfy both. The constants block — which contains
+ * `TITLE_URL_PATTERN`'s `[ ... {} ... ]` characters — lives at module scope
+ * and is never scanned by this helper.
  */
 function extractFunctionBody(source: string, name: string): string {
   // Match `export function name(...)` or `function name(...)` followed by an opening brace.
@@ -125,9 +136,34 @@ function extractFunctionBody(source: string, name: string): string {
   return source.slice(start, i - 1).replace(/\s+/g, ' ').trim();
 }
 
+/**
+ * Extracts the module-level constants block from TS source — from the line
+ * containing `const FALLBACK_TITLE_FOR_URL_ONLY` through the end of the line
+ * containing `const ALLOWED_PROTOCOLS`. Whitespace is collapsed for comparison.
+ *
+ * Throws if either anchor is not found, so drift in constant names surfaces
+ * immediately rather than silently passing an empty comparison.
+ */
+function extractConstantsBlock(source: string): string {
+  const startAnchor = 'const FALLBACK_TITLE_FOR_URL_ONLY';
+  const endAnchor = 'const ALLOWED_PROTOCOLS';
+  const start = source.indexOf(startAnchor);
+  if (start === -1) throw new Error(`Anchor not found: ${startAnchor}`);
+  const endLineStart = source.indexOf(endAnchor, start);
+  if (endLineStart === -1) throw new Error(`Anchor not found: ${endAnchor}`);
+  // include the rest of that line up to the next newline
+  const endLineEnd = source.indexOf('\n', endLineStart);
+  const block = source.slice(start, endLineEnd === -1 ? source.length : endLineEnd);
+  return block.replace(/\s+/g, ' ').trim();
+}
+
 describe('capture-parser parity: source text', () => {
   const canonical = readFileSync(CANONICAL_PATH, 'utf8');
   const mirror = readFileSync(MIRROR_PATH, 'utf8');
+
+  it('constants block matches canonical', () => {
+    expect(extractConstantsBlock(mirror)).toBe(extractConstantsBlock(canonical));
+  });
 
   it('extractUrlsFromTitle body matches canonical', () => {
     expect(extractFunctionBody(mirror, 'extractUrlsFromTitle')).toBe(

--- a/packages/mcp-server/src/__tests__/write-ops/task-operations-create.test.ts
+++ b/packages/mcp-server/src/__tests__/write-ops/task-operations-create.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { GsdConfig } from '../../types.js';
+import type { GsdConfig, Task } from '../../types.js';
 
 // Mock the helpers so we never touch real PocketBase.
 vi.mock('../../write-ops/helpers.js', async () => {
@@ -17,7 +17,7 @@ vi.mock('../../tools/list-tasks.js', () => ({
   listTasks: vi.fn().mockResolvedValue([]),
 }));
 
-import { createTask } from '../../write-ops/task-operations.js';
+import { createTask, updateTask } from '../../write-ops/task-operations.js';
 
 const config: GsdConfig = {
   pocketbaseUrl: 'http://example.invalid',
@@ -105,5 +105,39 @@ describe('createTask URL extraction', () => {
     expect(result.dryRun).toBe(true);
     expect(result.task.title).toBe('Read later');
     expect(helpers.createTaskInPB).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateTask URL parity', () => {
+  it('does NOT extract URLs from title (mirrors webapp non-extraction on edit)', async () => {
+    const { listTasks } = await import('../../tools/list-tasks.js');
+
+    const seedTask: Task = {
+      id: 'task-1',
+      title: 'Original',
+      description: 'Original description',
+      urgent: false,
+      important: false,
+      quadrant: 'not-urgent-not-important',
+      completed: false,
+      tags: [],
+      subtasks: [],
+      recurrence: 'none',
+      dependencies: [],
+      createdAt: '2026-04-01T00:00:00Z',
+      updatedAt: '2026-04-01T00:00:00Z',
+    };
+    vi.mocked(listTasks).mockResolvedValueOnce([seedTask]);
+
+    const result = await updateTask(config, {
+      id: 'task-1',
+      title: 'Read https://example.com later',
+      dryRun: true,
+    });
+
+    // URL must remain in the title — updateTask intentionally skips extraction
+    expect(result.task.title).toBe('Read https://example.com later');
+    // Description must not be modified by URL extraction
+    expect(result.task.description).toBe('Original description');
   });
 });

--- a/packages/mcp-server/src/__tests__/write-ops/task-operations-create.test.ts
+++ b/packages/mcp-server/src/__tests__/write-ops/task-operations-create.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { GsdConfig } from '../../types.js';
+
+// Mock the helpers so we never touch real PocketBase.
+vi.mock('../../write-ops/helpers.js', async () => {
+  const actual = await vi.importActual<typeof import('../../write-ops/helpers.js')>(
+    '../../write-ops/helpers.js'
+  );
+  return {
+    ...actual,
+    createTaskInPB: vi.fn().mockResolvedValue(undefined),
+    getAuthInfo: vi.fn().mockResolvedValue({ ownerId: 'owner-1', deviceId: 'device-1' }),
+  };
+});
+
+vi.mock('../../tools/list-tasks.js', () => ({
+  listTasks: vi.fn().mockResolvedValue([]),
+}));
+
+import { createTask } from '../../write-ops/task-operations.js';
+
+const config: GsdConfig = {
+  pocketbaseUrl: 'http://example.invalid',
+  authToken: 'fake',
+} as GsdConfig;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createTask URL extraction', () => {
+  it('extracts a single url from the title into the description', async () => {
+    const result = await createTask(config, {
+      title: 'Read https://example.com later',
+      urgent: false,
+      important: false,
+      dryRun: true,
+    });
+
+    expect(result.task.title).toBe('Read later');
+    expect(result.task.description).toBe('https://example.com/');
+  });
+
+  it('uses the fallback title when the title is url-only', async () => {
+    const result = await createTask(config, {
+      title: 'https://example.com',
+      urgent: false,
+      important: false,
+      dryRun: true,
+    });
+
+    expect(result.task.title).toBe('Review link below');
+    expect(result.task.description).toBe('https://example.com/');
+  });
+
+  it('appends the url below an existing description', async () => {
+    const result = await createTask(config, {
+      title: 'Read https://example.com later',
+      description: 'Notes here',
+      urgent: false,
+      important: false,
+      dryRun: true,
+    });
+
+    expect(result.task.title).toBe('Read later');
+    expect(result.task.description).toBe('Notes here\nhttps://example.com/');
+  });
+
+  it('does not extract javascript protocol urls', async () => {
+    const result = await createTask(config, {
+      title: 'Bad javascript:alert(1) link',
+      urgent: false,
+      important: false,
+      dryRun: true,
+    });
+
+    expect(result.task.title).toBe('Bad javascript:alert(1) link');
+    expect(result.task.description).toBe('');
+  });
+
+  it('leaves a no-url title unchanged', async () => {
+    const result = await createTask(config, {
+      title: 'Plain task',
+      description: 'Some notes',
+      urgent: true,
+      important: true,
+      dryRun: true,
+    });
+
+    expect(result.task.title).toBe('Plain task');
+    expect(result.task.description).toBe('Some notes');
+    expect(result.task.urgent).toBe(true);
+    expect(result.task.important).toBe(true);
+  });
+
+  it('returns the transformed task on dry run without persisting', async () => {
+    const helpers = await import('../../write-ops/helpers.js');
+    const result = await createTask(config, {
+      title: 'Read https://example.com later',
+      urgent: false,
+      important: false,
+      dryRun: true,
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.task.title).toBe('Read later');
+    expect(helpers.createTaskInPB).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mcp-server/src/text/capture-parser.ts
+++ b/packages/mcp-server/src/text/capture-parser.ts
@@ -1,0 +1,80 @@
+// MIRROR OF lib/capture-parser.ts (extractUrlsFromTitle + buildDescription only).
+// Keep this file in sync with the canonical webapp module. Drift is detected by
+// packages/mcp-server/src/__tests__/text/capture-parser-parity.test.ts.
+//
+// The MCP server is published as a standalone npm package built with plain `tsc`.
+// It cannot import from the webapp's lib/ tree because tsconfig.rootDir = "./src".
+// Vendoring + parity test was chosen over introducing a bundler or a separate
+// shared workspace package — see
+// docs/superpowers/specs/2026-05-02-mcp-url-extraction-parity-design.md.
+
+export interface ExtractedUrls {
+  cleanTitle: string;
+  urls: string[];
+}
+
+const FALLBACK_TITLE_FOR_URL_ONLY = "Review link below";
+
+// Matches http/https URLs; reuses the same pattern as lib/task-links.ts
+const TITLE_URL_PATTERN = /\bhttps?:\/\/[^\s<>"'`{}|\\^]+/giu;
+const TRAILING_PUNCTUATION = /[),.!?;:]+$/u;
+const MAX_URL_LENGTH = 2048;
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+function sanitizeTitleUrl(candidate: string): string | null {
+  const value = candidate.trim();
+  if (value.length === 0 || value.length > MAX_URL_LENGTH || /[\u0000-\u001F\u007F\s]/u.test(value)) {
+    return null;
+  }
+  try {
+    const url = new URL(value);
+    if (!ALLOWED_PROTOCOLS.has(url.protocol.toLowerCase())) return null;
+    if (!url.hostname || url.username || url.password) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Scans `title` for http/https URLs, removes them, and returns the sanitized
+ * URL list alongside the cleaned title text.
+ *
+ * Rules:
+ * - All valid URLs are extracted and sanitized (XSS-safe: http/https only, no credentials).
+ * - Invalid or unsafe URL candidates are left in the title unchanged.
+ * - If the title collapses to empty after extraction, `cleanTitle` is set to
+ *   FALLBACK_TITLE_FOR_URL_ONLY ("Review link below").
+ */
+export function extractUrlsFromTitle(title: string): ExtractedUrls {
+  const urls: string[] = [];
+  let working = title;
+
+  // We build the cleaned title by iterating matches and replacing valid URLs.
+  // Using a replacer lets us handle invalid candidates gracefully (leave them in place).
+  working = working.replace(TITLE_URL_PATTERN, (raw) => {
+    const trimmed = raw.replace(TRAILING_PUNCTUATION, "");
+    const safe = sanitizeTitleUrl(trimmed);
+    if (!safe) return raw; // leave invalid/unsafe candidates untouched
+    urls.push(safe);
+    // Trailing punctuation (e.g. a period at the end of a sentence) is dropped
+    // along with the URL — it was sentence-level punctuation around the link.
+    return "";
+  });
+
+  const cleanTitle = working.replace(/\s+/g, " ").trim() || (urls.length > 0 ? FALLBACK_TITLE_FOR_URL_ONLY : "");
+
+  return { cleanTitle, urls };
+}
+
+/**
+ * Merges extracted URLs into an existing description, separated by newlines.
+ * - If `urls` is empty, returns `existing` unchanged.
+ * - If `existing` is empty/whitespace, returns the URL block alone.
+ * - Otherwise returns `existing.trim() + "\n" + urls.join("\n")`.
+ */
+export function buildDescription(existing: string, urls: string[]): string {
+  if (urls.length === 0) return existing;
+  const urlBlock = urls.join("\n");
+  return existing.trim() ? `${existing.trim()}\n${urlBlock}` : urlBlock;
+}

--- a/packages/mcp-server/src/write-ops/task-operations.ts
+++ b/packages/mcp-server/src/write-ops/task-operations.ts
@@ -19,6 +19,7 @@ import {
   getAffectedByDeletion,
   formatDependencyError,
 } from '../dependencies.js';
+import { extractUrlsFromTitle, buildDescription } from '../text/capture-parser.js';
 
 /**
  * Create task result with dry-run information
@@ -38,6 +39,12 @@ export async function createTask(
 ): Promise<CreateTaskResult> {
   const warnings: string[] = [];
   const allTasks = input.dependencies?.length ? await listTasks(config) : [];
+
+  // Mirror the webapp capture flow: pull http(s) URLs out of the title and
+  // append them to the description. See lib/capture-parser.ts (canonical) and
+  // packages/mcp-server/src/text/capture-parser.ts (vendored mirror).
+  const { cleanTitle, urls } = extractUrlsFromTitle(input.title);
+  const mergedDescription = buildDescription(input.description ?? '', urls);
 
   // Validate dependencies if provided
   if (input.dependencies && input.dependencies.length > 0) {
@@ -72,8 +79,8 @@ export async function createTask(
 
   const newTask: Task = {
     id: taskId,
-    title: input.title,
-    description: input.description || '',
+    title: cleanTitle,
+    description: mergedDescription,
     urgent: input.urgent,
     important: input.important,
     quadrant,

--- a/tests/data/capture-parser.test.ts
+++ b/tests/data/capture-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseCapture, extractUrlsFromTitle } from "@/lib/capture-parser";
+import { parseCapture, extractUrlsFromTitle, buildDescription } from "@/lib/capture-parser";
 
 describe("parseCapture", () => {
   it("returns plain title with no flags when input has no markers", () => {
@@ -156,5 +156,33 @@ describe("extractUrlsFromTitle", () => {
     const result = extractUrlsFromTitle("Review https://example.com ! #work");
     expect(result.cleanTitle).toBe("Review ! #work");
     expect(result.urls).toEqual(["https://example.com/"]);
+  });
+});
+
+describe("buildDescription", () => {
+  it("returns existing unchanged when there are no urls", () => {
+    expect(buildDescription("Notes here", [])).toBe("Notes here");
+  });
+
+  it("returns urls joined by newline when existing is empty", () => {
+    expect(buildDescription("", ["https://a.test/", "https://b.test/"])).toBe(
+      "https://a.test/\nhttps://b.test/"
+    );
+  });
+
+  it("returns urls joined by newline when existing is whitespace only", () => {
+    expect(buildDescription("   \n  ", ["https://a.test/"])).toBe("https://a.test/");
+  });
+
+  it("appends urls below trimmed existing text separated by a single newline", () => {
+    expect(buildDescription("  Plan trip  ", ["https://a.test/"])).toBe(
+      "Plan trip\nhttps://a.test/"
+    );
+  });
+
+  it("preserves multi-line existing text and appends urls below", () => {
+    expect(
+      buildDescription("Line one\nLine two", ["https://a.test/", "https://b.test/"])
+    ).toBe("Line one\nLine two\nhttps://a.test/\nhttps://b.test/");
   });
 });

--- a/tests/ui/edit-drawer.test.tsx
+++ b/tests/ui/edit-drawer.test.tsx
@@ -23,13 +23,6 @@ const mockTask: TaskRecord = {
 } as TaskRecord;
 
 describe("<EditDrawer>", () => {
-<<<<<<< Updated upstream
-||||||| Stash base
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-27T12:00:00Z"));
-  });
-=======
   let user: ReturnType<typeof userEvent.setup>;
 
   beforeEach(() => {
@@ -37,7 +30,6 @@ describe("<EditDrawer>", () => {
     vi.setSystemTime(new Date("2026-04-27T12:00:00Z"));
     user = userEvent.setup();
   });
->>>>>>> Stashed changes
   afterEach(() => {
     // Defensive: ensure any per-test fake timers are cleared so they don't bleed
     // into userEvent-based tests, which hang under fake timers.


### PR DESCRIPTION
## Summary
- Vendor `extractUrlsFromTitle` + `buildDescription` from `lib/capture-parser.ts` into the MCP server at `packages/mcp-server/src/text/capture-parser.ts`
- Wire MCP `create_task` to apply the same URL-extraction the webapp's capture-bar / create-drawer applies (title to description merge, URL-only fallback, XSS-safe sanitizer)
- Add a parity test (`__tests__/text/capture-parser-parity.test.ts`) that asserts both behavioral and source-text equivalence between the canonical webapp module and the vendored mirror, so drift fails CI. Protected surfaces: bodies of `extractUrlsFromTitle`, `buildDescription`, `sanitizeTitleUrl`, plus the constants block (`MAX_URL_LENGTH`, `TITLE_URL_PATTERN`, `ALLOWED_PROTOCOLS`, etc.)
- Promote `buildDescription` out of `components/matrix-simplified/index.tsx` into the canonical module so both consumers share one implementation
- Lock the webapp-parity invariant for edits with a regression test asserting MCP `update_task` does NOT extract URLs from titles

`update_task` is intentionally unchanged — mirrors the webapp, which only extracts on creation.

**Drive-by fix:** Includes commit `1535ba4` resolving merge-conflict markers in `tests/ui/edit-drawer.test.tsx` that were left in by `62f3ab4` and were preventing the test file from parsing. The "Stashed changes" branch was the only viable resolution since the rest of the file uses the `user` variable that only that branch declares.

## Versions
- Webapp: 8.9.0 → 8.9.1 (patch — internal refactor only)
- MCP server: 1.0.0 → 1.1.0 (minor — `create_task` gains observable URL-extraction behavior)

## Spec & Plan
- Spec: `docs/superpowers/specs/2026-05-02-mcp-url-extraction-parity-design.md`
- Plan: `docs/superpowers/plans/2026-05-02-mcp-url-extraction-parity.md`

## Known CI gap (pre-existing)
Root vitest excludes `**/packages/mcp-server/**`, and the SonarCloud workflow only runs `bun run test`. As a result the MCP parity test does not run in CI today. Same gap applies to every other MCP test — out of scope for this PR but worth tracking.

## Test plan
- [x] \`bun run test\` passes (root): 1807 passed, 1 skipped
- [x] \`bun typecheck\` clean
- [x] \`bun lint\` clean
- [x] \`npm run test\` passes inside \`packages/mcp-server/\`: 83 passed
- [x] \`npx tsc --noEmit\` clean inside \`packages/mcp-server/\`
- [x] Drift sanity check: temporarily edited the mirror, confirmed parity test fails, reverted
- [ ] Manual: invoke MCP \`create_task\` with \`{ title: "Read https://example.com later" }\`; resulting task in webapp shows title \`"Read later"\` and description \`https://example.com/\`
- [ ] Manual: invoke MCP \`update_task\` with a URL in the title; URL stays in the title (parity confirmed by automated test, manual smoke optional)