### PR TITLE
feat(tasks): restore completion confetti dropped in v9 refactor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@radix-ui/react-tooltip": "1.2.8",
         "@tanstack/react-query": "5.95.2",
         "@tanstack/react-virtual": "3.13.23",
+        "canvas-confetti": "1.9.4",
         "clsx": "2.1.1",
         "cmdk": "1.1.1",
         "date-fns": "4.1.0",
@@ -38,6 +39,7 @@
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
         "@testing-library/user-event": "14.6.1",
+        "@types/canvas-confetti": "1.9.0",
         "@types/node": "25.5.0",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
@@ -476,6 +478,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/canvas-confetti": ["@types/canvas-confetti@1.9.0", "", {}, "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
@@ -667,6 +671,8 @@
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001775", "", {}, "sha512-s3Qv7Lht9zbVKE9XoTyRG6wVDCKdtOFIjBGg3+Yhn6JaytuNKPIjBMTMIY1AnOH3seL5mvF+x33oGAyK3hVt3A=="],
+
+    "canvas-confetti": ["canvas-confetti@1.9.4", "", {}, "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 

--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DndContext, DragOverlay } from "@dnd-kit/core";
 import { createTask, toggleCompleted, updateTask, deleteTask } from "@/lib/tasks";
+import { celebrateCompletion } from "@/lib/confetti";
 import { extractUrlsFromTitle, buildDescription } from "@/lib/capture-parser";
 import { useTasks } from "@/lib/use-tasks";
 import { useToast } from "@/components/ui/toast";
