### PR TITLE
feat(matrix): add bookmarklet share-capture URL action

### DIFF
--- a/components/matrix-simplified/icon-rail.tsx
+++ b/components/matrix-simplified/icon-rail.tsx
@@ -38,7 +38,7 @@ export function IconRail({ onHelp }: IconRailProps) {
   return (
     <>
       <aside
-        className="group/rail hidden md:flex md:w-[60px] md:shrink-0 md:flex-col md:items-stretch md:overflow-hidden md:border-r md:border-border/70 md:bg-background md:transition-[width] md:duration-[250ms] md:ease-out md:hover:w-[180px] md:focus-within:w-[180px]"
+        className="group/rail hidden md:flex md:w-[60px] md:shrink-0 md:flex-col md:items-stretch md:overflow-hidden md:border-r md:border-border/70 md:bg-background md:transition-[width] md:duration-[250ms] md:ease-out md:hover:w-[180px] md:hover:[transition-delay:500ms] md:focus-within:w-[180px] md:focus-within:[transition-delay:0s]"
         aria-label="Primary navigation"
       >
         <div className="sticky top-0 flex h-screen flex-col gap-1 px-2 py-3.5">

--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -5,6 +5,7 @@ import { DndContext, DragOverlay } from "@dnd-kit/core";
 import { createTask, toggleCompleted, updateTask, deleteTask } from "@/lib/tasks";
 import { celebrateCompletion } from "@/lib/confetti";
 import { extractUrlsFromTitle, buildDescription } from "@/lib/capture-parser";
+import { parseShareCaptureParams } from "@/lib/share-capture";
 import { useTasks } from "@/lib/use-tasks";
 import { useToast } from "@/components/ui/toast";
 import { useErrorHandlerWithUndo } from "@/lib/use-error-handler";
@@ -74,16 +75,31 @@ export function MatrixSimplified() {
     return () => window.removeEventListener(SHOW_COMPLETED_EVENT, handler);
   }, []);
 
-  // PWA shortcut: ?action=new-task → focus capture bar (not drawer)
+  // URL-driven actions: PWA shortcut focuses the capture bar; bookmarklet
+  // (`?action=capture&title=…&url=…&tags=…`) materializes a task in the
+  // Eliminate quadrant. Both clean their params off the URL afterward.
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    if (params.get("action") === "new-task") {
+    const action = params.get("action");
+    if (!action) return;
+
+    if (action === "new-task") {
       setTimeout(() => captureInputRef.current?.focus(), 50);
-      params.delete("action");
-      const next = params.toString();
-      window.history.replaceState({}, "", `${window.location.pathname}${next ? `?${next}` : ""}`);
+    } else if (action === "capture") {
+      const draft = parseShareCaptureParams(params);
+      if (draft) {
+        createTask(draft)
+          .then(() => showToast("Task captured", undefined, TOAST_DURATION.SHORT))
+          .catch(() => showToast("Failed to capture task", undefined, TOAST_DURATION.LONG));
+      }
+    } else {
+      return;
     }
-  }, []);
+
+    ["action", "title", "url", "tags"].forEach((k) => params.delete(k));
+    const next = params.toString();
+    window.history.replaceState({}, "", `${window.location.pathname}${next ? `?${next}` : ""}`);
+  }, [showToast]);
 
   // Global "/" focuses search; "n" handled by CaptureBar; "?" opens help
   useEffect(() => {

--- a/lib/share-capture.ts
+++ b/lib/share-capture.ts
@@ -1,0 +1,62 @@
+import { SCHEMA_LIMITS } from "@/lib/constants/schema";
+import type { TaskDraft } from "@/lib/types";
+
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+function safeUrl(value: string | null): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (!ALLOWED_PROTOCOLS.has(url.protocol.toLowerCase())) return null;
+    if (!url.hostname || url.username || url.password) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+function clampTitle(raw: string): string {
+  const trimmed = raw.replace(/\s+/g, " ").trim();
+  const max = SCHEMA_LIMITS.TASK_TITLE_MAX_LENGTH;
+  return trimmed.length > max ? `${trimmed.slice(0, max - 1)}…` : trimmed;
+}
+
+function parseTags(raw: string | null): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const piece of raw.split(",")) {
+    const tag = piece.trim().toLowerCase().slice(0, SCHEMA_LIMITS.TAG_MAX_LENGTH);
+    if (!tag || seen.has(tag)) continue;
+    seen.add(tag);
+    out.push(tag);
+    if (out.length >= SCHEMA_LIMITS.MAX_TAGS) break;
+  }
+  return out;
+}
+
+/**
+ * Parses `?action=capture&title=…&url=…&tags=…` query params into a TaskDraft
+ * destined for the Eliminate quadrant. Returns null when the action does not
+ * apply or when there is nothing meaningful to capture (no title and no URL).
+ *
+ * Why URL-driven: bookmarklets cannot reach this app's IndexedDB across origins,
+ * so the bookmarklet opens this app with params and we materialize the task here.
+ */
+export function parseShareCaptureParams(params: URLSearchParams): TaskDraft | null {
+  if (params.get("action") !== "capture") return null;
+
+  const safe = safeUrl(params.get("url"));
+  const rawTitle = (params.get("title") ?? "").trim();
+  const fallbackTitle = safe ? new URL(safe).hostname : "";
+  const titleSource = rawTitle || fallbackTitle;
+  if (!titleSource) return null;
+
+  return {
+    title: clampTitle(titleSource),
+    description: safe ?? "",
+    urgent: false,
+    important: false,
+    tags: parseTags(params.get("tags")),
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.0.2",
+	"version": "9.1.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '9.0.1';
+const CACHE_VERSION = '9.1.0';
 const CACHE_NAME = `gsd-cache-v${CACHE_VERSION}`;
 const OFFLINE_ASSETS = [
 	"/",

--- a/tests/data/share-capture.test.ts
+++ b/tests/data/share-capture.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { parseShareCaptureParams } from "@/lib/share-capture";
+
+function params(record: Record<string, string>): URLSearchParams {
+  return new URLSearchParams(record);
+}
+
+describe("parseShareCaptureParams", () => {
+  it("returns null when action is not 'capture'", () => {
+    expect(parseShareCaptureParams(params({ action: "new-task", title: "x" }))).toBeNull();
+    expect(parseShareCaptureParams(params({}))).toBeNull();
+  });
+
+  it("returns null when neither title nor url is provided", () => {
+    expect(parseShareCaptureParams(params({ action: "capture" }))).toBeNull();
+    expect(parseShareCaptureParams(params({ action: "capture", title: "  " }))).toBeNull();
+  });
+
+  it("places task in the Eliminate quadrant (urgent=false, important=false)", () => {
+    const draft = parseShareCaptureParams(
+      params({ action: "capture", title: "Read this article" })
+    );
+    expect(draft).not.toBeNull();
+    expect(draft?.urgent).toBe(false);
+    expect(draft?.important).toBe(false);
+  });
+
+  it("uses the page title verbatim and embeds the URL in the description", () => {
+    const draft = parseShareCaptureParams(
+      params({
+        action: "capture",
+        title: "Hacker News",
+        url: "https://news.ycombinator.com/",
+      })
+    );
+    expect(draft?.title).toBe("Hacker News");
+    expect(draft?.description).toBe("https://news.ycombinator.com/");
+  });
+
+  it("truncates titles longer than 80 chars with an ellipsis", () => {
+    const long = "A".repeat(120);
+    const draft = parseShareCaptureParams(params({ action: "capture", title: long }));
+    expect(draft?.title.length).toBe(80);
+    expect(draft?.title.endsWith("…")).toBe(true);
+  });
+
+  it("falls back to URL hostname when title is missing", () => {
+    const draft = parseShareCaptureParams(
+      params({ action: "capture", url: "https://example.com/some/path" })
+    );
+    expect(draft?.title).toBe("example.com");
+    expect(draft?.description).toBe("https://example.com/some/path");
+  });
+
+  it("drops non-http(s) URLs from the description", () => {
+    const draft = parseShareCaptureParams(
+      params({ action: "capture", title: "ok", url: "javascript:alert(1)" })
+    );
+    expect(draft?.description ?? "").toBe("");
+  });
+
+  it("parses comma-separated tags, lowercased and de-duplicated", () => {
+    const draft = parseShareCaptureParams(
+      params({ action: "capture", title: "x", tags: "Readme, todo, README, ,todo" })
+    );
+    expect(draft?.tags).toEqual(["readme", "todo"]);
+  });
+
+  it("truncates each tag to 30 chars and caps the list at 20 entries", () => {
+    const big = Array.from({ length: 30 }, (_, i) => `tag${i}`).join(",");
+    const longTag = "x".repeat(50);
+    const draft = parseShareCaptureParams(
+      params({ action: "capture", title: "x", tags: `${longTag},${big}` })
+    );
+    expect(draft?.tags?.length).toBe(20);
+    expect(draft?.tags?.[0].length).toBe(30);
+  });
+});


### PR DESCRIPTION
## Summary
- New `?action=capture&title=…&url=…&tags=…` query handler in the matrix shell that materializes a task in the **Eliminate** quadrant. Designed to be triggered by a browser bookmarklet (cross-origin same-origin policy prevents direct IndexedDB writes from a bookmarklet, so the URL-param round-trip is the privacy-first path).
- Pure parser at `lib/share-capture.ts` with 9 unit tests — handles 80-char title truncation, hostname fallback when the page has no title, comma-separated tag dedup (capped at 20), and rejection of non-http(s) URLs.
- Icon-rail hover-expand now waits 500ms before expanding (vs. instant) so accidental cursor drift no longer triggers expand/collapse churn. Keyboard `focus-within` remains instant.
- Version bump 9.0.2 → 9.1.0 plus matching SW cache key bump (returning users need a fresh cache to pick up the new URL handler).

## Bookmarklet for users
```
javascript:(function(){var u=encodeURIComponent(location.href);var t=encodeURIComponent(document.title||location.hostname);window.open('https://gsd.vinny.dev/?action=capture&title='+t+'&url='+u+'&tags=readme,todo','_blank');void 0;})();
```

## Test plan
- [x] `bun run test` — 1825/1825 pass (9 new tests in `tests/data/share-capture.test.ts`)
- [x] `bun typecheck` — clean
- [x] `bun lint` — no new warnings
- [x] Drag the bookmarklet to the bookmarks bar, click it from a third-party site (e.g. Hacker News), confirm a task appears in the Eliminate quadrant with title = page title, description = URL, tags = `readme`, `todo`
- [ ] Refresh the GSD tab after capture — verify the task does **not** double-add (params should be stripped via `replaceState`)
- [ ] Hover the icon-rail briefly (< 500ms) — should stay collapsed
- [ ] Hover and rest ≥ 500ms — should expand
- [ ] Tab into a rail button via keyboard — should expand instantly