### PR TITLE
chore(tooling): add branch-preflight skill + script

### DIFF
--- a/.claude/skills/branch-preflight/SKILL.md
+++ b/.claude/skills/branch-preflight/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: branch-preflight
+description: Sanity-check the working tree before starting plan execution or new branch work. Catches inherited damage that silently breaks verification later — merge conflict markers committed to tracked files, outstanding stash entries that may bleed into your work, uncommitted changes you may not realize you have. Runs in ~1 second. Trigger BEFORE invoking superpowers:executing-plans or superpowers:subagent-driven-development, BEFORE creating a new feature branch off main, or when verification mysteriously fails on files you did not touch.
+disable-model-invocation: false
+---
+
+# branch-preflight — Catch inherited working-tree damage early
+
+## When to invoke
+
+Trigger this skill BEFORE any of:
+- Starting plan execution (`superpowers:executing-plans`, `superpowers:subagent-driven-development`)
+- Creating a new feature branch off `main` (`git switch -c feat/...`)
+- Investigating a verification failure on files you do not recognize as yours
+
+You should also volunteer to run it if the user mentions:
+- "let's start implementing"
+- "execute the plan"
+- "kick off the work"
+
+## Why it exists
+
+A real session lost ~10 minutes when `tests/ui/edit-drawer.test.tsx` turned out to have unresolved merge conflict markers committed to `main` six commits before the session started (commit `62f3ab4`). The file failed to parse, blocking root `bun run test` and any PR CI. The damage was discovered mid-Task-2 of an implementation plan, requiring an out-of-plan fix and explicit scope-expansion approval from the user.
+
+This script catches that class of damage in under a second, before it becomes a Task-6 surprise.
+
+## What it checks
+
+1. **Merge conflict markers in tracked files.** Greps `git ls-files` for `<<<<<<<`, `=======`, or `>>>>>>>` line prefixes. Tracked-files-only avoids false positives on `.claude/` scratch notes.
+2. **Stash entries.** A non-empty `git stash list` is a yellow flag — most users don't realize an autostash is sitting there.
+3. **Uncommitted changes.** Surfaces both unstaged (`git diff`) and staged (`git diff --cached`) work.
+
+## How to use
+
+Just run it:
+
+```bash
+bash scripts/branch-preflight.sh
+```
+
+Exit code:
+- `0` — clean, safe to proceed
+- `1` — at least one finding; review the output before starting
+
+## What to do with findings
+
+| Finding | Suggested action |
+|---|---|
+| Merge conflict markers | Resolve them in a separate `fix(...)` commit on the current branch BEFORE starting plan execution. Do not stack feature work on top of broken files. |
+| Stash entries | Run `git stash list` to inspect. If it's stale or unrelated, drop it (`git stash drop`). If it's intentional in-progress work, acknowledge and proceed. |
+| Uncommitted changes | Either commit them, stash them deliberately, or revert. Don't start a plan with mystery diff in the working tree. |
+
+## Out of scope
+
+This script does NOT check:
+- Whether the branch is up to date with `main` (use `git fetch && git status`)
+- Whether dependencies are installed (use `bun install`)
+- Whether tests currently pass (use `bun run test`)
+- Whether CI is green for the branch (use `gh pr checks`)
+
+These are different problems with different feedback loops. This skill is the cheapest possible "is the working tree sane?" check.
+
+## Gotchas
+
+- The merge-marker grep uses `^<<<<<<< ` / `^>>>>>>> ` / `^={7}$` regex anchored at line start, so it won't false-positive on documentation that mentions conflict markers in prose.
+- The stash check counts ALL stash entries, including ones from other tools (autostash from `git pull --rebase`, IDE auto-stashes). It's a yellow flag, not a red one — the script exits non-zero but the message says "acknowledge before starting", not "fix immediately".

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ sync.md
 !.claude/skills/
 .claude/skills/*
 !.claude/skills/pb-collection/
+!.claude/skills/branch-preflight/
 
 *.tsbuildinfo
 

--- a/scripts/branch-preflight.sh
+++ b/scripts/branch-preflight.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# branch-preflight.sh — sanity-check the working tree before starting plan execution.
+#
+# Catches inherited damage that would silently break verification later:
+#   1. Unresolved merge-conflict markers in tracked files
+#   2. Outstanding stash entries that may bleed into your work
+#   3. Uncommitted changes you may not realize you have
+#
+# Exits 1 if any check finds something worth surfacing. Exits 0 if clean.
+# Output is human-readable; pipe to /dev/null if you only care about the exit code.
+
+set -u
+
+red()    { printf '\033[31m%s\033[0m' "$1"; }
+yellow() { printf '\033[33m%s\033[0m' "$1"; }
+green()  { printf '\033[32m%s\033[0m' "$1"; }
+
+findings=0
+
+# --- Check 1: merge conflict markers in tracked files ---------------------
+# Limit to tracked files so we don't false-positive on .claude/ scratch notes.
+marker_hits=$(git ls-files -z 2>/dev/null | xargs -0 grep -lE '^(<<<<<<< |={7}$|>>>>>>> )' 2>/dev/null || true)
+if [ -n "$marker_hits" ]; then
+  printf '%s ' "$(red '✗')"
+  printf 'Merge conflict markers in tracked files:\n'
+  printf '  %s\n' $marker_hits
+  findings=$((findings + 1))
+else
+  printf '%s ' "$(green '✓')"
+  printf 'No merge conflict markers in tracked files.\n'
+fi
+
+# --- Check 2: stash entries -----------------------------------------------
+stash_count=$(git stash list 2>/dev/null | wc -l | tr -d ' ')
+if [ "$stash_count" -gt 0 ]; then
+  printf '%s ' "$(yellow '!')"
+  printf '%s stash entr%s present:\n' "$stash_count" "$([ "$stash_count" = "1" ] && echo y || echo ies)"
+  git stash list | sed 's/^/  /'
+  findings=$((findings + 1))
+else
+  printf '%s ' "$(green '✓')"
+  printf 'No stash entries.\n'
+fi
+
+# --- Check 3: uncommitted changes -----------------------------------------
+if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+  printf '%s ' "$(yellow '!')"
+  printf 'Uncommitted changes in working tree:\n'
+  git status --short | sed 's/^/  /'
+  findings=$((findings + 1))
+else
+  printf '%s ' "$(green '✓')"
+  printf 'Working tree clean.\n'
+fi
+
+# --- Summary ---------------------------------------------------------------
+echo
+if [ "$findings" -eq 0 ]; then
+  printf '%s ' "$(green '→')"
+  printf 'Branch preflight clean. Safe to start plan execution.\n'
+  exit 0
+else
+  printf '%s ' "$(red '→')"
+  printf '%s finding(s). Resolve or acknowledge before starting plan execution.\n' "$findings"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
Adds a tiny dev-tooling skill that sanity-checks the working tree before plan execution starts, plus the bash script it invokes.

**Files:**
- `scripts/branch-preflight.sh` — the actual logic (3 checks: merge markers in tracked files, stash entries, uncommitted changes)
- `.claude/skills/branch-preflight/SKILL.md` — the Claude Code skill manifest with trigger guidance
- `.gitignore` — whitelist the new skill folder (the existing pattern requires per-skill opt-in)

## Why
A recent session lost ~10 minutes when merge conflict markers committed to \`main\` in \`62f3ab4\` (in \`tests/ui/edit-drawer.test.tsx\`) silently broke root tests. The damage was discovered mid-Task-2 of an implementation plan, requiring an out-of-plan fix and explicit scope expansion. Running this preflight at session start catches that class of damage in under a second.

Output:
\`\`\`
✓ No merge conflict markers in tracked files.
✓ No stash entries.
✓ Working tree clean.
→ Branch preflight clean. Safe to start plan execution.
\`\`\`

Exit code is non-zero on any finding so it can also be used in pre-execution hooks if desired later.

## Test plan
- [x] Script runs against the current working tree and produces correct output for clean / dirty / stashed states
- [x] SKILL.md has `disable-model-invocation: false` and a description with explicit trigger words
- [x] Script doesn't false-positive on `.claude/` scratch notes (limited to `git ls-files`)
- [x] No external dependencies — pure bash + git