### PR TITLE
fix(tasks): extract URLs from title in central createTask path

### DIFF
--- a/lib/tasks/crud/create.ts
+++ b/lib/tasks/crud/create.ts
@@ -1,3 +1,4 @@
+import { buildDescription, extractUrlsFromTitle } from "@/lib/capture-parser";
 import { getDb } from "@/lib/db";
 import { generateId } from "@/lib/id-generator";
 import { createLogger } from "@/lib/logger";
@@ -10,10 +11,22 @@ import { enqueueSyncOperation, getSyncContext } from "./helpers";
 const logger = createLogger("TASK_CRUD");
 
 /**
- * Create a new task with validation and sync support
+ * Create a new task with validation and sync support.
+ *
+ * URL extraction runs unconditionally so every task-creation path (capture-bar,
+ * edit-drawer, WebMCP, future callers) gets the same XSS-safe link handling.
+ * Idempotent: callers that already extracted URLs pass a clean title and the
+ * second pass is a no-op.
  */
 export async function createTask(input: TaskDraft): Promise<TaskRecord> {
-  const result = taskDraftSchema.safeParse(input);
+  const { cleanTitle, urls } = extractUrlsFromTitle(input.title);
+  const normalized: TaskDraft = {
+    ...input,
+    title: cleanTitle,
+    description: buildDescription(input.description ?? "", urls),
+  };
+
+  const result = taskDraftSchema.safeParse(normalized);
   if (!result.success) {
     const msg = result.error.issues.map(i => i.message).join(", ");
     logger.error("Task validation failed", undefined, { input, validationErrors: msg });

--- a/tests/data/tasks/crud.test.ts
+++ b/tests/data/tasks/crud.test.ts
@@ -168,56 +168,42 @@ describe('Task CRUD Operations', () => {
       await expect(createTask(invalid)).rejects.toThrow();
     });
 
-    it('should extract URLs from title into description', async () => {
-      mockDb.tasks.add.mockResolvedValue(undefined);
-
-      const result = await createTask({
-        ...baseDraft,
+    it.each([
+      {
+        scenario: 'extracts URLs from title into description',
         title: 'Read https://example.com/article later',
         description: '',
-      });
-
-      expect(result.title).toBe('Read later');
-      expect(result.description).toBe('https://example.com/article');
-    });
-
-    it('should append extracted URLs to existing description', async () => {
-      mockDb.tasks.add.mockResolvedValue(undefined);
-
-      const result = await createTask({
-        ...baseDraft,
+        expectedTitle: 'Read later',
+        expectedDescription: 'https://example.com/article',
+      },
+      {
+        scenario: 'appends extracted URLs to existing description',
         title: 'Watch https://example.com/video',
         description: 'Existing notes',
-      });
-
-      expect(result.title).toBe('Watch');
-      expect(result.description).toBe('Existing notes\nhttps://example.com/video');
-    });
-
-    it('should fall back to placeholder title when title is URL-only', async () => {
-      mockDb.tasks.add.mockResolvedValue(undefined);
-
-      const result = await createTask({
-        ...baseDraft,
+        expectedTitle: 'Watch',
+        expectedDescription: 'Existing notes\nhttps://example.com/video',
+      },
+      {
+        scenario: 'falls back to placeholder title when title is URL-only',
         title: 'https://example.com',
         description: '',
-      });
-
-      expect(result.title).toBe('Review link below');
-      expect(result.description).toBe('https://example.com/');
-    });
-
-    it('should leave title unchanged when no URLs are present', async () => {
-      mockDb.tasks.add.mockResolvedValue(undefined);
-
-      const result = await createTask({
-        ...baseDraft,
+        expectedTitle: 'Review link below',
+        expectedDescription: 'https://example.com/',
+      },
+      {
+        scenario: 'leaves title unchanged when no URLs are present',
         title: 'Plain task title',
         description: 'Plain description',
-      });
+        expectedTitle: 'Plain task title',
+        expectedDescription: 'Plain description',
+      },
+    ])('$scenario', async ({ title, description, expectedTitle, expectedDescription }) => {
+      mockDb.tasks.add.mockResolvedValue(undefined);
 
-      expect(result.title).toBe('Plain task title');
-      expect(result.description).toBe('Plain description');
+      const result = await createTask({ ...baseDraft, title, description });
+
+      expect(result.title).toBe(expectedTitle);
+      expect(result.description).toBe(expectedDescription);
     });
   });
 

--- a/tests/data/tasks/crud.test.ts
+++ b/tests/data/tasks/crud.test.ts
@@ -167,6 +167,58 @@ describe('Task CRUD Operations', () => {
 
       await expect(createTask(invalid)).rejects.toThrow();
     });
+
+    it('should extract URLs from title into description', async () => {
+      mockDb.tasks.add.mockResolvedValue(undefined);
+
+      const result = await createTask({
+        ...baseDraft,
+        title: 'Read https://example.com/article later',
+        description: '',
+      });
+
+      expect(result.title).toBe('Read later');
+      expect(result.description).toBe('https://example.com/article');
+    });
+
+    it('should append extracted URLs to existing description', async () => {
+      mockDb.tasks.add.mockResolvedValue(undefined);
+
+      const result = await createTask({
+        ...baseDraft,
+        title: 'Watch https://example.com/video',
+        description: 'Existing notes',
+      });
+
+      expect(result.title).toBe('Watch');
+      expect(result.description).toBe('Existing notes\nhttps://example.com/video');
+    });
+
+    it('should fall back to placeholder title when title is URL-only', async () => {
+      mockDb.tasks.add.mockResolvedValue(undefined);
+
+      const result = await createTask({
+        ...baseDraft,
+        title: 'https://example.com',
+        description: '',
+      });
+
+      expect(result.title).toBe('Review link below');
+      expect(result.description).toBe('https://example.com/');
+    });
+
+    it('should leave title unchanged when no URLs are present', async () => {
+      mockDb.tasks.add.mockResolvedValue(undefined);
+
+      const result = await createTask({
+        ...baseDraft,
+        title: 'Plain task title',
+        description: 'Plain description',
+      });
+
+      expect(result.title).toBe('Plain task title');
+      expect(result.description).toBe('Plain description');
+    });
   });
 
   describe('updateTask', () => {


### PR DESCRIPTION
## Summary

Audit of every task-creation path found that PR #253 (webapp) and PR #254 (standalone MCP server) wired URL extraction into their respective entry points but left two paths unprotected:

- **WebMCP** (`components/webmcp-register.tsx`) calls `lib/tasks.createTask` directly with raw input from the in-browser `navigator.modelContext` model — URLs in the title reached IndexedDB unchanged.
- **`lib/tasks/crud/create.ts`** itself didn't enforce the rule, so any future caller (command palette resurrection, scripts, etc.) would silently lose the protection.

This PR moves `extractUrlsFromTitle` + `buildDescription` into the central `createTask` so every webapp creation path — capture-bar, edit-drawer, WebMCP, and any future caller — gets identical XSS-safe link handling. The extraction is idempotent, so existing callers in `matrix-simplified` (which still extract for UX preview) are unaffected.

The standalone MCP server (`packages/mcp-server`) is a separate npm package that can't import from `lib/`; it already has the extraction wired in via PR #254 and a parity test guards against drift.

## Audit results

| Path | Before | After |
|---|---|---|
| `components/matrix-simplified/index.tsx` (capture-bar, drawer pre-fill, drawer submit) | ✓ | ✓ |
| `packages/mcp-server/.../task-operations.ts` (Claude Desktop MCP) | ✓ | ✓ |
| `components/webmcp-register.tsx` (browser-side WebMCP) | ✗ | ✓ (via central createTask) |
| `lib/tasks/crud/create.ts` (any direct caller) | ✗ | ✓ |

## Test plan

- [x] `bun run test` — 1811 tests pass (4 new for URL extraction in `createTask`)
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] MCP server tests — 83 pass
- [ ] Manual: create a task in WebMCP with a URL in the title and confirm it lands in the description

https://claude.ai/code/session_01WexMLWUmUGEYyn8NPSjcfk

---
_Generated by [Claude Code](https://claude.ai/code/session_01WexMLWUmUGEYyn8NPSjcfk)_