### PR TITLE
feat(polish): v0.9.2 — items 1-10 from design polish handoff + perf refactor

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+  "entry": [
+    "src/index.{ts,tsx,js,jsx}",
+    "src/main.{ts,tsx,js,jsx}"
+  ],
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ]
+  },
+  "duplicates": {
+    // Common additions (uncomment to enable):
+    // "ignore": [
+    //   "**/lib/**",          // for repos that publish transpiled output to lib/
+    //   "**/legacy/**",       // for repos with legacy-build artifacts
+    //   "**/__generated__/**", // Relay, GraphQL Code Generator
+    //   "**/generated/**"     // OpenAPI, Protobuf codegen
+    // ]
+  },
+  "rules": {
+    "unused-dependencies": "warn"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ coverage/
 
 # Design reference bundle — not for deploy
 design_handoff_gsd_redesign/
+design_handoff_gsd_polish/
+.fallow/

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { Route } from "next";
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   CheckCircle2Icon,
@@ -57,15 +57,39 @@ export default function DashboardPage() {
     [tasks],
   );
   const timeByQuadrant = useMemo(() => getTimeByQuadrant(tasks), [tasks]);
-  const todayTrend = last7TrendData.at(-1)?.completed ?? 0;
-  const previousSixDays = last7TrendData.slice(0, -1);
-  const previousSixAverage = previousSixDays.length > 0
-    ? previousSixDays.reduce((sum, point) => sum + point.completed, 0) / previousSixDays.length
-    : 0;
-  const completedTrend = previousSixAverage > 0
-    ? Math.round(((todayTrend - previousSixAverage) / previousSixAverage) * 100)
-    : todayTrend > 0 ? 100 : 0;
-  const completionPeak = Math.max(1, ...last7TrendData.map((point) => point.completed));
+  const completedSeries = useMemo(
+    () => last7TrendData.map((p) => p.completed),
+    [last7TrendData],
+  );
+  const createdSeries = useMemo(
+    () => last7TrendData.map((p) => p.created),
+    [last7TrendData],
+  );
+  const completionRateSeries = useMemo(
+    () =>
+      last7TrendData.map((p) => {
+        const denom = p.created || 1;
+        return Math.round((p.completed / denom) * 100);
+      }),
+    [last7TrendData],
+  );
+  const { completedTrend, previousSixAverage } = useMemo(() => {
+    const todayTrend = last7TrendData.at(-1)?.completed ?? 0;
+    let previousTotal = 0;
+    for (let i = 0; i < last7TrendData.length - 1; i += 1) {
+      previousTotal += last7TrendData[i].completed;
+    }
+    const previousCount = Math.max(0, last7TrendData.length - 1);
+    const nextPreviousSixAverage =
+      previousCount > 0 ? previousTotal / previousCount : 0;
+    const nextCompletedTrend = nextPreviousSixAverage > 0
+      ? Math.round(((todayTrend - nextPreviousSixAverage) / nextPreviousSixAverage) * 100)
+      : todayTrend > 0 ? 100 : 0;
+    return {
+      completedTrend: nextCompletedTrend,
+      previousSixAverage: nextPreviousSixAverage,
+    };
+  }, [last7TrendData]);
   const completedInsight = metrics.completedToday === 0
     ? "Ready to start today"
     : completedTrend > 10
@@ -87,11 +111,29 @@ export default function DashboardPage() {
       ? "Healthy momentum"
       : "Room to tighten execution";
 
-  const openMatrixAction = (params?: URLSearchParams) => {
+  const openMatrixAction = useCallback((params?: URLSearchParams) => {
     const query = params?.toString();
     const href = query ? (`/?${query}` as Route) : ROUTES.HOME;
     router.push(href);
-  };
+  }, [router]);
+
+  const handleDeadlineTaskClick = useCallback(
+    (task: { id: string }) => {
+      const params = new URLSearchParams();
+      params.set("highlight", task.id);
+      openMatrixAction(params);
+    },
+    [openMatrixAction]
+  );
+
+  const trendOptions = useMemo(
+    () => [
+      { value: "7", label: "7 Days" },
+      { value: "30", label: "30 Days" },
+      { value: "90", label: "90 Days" },
+    ],
+    []
+  );
 
   useKeyboardShortcuts(
     {
@@ -149,33 +191,27 @@ export default function DashboardPage() {
                   <StatsCard
                     title="Completed Today"
                     value={metrics.completedToday}
-                    subtitle={`${metrics.completedThisWeek} this week`}
                     icon={CheckCircle2Icon}
                     trend={previousSixAverage > 0 ? { value: completedTrend, isPositive: completedTrend >= 0 } : undefined}
                     insight={completedInsight}
-                    progressValue={Math.round((metrics.completedToday / completionPeak) * 100)}
-                    progressLabel="Vs. recent best day"
-                    accentColor="emerald"
+                    footerMeta={`${metrics.completedThisWeek} / 7d`}
+                    series={completedSeries}
                   />
                   <StatsCard
                     title="Active Tasks"
                     value={metrics.activeTasks}
-                    subtitle={`${metrics.totalTasks} total tasks`}
                     icon={ListTodoIcon}
                     insight={activeInsight}
-                    progressValue={plannedActiveShare}
-                    progressLabel="Have a due date"
-                    accentColor="blue"
+                    footerMeta={`${plannedActiveShare}% scheduled`}
+                    series={createdSeries}
                   />
                   <StatsCard
                     title="Completion Rate"
                     value={`${metrics.completionRate}%`}
-                    subtitle={`${metrics.completedTasks} completed`}
                     icon={TrendingUpIcon}
                     insight={completionInsight}
-                    progressValue={metrics.completionRate}
-                    progressLabel="Done overall"
-                    accentColor="amber"
+                    footerMeta={`${metrics.completedTasks} done overall`}
+                    series={completionRateSeries}
                   />
                   <StreakIndicator streakData={streakData} />
                 </div>
@@ -202,11 +238,7 @@ export default function DashboardPage() {
                   <div className="space-y-4 lg:col-span-2">
                     <div className="flex items-center">
                       <SegmentedControl
-                        options={[
-                          { value: "7", label: "7 Days" },
-                          { value: "30", label: "30 Days" },
-                          { value: "90", label: "90 Days" },
-                        ]}
+                        options={trendOptions}
                         value={String(trendPeriod) as "7" | "30" | "90"}
                         onChange={(v) =>
                           setTrendPeriod(Number(v) as 7 | 30 | 90)
@@ -223,11 +255,7 @@ export default function DashboardPage() {
                 <div className="grid gap-6 lg:grid-cols-2">
                   <UpcomingDeadlines
                     tasks={tasks}
-                    onTaskClick={(task) => {
-                      const params = new URLSearchParams();
-                      params.set("highlight", task.id);
-                      openMatrixAction(params);
-                    }}
+                    onTaskClick={handleDeadlineTaskClick}
                   />
                   {metrics.tagStats.length > 0 ? (
                     <TagAnalytics tagStats={metrics.tagStats} maxTags={8} />

--- a/app/globals.css
+++ b/app/globals.css
@@ -337,6 +337,21 @@ main {
     animation: slide-in-card 0.3s ease-out both;
   }
 
+  @keyframes quadrant-pill-in {
+    from {
+      opacity: 0;
+      transform: translateX(-4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  .animate-quadrant-pill-in {
+    animation: quadrant-pill-in 0.16s ease-out both;
+  }
+
   @keyframes complete-flash {
     0% {
       box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.4);

--- a/bun.lock
+++ b/bun.lock
@@ -59,7 +59,7 @@
     },
     "packages/mcp-server": {
       "name": "gsd-mcp-server",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "bin": {
         "gsd-mcp-server": "dist/index.js",
       },

--- a/components/command-palette/index.tsx
+++ b/components/command-palette/index.tsx
@@ -5,7 +5,7 @@ import { useCommandPalette } from "@/lib/use-command-palette";
 import { buildCommandActions, type CommandActionHandlers } from "@/lib/command-actions";
 import { getSmartViews } from "@/lib/smart-views";
 import { useTasks } from "@/lib/use-tasks";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import type { SmartView } from "@/lib/filters";
 import { CommandGroup } from "./command-group";
 import { TaskItem } from "./task-item";
@@ -38,8 +38,10 @@ export function CommandPalette({ handlers, conditions }: CommandPaletteProps) {
     loadViews();
   }, []);
 
-  // Build command actions
-  const actions = buildCommandActions(handlers, smartViews, conditions);
+  const actions = useMemo(
+    () => buildCommandActions(handlers, smartViews, conditions),
+    [conditions, handlers, smartViews]
+  );
 
   const {
     open,
@@ -53,15 +55,19 @@ export function CommandPalette({ handlers, conditions }: CommandPaletteProps) {
   } = useCommandPalette({ actions, tasks });
 
   // Group actions by section
-  const actionsBySection = filteredActions.reduce(
-    (acc, action) => {
-      if (!acc[action.section]) {
-        acc[action.section] = [];
-      }
-      acc[action.section].push(action);
-      return acc;
-    },
-    {} as Record<string, typeof filteredActions>
+  const actionsBySection = useMemo(
+    () =>
+      filteredActions.reduce(
+        (acc, action) => {
+          if (!acc[action.section]) {
+            acc[action.section] = [];
+          }
+          acc[action.section].push(action);
+          return acc;
+        },
+        {} as Record<string, typeof filteredActions>
+      ),
+    [filteredActions]
   );
 
   return (

--- a/components/dashboard/completion-chart.tsx
+++ b/components/dashboard/completion-chart.tsx
@@ -2,8 +2,8 @@
 
 import { useMemo } from "react";
 import {
-  AreaChart,
-  Area,
+  LineChart,
+  Line,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -17,8 +17,10 @@ interface CompletionChartProps {
 }
 
 /**
- * Area chart showing task completion and creation trends.
- * Uses theme-aware colors via CSS variable-derived values.
+ * Line chart showing task completion vs creation. Encoding:
+ *   Completed → solid green (status-success), strokeWidth 2
+ *   Created   → dotted indigo (accent), strokeWidth 1.6
+ * No fills — keeps the comparison legible at small sizes.
  */
 export function CompletionChart({ data }: CompletionChartProps) {
   const chartData = useMemo(() => {
@@ -41,24 +43,22 @@ export function CompletionChart({ data }: CompletionChartProps) {
           </p>
         </div>
         <div className="flex items-center gap-2 rounded-full border border-border/70 bg-background-muted/70 px-3 py-1.5">
-          <div className="h-2.5 w-2.5 rounded-full bg-[rgb(var(--accent))]" />
+          <span className="h-[2px] w-3 rounded-full bg-status-success" />
           <span className="text-xs font-medium text-foreground-muted">Completed</span>
-          <div className="ml-2 h-2.5 w-2.5 rounded-full bg-[rgb(var(--chart-series-2))]" />
+          <span
+            className="ml-2 h-[2px] w-3 rounded-full bg-accent"
+            style={{
+              backgroundImage: "linear-gradient(to right, currentColor 50%, transparent 50%)",
+              backgroundSize: "4px 2px",
+              backgroundColor: "transparent",
+              color: "rgb(var(--accent))",
+            }}
+          />
           <span className="text-xs font-medium text-foreground-muted">Created</span>
         </div>
       </div>
       <ResponsiveContainer width="100%" height={280}>
-        <AreaChart data={chartData}>
-          <defs>
-            <linearGradient id="gradientCompleted" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor="rgb(var(--accent))" stopOpacity={0.3} />
-              <stop offset="95%" stopColor="rgb(var(--accent))" stopOpacity={0.02} />
-            </linearGradient>
-            <linearGradient id="gradientCreated" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor="rgb(var(--chart-series-2))" stopOpacity={0.22} />
-              <stop offset="95%" stopColor="rgb(var(--chart-series-2))" stopOpacity={0.02} />
-            </linearGradient>
-          </defs>
+        <LineChart data={chartData}>
           <CartesianGrid
             strokeDasharray="3 3"
             stroke="currentColor"
@@ -92,25 +92,24 @@ export function CompletionChart({ data }: CompletionChartProps) {
             }}
             cursor={{ stroke: "rgb(var(--foreground-muted))", strokeOpacity: 0.3 }}
           />
-          <Area
+          <Line
             type="monotone"
             dataKey="Completed"
-            stroke="rgb(var(--accent))"
+            stroke="rgb(var(--status-success))"
             strokeWidth={2}
-            fill="url(#gradientCompleted)"
+            dot={false}
+            activeDot={{ r: 5, fill: "rgb(var(--status-success))", stroke: "#fff", strokeWidth: 2 }}
+          />
+          <Line
+            type="monotone"
+            dataKey="Created"
+            stroke="rgb(var(--accent))"
+            strokeWidth={1.6}
+            strokeDasharray="3 3"
             dot={false}
             activeDot={{ r: 5, fill: "rgb(var(--accent))", stroke: "#fff", strokeWidth: 2 }}
           />
-          <Area
-            type="monotone"
-            dataKey="Created"
-            stroke="rgb(var(--chart-series-2))"
-            strokeWidth={2}
-            fill="url(#gradientCreated)"
-            dot={false}
-            activeDot={{ r: 5, fill: "rgb(var(--chart-series-2))", stroke: "#fff", strokeWidth: 2 }}
-          />
-        </AreaChart>
+        </LineChart>
       </ResponsiveContainer>
     </div>
   );

--- a/components/dashboard/quadrant-distribution.tsx
+++ b/components/dashboard/quadrant-distribution.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
+import { useMemo } from "react";
 import type { QuadrantId } from "@/lib/types";
 import { quadrants, QUADRANT_ACCENT_BY_ID } from "@/lib/quadrants";
 
@@ -16,104 +16,84 @@ const SHORT_LABELS: Record<QuadrantId, string> = {
 };
 
 /**
- * Donut chart showing task distribution across Eisenhower quadrants.
- * Displays the total task count in the center of the donut.
+ * Active task split across the matrix, rendered as a single horizontal
+ * segmented bar. Saves vertical space and reinforces quadrant identity by
+ * placing labels and colors on the same visual axis.
  */
 export function QuadrantDistribution({ distribution }: QuadrantDistributionProps) {
-  const data = quadrants
-    .map((quadrant) => ({
-      name: quadrant.title,
-      shortName: SHORT_LABELS[quadrant.id],
-      value: distribution[quadrant.id],
-      id: quadrant.id,
-    }))
-    .filter((item) => item.value > 0);
+  const { segments, total } = useMemo(() => {
+    const items = quadrants
+      .map((quadrant) => ({
+        name: quadrant.title,
+        shortName: SHORT_LABELS[quadrant.id],
+        value: distribution[quadrant.id],
+        id: quadrant.id,
+        color: QUADRANT_ACCENT_BY_ID[quadrant.id],
+      }))
+      .filter((item) => item.value > 0);
 
-  const total = data.reduce((sum, item) => sum + item.value, 0);
-
-  if (data.length === 0) {
-    return (
-      <div className="rounded-3xl border border-border/70 bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
-        <h3 className="rd-serif text-title text-foreground">
-          Quadrant Distribution
-        </h3>
-        <p className="mt-1 text-sm text-foreground-muted">
-          Active work split across the matrix.
-        </p>
-        <div className="flex h-[280px] items-center justify-center">
-          <p className="text-sm text-foreground-muted">No active tasks to display</p>
-        </div>
-      </div>
-    );
-  }
+    return {
+      segments: items,
+      total: items.reduce((sum, item) => sum + item.value, 0),
+    };
+  }, [distribution]);
 
   return (
     <div className="rounded-3xl border border-border/70 bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
-      <h3 className="rd-serif text-title text-foreground">
-        Quadrant Distribution
-      </h3>
-      <p className="mt-1 text-sm text-foreground-muted">
-        Active work split across the matrix.
-      </p>
-      <div className="relative">
-        <ResponsiveContainer width="100%" height={240}>
-          <PieChart>
-            <Pie
-              data={data}
-              cx="50%"
-              cy="50%"
-              innerRadius={65}
-              outerRadius={95}
-              paddingAngle={3}
-              dataKey="value"
-              strokeWidth={0}
-            >
-              {data.map((entry) => (
-                <Cell
-                  key={`cell-${entry.id}`}
-                  fill={QUADRANT_ACCENT_BY_ID[entry.id as QuadrantId]}
-                  className="transition-opacity hover:opacity-85"
+      <div className="flex items-baseline justify-between gap-3">
+        <div>
+          <h3 className="rd-serif text-title text-foreground">
+            Quadrant Distribution
+          </h3>
+          <p className="mt-1 text-sm text-foreground-muted">
+            Active work split across the matrix.
+          </p>
+        </div>
+        <p className="text-sm tabular-nums text-foreground-muted">
+          <span className="font-semibold text-foreground">{total}</span> active
+        </p>
+      </div>
+
+      {segments.length === 0 ? (
+        <div className="mt-6 flex h-[120px] items-center justify-center rounded-xl border border-dashed border-border/70 bg-background-muted/30">
+          <p className="text-sm text-foreground-muted">No active tasks to display</p>
+        </div>
+      ) : (
+        <div className="mt-6 space-y-3">
+          <div className="grid gap-2" style={{ gridTemplateColumns: segments.map((s) => `${s.value}fr`).join(" ") }}>
+            {segments.map((segment) => {
+              const pct = Math.round((segment.value / total) * 100);
+              return (
+                <div key={segment.id} className="min-w-0 text-xs">
+                  <div className="flex items-baseline gap-1.5 truncate">
+                    <span className="font-medium text-foreground">{segment.shortName}</span>
+                    <span className="tabular-nums text-foreground-muted">{segment.value}</span>
+                    <span className="tabular-nums text-foreground-muted/70">·</span>
+                    <span className="tabular-nums text-foreground-muted">{pct}%</span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <div
+            className="flex h-3 overflow-hidden rounded-full"
+            role="img"
+            aria-label={`${total} active tasks across ${segments.length} quadrants`}
+          >
+            {segments.map((segment) => {
+              const pct = (segment.value / total) * 100;
+              return (
+                <div
+                  key={segment.id}
+                  className="h-full"
+                  style={{ width: `${pct}%`, backgroundColor: segment.color }}
+                  title={`${segment.name}: ${segment.value} (${Math.round(pct)}%)`}
                 />
-              ))}
-            </Pie>
-            <Tooltip
-              contentStyle={{
-                backgroundColor: "rgb(var(--card-background))",
-                border: "1px solid rgb(var(--border))",
-                borderRadius: "10px",
-                fontSize: "13px",
-                color: "rgb(var(--foreground))",
-                boxShadow: "var(--shadow-card-hover)",
-              }}
-              formatter={(value, name) => [
-                `${value} task${Number(value) !== 1 ? "s" : ""}`,
-                String(name),
-              ]}
-            />
-          </PieChart>
-        </ResponsiveContainer>
-        {/* Center label — total count */}
-        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-          <div className="text-center">
-            <p className="text-3xl font-bold tabular-nums text-foreground">{total}</p>
-            <p className="text-xs text-foreground-muted">active</p>
+              );
+            })}
           </div>
         </div>
-      </div>
-      {/* Legend */}
-      <div className="mt-2 grid grid-cols-2 gap-2">
-        {data.map((entry) => (
-          <div key={entry.id} className="flex items-center gap-2 rounded-2xl border border-border/60 bg-background-muted/40 px-3 py-2">
-            <div className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ backgroundColor: QUADRANT_ACCENT_BY_ID[entry.id as QuadrantId] }} />
-            <span className="truncate text-xs font-medium text-foreground-muted">
-              {entry.shortName}
-            </span>
-            <span className="ml-auto text-xs font-semibold tabular-nums text-foreground">
-              {entry.value}
-            </span>
-          </div>
-        ))}
-      </div>
+      )}
     </div>
   );
 }

--- a/components/dashboard/stats-card.tsx
+++ b/components/dashboard/stats-card.tsx
@@ -1,178 +1,153 @@
-import { LucideIcon } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { useCountUp } from "@/lib/use-count-up";
+import { cn } from "@/lib/utils";
 
 interface StatsCardProps {
   title: string;
   value: string | number;
-  subtitle?: string;
+  /** Footer meta string, e.g. "20 / 7d". Sits next to the trend delta. */
+  footerMeta?: string;
   icon?: LucideIcon;
   trend?: {
+    /** Percentage delta vs previous period. */
     value: number;
     isPositive: boolean;
+    /** Comparison label, e.g. "vs last week". Defaults to "vs last week". */
+    label?: string;
   };
+  /** Neutral status pill copy ("Holding steady", "3 overdue"). */
   insight?: string;
-  progressValue?: number;
-  progressLabel?: string;
-  accentColor?: "blue" | "emerald" | "amber" | "red";
+  /** 7–12 numeric points rendered as the inline sparkline. */
+  series?: number[];
   className?: string;
 }
 
-function getAccentClasses(color?: string): {
-  iconBg: string;
-  iconText: string;
-  chipBg: string;
-  chipText: string;
-  railBg: string;
-  railFill: string;
-  glow: string;
-} {
-  const map: Record<string, {
-    iconBg: string;
-    iconText: string;
-    chipBg: string;
-    chipText: string;
-    railBg: string;
-    railFill: string;
-    glow: string;
-  }> = {
-    blue: {
-      iconBg: "bg-blue-100/80 dark:bg-blue-900/40",
-      iconText: "text-blue-600 dark:text-blue-400",
-      chipBg: "bg-blue-500/10",
-      chipText: "text-blue-700 dark:text-blue-300",
-      railBg: "bg-blue-500/10",
-      railFill: "from-blue-500 to-cyan-400",
-      glow: "from-blue-500/14 via-blue-500/6 to-transparent",
-    },
-    emerald: {
-      iconBg: "bg-emerald-100/80 dark:bg-emerald-900/40",
-      iconText: "text-emerald-600 dark:text-emerald-400",
-      chipBg: "bg-emerald-500/10",
-      chipText: "text-emerald-700 dark:text-emerald-300",
-      railBg: "bg-emerald-500/10",
-      railFill: "from-emerald-500 to-teal-400",
-      glow: "from-emerald-500/14 via-emerald-500/6 to-transparent",
-    },
-    amber: {
-      iconBg: "bg-amber-100/80 dark:bg-amber-900/40",
-      iconText: "text-amber-600 dark:text-amber-400",
-      chipBg: "bg-amber-500/10",
-      chipText: "text-amber-700 dark:text-amber-300",
-      railBg: "bg-amber-500/10",
-      railFill: "from-amber-500 to-orange-400",
-      glow: "from-amber-500/14 via-amber-500/6 to-transparent",
-    },
-    red: {
-      iconBg: "bg-red-100/80 dark:bg-red-900/40",
-      iconText: "text-red-600 dark:text-red-400",
-      chipBg: "bg-red-500/10",
-      chipText: "text-red-700 dark:text-red-300",
-      railBg: "bg-red-500/10",
-      railFill: "from-red-500 to-rose-400",
-      glow: "from-red-500/14 via-red-500/6 to-transparent",
-    },
-  };
-  if (color && map[color]) return map[color];
-  return {
-    iconBg: "bg-accent/10",
-    iconText: "text-accent",
-    chipBg: "bg-accent/10",
-    chipText: "text-accent",
-    railBg: "bg-accent/10",
-    railFill: "from-[rgb(var(--accent))] to-[rgb(var(--accent-hover))]",
-    glow: "from-accent/14 via-accent/6 to-transparent",
-  };
-}
-
 /**
- * Reusable card for displaying a single metric
+ * Unified stat card. One rhythm: eyebrow → neutral pill → serif hero number →
+ * footer (delta + meta) → sparkline. Color is reserved for state deltas only.
  */
 export function StatsCard({
   title,
   value,
-  subtitle,
+  footerMeta,
   icon: Icon,
   trend,
   insight,
-  progressValue,
-  progressLabel,
-  accentColor,
-  className = "",
+  series,
+  className,
 }: StatsCardProps) {
   const animatedValue = useCountUp(value);
-  const {
-    iconBg,
-    iconText,
-    chipBg,
-    chipText,
-    railBg,
-    railFill,
-    glow,
-  } = getAccentClasses(accentColor);
-  const clampedProgress = progressValue === undefined
-    ? undefined
-    : Math.max(0, Math.min(100, progressValue));
+  const trendColor = trend
+    ? trend.isPositive
+      ? "text-status-success"
+      : "text-status-overdue"
+    : "text-foreground-muted";
 
   return (
     <div
-      className={`relative overflow-hidden rounded-[20px] border border-border bg-card p-6 ${className}`}
+      className={cn(
+        "relative overflow-hidden rounded-[20px] border border-border bg-card p-6",
+        className
+      )}
       style={{ boxShadow: "var(--shadow-card)" }}
     >
-      <div className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${glow}`} />
-      <div className="pointer-events-none absolute inset-x-6 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent dark:via-white/10" />
-
       <div className="relative flex items-start justify-between gap-4">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-foreground-muted">
+            <p className="text-label font-semibold uppercase text-foreground-muted">
               {title}
             </p>
             {insight ? (
-              <span className={`inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold ${chipBg} ${chipText}`}>
+              <span className="inline-flex rounded-full bg-background-muted px-2 py-0.5 text-[10px] font-medium text-foreground-muted">
                 {insight}
               </span>
             ) : null}
           </div>
-          <p className="mt-3 text-4xl font-bold tabular-nums tracking-tight text-foreground">
+          <p className="rd-serif mt-3 text-[48px] leading-none tabular-nums tracking-tight text-foreground">
             {animatedValue}
           </p>
-          {subtitle && (
-            <p className="mt-1.5 text-sm text-foreground-muted">{subtitle}</p>
-          )}
-          {trend && (
-            <div className="mt-3 flex items-center gap-1">
-              <span className={`text-xs font-medium ${trend.isPositive ? "text-emerald-600 dark:text-emerald-400" : "text-red-600 dark:text-red-400"}`}>
-                {trend.isPositive ? "↑" : "↓"} {Math.abs(trend.value)}%
-              </span>
-              <span className="text-xs text-foreground-muted">from last week</span>
-            </div>
-          )}
         </div>
         {Icon && (
-          <div className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-white/40 dark:border-white/5 ${iconBg}`}>
-            <Icon className={`h-6 w-6 ${iconText}`} />
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent/10">
+            <Icon className="h-4 w-4 text-accent" aria-hidden />
           </div>
         )}
       </div>
 
-      {clampedProgress !== undefined ? (
-        <div className="relative mt-5">
-          <div className="mb-2 flex items-center justify-between gap-3">
-            <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-foreground-muted">
-              {progressLabel ?? "Progress"}
-            </span>
-            <span className="text-xs font-semibold tabular-nums text-foreground">
-              {Math.round(clampedProgress)}%
-            </span>
-          </div>
-          <div className={`h-2 rounded-full ${railBg}`}>
-            <div
-              className={`h-full rounded-full bg-gradient-to-r ${railFill}`}
-              style={{ width: `${clampedProgress}%` }}
-            />
-          </div>
-        </div>
+      <div className="mt-4 flex items-center gap-2 text-xs">
+        {trend ? (
+          <span className={cn("font-medium tabular-nums", trendColor)}>
+            {trend.isPositive ? "↑" : "↓"} {Math.abs(trend.value)}%
+          </span>
+        ) : null}
+        {trend ? (
+          <span className="text-foreground-muted">{trend.label ?? "vs last week"}</span>
+        ) : null}
+        {footerMeta ? (
+          <>
+            {trend ? <span className="text-foreground-muted/60">·</span> : null}
+            <span className="text-foreground-muted">{footerMeta}</span>
+          </>
+        ) : null}
+      </div>
+
+      {series && series.length > 1 ? (
+        <Sparkline
+          values={series}
+          isPositive={trend ? trend.isPositive : undefined}
+        />
       ) : null}
     </div>
+  );
+}
+
+/**
+ * Inline SVG sparkline. Stroke color follows the trend delta:
+ * success (up), overdue (down), muted (flat / no trend).
+ */
+function Sparkline({
+  values,
+  isPositive,
+}: {
+  values: number[];
+  isPositive?: boolean;
+}) {
+  const width = 120;
+  const height = 28;
+  const max = Math.max(...values, 1);
+  const min = Math.min(...values);
+  const range = max - min || 1;
+  const step = values.length > 1 ? width / (values.length - 1) : width;
+  const points = values
+    .map((value, i) => {
+      const x = i * step;
+      const y = height - ((value - min) / range) * height;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+
+  const stroke =
+    isPositive === undefined
+      ? "stroke-foreground-muted"
+      : isPositive
+        ? "stroke-status-success"
+        : "stroke-status-overdue";
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="mt-3 h-7 w-full"
+      preserveAspectRatio="none"
+      aria-hidden
+    >
+      <polyline
+        points={points}
+        fill="none"
+        strokeWidth={1.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={stroke}
+      />
+    </svg>
   );
 }

--- a/components/dashboard/tag-analytics.tsx
+++ b/components/dashboard/tag-analytics.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import type { TagStatistic } from "@/lib/analytics";
 
 interface TagAnalyticsProps {
@@ -25,8 +26,14 @@ const BAR_COLORS = [
  * Replaces the previous table layout with a more visual, dashboard-friendly design.
  */
 export function TagAnalytics({ tagStats, maxTags = 10 }: TagAnalyticsProps) {
-  const displayTags = tagStats.slice(0, maxTags);
-  const maxCount = Math.max(...displayTags.map((t) => t.count), 1);
+  const { displayTags, maxCount } = useMemo(() => {
+    const nextDisplayTags = tagStats.slice(0, maxTags);
+    let nextMaxCount = 1;
+    for (const tag of nextDisplayTags) {
+      if (tag.count > nextMaxCount) nextMaxCount = tag.count;
+    }
+    return { displayTags: nextDisplayTags, maxCount: nextMaxCount };
+  }, [maxTags, tagStats]);
 
   if (displayTags.length === 0) {
     return (

--- a/components/dashboard/upcoming-deadlines.tsx
+++ b/components/dashboard/upcoming-deadlines.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { AlertCircleIcon, CalendarIcon, ClockIcon } from "lucide-react";
 import type { TaskRecord } from "@/lib/types";
 import { quadrants } from "@/lib/quadrants";
@@ -11,31 +12,43 @@ interface UpcomingDeadlinesProps {
   onTaskClick?: (task: TaskRecord) => void;
 }
 
+const QUADRANT_BY_ID = new Map(quadrants.map((quadrant) => [quadrant.id, quadrant]));
+
 /**
  * Widget showing tasks due soon, grouped by urgency.
  * Uses theme-aware colors for proper dark mode support.
  */
 export function UpcomingDeadlines({ tasks, onTaskClick }: UpcomingDeadlinesProps) {
-  const now = new Date();
-
-  const overdueTasks = tasks.filter(
-    (t) => !t.completed && t.dueDate && isOverdue(t.dueDate),
-  );
-  const dueTodayTasks = tasks.filter(
-    (t) => !t.completed && t.dueDate && isDueToday(t.dueDate),
-  );
-  const dueThisWeekTasks = tasks.filter((t) => {
-    if (!t.dueDate || t.completed) return false;
-    const dueDate = new Date(t.dueDate);
+  const { overdueTasks, dueTodayTasks, dueThisWeekTasks, hasDeadlines } = useMemo(() => {
+    const now = new Date();
     const weekFromNow = new Date(now);
     weekFromNow.setDate(weekFromNow.getDate() + 7);
-    return dueDate > now && dueDate <= weekFromNow && !isDueToday(t.dueDate);
-  });
 
-  const hasDeadlines =
-    overdueTasks.length > 0 ||
-    dueTodayTasks.length > 0 ||
-    dueThisWeekTasks.length > 0;
+    const overdue: TaskRecord[] = [];
+    const today: TaskRecord[] = [];
+    const thisWeek: TaskRecord[] = [];
+
+    for (const task of tasks) {
+      if (task.completed || !task.dueDate) continue;
+      if (isOverdue(task.dueDate)) {
+        overdue.push(task);
+      } else if (isDueToday(task.dueDate)) {
+        today.push(task);
+      } else {
+        const dueDate = new Date(task.dueDate);
+        if (dueDate > now && dueDate <= weekFromNow) {
+          thisWeek.push(task);
+        }
+      }
+    }
+
+    return {
+      overdueTasks: overdue,
+      dueTodayTasks: today,
+      dueThisWeekTasks: thisWeek,
+      hasDeadlines: overdue.length > 0 || today.length > 0 || thisWeek.length > 0,
+    };
+  }, [tasks]);
 
   return (
     <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
@@ -123,7 +136,7 @@ function DeadlineSection({
       </div>
       <ul className="space-y-1.5">
         {tasks.slice(0, 5).map((task) => {
-          const quadrant = quadrants.find((q) => q.id === task.quadrant);
+          const quadrant = QUADRANT_BY_ID.get(task.quadrant);
           return (
             <li key={task.id}>
               <button

--- a/components/matrix-simplified/capture-bar.tsx
+++ b/components/matrix-simplified/capture-bar.tsx
@@ -149,14 +149,18 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
       {text.trim() ? (
         <>
           <button
+            key={effectiveKey}
             type="button"
             onClick={cycleQuadrant}
             title="Tab to cycle quadrant"
-            className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide"
-            style={{ backgroundColor: `${accent}1a`, color: accent }}
+            className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[11px] font-medium animate-quadrant-pill-in"
+            style={{ backgroundColor: `${accent}33`, color: accent }}
           >
-            <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: accent }} />
-            {meta.rdShort}
+            <span
+              className="h-[5px] w-[5px] rounded-full bg-current"
+              aria-hidden
+            />
+            {meta.title}
             {override ? <span className="ml-1 font-normal normal-case opacity-60">·fixed</span> : null}
           </button>
           {onMoreOptions ? (
@@ -185,11 +189,12 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
       )}
       <button
         type="submit"
-        disabled={!parsed.title}
+        aria-disabled={!parsed.title}
         className={cn(
-          "inline-flex h-9 items-center gap-1.5 rounded-lg px-4 text-[14px] font-semibold",
-          "bg-foreground text-background hover:bg-foreground/90",
-          "disabled:cursor-not-allowed disabled:opacity-40"
+          "inline-flex h-9 items-center gap-1.5 rounded-lg px-4 text-[14px] font-semibold transition-colors duration-[120ms]",
+          parsed.title
+            ? "bg-accent text-white hover:bg-accent-hover"
+            : "bg-accent/15 text-accent hover:bg-accent/20"
         )}
       >
         Add

--- a/components/matrix-simplified/edit-drawer.tsx
+++ b/components/matrix-simplified/edit-drawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, type FormEvent } from "react";
-import { XIcon, CheckIcon } from "lucide-react";
+import { XIcon, CheckIcon, CalendarIcon } from "lucide-react";
 import type { TaskRecord } from "@/lib/types";
 import { quadrants, QUADRANT_ACCENT } from "@/lib/quadrants";
 import { resolveDuePreset, DUE_PRESETS, type DuePreset } from "@/lib/due-date-presets";
@@ -39,6 +39,26 @@ function classifyExistingDate(iso: string | undefined): DuePreset {
   return "none";
 }
 
+/**
+ * If an existing iso date doesn't fall into a preset bucket but is set,
+ * surface it as a custom date string ("YYYY-MM-DD"). Otherwise undefined.
+ */
+function classifyExistingCustomDate(iso: string | undefined): string | undefined {
+  if (!iso) return undefined;
+  const dateOnly = iso.slice(0, 10);
+  if (classifyExistingDate(iso) !== "none") return undefined;
+  return dateOnly;
+}
+
+function formatChipDate(iso: string): string {
+  const date = new Date(`${iso}T00:00:00`);
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}
+
 export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: EditDrawerProps) {
   const titleRef = useRef<HTMLInputElement>(null);
   const [title, setTitle] = useState("");
@@ -46,6 +66,8 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
   const [urgent, setUrgent] = useState(false);
   const [important, setImportant] = useState(false);
   const [duePreset, setDuePreset] = useState<DuePreset>("none");
+  const [customDate, setCustomDate] = useState<string | undefined>(undefined);
+  const [showCustomDateInput, setShowCustomDateInput] = useState(false);
   const [tags, setTags] = useState<string[]>([]);
   const [tagInput, setTagInput] = useState("");
 
@@ -59,6 +81,7 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
       setUrgent(task.urgent);
       setImportant(task.important);
       setDuePreset(classifyExistingDate(task.dueDate));
+      setCustomDate(classifyExistingCustomDate(task.dueDate));
       setTags(task.tags ?? []);
     } else {
       setTitle(initialDraft?.title ?? "");
@@ -66,8 +89,10 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
       setUrgent(initialDraft?.urgent ?? false);
       setImportant(initialDraft?.important ?? false);
       setDuePreset("none");
+      setCustomDate(undefined);
       setTags(initialDraft?.tags ?? []);
     }
+    setShowCustomDateInput(false);
     setTagInput("");
     setTimeout(() => titleRef.current?.focus(), 50);
   }, [open, task, initialDraft]);
@@ -91,7 +116,8 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
   const submit = (e?: FormEvent) => {
     e?.preventDefault();
     if (!title.trim()) return;
-    const rawDate = resolveDuePreset(duePreset);
+    // Custom date wins over preset when set.
+    const rawDate = customDate ?? resolveDuePreset(duePreset);
     // Convert date-only "YYYY-MM-DD" to full ISO datetime required by taskDraftSchema
     const dueDate = rawDate ? new Date(`${rawDate}T00:00:00`).toISOString() : undefined;
     void onSubmit(
@@ -198,23 +224,73 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
           </Field>
 
           <Field label="Due date">
-            <div className="inline-flex rounded-lg border border-border bg-background-muted p-1">
-              {DUE_PRESETS.map((p) => (
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="inline-flex rounded-lg border border-border bg-background-muted p-1">
+                {DUE_PRESETS.map((p) => {
+                  const isActive = !customDate && duePreset === p.value;
+                  return (
+                    <button
+                      key={p.value}
+                      type="button"
+                      onClick={() => {
+                        setDuePreset(p.value);
+                        setCustomDate(undefined);
+                        setShowCustomDateInput(false);
+                      }}
+                      className={cn(
+                        "rounded-md px-3 py-1.5 text-[12.5px] font-medium transition-all duration-200",
+                        isActive
+                          ? "bg-background text-foreground shadow-sm"
+                          : "text-foreground-muted hover:text-foreground"
+                      )}
+                      aria-pressed={isActive}
+                    >
+                      {p.label}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {customDate ? (
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-foreground-muted/30 bg-background px-2.5 py-1 text-[12px] font-medium text-foreground">
+                  <CalendarIcon className="h-3 w-3" aria-hidden />
+                  {formatChipDate(customDate)}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setCustomDate(undefined);
+                      setShowCustomDateInput(false);
+                    }}
+                    aria-label="Clear custom date"
+                    className="ml-0.5 text-foreground-muted hover:text-foreground"
+                  >
+                    <XIcon className="h-3 w-3" />
+                  </button>
+                </span>
+              ) : showCustomDateInput ? (
+                <input
+                  type="date"
+                  autoFocus
+                  onChange={(e) => {
+                    if (e.target.value) {
+                      setCustomDate(e.target.value);
+                      setShowCustomDateInput(false);
+                    }
+                  }}
+                  onBlur={() => setShowCustomDateInput(false)}
+                  className="rounded-md border border-border bg-background px-2.5 py-1 text-[12.5px] font-medium text-foreground outline-none focus:border-foreground-muted"
+                  aria-label="Pick a custom due date"
+                />
+              ) : (
                 <button
-                  key={p.value}
                   type="button"
-                  onClick={() => setDuePreset(p.value)}
-                  className={cn(
-                    "rounded-md px-3 py-1.5 text-[12.5px] font-medium transition-all duration-200",
-                    duePreset === p.value
-                      ? "bg-background text-foreground shadow-sm"
-                      : "text-foreground-muted hover:text-foreground"
-                  )}
-                  aria-pressed={duePreset === p.value}
+                  onClick={() => setShowCustomDateInput(true)}
+                  className="inline-flex items-center gap-1 rounded-md border border-dashed border-border px-2.5 py-1 text-[12.5px] font-medium text-foreground-muted transition-colors hover:border-foreground-muted/50 hover:text-foreground"
                 >
-                  {p.label}
+                  <CalendarIcon className="h-3 w-3" aria-hidden />
+                  Pick a date…
                 </button>
-              ))}
+              )}
             </div>
           </Field>
 

--- a/components/matrix-simplified/icon-rail.tsx
+++ b/components/matrix-simplified/icon-rail.tsx
@@ -38,12 +38,15 @@ export function IconRail({ onHelp }: IconRailProps) {
   return (
     <>
       <aside
-        className="hidden md:flex md:w-[60px] md:shrink-0 md:flex-col md:items-center md:border-r md:border-border/70 md:bg-background"
+        className="group/rail hidden md:flex md:w-[60px] md:shrink-0 md:flex-col md:items-stretch md:overflow-hidden md:border-r md:border-border/70 md:bg-background md:transition-[width] md:duration-[250ms] md:ease-out md:hover:w-[180px] md:focus-within:w-[180px]"
         aria-label="Primary navigation"
       >
-        <div className="sticky top-0 flex h-screen flex-col items-center gap-1 py-3.5">
-          <div className="mb-2.5 flex h-8 w-8 items-center justify-center" title="GSD">
+        <div className="sticky top-0 flex h-screen flex-col gap-1 px-2 py-3.5">
+          <div className="mb-2.5 flex h-8 items-center gap-2.5 px-1.5" title="GSD">
             <GsdLogo size={28} />
+            <span className="rd-serif whitespace-nowrap text-[15px] tracking-tight text-foreground opacity-0 transition-opacity duration-200 group-hover/rail:opacity-100 group-focus-within/rail:opacity-100">
+              GSD
+            </span>
           </div>
           <div className="my-1 h-px w-6 bg-border/70" aria-hidden />
           {PRIMARY.map((item) => (
@@ -72,9 +75,10 @@ export function IconRail({ onHelp }: IconRailProps) {
             active={isRouteActive(pathname, item.routeKey)}
             disabled={isPending}
             onClick={() => navigateWithTransition(ROUTES[item.routeKey])}
+            mobile
           />
         ))}
-        <RailButton label="Help" icon={CircleHelpIcon} onClick={onHelp} />
+        <RailButton label="Help" icon={CircleHelpIcon} onClick={onHelp} mobile />
       </nav>
     </>
   );
@@ -86,13 +90,38 @@ function RailButton({
   active = false,
   disabled = false,
   onClick,
+  mobile = false,
 }: {
   label: string;
   icon: LucideIcon;
   active?: boolean;
   disabled?: boolean;
   onClick: () => void;
+  mobile?: boolean;
 }) {
+  if (mobile) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        title={label}
+        aria-label={label}
+        aria-current={active ? "page" : undefined}
+        className={cn(
+          "group relative flex h-10 w-10 items-center justify-center rounded-xl transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1",
+          active
+            ? "bg-background-muted text-foreground"
+            : "text-foreground-muted hover:bg-background-muted/60 hover:text-foreground",
+          disabled && "cursor-wait opacity-60"
+        )}
+      >
+        <Icon className="h-5 w-5" aria-hidden />
+      </button>
+    );
+  }
+
   return (
     <button
       type="button"
@@ -102,15 +131,18 @@ function RailButton({
       aria-label={label}
       aria-current={active ? "page" : undefined}
       className={cn(
-        "group relative flex h-10 w-10 items-center justify-center rounded-xl transition-colors",
+        "relative flex h-10 w-full items-center gap-3 rounded-xl pl-2.5 pr-3 text-body transition-colors",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1",
         active
-          ? "bg-background-muted text-foreground"
+          ? "text-foreground before:absolute before:inset-y-1.5 before:left-0 before:w-[2px] before:rounded-full before:bg-accent before:content-['']"
           : "text-foreground-muted hover:bg-background-muted/60 hover:text-foreground",
         disabled && "cursor-wait opacity-60"
       )}
     >
-      <Icon className="h-5 w-5" aria-hidden />
+      <Icon className="h-5 w-5 shrink-0" aria-hidden />
+      <span className="whitespace-nowrap opacity-0 transition-opacity duration-200 group-hover/rail:opacity-100 group-focus-within/rail:opacity-100">
+        {label}
+      </span>
     </button>
   );
 }

--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -17,6 +17,7 @@ import {
   readShowCompleted,
 } from "@/lib/preferences/show-completed";
 import type { TaskRecord } from "@/lib/types";
+import { quadrantByRdKey, type RedesignQuadrantKey } from "@/lib/quadrants";
 import { TaskCard } from "@/components/task-card";
 import { AppShell } from "./app-shell";
 import { CaptureBar, type CapturePayload } from "./capture-bar";
@@ -29,9 +30,9 @@ function isEditable(el: Element | null): boolean {
   return t === "INPUT" || t === "TEXTAREA" || el.isContentEditable;
 }
 
-function filterTasks(tasks: TaskRecord[], query: string): TaskRecord[] {
-  if (!query.trim()) return tasks;
-  const q = query.trim().toLowerCase();
+function filterTasks(tasks: TaskRecord[], trimmedQuery: string): TaskRecord[] {
+  if (!trimmedQuery) return tasks;
+  const q = trimmedQuery.toLowerCase();
   return tasks.filter((t) => {
     const hay = [
       t.title,
@@ -99,16 +100,32 @@ export function MatrixSimplified() {
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
-  const visibleTasks = useMemo(() => {
-    const base = showCompleted ? all : all.filter((t) => !t.completed);
-    return filterTasks(base, searchQuery);
-  }, [all, searchQuery, showCompleted]);
-  const total = all.length;
-  const completed = all.filter((t) => t.completed).length;
-  const overdue = all.filter((t) => {
-    if (t.completed || !t.dueDate) return false;
-    return t.dueDate < new Date().toISOString().slice(0, 10);
-  }).length;
+  const trimmedSearchQuery = searchQuery.trim();
+  const { visibleTasks, total, completed, overdue } = useMemo(() => {
+    const todayIso = new Date().toISOString().slice(0, 10);
+    let completedCount = 0;
+    let overdueCount = 0;
+    const activeTasks: TaskRecord[] = [];
+
+    for (const task of all) {
+      if (task.completed) {
+        completedCount += 1;
+      } else {
+        activeTasks.push(task);
+        if (task.dueDate && task.dueDate < todayIso) {
+          overdueCount += 1;
+        }
+      }
+    }
+
+    const base = showCompleted ? all : activeTasks;
+    return {
+      visibleTasks: filterTasks(base, trimmedSearchQuery),
+      total: all.length,
+      completed: completedCount,
+      overdue: overdueCount,
+    };
+  }, [all, showCompleted, trimmedSearchQuery]);
 
   const handleCapture = useCallback(
     async ({ title, urgent, important, tags }: CapturePayload) => {
@@ -129,8 +146,15 @@ export function MatrixSimplified() {
     [showToast]
   );
 
-  const handleAddInQuadrant = useCallback(() => {
-    captureInputRef.current?.focus();
+  const handleAddInQuadrant = useCallback((key: RedesignQuadrantKey) => {
+    const meta = quadrantByRdKey(key);
+    setCreateInitial({
+      title: "",
+      urgent: meta.urgent,
+      important: meta.important,
+      tags: [],
+    });
+    setCreateDrawerOpen(true);
   }, []);
 
   const handleToggle = useCallback(
@@ -207,24 +231,30 @@ export function MatrixSimplified() {
     [showToast]
   );
 
-  const activeDragTask = activeId ? all.find((t) => t.id === activeId) ?? null : null;
+  const activeDragTask = useMemo(
+    () => (activeId ? all.find((t) => t.id === activeId) ?? null : null),
+    [activeId, all]
+  );
 
-  const caption = (
-    <>
-      <span>
-        <strong className="font-semibold text-foreground">{total - completed}</strong> active
-      </span>
-      <span className="text-foreground-muted/60">·</span>
-      <span>
-        <strong className="font-semibold text-foreground">{completed}</strong> done
-      </span>
-      {overdue > 0 ? (
-        <>
-          <span className="text-foreground-muted/60">·</span>
-          <span className="text-status-overdue">{overdue} overdue</span>
-        </>
-      ) : null}
-    </>
+  const caption = useMemo(
+    () => (
+      <>
+        <span>
+          <strong className="font-semibold text-foreground">{total - completed}</strong> active
+        </span>
+        <span className="text-foreground-muted/60">·</span>
+        <span>
+          <strong className="font-semibold text-foreground">{completed}</strong> done
+        </span>
+        {overdue > 0 ? (
+          <>
+            <span className="text-foreground-muted/60">·</span>
+            <span className="text-status-overdue">{overdue} overdue</span>
+          </>
+        ) : null}
+      </>
+    ),
+    [completed, overdue, total]
   );
 
   return (
@@ -241,6 +271,7 @@ export function MatrixSimplified() {
         </div>
         <MatrixGrid
           tasks={visibleTasks}
+          allTasks={all}
           onEdit={handleEditOpen}
           onToggleComplete={handleToggle}
           onDelete={handleDelete}

--- a/components/matrix-simplified/matrix-grid.tsx
+++ b/components/matrix-simplified/matrix-grid.tsx
@@ -7,6 +7,7 @@ import { QuadrantPane } from "./quadrant-pane";
 
 interface MatrixGridProps {
   tasks: TaskRecord[];
+  allTasks: TaskRecord[];
   onEdit: (task: TaskRecord) => void;
   onToggleComplete: (task: TaskRecord, completed: boolean) => void | Promise<void>;
   onDelete: (task: TaskRecord) => void | Promise<void>;
@@ -15,6 +16,7 @@ interface MatrixGridProps {
 
 export function MatrixGrid({
   tasks,
+  allTasks,
   onEdit,
   onToggleComplete,
   onDelete,
@@ -48,7 +50,7 @@ export function MatrixGrid({
           meta={meta}
           position={POSITIONS[index]}
           tasks={grouped[meta.rdKey]}
-          allTasks={tasks}
+          allTasks={allTasks}
           onEdit={onEdit}
           onToggleComplete={onToggleComplete}
           onDelete={onDelete}

--- a/components/matrix-simplified/quadrant-pane.tsx
+++ b/components/matrix-simplified/quadrant-pane.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { useMemo } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
-import { PlusIcon, FlameIcon, CalendarIcon, UsersIcon, TrashIcon, type LucideIcon } from "lucide-react";
+import { PlusIcon } from "lucide-react";
 import { TaskCard } from "@/components/task-card";
 import type { TaskRecord } from "@/lib/types";
 import type { QuadrantMeta, RedesignQuadrantKey } from "@/lib/quadrants";
@@ -21,13 +22,6 @@ const HEADER_CLASS: Record<RedesignQuadrantKey, string> = {
   q2: "quadrant-header-q2",
   q3: "quadrant-header-q3",
   q4: "quadrant-header-q4",
-};
-
-const EMPTY_ICON: Record<RedesignQuadrantKey, LucideIcon> = {
-  q1: FlameIcon,
-  q2: CalendarIcon,
-  q3: UsersIcon,
-  q4: TrashIcon,
 };
 
 export type QuadrantPosition = "tl" | "tr" | "bl" | "br";
@@ -65,8 +59,11 @@ export function QuadrantPane({
 }: QuadrantPaneProps) {
   const { setNodeRef, isOver } = useDroppable({ id: meta.id });
   const accent = QUADRANT_ACCENT[meta.rdKey];
-  const taskIds = tasks.map((t) => t.id);
-
+  const taskIds = useMemo(() => tasks.map((t) => t.id), [tasks]);
+  const activeTaskCount = useMemo(
+    () => tasks.reduce((count, task) => count + (task.completed ? 0 : 1), 0),
+    [tasks]
+  );
   return (
     <section
       ref={setNodeRef}
@@ -94,7 +91,7 @@ export function QuadrantPane({
         </span>
         <span className="text-[12.5px] text-foreground-muted">{meta.rdHint}</span>
         <span className="ml-auto rounded bg-background-muted px-1.5 text-[11px] font-medium tabular-nums text-foreground-muted">
-          {tasks.filter((t) => !t.completed).length}
+          {activeTaskCount}
         </span>
         <button
           type="button"
@@ -109,11 +106,25 @@ export function QuadrantPane({
       <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>
         <div className="flex flex-1 flex-col gap-2">
           {tasks.length === 0 ? (
-            <div className="my-auto flex flex-col items-center gap-2 py-4">
-              {(() => { const Icon = EMPTY_ICON[meta.rdKey]; return <Icon className="h-5 w-5 text-foreground-muted/30" aria-hidden />; })()}
-              <p className="rd-serif text-center text-sm text-foreground-muted">
-                {meta.rdEmpty}
+            <div className="my-auto flex flex-col items-center gap-1.5 py-4 text-center">
+              <p
+                className="rd-serif text-[18px] leading-tight text-foreground"
+                style={{ letterSpacing: "-0.01em" }}
+              >
+                {meta.rdEmptyHeadline}
               </p>
+              <p className="max-w-[26ch] text-caption text-foreground-muted">
+                {meta.rdEmptySupporting}
+              </p>
+              <button
+                type="button"
+                onClick={() => onAddInQuadrant(meta.rdKey)}
+                className="mt-2 inline-flex items-center gap-1.5 rounded-full border border-dashed px-2.5 py-1 text-[11px] font-medium transition-colors hover:bg-background-muted/40"
+                style={{ borderColor: accent, color: accent }}
+              >
+                <PlusIcon className="h-3 w-3" aria-hidden />
+                Add to {meta.title}
+              </button>
             </div>
           ) : (
             tasks.map((task) => (

--- a/components/settings-page/index.tsx
+++ b/components/settings-page/index.tsx
@@ -19,6 +19,7 @@ import { createLogger } from "@/lib/logger";
 import {
   SHOW_COMPLETED_EVENT,
   SHOW_COMPLETED_KEY,
+  readShowCompleted,
 } from "@/lib/preferences/show-completed";
 
 import { AppearanceSettings } from "@/components/settings/appearance-settings";
@@ -83,10 +84,7 @@ export function SettingsPage() {
         setNotificationSettings(notif);
         setSyncEnabled(sync.enabled);
         setPendingSync(sync.pendingCount);
-        setShowCompleted(
-          typeof window !== "undefined" &&
-            localStorage.getItem(SHOW_COMPLETED_KEY) === "true",
-        );
+        setShowCompleted(readShowCompleted());
         setDataLoaded(true);
       } catch (error) {
         logger.error(
@@ -201,11 +199,25 @@ export function SettingsPage() {
     }
   }, [activeSection, visibleSectionIds]);
 
-  const activeMeta =
-    SETTINGS_SECTIONS.find((s) => s.id === activeSection) ?? SETTINGS_SECTIONS[0];
-  const activeTaskCount = tasks.filter((t) => !t.completed).length;
-  const completedTaskCount = tasks.filter((t) => t.completed).length;
-  const estimatedKb = (JSON.stringify(tasks).length / 1024).toFixed(1);
+  const activeMeta = useMemo(
+    () => SETTINGS_SECTIONS.find((s) => s.id === activeSection) ?? SETTINGS_SECTIONS[0],
+    [activeSection]
+  );
+  const { activeTaskCount, completedTaskCount, estimatedKb } = useMemo(() => {
+    let activeCount = 0;
+    let completedCount = 0;
+
+    for (const task of tasks) {
+      if (task.completed) completedCount += 1;
+      else activeCount += 1;
+    }
+
+    return {
+      activeTaskCount: activeCount,
+      completedTaskCount: completedCount,
+      estimatedKb: (JSON.stringify(tasks).length / 1024).toFixed(1),
+    };
+  }, [tasks]);
 
   return (
     <TooltipProvider delayDuration={300}>

--- a/components/settings-page/settings-sidebar.tsx
+++ b/components/settings-page/settings-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import {
   PaletteIcon,
   BellIcon,
@@ -52,8 +53,12 @@ interface SettingsSidebarProps {
  * vertical bar and tinted pill. Collapses into a horizontal scroller on mobile.
  */
 export function SettingsSidebar({ activeId, onSelect, visibleSections }: SettingsSidebarProps) {
-  const sections = SETTINGS_SECTIONS.filter((s) => visibleSections.includes(s.id));
-  const groups = groupByGroup(sections);
+  const visibleSectionSet = useMemo(() => new Set(visibleSections), [visibleSections]);
+  const sections = useMemo(
+    () => SETTINGS_SECTIONS.filter((s) => visibleSectionSet.has(s.id)),
+    [visibleSectionSet]
+  );
+  const groups = useMemo(() => groupByGroup(sections), [sections]);
 
   return (
     <>

--- a/components/settings/appearance-settings.tsx
+++ b/components/settings/appearance-settings.tsx
@@ -52,6 +52,7 @@ export function AppearanceSettings({
 			<SettingsRow
 				label="Show completed"
 				description="Display finished tasks in the matrix"
+				state={showCompleted}
 			>
 				<Switch
 					checked={showCompleted}

--- a/components/settings/archive-settings.tsx
+++ b/components/settings/archive-settings.tsx
@@ -92,7 +92,11 @@ export function ArchiveSettings({
 	return (
 		<>
 			{/* Auto-Archive Toggle */}
-			<SettingsRow label="Auto-archive" description="Archive old completed tasks">
+			<SettingsRow
+				label="Auto-archive"
+				description="Archive old completed tasks"
+				state={settings.enabled}
+			>
 				<Switch
 					checked={settings.enabled}
 					onCheckedChange={handleToggleEnabled}

--- a/components/settings/notification-settings.tsx
+++ b/components/settings/notification-settings.tsx
@@ -41,7 +41,11 @@ export function NotificationSettingsSection({
 	return (
 		<>
 			{/* Enable Notifications Row */}
-			<SettingsRow label="Push notifications" description="Get reminded about tasks">
+			<SettingsRow
+				label="Push notifications"
+				description="Get reminded about tasks"
+				state={settings.enabled}
+			>
 				<Switch
 					checked={settings.enabled}
 					onCheckedChange={onNotificationToggle}

--- a/components/settings/shared-components.tsx
+++ b/components/settings/shared-components.tsx
@@ -10,13 +10,15 @@ import { ChevronRightIcon } from "lucide-react";
 interface SettingsRowProps {
 	label: string;
 	description?: string;
+	/** Optional toggle state — when provided, appends "· on" / "· off" to the description for skim readers and screen readers. */
+	state?: boolean;
 	children: React.ReactNode;
 }
 
 /**
  * Settings row with label, optional description, and inline content
  */
-export function SettingsRow({ label, description, children }: SettingsRowProps) {
+export function SettingsRow({ label, description, state, children }: SettingsRowProps) {
 	return (
 		<div className="flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px]">
 			<div className="flex-1 min-w-0">
@@ -24,6 +26,14 @@ export function SettingsRow({ label, description, children }: SettingsRowProps) 
 				{description && (
 					<p className="text-xs text-foreground-muted mt-0.5">
 						{description}
+						{state !== undefined && (
+							<span
+								className={state ? "text-foreground" : "text-foreground-muted"}
+							>
+								{" · "}
+								{state ? "on" : "off"}
+							</span>
+						)}
 					</p>
 				)}
 			</div>

--- a/components/settings/sync-settings.tsx
+++ b/components/settings/sync-settings.tsx
@@ -96,7 +96,11 @@ export function SyncSettings({
 	return (
 		<>
 			{/* Auto-Sync Toggle */}
-			<SettingsRow label="Auto-sync" description="Sync changes in the background">
+			<SettingsRow
+				label="Auto-sync"
+				description="Sync changes in the background"
+				state={autoSyncEnabled}
+			>
 				<Switch
 					checked={autoSyncEnabled}
 					onCheckedChange={handleAutoSyncToggle}

--- a/components/task-card/index.tsx
+++ b/components/task-card/index.tsx
@@ -3,7 +3,7 @@
 import { memo } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { cn, isOverdue, isDueToday } from "@/lib/utils";
+import { cn, isOverdue, isDueToday, daysOverdue } from "@/lib/utils";
 import { getUncompletedBlockingTasks, getBlockedTasks } from "@/lib/dependencies";
 import { areTaskCardPropsEqual, type TaskCardProps } from "@/lib/task-card-memo";
 import { TaskCardHeader } from "@/components/task-card/task-card-header";
@@ -29,6 +29,7 @@ function TaskCardComponent({
 }: TaskCardProps) {
   const taskIsOverdue = !task.completed && isOverdue(task.dueDate);
   const taskIsDueToday = !task.completed && isDueToday(task.dueDate);
+  const overdueDays = taskIsOverdue ? daysOverdue(task.dueDate) : 0;
   const completedSubtasks = task.subtasks.filter(st => st.completed).length;
   const totalSubtasks = task.subtasks.length;
 
@@ -58,15 +59,22 @@ function TaskCardComponent({
       }}
       style={style}
       className={cn(
-        "group flex flex-col gap-2 rounded-xl border bg-card p-3 transition-all duration-200 animate-slide-in-card",
+        "group relative flex flex-col gap-2 rounded-xl border bg-card p-3 transition-all duration-200 animate-slide-in-card",
+        "border-card-border",
         task.completed ? "opacity-60" : "opacity-100 hover:-translate-y-0.5 hover:border-accent/40",
         task.completed && "animate-complete-flash",
         isDragging && "cursor-grabbing",
-        taskIsOverdue ? "overdue-task border-l-4 border-status-overdue/30 bg-status-overdue-muted/40" : "border-card-border",
+        taskIsOverdue && "overdue-task border-l-[3px] border-l-status-overdue",
         selectionMode && isSelected && "ring-2 ring-accent ring-offset-2",
         isHighlighted && "animate-pulse-highlight ring-4 ring-accent ring-offset-2"
       )}
     >
+      {taskIsOverdue ? (
+        <span className="pointer-events-none absolute right-2.5 top-2 text-[10px] font-semibold uppercase tracking-wide text-status-overdue">
+          {overdueDays}D Overdue
+        </span>
+      ) : null}
+
       <TaskCardHeader
         task={task}
         selectionMode={selectionMode}

--- a/components/task-card/task-card-actions.tsx
+++ b/components/task-card/task-card-actions.tsx
@@ -31,17 +31,12 @@ export function TaskCardActions({
   return (
     <div className="flex items-center justify-between gap-2 text-xs text-foreground-muted">
       <div className="flex items-center gap-2">
-        {taskIsOverdue ? (
-          <span className="flex items-center gap-1 rounded-full bg-red-50 dark:bg-red-950/40 px-2 py-0.5 text-red-600 dark:text-red-400 font-medium">
-            <AlertCircleIcon className="h-3 w-3" />
-            Overdue
-          </span>
-        ) : taskIsDueToday ? (
+        {taskIsDueToday && !taskIsOverdue ? (
           <span className="flex items-center gap-1 rounded-full bg-amber-50 dark:bg-amber-950/40 px-2 py-0.5 text-amber-600 dark:text-amber-400 font-medium">
             <AlertCircleIcon className="h-3 w-3" />
             Due today
           </span>
-        ) : task.dueDate ? (
+        ) : task.dueDate && !taskIsOverdue ? (
           <span className="truncate">{formatRelative(task.dueDate)}</span>
         ) : null}
         {task.recurrence !== "none" ? (

--- a/components/task-card/task-card-metadata.tsx
+++ b/components/task-card/task-card-metadata.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TagIcon, LockIcon, LinkIcon } from "lucide-react";
+import { LockIcon, LinkIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { TaskTimer } from "@/components/task-timer";
 import type { TaskRecord } from "@/lib/types";
@@ -30,15 +30,15 @@ export function TaskCardMetadata({
 }: TaskCardMetadataProps) {
   return (
     <>
-      {/* Tags */}
+      {/* Tags — neutral chips, leading dot, no hashtag glyph (implied) */}
       {task.tags.length > 0 ? (
         <div className="flex flex-wrap gap-1">
           {task.tags.map((tag) => (
             <span
               key={tag}
-              className="inline-flex items-center gap-1 rounded-full bg-accent/10 px-2 py-0.5 text-xs font-medium text-accent transition-colors hover:bg-accent/20"
+              className="inline-flex items-center gap-1 rounded-full border border-border-muted bg-background-muted px-2 py-0.5 text-xs font-medium text-foreground-muted"
             >
-              <TagIcon className="h-2.5 w-2.5" />
+              <span className="h-[5px] w-[5px] rounded-full bg-current" aria-hidden />
               {tag}
             </span>
           ))}

--- a/components/task-description.tsx
+++ b/components/task-description.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { getDescriptionSegments } from "@/lib/task-links";
 import { cn } from "@/lib/utils";
 
@@ -7,7 +8,7 @@ interface TaskDescriptionProps {
 }
 
 export function TaskDescription({ description, className }: TaskDescriptionProps) {
-  const segments = getDescriptionSegments(description);
+  const segments = useMemo(() => getDescriptionSegments(description), [description]);
 
   return (
     <span className={cn("break-words", className)}>

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -10,7 +10,12 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-accent data-[state=unchecked]:bg-input",
+      "peer inline-flex h-[22px] w-[38px] shrink-0 cursor-pointer items-center rounded-full transition-colors",
+      "shadow-[inset_0_0_0_1px_rgb(var(--border))]",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+      "disabled:cursor-not-allowed disabled:opacity-50",
+      "data-[state=checked]:bg-accent data-[state=checked]:shadow-none",
+      "data-[state=unchecked]:bg-border",
       className
     )}
     {...props}
@@ -18,7 +23,8 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+        "pointer-events-none block h-[18px] w-[18px] rounded-full bg-white shadow-sm ring-0 transition-transform",
+        "data-[state=checked]:translate-x-[18px] data-[state=unchecked]:translate-x-[2px]"
       )}
     />
   </SwitchPrimitives.Root>

--- a/lib/quadrants.ts
+++ b/lib/quadrants.ts
@@ -39,6 +39,10 @@ export interface QuadrantMeta {
   rdHint: string; // "Crises, deadlines. Handle now."
   rdIcon: RedesignIconKey;
   rdEmpty: string;
+  /** Editorial serif headline shown in the empty quadrant pane. */
+  rdEmptyHeadline: string;
+  /** Body copy under the headline in the empty quadrant pane. */
+  rdEmptySupporting: string;
   urgent: boolean;
   important: boolean;
 }
@@ -63,6 +67,8 @@ export const quadrants: QuadrantMeta[] = [
     rdHint: "Crises, deadlines. Handle now.",
     rdIcon: "flame",
     rdEmpty: "Clear. Nothing urgent demanding you right now.",
+    rdEmptyHeadline: "Nothing on fire.",
+    rdEmptySupporting: "Stay sharp.",
     urgent: true,
     important: true,
   },
@@ -85,6 +91,8 @@ export const quadrants: QuadrantMeta[] = [
     rdHint: "Strategy, growth. Protect time.",
     rdIcon: "calendar",
     rdEmpty: "Plan something meaningful. This is where growth lives.",
+    rdEmptyHeadline: "Plan the week.",
+    rdEmptySupporting: "What's important but not on fire? Block time before it becomes urgent.",
     urgent: false,
     important: true,
   },
@@ -107,6 +115,8 @@ export const quadrants: QuadrantMeta[] = [
     rdHint: "Interruptions. Hand these off.",
     rdIcon: "users",
     rdEmpty: "Nothing to hand off.",
+    rdEmptyHeadline: "Hand it off.",
+    rdEmptySupporting: "Save your attention for the matrix. Route interruptions elsewhere.",
     urgent: true,
     important: false,
   },
@@ -129,6 +139,8 @@ export const quadrants: QuadrantMeta[] = [
     rdHint: "Noise. Stop doing these.",
     rdIcon: "trash",
     rdEmpty: "No noise to clear. Good.",
+    rdEmptyHeadline: "No noise to clear.",
+    rdEmptySupporting: "Good.",
     urgent: false,
     important: false,
   }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -67,6 +67,20 @@ export function isOverdue(value?: string): boolean {
 }
 
 /**
+ * How many whole days a due date is overdue. Returns 0 for today or future dates.
+ * Used by the task-card overdue caption (e.g. "2D OVERDUE").
+ */
+export function daysOverdue(value?: string): number {
+  if (!value) return 0;
+  const due = new Date(value);
+  const now = new Date();
+  due.setHours(0, 0, 0, 0);
+  now.setHours(0, 0, 0, 0);
+  const diff = now.getTime() - due.getTime();
+  return diff > 0 ? Math.floor(diff / TIME_MS.DAY) : 0;
+}
+
+/**
  * Check if a date is due today
  */
 export function isDueToday(value?: string): boolean {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.9.1",
+	"version": "8.10.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-mcp-server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "MCP server for GSD Task Manager — 20 tools for task CRUD, analytics, and diagnostics over PocketBase. Validated inputs, dry-run support, JWT-aware token health, and dependency-safe deletes.",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/ui/coverage-boost-ui.test.tsx
+++ b/tests/ui/coverage-boost-ui.test.tsx
@@ -268,7 +268,7 @@ describe("TaskCardActions", () => {
     expect(screen.getByRole("button", { name: /duplicate task/i })).toBeInTheDocument();
   });
 
-  it("shows overdue badge", async () => {
+  it("does not render overdue badge in actions row (now hoisted to card root)", async () => {
     const { TaskCardActions } = await import(
       "@/components/task-card/task-card-actions"
     );
@@ -299,7 +299,9 @@ describe("TaskCardActions", () => {
       />
     );
 
-    expect(screen.getByText("Overdue")).toBeInTheDocument();
+    // Polish v0.9.2: the overdue caption now lives on the TaskCard root,
+    // not in the actions footer. Confirm it is gone from this scope.
+    expect(screen.queryByText("Overdue")).not.toBeInTheDocument();
   });
 
   it("shows recurrence icon", async () => {

--- a/tests/ui/dashboard-components.test.tsx
+++ b/tests/ui/dashboard-components.test.tsx
@@ -76,28 +76,25 @@ describe('Dashboard Components', () => {
       expect(screen.getByText('No Icon')).toBeInTheDocument();
     });
 
-    it('should render with subtitle', () => {
-      render(<StatsCard value={5} title="Active" subtitle="23 total" />);
+    it('should render footer meta string when provided', () => {
+      render(<StatsCard value={5} title="Active" footerMeta="20 / 7d" />);
 
-      expect(screen.getByText('23 total')).toBeInTheDocument();
+      expect(screen.getByText('20 / 7d')).toBeInTheDocument();
     });
 
-    it('should apply fallback accent when no accentColor provided', () => {
-      const { container } = render(<StatsCard value={5} title="Default Accent" />);
+    it('should render insight pill when provided', () => {
+      render(<StatsCard value={5} title="Completed" insight="Holding steady" />);
 
-      // Should render without errors (fallback accent classes applied)
-      expect(container.querySelector('div')).toBeInTheDocument();
+      expect(screen.getByText('Holding steady')).toBeInTheDocument();
     });
 
-    it('should apply each accent color variant', () => {
-      const colors = ['blue', 'emerald', 'amber', 'red'] as const;
-      for (const color of colors) {
-        const { unmount } = render(
-          <StatsCard value={1} title={`Color ${color}`} accentColor={color} />
-        );
-        expect(screen.getByText(`Color ${color}`)).toBeInTheDocument();
-        unmount();
-      }
+    it('should render an inline sparkline when series has 2+ points', () => {
+      const { container } = render(
+        <StatsCard value={5} title="Trend" series={[1, 2, 3, 4, 5]} />
+      );
+
+      // Sparkline is an SVG polyline; presence is enough to verify the wiring.
+      expect(container.querySelector('svg polyline')).toBeInTheDocument();
     });
   });
 

--- a/tests/ui/edit-drawer.test.tsx
+++ b/tests/ui/edit-drawer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { EditDrawer } from "@/components/matrix-simplified/edit-drawer";
 import type { TaskRecord } from "@/lib/types";
@@ -137,6 +137,32 @@ describe("<EditDrawer>", () => {
     it("disables Create task button when title is empty", () => {
       render(<EditDrawer open task={null} onClose={vi.fn()} onSubmit={vi.fn()} />);
       expect(screen.getByRole("button", { name: /create task/i })).toBeDisabled();
+    });
+  });
+
+  describe("custom due date pill (polish v0.9.2 — item 10)", () => {
+    it("renders a 'Pick a date…' affordance after the preset chips", () => {
+      render(<EditDrawer open task={null} onClose={vi.fn()} onSubmit={vi.fn()} />);
+      expect(screen.getByRole("button", { name: "Pick a date…" })).toBeInTheDocument();
+    });
+
+    it("submits the custom-picked date as the task's dueDate", async () => {
+      const onSubmit = vi.fn();
+      render(<EditDrawer open task={null} onClose={vi.fn()} onSubmit={onSubmit} />);
+
+      await user.type(screen.getByLabelText(/^title$/i), "Pick test");
+      await user.click(screen.getByRole("button", { name: "Pick a date…" }));
+
+      // The native date input is revealed once the pill is clicked.
+      const dateInput = screen.getByLabelText(/pick a custom due date/i);
+      // userEvent.type doesn't drive type=date reliably in jsdom — fireEvent.change
+      // routes the value through React's synthetic event system.
+      fireEvent.change(dateInput, { target: { value: "2026-05-12" } });
+
+      await user.click(screen.getByRole("button", { name: /create task/i }));
+
+      const submitted = onSubmit.mock.calls.at(-1)?.[0];
+      expect(submitted?.dueDate?.slice(0, 10)).toBe("2026-05-12");
     });
   });
 });

--- a/tests/ui/matrix-simplified.test.tsx
+++ b/tests/ui/matrix-simplified.test.tsx
@@ -175,5 +175,24 @@ describe("<MatrixSimplified>", () => {
         expect(screen.getByText("Done bravo")).toBeInTheDocument(),
       );
     });
+
+    it("opens the create drawer pre-set to a quadrant when its empty-state pill is clicked (polish v0.9.2 — item 3)", async () => {
+      const user = userEvent.setup();
+      tasksFixture.current = [];
+      render(<MatrixSimplified />);
+
+      // The drawer header is "New task" — only present once it opens.
+      expect(screen.queryByRole("heading", { name: /new task/i })).not.toBeInTheDocument();
+
+      // Target the visible-text empty-state pill (not the icon-only header "+").
+      await user.click(screen.getByText("Add to Do First"));
+
+      const heading = await screen.findByRole("heading", { name: /new task/i });
+      expect(heading).toBeInTheDocument();
+
+      // Pre-selected quadrant button should be Do First (urgent + important).
+      const doFirstQuadrant = screen.getByRole("button", { name: /^do first$/i, pressed: true });
+      expect(doFirstQuadrant).toBeInTheDocument();
+    });
   });
 });

--- a/tests/ui/task-card.test.tsx
+++ b/tests/ui/task-card.test.tsx
@@ -154,7 +154,8 @@ describe("TaskCard", () => {
 
     render(<TaskCard task={overdueTask} allTasks={[overdueTask]} {...mockHandlers} />);
 
-    expect(screen.getByText("Overdue")).toBeInTheDocument();
+    // Polished overdue surface: top-right caption like "1D Overdue".
+    expect(screen.getByText(/\dD Overdue/i)).toBeInTheDocument();
   });
 
   it("displays due today alert for today's due date", () => {
@@ -175,14 +176,15 @@ describe("TaskCard", () => {
     expect(repeatIcon).toBeInTheDocument();
   });
 
-  it("applies red border styling for overdue tasks", () => {
+  it("applies overdue border styling for overdue tasks", () => {
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
     const overdueTask = { ...mockTask, dueDate: yesterday.toISOString() };
     const { container } = render(<TaskCard task={overdueTask} allTasks={[overdueTask]} {...mockHandlers} />);
 
     const article = container.querySelector("article");
-    expect(article).toHaveClass("overdue-task", "border-l-4");
+    // Polish v0.9.2: 3px left edge in status-overdue, no pink fill.
+    expect(article).toHaveClass("overdue-task", "border-l-status-overdue");
   });
 
   it("does not show overdue warning for completed tasks", () => {


### PR DESCRIPTION
## Summary

Implements the v0.9.2 high+medium tier of `design_handoff_gsd_polish/` (items 1–10). All changes use existing tailwind tokens — **no new tokens, no new dependencies**. Bundles a previously-uncommitted memoization / single-pass-loop refactor of the dashboard, matrix-simplified, and settings-page surfaces (originally outside this PR's scope, included per request).

### Polish items (handoff README, items 1–10)

| # | Surface | Change |
|---|---|---|
| 1 | Capture-bar Add button | Replaced disabled-grey with idle accent wash (`bg-accent/15`) → solid accent on input, 120ms color crossfade. |
| 2 | Capture-bar quadrant pill | Uses full quadrant title, 5px leading dot, 160ms slide-in on quadrant change. |
| 3 | Per-quadrant empty states | Serif 18px headline, body supporting line, dashed "Add to {Quadrant}" pill that opens the create drawer pre-set to that quadrant. |
| 4 | Tags + overdue card | Neutral chips (no rainbow), no hashtag glyph, 5px leading dot. Overdue: drop pink fill, 3px `border-l-status-overdue`, "ND OVERDUE" caption at top-right. |
| 5 | Visible Settings toggles | `bg-border` (off) / `bg-accent` (on), white 18px thumb, "· on" / "· off" suffix on row description. |
| 6 | Unify Dashboard stat cards | Eyebrow + neutral pill + serif 48px hero + footer (delta + meta) + inline SVG sparkline. Drops per-card `accentColor`; color reserved for state deltas only. |
| 7 | Sidebar labels on hover | Icon rail expands 60→180px on `:hover`/`:focus-within` with 250ms ease-out, accent left-bar on active item. |
| 8 | Completion Trend distinction | Created → dotted indigo (1.6px); Completed → solid green (2px); drop gradient fills. |
| 9 | Quadrant Distribution as horizontal stack | Single `h-3 rounded-full` segmented bar, inline labels with count + percent. |
| 10 | "Pick a date…" pill in new-task drawer | Fifth chip reveals native `<input type="date">`; selection renders as a chip ("Mon, May 12"). |

**Note on item 10:** The README references `react-day-picker` as if installed, but it isn't. Used a native `<input type="date">` instead, which is accessible, has zero bundle cost, and respects the README's "no new dependencies" anti-goal.

### Perf refactor (bundled in)
- Single-pass loops for `activeTaskCount` / `completedCount` / `overdueCount` in `matrix-simplified/index.tsx` and `settings-page/index.tsx`.
- `useMemo` for `activeDragTask`, `caption`, settings sidebar groups, quadrant-distribution `chartData`/`total`.
- Factored `trimmedSearchQuery`, used `readShowCompleted` helper.

### Out of scope (deferred to follow-up PRs)
Items 11–14 (medium tier — title field, header pills, About hero, About headlines) and 15–20 (low tier opportunistic fixes). Per the handoff README, those are v0.10.

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun run test` — 1814 passed, 1 skipped, 0 failed (3 new tests added for items 3 + 10 contracts)
- [x] Manual browser verification (item 1, 2, 3 visual, 4 visual, 5 on/off states, 6, 7, 8, 9 — captured screenshots locally)
- [x] Smoke-test on staging: capture bar, drawer, settings toggles, dashboard cards
- [x] Verify dark mode parity for new tokens (`status-success` sparkline, dashed dotted indigo line)
- [x] Confirm overdue caption ("ND OVERDUE") doesn't collide with the completion button on narrow cards

## Co-authored-by

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>