### PR TITLE
feat(polish): v0.10 — items 11-20 from design polish handoff

### DIFF
--- a/components/about/feature-card.tsx
+++ b/components/about/feature-card.tsx
@@ -15,7 +15,9 @@ export function FeatureCard({ icon: Icon, title, description, className }: Featu
       "hover:border-foreground/10 hover:bg-background-muted/35",
       className
     )}>
-      <Icon className="mb-4 h-5 w-5 text-accent" aria-hidden="true" />
+      <div className="mb-4 grid h-9 w-9 place-items-center rounded-lg bg-accent/10">
+        <Icon className="h-4 w-4 text-accent" aria-hidden="true" />
+      </div>
       <h3 className="rd-serif mb-2 text-xl tracking-tight text-foreground">
         {title}
       </h3>

--- a/components/about/features-section.tsx
+++ b/components/about/features-section.tsx
@@ -20,6 +20,8 @@ interface Feature {
   description: string;
 }
 
+// First three are hero features (Eisenhower Matrix, Privacy First, MCP Server) —
+// they render full-width on the first row. Layout is driven by index, not a flag.
 const features: Feature[] = [
   {
     icon: Grid2x2,
@@ -32,6 +34,12 @@ const features: Feature[] = [
     title: "Privacy First",
     description:
       "Your tasks never leave your browser. No account, no server, no tracking.",
+  },
+  {
+    icon: Bot,
+    title: "MCP Server",
+    description:
+      "Let Claude query your tasks with natural language. AI meets your to-do list.",
   },
   {
     icon: BarChart3,
@@ -70,12 +78,6 @@ const features: Feature[] = [
       "Install on desktop or mobile. Full offline support. No app store required.",
   },
   {
-    icon: Bot,
-    title: "MCP Server",
-    description:
-      "Let Claude query your tasks with natural language. AI meets your to-do list.",
-  },
-  {
     icon: Cloud,
     title: "Optional Cloud Sync",
     description:
@@ -91,21 +93,34 @@ export function FeaturesSection() {
           <p className="text-xs uppercase tracking-widest text-accent mb-3 text-center">
             Features
           </p>
-          <h2 className="text-2xl sm:text-3xl font-bold tracking-tight text-foreground mb-12 text-center">
+          <h2 className="rd-serif font-normal text-display tracking-tight text-foreground mb-12 text-center">
             Everything you need. Nothing you don&apos;t.
           </h2>
         </ScrollReveal>
 
         <ScrollReveal>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {features.map((feature) => (
-              <FeatureCard
-                key={feature.title}
-                icon={feature.icon}
-                title={feature.title}
-                description={feature.description}
-              />
-            ))}
+          {/* lg layout uses a 12-col grid:
+                row 1: 3 hero cards × col-span-4  → 12
+                row 2: 4 regular cards × col-span-3 → 12
+                row 3: 3 regular cards × col-span-4 → 12
+              No lonely cards.
+          */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-12 gap-4">
+            {features.map((feature, i) => {
+              const isHeroRow = i < 3;
+              const isFinalRow = i >= 7;
+              const lgSpan =
+                isHeroRow || isFinalRow ? "lg:col-span-4" : "lg:col-span-3";
+              return (
+                <FeatureCard
+                  key={feature.title}
+                  icon={feature.icon}
+                  title={feature.title}
+                  description={feature.description}
+                  className={lgSpan}
+                />
+              );
+            })}
           </div>
         </ScrollReveal>
       </div>

--- a/components/about/hero-section.tsx
+++ b/components/about/hero-section.tsx
@@ -56,20 +56,22 @@ export function HeroSection() {
             </a>
           </div>
 
-          {/* Trust signals */}
-          <div className="mt-12 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm text-foreground-muted">
-            <span className="inline-flex items-center gap-1.5">
-              <Lock size={16} />
-              No account required
-            </span>
-            <span className="inline-flex items-center gap-1.5">
-              <Monitor size={16} />
-              Works offline
-            </span>
-            <span className="inline-flex items-center gap-1.5">
-              <Code2 size={16} />
-              MIT open source
-            </span>
+          {/* Trust signals — hairline divider above frames the row visually */}
+          <div className="mx-auto mt-12 max-w-2xl border-t border-border-muted pt-6">
+            <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-caption text-foreground-muted">
+              <span className="inline-flex items-center gap-1.5">
+                <Lock size={16} strokeWidth={1.75} aria-hidden />
+                No account required
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <Monitor size={16} strokeWidth={1.75} aria-hidden />
+                Works offline
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <Code2 size={16} strokeWidth={1.75} aria-hidden />
+                MIT open source
+              </span>
+            </div>
           </div>
         </ScrollReveal>
       </div>

--- a/components/about/matrix-section.tsx
+++ b/components/about/matrix-section.tsx
@@ -38,7 +38,7 @@ export function MatrixSection() {
               <p className="text-xs uppercase tracking-widest text-accent mb-3">
                 The Eisenhower Matrix
               </p>
-              <h2 className="text-2xl sm:text-3xl font-bold tracking-tight text-foreground mb-6">
+              <h2 className="rd-serif font-normal text-display tracking-tight text-foreground mb-6">
                 Prioritize by urgency and importance. Not just vibes.
               </h2>
               <div className="text-foreground-muted leading-relaxed space-y-4">
@@ -70,10 +70,10 @@ export function MatrixSection() {
                     <span className="text-[10px] uppercase tracking-widest text-foreground-muted font-medium">
                       {q.label}
                     </span>
-                    <h3 className="text-sm sm:text-base font-semibold text-foreground mt-1">
+                    <h3 className="rd-serif text-base text-foreground mt-1">
                       {q.name}
                     </h3>
-                    <p className="text-xs text-foreground-muted mt-1">
+                    <p className="text-caption text-foreground-muted mt-0.5">
                       {q.description}
                     </p>
                   </div>

--- a/components/matrix-simplified/edit-drawer.tsx
+++ b/components/matrix-simplified/edit-drawer.tsx
@@ -6,6 +6,7 @@ import type { TaskRecord } from "@/lib/types";
 import { quadrants, QUADRANT_ACCENT } from "@/lib/quadrants";
 import { resolveDuePreset, DUE_PRESETS, type DuePreset } from "@/lib/due-date-presets";
 import { cn } from "@/lib/utils";
+import { DrawerHint } from "@/components/ui/drawer-hint";
 
 export interface EditDraft {
   title: string;
@@ -173,16 +174,15 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
         </header>
 
         <div className="flex flex-1 flex-col gap-5 overflow-auto px-5 py-5">
-          <Field label="Title">
-            <input
-              ref={titleRef}
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="What needs doing?"
-              className="w-full rounded-lg border border-border bg-background px-3 py-2.5 text-[15px] font-medium text-foreground outline-none focus:border-foreground-muted"
-              aria-label="Title"
-            />
-          </Field>
+          {/* Title — placeholder carries affordance, the uppercase label is dropped */}
+          <input
+            ref={titleRef}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="What needs doing?"
+            className="w-full rounded-lg border border-border bg-background px-3 py-3 text-[18px] font-medium text-foreground outline-none focus:border-foreground-muted placeholder:font-normal"
+            aria-label="Title"
+          />
 
           <Field label="Description">
             <textarea
@@ -333,9 +333,7 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
         </div>
 
         <footer className="flex items-center gap-2.5 border-t border-border/60 bg-background px-5 py-3.5">
-          <span className="text-[12px] text-foreground-muted">
-            <kbd>Esc</kbd> to cancel
-          </span>
+          <DrawerHint />
           <div className="flex-1" />
           <button
             type="button"

--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -236,21 +236,22 @@ export function MatrixSimplified() {
     [activeId, all]
   );
 
+  // Header counts — three small inline pills, semantic colors. Overdue
+  // pill is conditional on count > 0. Sits on the same baseline as the title
+  // (the topbar wraps the caption slot in a flex row).
   const caption = useMemo(
     () => (
       <>
-        <span>
-          <strong className="font-semibold text-foreground">{total - completed}</strong> active
+        <span className="inline-flex items-center rounded-full bg-background-muted px-2 py-0.5 text-[11px] font-medium tabular-nums text-foreground">
+          {total - completed} active
         </span>
-        <span className="text-foreground-muted/60">·</span>
-        <span>
-          <strong className="font-semibold text-foreground">{completed}</strong> done
+        <span className="inline-flex items-center rounded-full bg-status-success-muted px-2 py-0.5 text-[11px] font-medium tabular-nums text-status-success">
+          {completed} done
         </span>
         {overdue > 0 ? (
-          <>
-            <span className="text-foreground-muted/60">·</span>
-            <span className="text-status-overdue">{overdue} overdue</span>
-          </>
+          <span className="inline-flex items-center rounded-full bg-status-overdue-muted px-2 py-0.5 text-[11px] font-medium tabular-nums text-status-overdue">
+            {overdue} overdue
+          </span>
         ) : null}
       </>
     ),

--- a/components/matrix-simplified/quadrant-pane.tsx
+++ b/components/matrix-simplified/quadrant-pane.tsx
@@ -79,7 +79,7 @@ export function QuadrantPane({
     >
       <header
         className={cn(
-          "-mx-5 -mt-5 mb-4 flex items-center gap-2.5 border-b border-border-muted px-5 py-3",
+          "-mx-5 -mt-5 mb-4 flex items-baseline gap-1 border-b border-border-muted px-5 py-3",
           HEADER_CLASS[meta.rdKey]
         )}
       >
@@ -89,7 +89,7 @@ export function QuadrantPane({
         >
           {meta.title}
         </span>
-        <span className="text-[12.5px] text-foreground-muted">{meta.rdHint}</span>
+        <span className="ml-1 text-caption text-foreground-muted">{meta.rdHint}</span>
         <span className="ml-auto rounded bg-background-muted px-1.5 text-[11px] font-medium tabular-nums text-foreground-muted">
           {activeTaskCount}
         </span>

--- a/components/settings-page/settings-sidebar.tsx
+++ b/components/settings-page/settings-sidebar.tsx
@@ -94,10 +94,10 @@ export function SettingsSidebar({ activeId, onSelect, visibleSections }: Setting
 
       {/* Desktop: vertical nav card */}
       <aside className="hidden lg:block lg:w-[260px] lg:shrink-0">
-        <div className="sticky top-24 rounded-2xl border border-border bg-card p-2 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+        <div className="sticky top-24 flex flex-col gap-3 rounded-2xl border border-border bg-card p-2 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
           {groups.map(({ group, items }) => (
-            <div key={group} className="pb-2 last:pb-0">
-              <p className="px-3 pb-1 pt-3 text-[10px] font-semibold uppercase tracking-[0.12em] text-foreground-muted/80">
+            <div key={group}>
+              <p className="px-3 pb-2 pt-4 text-[10px] font-semibold uppercase tracking-[0.12em] text-foreground-muted/80">
                 {group}
               </p>
               <ul className="space-y-0.5">

--- a/components/task-card/task-card-actions.tsx
+++ b/components/task-card/task-card-actions.tsx
@@ -1,11 +1,20 @@
 "use client";
 
-import { PencilIcon, Trash2Icon, RepeatIcon, AlertCircleIcon, Share2Icon, CopyIcon, MoreHorizontalIcon } from "lucide-react";
-import { formatRelative } from "@/lib/utils";
+import { PencilIcon, Trash2Icon, RepeatIcon, AlertCircleIcon, Share2Icon, CopyIcon, MoreHorizontalIcon, ClockIcon } from "lucide-react";
+import { cn, formatRelative } from "@/lib/utils";
+import { TIME_MS } from "@/lib/constants";
 import { SnoozeDropdown } from "@/components/snooze-dropdown";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import type { TaskRecord } from "@/lib/types";
+
+/** True when a future due date is within 24h. Used to color-shift the clock glyph. */
+function isWithinDay(iso: string): boolean {
+  const due = new Date(iso).getTime();
+  const now = Date.now();
+  const diff = due - now;
+  return diff > 0 && diff < TIME_MS.DAY;
+}
 
 export interface TaskCardActionsProps {
   task: TaskRecord;
@@ -37,7 +46,15 @@ export function TaskCardActions({
             Due today
           </span>
         ) : task.dueDate && !taskIsOverdue ? (
-          <span className="truncate">{formatRelative(task.dueDate)}</span>
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 truncate",
+              isWithinDay(task.dueDate) && "text-status-overdue"
+            )}
+          >
+            <ClockIcon className="h-3 w-3 shrink-0" aria-hidden />
+            {formatRelative(task.dueDate)}
+          </span>
         ) : null}
         {task.recurrence !== "none" ? (
           <span

--- a/components/ui/drawer-hint.tsx
+++ b/components/ui/drawer-hint.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@/lib/utils";
+
+interface DrawerHintProps {
+  /** Keyboard shortcut to display (defaults to "Esc"). */
+  shortcut?: string;
+  /** Action description ("to cancel", "to close"). */
+  action?: string;
+  className?: string;
+}
+
+/**
+ * Mono caption for modal/drawer footers. Reusable shortcut hint, e.g.
+ * "Esc to cancel". Pin to the bottom-right of a footer; the parent owns
+ * positioning.
+ */
+export function DrawerHint({
+  shortcut = "Esc",
+  action = "to cancel",
+  className,
+}: DrawerHintProps) {
+  return (
+    <span className={cn("font-mono text-[11px] text-foreground-muted", className)}>
+      <kbd className="rounded border border-border-muted bg-background-muted px-1 py-0.5 text-[10px]">
+        {shortcut}
+      </kbd>
+      <span className="ml-1.5">{action}</span>
+    </span>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "8.10.0",
+	"version": "8.11.0",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

Implements the v0.10 medium + low impact tier of `design_handoff_gsd_polish/` (items 11–20). Closes the design polish backlog (PR #257 covered items 1–10). All changes use existing tailwind tokens — **no new tokens, no new dependencies**.

### Polish items (handoff README, items 11–20)

| # | Surface | Change |
|---|---|---|
| 11 | New-task drawer title | Drop uppercase "TITLE" label, push input to 18px `font-medium py-3` — placeholder carries the affordance. Other field labels stay. |
| 12 | Matrix header counts | "4 active · 84 done · 1 overdue" rebuilt as three semantic pills (`bg-background-muted`, `bg-status-success-muted`, `bg-status-overdue-muted`). Overdue pill only renders when count > 0. |
| 13 | About features grid | Hero features (Eisenhower Matrix, Privacy First, MCP Server) span 4/12 cols each on row 1. Remaining 7 split 4+3 to avoid the previous lonely-card last row. |
| 14 | About section headlines | Features and matrix-section h2s switch from `font-bold` sans to `rd-serif text-display` to keep editorial momentum from the hero. |
| 15 | Quadrant supporting copy | Matrix pane hint and About matrix-section descriptions demote from body to `text-caption text-foreground-muted` with `items-baseline` alignment so the hint sits 2–4px below the serif label. |
| 16 | About feature cards | Each lucide icon wraps in a `w-9 h-9 rounded-lg bg-accent/10 grid place-items-center` plate. Icon stays `text-accent` but reads as an intentional element. |
| 17 | Task-card due-date glyph | Adds a 12px `ClockIcon` prefix to "in 5 days" / "today" / "tomorrow" relative dates. Text + icon shift to `text-status-overdue` when due within 24h (new `isWithinDay()` helper). |
| 18 | About hero trust strip | "No account required · Works offline · MIT open source" bumps to `text-caption`, icon `strokeWidth` to 1.75, hairline divider (`border-t border-border-muted`) above the row to frame it. |
| 19 | DrawerHint primitive | Extracted "Esc to cancel" hint into `components/ui/drawer-hint.tsx`. Wired into edit-drawer footer; opt-in for future modals. |
| 20 | Settings sidebar groups | Adds 12px vertical gap (`gap-3`) between Preferences/Data/Info groups, lifts eyebrow padding (`pb-1 pt-3` → `pb-2 pt-4`) for ~4px breathing room. No new dividers. |

### Out of scope
The handoff backlog is now closed. No follow-up polish PR planned.

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun run test` — 1814 passed, 1 skipped (no test churn — items are presentation-only; the behavioral contracts touched by PR #257 still hold)
- [x] Manual browser verification on `bun dev`:
  - [x] Item 11: drawer renders 18px title input, no TITLE label
  - [x] Item 12: matrix header shows three semantic pills
  - [x] Items 13, 14, 16, 18: About hero + features grid + section headlines + trust strip
  - [x] Item 15: quadrant supporting copy demoted to caption alongside serif label
  - [x] Item 17: clock glyph appears on a `<24h` task with `text-status-overdue` color
  - [x] Item 19: edit-drawer footer renders the new `<DrawerHint />` primitive
  - [x] Item 20: settings sidebar groups visibly breathe
- [ ] Smoke-test on staging
- [ ] Verify dark mode parity for new tokens (status-success-muted/status-overdue-muted on header pills, bg-accent/10 plates)

## Co-authored-by

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>