@@ -161,6 +162,7 @@ export function MatrixSimplified() {
     async (task: TaskRecord, completedNext: boolean) => {
       try {
         await toggleCompleted(task.id, completedNext);
+        if (completedNext) celebrateCompletion();
       } catch {
         showToast("Failed to update task", undefined, TOAST_DURATION.LONG);
       }

--- a/lib/confetti.ts
+++ b/lib/confetti.ts
@@ -1,0 +1,84 @@
+/**
+ * Celebration confetti for task completions.
+ *
+ * Uses canvas-confetti's `useWorker: false` mode so the animation runs on
+ * the main thread instead of a Web Worker. The worker approach creates a
+ * blob: URL worker which is blocked by our CSP (`script-src 'self'` has
+ * no blob: fallback, and `worker-src` is not set).
+ *
+ * Respects `prefers-reduced-motion` so users who opt out of motion get
+ * only the toast — no animation. Feature-detects canvas so jsdom-based
+ * tests don't crash on its stubbed getContext().
+ */
+import confetti, { type CreateTypes } from "canvas-confetti";
+
+let fireConfetti: CreateTypes | null = null;
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+/**
+ * jsdom (used in tests) returns null from canvas.getContext('2d'),
+ * which makes canvas-confetti crash inside its animation loop.
+ */
+function canRenderCanvas(): boolean {
+  if (typeof document === "undefined") return false;
+  try {
+    const canvas = document.createElement("canvas");
+    return !!canvas.getContext?.("2d");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Lazily create a fullscreen confetti canvas attached to document.body
+ * with the worker disabled (CSP-safe). Reused across calls.
+ *
+ * z-index 1000000 keeps confetti above Sonner's default z-index (999999)
+ * and all other UI layers.
+ */
+function getConfettiInstance(): CreateTypes | null {
+  if (fireConfetti) return fireConfetti;
+  if (typeof document === "undefined") return null;
+
+  const canvas = document.createElement("canvas");
+  canvas.style.position = "fixed";
+  canvas.style.inset = "0";
+  canvas.style.width = "100%";
+  canvas.style.height = "100%";
+  canvas.style.pointerEvents = "none";
+  canvas.style.zIndex = "1000000";
+  document.body.appendChild(canvas);
+
+  fireConfetti = confetti.create(canvas, { resize: true, useWorker: false });
+  return fireConfetti;
+}
+
+export function celebrateCompletion(): void {
+  if (typeof window === "undefined") return;
+  if (prefersReducedMotion()) return;
+  if (!canRenderCanvas()) return;
+
+  try {
+    const fire = getConfettiInstance();
+    if (!fire) return;
+
+    fire({
+      particleCount: 120,
+      spread: 90,
+      startVelocity: 45,
+      origin: { x: 0.5, y: 0.6 },
+      scalar: 1.1,
+    });
+
+    setTimeout(() => {
+      fire({ particleCount: 60, angle: 60, spread: 70, origin: { x: 0, y: 0.7 } });
+      fire({ particleCount: 60, angle: 120, spread: 70, origin: { x: 1, y: 0.7 } });
+    }, 150);
+  } catch {
+    // Confetti is a nice-to-have — never surface rendering failures.
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.0.1",
+	"version": "9.0.2",
 	"private": true,
 	"type": "module",
 	"scripts": {
@@ -30,6 +30,7 @@
 		"@radix-ui/react-tooltip": "1.2.8",
 		"@tanstack/react-query": "5.95.2",
 		"@tanstack/react-virtual": "3.13.23",
+		"canvas-confetti": "1.9.4",
 		"clsx": "2.1.1",
 		"cmdk": "1.1.1",
 		"date-fns": "4.1.0",
@@ -53,6 +54,7 @@
 		"@testing-library/jest-dom": "6.9.1",
 		"@testing-library/react": "16.3.2",
 		"@testing-library/user-event": "14.6.1",
+		"@types/canvas-confetti": "1.9.0",
 		"@types/node": "25.5.0",
 		"@types/react": "19.2.14",
 		"@types/react-dom": "19.2.3",

--- a/tests/ui/matrix-simplified.test.tsx
+++ b/tests/ui/matrix-simplified.test.tsx
@@ -46,6 +46,10 @@ vi.mock("@/lib/tasks", () => ({
   deleteTask: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("@/lib/confetti", () => ({
+  celebrateCompletion: vi.fn(),
+}));
+
 vi.mock("@/lib/use-auto-archive", () => ({
   useAutoArchive: vi.fn(),
 }));
@@ -95,12 +99,40 @@ vi.mock("@/components/matrix-simplified/app-shell", () => ({
 }));
 
 import { MatrixSimplified } from "@/components/matrix-simplified";
-import { createTask } from "@/lib/tasks";
+import { createTask, toggleCompleted } from "@/lib/tasks";
+import { celebrateCompletion } from "@/lib/confetti";
 
 describe("<MatrixSimplified>", () => {
   beforeEach(() => {
     tasksFixture.current = [];
     localStorage.removeItem("gsd:show-completed");
+    vi.mocked(celebrateCompletion).mockClear();
+    vi.mocked(toggleCompleted).mockClear();
+  });
+
+  describe("completion celebration", () => {
+    it("fires confetti when a task is marked complete", async () => {
+      const user = userEvent.setup();
+      tasksFixture.current = [makeTask({ id: "a", title: "Active alpha", completed: false })];
+      render(<MatrixSimplified />);
+
+      await user.click(screen.getByRole("button", { name: /mark as complete/i }));
+
+      await waitFor(() => expect(toggleCompleted).toHaveBeenCalledWith("a", true));
+      expect(celebrateCompletion).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not fire confetti when a task is uncompleted", async () => {
+      const user = userEvent.setup();
+      localStorage.setItem("gsd:show-completed", "true");
+      tasksFixture.current = [makeTask({ id: "b", title: "Done bravo", completed: true })];
+      render(<MatrixSimplified />);
+
+      await user.click(screen.getByRole("button", { name: /mark as incomplete/i }));
+
+      await waitFor(() => expect(toggleCompleted).toHaveBeenCalledWith("b", false));
+      expect(celebrateCompletion).not.toHaveBeenCalled();
+    });
   });
 
   it("submitting capture bar calls createTask with parsed payload", async () => {


### PR DESCRIPTION
## Summary

- Confetti was collateral damage in #238 when the v8 `matrix-board/` surface was deleted (ADR 0011 listed `lib/confetti.ts` and `canvas-confetti` under "orphan utilities", not "removed features"). Restoring it.
- Re-adds `lib/confetti.ts` verbatim from `8755e8f^` (already includes the `e4f5770` z-index + try/catch fix), wires `celebrateCompletion()` into the v9 `handleToggle` in `components/matrix-simplified/index.tsx`, and pins `canvas-confetti` to exact `1.9.4` (v2 changed the API).
- Bumps version `9.0.1` → `9.0.2`.

## What it preserves

- **CSP-safe**: `useWorker: false` (our CSP blocks `blob:` worker URLs).
- **prefers-reduced-motion**: opt-out users still get the toast, no animation.
- **jsdom-safe**: feature-detects canvas so unit tests don't crash.
- **z-index 1000000**: stays above Sonner toasts (999999).

## Test plan

- [x] `bun run test` — 1816 pass, 1 skipped (unchanged)
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun audit` — 0 vulnerabilities
- [x] New tests in `tests/ui/matrix-simplified.test.tsx`:
  - confetti fires when a task is marked complete
  - confetti does NOT fire when a task is uncompleted
- [ ] Manual: `bun dev` → complete a task in the matrix and verify the burst renders above all UI layers
- [ ] Manual: enable "Reduce motion" in OS settings → confirm only the toast shows