### PR TITLE
feat(design): adopt Inkwell as default design system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ coverage/
 design_handoff_gsd_redesign/
 design_handoff_gsd_polish/
 .fallow/
+.inkwell-screenshots/

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,68 +4,84 @@
 :root {
   color-scheme: light;
 
-  /* Surfaces — warm paper */
-  --background: 246 245 241;           /* #f6f5f1 */
-  --background-muted: 239 237 231;     /* #efede7 */
-  --background-accent: 235 232 224;    /* #ebe8e0 */
+  /* ──────────────────────────────────────────────────────────────
+   * Inkwell — Indigo & Cloud (light mode)
+   * Tokens map GSD's existing names onto Inkwell's palette so
+   * the entire Tailwind utility surface keeps working unchanged.
+   * Reference: inkwell/DESIGN_SYSTEM.md
+   * ────────────────────────────────────────────────────────────── */
 
-  /* Text */
-  --foreground: 24 24 27;              /* #18181b */
-  --foreground-muted: 113 113 122;     /* #71717a — AA on paper 4.8:1 */
+  /* Surfaces — cool stone (Inkwell ivory / paper / oat) */
+  --background: 244 244 240;           /* ivory  #F4F4F0 */
+  --background-muted: 237 237 234;     /* gray-100 #EDEDEA */
+  --background-accent: 225 225 222;    /* gray-200 #E1E1DE */
 
-  /* Borders — warm */
-  --border: 230 227 219;               /* #e6e3db */
-  --border-muted: 239 237 231;         /* #efede7 */
+  /* Text — slate (cool, never pure black) */
+  --foreground: 19 20 27;              /* slate  #13141B */
+  --foreground-muted: 133 133 138;     /* gray-500 #85858A */
 
-  /* Accent */
-  --accent: 67 56 202;                  /* #4338ca — indigo-700, AA on paper 7.1:1 */
-  --accent-hover: 79 70 229;           /* #4f46e5 */
-  --accent-muted: 199 210 254;         /* #c7d2fe */
+  /* Borders — cool putty hairlines */
+  --border: 207 207 204;               /* gray-300 #CFCFCC — the 1.5px hairline color */
+  --border-muted: 237 237 234;         /* gray-100 #EDEDEA */
 
-  /* Quadrant tint pairs (match redesign scope) */
-  --quadrant-focus: 253 241 231;       /* #fdf1e7 */
-  --quadrant-schedule: 238 242 253;    /* #eef2fd */
-  --quadrant-delegate: 232 242 236;    /* #e8f2ec */
-  --quadrant-eliminate: 245 239 223;   /* #f5efdf */
+  /* Accent — saturated indigo */
+  --accent: 59 74 140;                 /* #3B4A8C  AA on paper */
+  --accent-hover: 42 55 104;           /* accent-d #2A3768 — pressed/hover (darker) */
+  --accent-muted: 197 205 228;         /* light periwinkle for tinted surfaces */
 
-  /* Quadrant washes — ~5% accent for pane backgrounds (v9 simplified) */
-  --q1-wash: 194 65 12;        /* #c2410c */
-  --q2-wash: 29 78 216;        /* #1d4ed8 */
-  --q3-wash: 21 128 61;        /* #15803d */
-  --q4-wash: 133 77 14;        /* #854d0e */
+  /* Quadrant pane tints (Inkwell-aligned: rust/sky/olive/warning) */
+  --quadrant-focus: 253 235 232;       /* rust tint */
+  --quadrant-schedule: 225 232 240;    /* sky tint */
+  --quadrant-delegate: 230 235 220;    /* olive tint */
+  --quadrant-eliminate: 250 240 220;   /* warning tint */
 
-  /* Card */
-  --card-background: 251 250 246;      /* #fbfaf6 — paper */
-  --card-border: 230 227 219;          /* matches --border */
+  /* Quadrant washes — accent bars and pane backgrounds */
+  --q1-wash: 176 74 63;                /* rust    #B04A3F */
+  --q2-wash: 92 124 163;               /* info    #5C7CA3 */
+  --q3-wash: 120 140 93;               /* olive   #788C5D */
+  --q4-wash: 199 142 63;               /* warning #C78E3F */
+
+  /* Quadrant accents — mode-aware. Light values are deeper saturations
+   * that hold ≥4.5:1 against the soft tint header bands; the lighter
+   * Inkwell rust/info/olive/warning hues live in --qN-wash and are
+   * used for tinted bg fills, where contrast isn't load-bearing. */
+  --q1: #9A3F3F;
+  --q2: #3D5577;
+  --q3: #3F5034;
+  --q4: #85581A;
+
+  /* Card — pure white surface against ivory page (Inkwell convention) */
+  --card-background: 255 255 255;      /* paper #FFFFFF */
+  --card-border: 207 207 204;          /* matches --border (gray-300) */
 
   --overlay: 0 0 0;
 
-  /* Shadows — softer for paper */
-  --shadow-card: 0 1px 0 rgba(24, 24, 27, 0.04), 0 1px 2px rgba(24, 24, 27, 0.04);
-  --shadow-card-hover: 0 1px 0 rgba(24, 24, 27, 0.04), 0 6px 18px -8px rgba(24, 24, 27, 0.12);
-  --shadow-column: 0 1px 2px rgba(24, 24, 27, 0.05), 0 1px 0 rgba(24, 24, 27, 0.04);
-  --shadow-fab: 0 8px 30px rgba(67, 56, 202, 0.35);
+  /* Shadows — Inkwell low-spread, slight orange undertone */
+  --shadow-card: 0 1px 2px rgba(20, 20, 19, 0.06);
+  --shadow-card-hover: 0 10px 30px rgba(20, 20, 19, 0.10);
+  --shadow-column: 0 1px 2px rgba(20, 20, 19, 0.05);
+  --shadow-fab: 0 8px 30px rgba(59, 74, 140, 0.35);
 
-  /* Quadrant solid gradients — used by dashboard donut, etc. */
-  --gradient-focus: linear-gradient(135deg, #c2410c, #ea580c);
-  --gradient-schedule: linear-gradient(135deg, #1d4ed8, #3b82f6);
-  --gradient-delegate: linear-gradient(135deg, #15803d, #22c55e);
-  --gradient-eliminate: linear-gradient(135deg, #854d0e, #ca8a04);
+  /* Quadrant gradients — desaturated to sit on the cool palette */
+  --gradient-focus: linear-gradient(135deg, #9A3F3F, #B04A3F);
+  --gradient-schedule: linear-gradient(135deg, #465F87, #5C7CA3);
+  --gradient-delegate: linear-gradient(135deg, #5F724B, #788C5D);
+  --gradient-eliminate: linear-gradient(135deg, #A47026, #C78E3F);
 
-  /* Chart palette — series 1 uses --accent; series 2+ are tokenized here. */
-  --chart-series-2: 59 130 246;        /* blue-500 */
+  /* Chart palette — series 1 uses --accent; series 2 is Inkwell info */
+  --chart-series-2: 92 124 163;        /* info #5C7CA3 */
 
-  /* Semantic status colors */
-  --status-overdue: 220 38 38;          /* red-600 */
-  --status-overdue-muted: 254 226 226;  /* red-100 */
-  --status-blocked: 217 119 6;          /* amber-600 */
-  --status-blocked-muted: 254 243 199;  /* amber-100 */
-  --status-blocking: 37 99 235;         /* blue-600 */
-  --status-blocking-muted: 219 234 254; /* blue-100 */
-  --status-success: 22 163 74;          /* green-600 */
-  --status-success-muted: 220 252 231;  /* green-100 */
+  /* Semantic status colors — Inkwell rust/warning/info/olive */
+  --status-overdue: 176 74 63;          /* rust */
+  --status-overdue-muted: 253 235 232;  /* rust tint */
+  --status-blocked: 199 142 63;         /* warning */
+  --status-blocked-muted: 250 240 220;  /* warning tint */
+  --status-blocking: 92 124 163;        /* info */
+  --status-blocking-muted: 225 232 240; /* sky tint */
+  --status-success: 120 140 93;         /* olive */
+  --status-success-muted: 230 235 220;  /* olive tint */
 
-  /* Motion tokens */
+  /* Motion tokens — match Inkwell --t-base / --t-slow */
   --duration-fast: 150ms;
   --duration-normal: 250ms;
 }
@@ -73,52 +89,73 @@
 .dark {
   color-scheme: dark;
 
-  --background: 12 12 13;              /* #0c0c0d */
-  --background-muted: 23 23 26;        /* #17171a */
-  --background-accent: 31 31 34;       /* #1f1f22 */
+  /* ──────────────────────────────────────────────────────────────
+   * Inkwell — Indigo & Cloud (dark mode)
+   * Hue-preserved, luminance-lifted: accent goes periwinkle,
+   * semantics stay desaturated. Reference: DESIGN_SYSTEM.md §1.1
+   * ────────────────────────────────────────────────────────────── */
 
-  --foreground: 244 244 245;           /* #f4f4f5 */
-  --foreground-muted: 161 161 170;     /* #a1a1aa — AA 5.5:1 */
+  /* Surfaces */
+  --background: 15 16 24;              /* ivory dark  #0F1018 */
+  --background-muted: 30 31 41;        /* gray-100 dk #1E1F29 */
+  --background-accent: 38 39 50;       /* gray-200 dk #262732 */
 
-  --border: 39 39 42;                  /* #27272a */
-  --border-muted: 31 31 34;            /* #1f1f22 */
+  /* Text */
+  --foreground: 232 232 238;           /* slate dk    #E8E8EE */
+  --foreground-muted: 154 154 160;     /* gray-500 dk #9A9AA0 */
 
-  --accent: 129 140 248;               /* #818cf8 */
-  --accent-hover: 165 180 252;         /* #a5b4fc */
-  --accent-muted: 165 180 252;         /* #a5b4fc — lighter for dark mode readability */
+  /* Borders */
+  --border: 52 54 63;                  /* gray-300 dk #34363F */
+  --border-muted: 30 31 41;            /* gray-100 dk #1E1F29 */
 
-  --quadrant-focus: 42 22 9;           /* #2a1609 */
-  --quadrant-schedule: 15 26 58;       /* #0f1a3a */
-  --quadrant-delegate: 11 36 26;       /* #0b241a */
-  --quadrant-eliminate: 44 32 9;       /* #2c2009 */
+  /* Accent — lifted periwinkle so it reads as "highlighted element" on dark */
+  --accent: 122 138 209;               /* #7A8AD1 */
+  --accent-hover: 98 115 192;          /* accent-d  #6273C0 */
+  --accent-muted: 165 180 252;         /* lifted periwinkle for tinted surfaces */
 
-  /* Wash channels reused; opacity bumped at use-site for dark legibility */
-  --q1-wash: 194 65 12;
-  --q2-wash: 29 78 216;
-  --q3-wash: 21 128 61;
-  --q4-wash: 133 77 14;
+  /* Quadrant pane tints (dark, low-luminance) */
+  --quadrant-focus: 60 28 25;          /* rust dark soft */
+  --quadrant-schedule: 30 45 65;       /* sky dark soft */
+  --quadrant-delegate: 35 45 25;       /* olive dark soft */
+  --quadrant-eliminate: 60 45 20;      /* warning dark soft */
 
-  --card-background: 26 26 29;         /* #1a1a1d */
-  --card-border: 39 39 42;
+  /* Quadrant washes — lifted hue versions */
+  --q1-wash: 210 116 104;              /* rust dk    #D27468 */
+  --q2-wash: 124 159 210;              /* info dk    #7C9FD2 */
+  --q3-wash: 156 176 122;              /* olive dk   #9CB07A */
+  --q4-wash: 217 165 95;               /* warning dk #D9A55F */
+
+  /* Quadrant accents (dark) — extra-lifted so labels clear AA
+   * (4.5:1) on the 20%-wash dark header band. The wash hue still
+   * carries quadrant identity; the label rides above it brightly. */
+  --q1: #E89788;
+  --q2: #9CB8DA;
+  --q3: #B5C497;
+  --q4: #E8C58B;
+
+  /* Card */
+  --card-background: 24 26 36;         /* paper dk #181A24 */
+  --card-border: 52 54 63;
 
   --overlay: 0 0 0;
 
-  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
-  --shadow-card-hover: 0 10px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.3);
-  --shadow-column: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -2px rgba(0, 0, 0, 0.2);
-  --shadow-fab: 0 8px 30px rgba(129, 140, 248, 0.35);
+  /* Shadows — deeper black, larger spread on dark surfaces */
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.45);
+  --shadow-card-hover: 0 10px 30px rgba(0, 0, 0, 0.50);
+  --shadow-column: 0 1px 2px rgba(0, 0, 0, 0.40);
+  --shadow-fab: 0 8px 30px rgba(122, 138, 209, 0.35);
 
-  --chart-series-2: 96 165 250;        /* blue-400 — slightly lighter for dark mode */
+  --chart-series-2: 124 159 210;       /* info dk */
 
-  /* Semantic status colors — dark */
-  --status-overdue: 248 113 113;        /* red-400 */
-  --status-overdue-muted: 69 10 10;     /* red-950/50 */
-  --status-blocked: 251 191 36;         /* amber-400 */
-  --status-blocked-muted: 69 26 3;      /* amber-950/50 */
-  --status-blocking: 96 165 250;        /* blue-400 */
-  --status-blocking-muted: 23 37 84;    /* blue-950/50 */
-  --status-success: 74 222 128;         /* green-400 */
-  --status-success-muted: 5 46 22;      /* green-950/50 */
+  /* Semantic status colors — Inkwell dark variants */
+  --status-overdue: 210 116 104;        /* rust dk */
+  --status-overdue-muted: 60 28 25;
+  --status-blocked: 217 165 95;         /* warning dk */
+  --status-blocked-muted: 60 45 20;
+  --status-blocking: 124 159 210;       /* info dk */
+  --status-blocking-muted: 30 45 65;
+  --status-success: 156 176 122;        /* olive dk */
+  --status-success-muted: 35 45 25;
 }
 
 body {
@@ -518,10 +555,11 @@ main {
   --rd-accent: rgb(var(--accent));
   --rd-accent-soft: rgb(var(--accent-muted) / 0.25);
 
-  --q1: #c2410c; --q1-soft: #fdf1e7; --q1-tint: #faebdd;
-  --q2: #1d4ed8; --q2-soft: #eef2fd; --q2-tint: #e3e9fb;
-  --q3: #15803d; --q3-soft: #e8f2ec; --q3-tint: #dbebe1;
-  --q4: #854d0e; --q4-soft: #f5efdf; --q4-tint: #ede4cd;
+  /* Inkwell-aligned quadrant accents (rust / sky / olive / warning) */
+  --q1: #B04A3F; --q1-soft: #FDEBE8; --q1-tint: #F8DDD8;
+  --q2: #5C7CA3; --q2-soft: #E1E8F0; --q2-tint: #D1DCE8;
+  --q3: #788C5D; --q3-soft: #E6EBDC; --q3-tint: #D7DEC9;
+  --q4: #C78E3F; --q4-soft: #FAF0DC; --q4-tint: #F5E5C2;
 
   --rd-radius: 14px;
   --rd-radius-sm: 10px;
@@ -537,10 +575,11 @@ main {
 }
 
 .dark .redesign-scope {
-  --q1-soft: #2a1609; --q1-tint: #3a1e0c;
-  --q2-soft: #0f1a3a; --q2-tint: #152350;
-  --q3-soft: #0b241a; --q3-tint: #0f2e22;
-  --q4-soft: #2c2009; --q4-tint: #3a2a0d;
+  /* Inkwell dark — keep accent hues identical to light, only tint surfaces shift */
+  --q1: #D27468; --q1-soft: #3C1C19; --q1-tint: #4A2520;
+  --q2: #7C9FD2; --q2-soft: #1E2D41; --q2-tint: #2A3D55;
+  --q3: #9CB07A; --q3-soft: #232D19; --q3-tint: #2F3D22;
+  --q4: #D9A55F; --q4-soft: #3C2D14; --q4-tint: #4D3A1B;
 }
 
 /* Editorial serif utility — global so dashboard and settings pages can use
@@ -800,9 +839,98 @@ main {
 }
 
 .overdue-task {
-  border-left-color: rgb(239 68 68);
+  border-left-color: rgb(var(--status-overdue));
 }
 
 .dark .overdue-task {
-  border-left-color: rgb(248 113 113);
+  border-left-color: rgb(var(--status-overdue));
+}
+
+/* ─────────────────────────────────────────────── */
+/* Inkwell — editorial typography utilities         */
+/* Cherry-picked from inkwell/tokens.css. Use serif */
+/* for headings, mono for technical metadata, and   */
+/* an accent-ruled eyebrow for section labels.      */
+/* ─────────────────────────────────────────────── */
+
+@layer utilities {
+  .t-display {
+    font-family: var(--font-instrument-serif), ui-serif, Georgia, "Times New Roman", Times, serif;
+    font-weight: 500;
+    font-size: 48px;
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+  }
+
+  .t-h1 {
+    font-family: var(--font-instrument-serif), ui-serif, Georgia, "Times New Roman", Times, serif;
+    font-weight: 500;
+    font-size: 32px;
+    line-height: 1.2;
+    letter-spacing: -0.01em;
+  }
+
+  .t-h2 {
+    font-family: var(--font-instrument-serif), ui-serif, Georgia, "Times New Roman", Times, serif;
+    font-weight: 500;
+    font-size: 24px;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+  }
+
+  .t-h3 {
+    font-family: var(--font-instrument-serif), ui-serif, Georgia, "Times New Roman", Times, serif;
+    font-weight: 500;
+    font-size: 19px;
+    line-height: 1.22;
+    letter-spacing: -0.008em;
+  }
+
+  .t-body {
+    font-family: var(--font-sans), system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-weight: 430;
+    font-size: 16px;
+    line-height: 1.55;
+  }
+
+  .t-small {
+    font-family: var(--font-sans), system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-weight: 430;
+    font-size: 14px;
+    line-height: 1.5;
+    color: rgb(var(--foreground-muted));
+  }
+
+  .t-caption {
+    font-family: var(--font-sans), system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-weight: 500;
+    font-size: 12px;
+    line-height: 1.4;
+    color: rgb(var(--foreground-muted));
+  }
+
+  /* Eyebrow — small uppercase mono label with leading accent rule */
+  .eyebrow {
+    font-family: var(--font-mono), ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgb(var(--foreground-muted));
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .eyebrow::before {
+    content: "";
+    width: 24px;
+    height: 1.5px;
+    background: rgb(var(--accent));
+  }
+
+  /* Inkwell signature — 1.5px hairline border using the same gray-300 stop */
+  .border-hairline {
+    border: 1.5px solid rgb(var(--border));
+  }
 }

--- a/components/matrix-simplified/capture-bar.tsx
+++ b/components/matrix-simplified/capture-bar.tsx
@@ -154,7 +154,7 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
             onClick={cycleQuadrant}
             title="Tab to cycle quadrant"
             className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[11px] font-medium animate-quadrant-pill-in"
-            style={{ backgroundColor: `${accent}33`, color: accent }}
+            style={{ backgroundColor: `color-mix(in srgb, ${accent} 20%, transparent)`, color: accent }}
           >
             <span
               className="h-[5px] w-[5px] rounded-full bg-current"

--- a/components/matrix-simplified/edit-drawer.tsx
+++ b/components/matrix-simplified/edit-drawer.tsx
@@ -112,7 +112,7 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
   const isCreateMode = !task;
 
   const activeQuadrant = quadrants.find((q) => q.urgent === urgent && q.important === important);
-  const accent = activeQuadrant ? QUADRANT_ACCENT[activeQuadrant.rdKey] : "#c2410c";
+  const accent = activeQuadrant ? QUADRANT_ACCENT[activeQuadrant.rdKey] : "var(--q1)";
 
   const submit = (e?: FormEvent) => {
     e?.preventDefault();
@@ -212,7 +212,15 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
                       "rounded-lg border px-3 py-2.5 text-left transition-colors",
                       active ? "border-2" : "border-border hover:bg-background-muted/50"
                     )}
-                    style={active ? { borderColor: a, backgroundColor: `${a}14`, color: a } : undefined}
+                    style={
+                      active
+                        ? {
+                            borderColor: a,
+                            backgroundColor: `color-mix(in srgb, ${a} 8%, transparent)`,
+                            color: a,
+                          }
+                        : undefined
+                    }
                     aria-pressed={active}
                   >
                     <div className="text-[12px] font-bold uppercase tracking-wider">{q.title}</div>

--- a/inkwell/DESIGN_SYSTEM.md
+++ b/inkwell/DESIGN_SYSTEM.md
@@ -1,0 +1,260 @@
+# Inkwell
+
+A reusable design system for product UI, dashboards, and technical interfaces. Drop-in CSS tokens, ten core components, light + dark mode out of the box.
+
+**Inkwell** ships with the **Indigo & Cloud** palette — cool stone background, deep indigo accent, serif headlines for gravitas, monospace for technical metadata, hairline 1.5px borders. Reads as Linear/Stripe/Notion-adjacent without being a clone of any of them.
+
+The system separates *structure* (borders, type scale, spacing, motion, components) from *brand* (colors). Three alternate palettes — warm clay, forest sage, literary burgundy — are preserved in `variants/` for reference. The structural layer is identical across all four; only the brand-layer tokens differ.
+
+> **Why "Inkwell"?** Print metaphor for editorial discipline; an inkwell is also a dark vessel, which signals dark mode is a first-class concern. Color-agnostic — the name still fits if you ever swap palettes.
+
+---
+
+## 1. Foundations
+
+### 1.1 Color
+
+A small palette (12 hues) with one accent doing all the work. Neutrals are *cool putty* — slightly warm but biased away from cream. Both light and dark modes are defined; dark mode applies automatically via `prefers-color-scheme: dark` unless overridden by `data-theme="light"`.
+
+| Token | Light | Dark | Role |
+|---|---|---|---|
+| `--ivory` | `#F4F4F0` | `#0F1018` | Page background |
+| `--paper` | `#FFFFFF` | `#181A24` | Cards, panels, inputs |
+| `--slate` | `#13141B` | `#E8E8EE` | Primary text |
+| `--oat` | `#DDDCDF` | `#2B2D38` | Tertiary surface, hover thumbnails |
+| `--accent` | `#3B4A8C` | `#7A8AD1` | **Primary accent** — links, focus, active state |
+| `--accent-d` | `#2A3768` | `#6273C0` | Hover/pressed accent |
+| `--accent-tint` | `rgba(59,74,140,0.14)` | `rgba(122,138,209,0.18)` | Badge background |
+| `--accent-focus-ring` | `rgba(59,74,140,0.18)` | `rgba(122,138,209,0.28)` | Input focus halo |
+| `--accent-strong-border` | `rgba(59,74,140,0.5)` | `rgba(122,138,209,0.6)` | Tinted chip border |
+| `--olive` | `#788C5D` | `#9CB07A` | Success, additions |
+| `--rust` | `#B04A3F` | `#D27468` | Danger, deletions |
+| `--warning` | `#C78E3F` | `#D9A55F` | Amber warning |
+| `--info` / `--sky` | `#5C7CA3` / `#6A8CAF` | `#7C9FD2` / `#85A6CB` | Informational accents |
+| `--gray-100` | `#EDEDEA` | `#1E1F29` | Subtle row stripe, code-chip bg |
+| `--gray-200` | `#E1E1DE` | `#262732` | Divider on white |
+| `--gray-300` | `#CFCFCC` | `#34363F` | **Default border** — the 1.5px hairline |
+| `--gray-500` | `#85858A` | `#9A9AA0` | Muted text, captions |
+| `--gray-700` | `#3A3B41` | `#C0C0C7` | Secondary body text |
+
+**Why the dark accent is *lifted***: `#3B4A8C` against a near-black background reads as a hole punched in the page rather than an accent. The dark variant `#7A8AD1` (periwinkle) restores the sense of a "highlighted element" by retaining hue while gaining luminance. This pattern — saturated in light, lifted in dark — applies to all colored tokens.
+
+### 1.2 Typography
+
+Three font families, each with a clear job. No custom fonts — platform stacks for instant load and zero FOUT.
+
+```css
+--serif: ui-serif, Georgia, "Times New Roman", Times, serif;
+--sans:  system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+--mono:  ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+```
+
+| Family | Job |
+|---|---|
+| **Serif** | All headings, stat numbers, italic-emphasized phrases. Editorial gravitas. |
+| **Sans** (system-ui) | Body text, buttons, labels. The default. |
+| **Mono** | Eyebrows, file names, hex codes, code chips, table headers, table-numeric cells. Anything that signals "technical metadata." |
+
+Type scale (use the `.t-*` classes shipped in `tokens.css`):
+
+| Class | Family | Size | Line-height | Weight | Tracking |
+|---|---|---|---|---|---|
+| `.t-display` | serif | 48px | 1.1 | 500 | -0.02em |
+| `.t-h1` | serif | 32px | 1.2 | 500 | -0.01em |
+| `.t-h2` | serif | 24px | 1.3 | 500 | — |
+| `.t-h3` | serif | 19px | 1.22 | 500 | -0.008em |
+| `.t-body` | sans | 16px | 1.55 | 430 | — |
+| `.t-small` | sans | 14px | 1.5 | 430 | — |
+| `.t-caption` | sans | 12px | 1.4 | 500 | — |
+| `.eyebrow` | mono | 11–12px | 1 | 500 | 0.12em, UPPERCASE |
+
+Heading hero pattern uses `clamp()` for fluid scaling:
+```css
+font-size: clamp(38px, 5.4vw, 62px);
+```
+
+### 1.3 Spacing
+
+8px-based scale with a 4px micro step:
+
+`4 · 8 · 12 · 16 · 24 · 32 · 48 · 64`
+
+Tokens: `--sp-1` through `--sp-8`. Section gaps tend to be 48–72px; card padding 18–24px; inline gaps 8–16px.
+
+### 1.4 Radius
+
+| Token | Value | Use |
+|---|---|---|
+| `--r-xs` | 4px | Code chips, tight tags |
+| `--r-sm` | 8px | Inputs, table rows, small buttons |
+| `--r-md` | 12px | Panels, stat cards |
+| `--r-lg` | 14px | Feature/link cards |
+| `--r-xl` | 20px | Large containers |
+| `--r-pill` | 999px | Badges, pills, TOC chips |
+
+### 1.5 Borders — the signature
+
+Every panel uses **1.5px** borders, not 1px. This is the system's most distinctive technical choice: 1px reads as "wireframe," 2px reads as "playful," 1.5px reads as "hairline." Always pair with `--gray-300`.
+
+```css
+--border: 1.5px solid var(--gray-300);
+```
+
+Hairline dividers inside panels drop to 1px (`--gray-100`) so the outer frame stays dominant.
+
+### 1.6 Shadows
+
+Warm low-spread in light mode (slight orange undertone via `rgba(20,20,19, …)`); deep-pure-black in dark mode (warm shadows would vanish on dark surfaces).
+
+| Token | Light | Dark |
+|---|---|---|
+| `--shadow-sm` | `0 1px 2px rgba(20,20,19,0.06)` | `0 1px 2px rgba(0,0,0,0.45)` |
+| `--shadow-md` | `0 4px 14px rgba(20,20,19,0.08)` | `0 4px 14px rgba(0,0,0,0.50)` |
+| `--shadow-lg` | `0 12px 28px rgba(20,20,19,0.12)` | `0 12px 28px rgba(0,0,0,0.55)` |
+| `--shadow-card-hover` | `0 10px 30px rgba(20,20,19,0.10)` | `0 10px 30px rgba(0,0,0,0.50)` |
+
+### 1.7 Motion
+
+| Token | Value | Use |
+|---|---|---|
+| `--t-fast` | 120ms | Color/border state changes |
+| `--t-base` | 150ms | Card hover, transform |
+| `--t-slow` | 300ms | Larger reveals |
+| `--ease-out` | `cubic-bezier(0.2, 0.8, 0.2, 1)` | Default |
+| `--ease-pop` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Slight overshoot |
+
+The signature card-hover gesture is a 3px translateY lift + shadow swap + border-color shift to slate. `prefers-reduced-motion` is respected automatically.
+
+### 1.8 Layout
+
+| Token | Width | Use |
+|---|---|---|
+| `--content-narrow` | 820px | Single-column reading |
+| `--content-default` | 920px | Mixed prose + components |
+| `--content-wide` | 1120px | Index/grid pages |
+
+Wrappers ship as classes: `.wrap`, `.wrap-narrow`, `.wrap-wide`. Page padding is `0 24px`.
+
+---
+
+## 2. Dark mode
+
+Pattern B is built in: dark mode applies automatically, with an opt-out for users who want to override.
+
+```html
+<!-- Auto: respects OS preference -->
+<html>
+
+<!-- Force light (overrides OS dark mode) -->
+<html data-theme="light">
+
+<!-- Force dark (overrides OS light mode) -->
+<html data-theme="dark">
+```
+
+Cascade:
+
+1. `prefers-color-scheme: dark` activates dark tokens — UNLESS `[data-theme="light"]` is set
+2. `[data-theme="dark"]` always activates dark tokens
+3. `[data-theme="light"]` always keeps light tokens
+
+To wire a manual toggle, set/remove the attribute on `<html>` from JS and persist to `localStorage`. The `preview.html` and `index.html` files include a working three-state toggle (Auto / Light / Dark) you can lift directly.
+
+`color-scheme: light dark` is declared on `:root`, so native UI (scrollbars, form controls) follows the active scheme automatically.
+
+---
+
+## 3. Components
+
+`tokens.css` ships ten reusable component classes. Open `preview.html` for a live tour of all of them in both light and dark mode.
+
+| Class | Purpose |
+|---|---|
+| `.btn` (+ `-primary` / `-secondary` / `-ghost` / `-danger`) | Buttons across all intents |
+| `.input` | Text inputs with accent focus halo |
+| `.checkbox` | Custom checkbox with accent fill |
+| `.badge` (+ neutral / accent / success / warning / danger) | Pill-shaped status labels |
+| `.card` (+ `.is-link`) | Generic card; the `.is-link` variant adds the 3px hover-lift gesture |
+| `.stat-card` (+ `.warn`) | Big-number metric tile |
+| `.tbl` | Table with mono header labels and hairline row dividers |
+| `.tldr` | Inverted callout — dark in light mode, light in dark mode |
+| `.pill` (+ sev / resolved / neutral) | Severity / status pill |
+| `.timeline` (+ `.tl-entry`) | Vertical event timeline |
+| `.chip-dot` (+ safe / medium / attention) | Mono label with colored status dot |
+| `.avatar` | 36px monogram circle |
+| `.eyebrow` | Uppercase mono lead-in label with accent rule |
+| `.sec-head` | Numbered section header (mono index + serif title + count pill) |
+| `.toc` | Pill-shaped link list with optional mono numerals |
+
+---
+
+## 4. Anti-patterns
+
+These will break the look — avoid them:
+
+- **Pure white page background.** Use `--ivory`. White on white kills depth.
+- **Pure black text.** Use `--slate` (`#13141B`). Pure black is too cold for the system's tone.
+- **Warm grays.** The neutrals here are *cool putty*. Mixing in warm beige grays (e.g., `#F0EEE6`) makes the cool indigo accent feel orphaned.
+- **Multiple accent colors.** One indigo, period. If you need a second accent for data viz, use olive or sky — not a second saturated hue.
+- **1px or 2px borders.** Stick to 1.5px for the signature outer frames.
+- **Sans-serif headings.** Serifs do the editorial work; replacing them collapses the personality and makes everything read as "generic SaaS."
+- **Heavy drop shadows.** Stay under 12% opacity in light mode; under 55% in dark. Big floaty shadows feel "Material Design"; this system is letterpress-quiet.
+- **Emoji icons.** Use inline SVG strokes.
+- **Gradients on surfaces.** Surfaces are flat.
+- **Saturated semantic colors.** Olive/rust/warning are deliberately desaturated to sit on the cool palette without screaming.
+- **Hardcoded hex values in component CSS.** Always reference tokens. Adding a new variant later (or theming for a customer) is trivial when everything is tokenized — painful when literals are scattered.
+
+---
+
+## 5. Quick start
+
+Drop `inkwell.css` and `tokens.css` into your project and link `inkwell.css` from `<head>`. The body inherits ivory background, slate text, sans body, and the active light/dark scheme automatically.
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="inkwell.css">
+  <title>My new app</title>
+</head>
+<body>
+  <div class="wrap">
+    <div class="eyebrow">Section label</div>
+    <h1 class="t-h1">A serif headline with <em class="accent">italic accent</em></h1>
+    <p class="t-body">Body copy at 16/1.55, sans, weight 430.</p>
+
+    <button class="btn btn-primary">Primary action</button>
+    <button class="btn btn-secondary">Cancel</button>
+  </div>
+</body>
+</html>
+```
+
+For a fuller starting point, copy `index.html` — it includes the navbar, layout shell, sample components, and a working light/dark/auto toggle. For a comprehensive component reference, open `preview.html`.
+
+---
+
+## 6. Project structure
+
+```
+design-system/
+├── inkwell.css             ← link this in <head> (brand-named alias)
+├── tokens.css              ← the actual system tokens; inkwell.css re-exports it
+├── DESIGN_SYSTEM.md        ← this file
+├── index.html              ← starter template (copy as seed of a new project)
+├── preview.html            ← comprehensive component showcase
+└── variants/               ← archived alternative palettes (warm clay / sage / burgundy)
+    ├── tokens-clay.css     ← original warm-editorial palette
+    ├── tokens-sage.css     ← forest / knowledge-product palette
+    ├── tokens-burgundy.css ← literary / magazine palette
+    ├── tokens-indigo.css   ← variant-format version of this palette
+    ├── preview-clay.html
+    ├── preview-sage.html
+    ├── preview-burgundy.html
+    ├── preview-indigo.html
+    └── compare.html        ← side-by-side comparison of all four
+```
+
+If you ever want to swap palettes, the variant files in `variants/` show the pattern: a ~30-line CSS file overriding only the brand-layer tokens. The structural layer (everything below the `:root` block in `tokens.css`) doesn't need to change.

--- a/inkwell/inkwell.css
+++ b/inkwell/inkwell.css
@@ -1,0 +1,12 @@
+/* =====================================================================
+   Inkwell — brand-named alias for tokens.css.
+
+   Most projects link this file from <head>:
+       <link rel="stylesheet" href="inkwell.css">
+
+   Under the hood it re-exports tokens.css; you can link either one.
+   The branded name is recommended for brand-consistent imports —
+   "inkwell" is what your team will say in conversation.
+   ===================================================================== */
+
+@import url('tokens.css');

--- a/inkwell/tokens.css
+++ b/inkwell/tokens.css
@@ -1,0 +1,544 @@
+/* =====================================================================
+   Inkwell — design system tokens.
+   Default palette: Indigo & Cloud (cool stone + deep indigo).
+
+   Self-contained foundation: link from <head> (preferably via the
+   brand-named alias inkwell.css, which re-exports this file), then
+   use `var(--accent)`, `var(--ivory)`, etc. Pattern B dark mode is
+   built in (auto via prefers-color-scheme + manual override via
+   [data-theme="dark"|"light"] on <html>).
+
+   The system separates structure (borders, type scale, spacing,
+   motion, components) from brand (colors). Three alternate palettes
+   — clay, sage, burgundy — live in /variants/ as standalone files
+   that override only the brand-layer tokens.
+   ===================================================================== */
+
+:root {
+  /* ---------- Surfaces ---------- */
+  --ivory: #F4F4F0;       /* page background — cool stone, barely warm */
+  --paper: #FFFFFF;       /* card / panel surface */
+  --slate: #13141B;       /* primary text, slight cool undertone */
+  --oat:   #DDDCDF;       /* tertiary surface, hover thumbnails */
+
+  /* ---------- Accent (saturated indigo) ---------- */
+  --accent:               #3B4A8C;
+  --accent-d:             #2A3768;                /* hover/pressed */
+  --accent-tint:          rgba(59, 74, 140, 0.14); /* badge bg, periwinkle on cool paper */
+  --accent-focus-ring:    rgba(59, 74, 140, 0.18); /* input focus halo */
+  --accent-strong-border: rgba(59, 74, 140, 0.5);  /* tinted chip border */
+
+  /* ---------- Semantic ---------- */
+  --olive:        #788C5D;                         /* success, additions */
+  --olive-tint:   rgba(120, 140, 93, 0.16);
+  --rust:         #B04A3F;                         /* danger, deletions */
+  --warning:      #C78E3F;
+  --warning-tint: rgba(199, 142, 63, 0.16);
+  --info:         #5C7CA3;                         /* informational */
+  --sky:          #6A8CAF;                         /* alt info / data viz */
+
+  /* ---------- Neutral scale (cool putty) ---------- */
+  --gray-100: #EDEDEA;
+  --gray-200: #E1E1DE;
+  --gray-300: #CFCFCC;
+  --gray-500: #85858A;
+  --gray-700: #3A3B41;
+
+  /* ---------- Typography ---------- */
+  --serif: ui-serif, Georgia, "Times New Roman", Times, serif;
+  --sans:  system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --mono:  ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale */
+  --t-display: 48px;
+  --t-h1:      32px;
+  --t-h2:      24px;
+  --t-h3:      19px;
+  --t-body:    16px;
+  --t-small:   14px;
+  --t-caption: 12px;
+  --t-eyebrow: 11px;
+
+  /* ---------- Spacing (8px base, 4px micro) ---------- */
+  --sp-1:  4px;
+  --sp-2:  8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 24px;
+  --sp-6: 32px;
+  --sp-7: 48px;
+  --sp-8: 64px;
+
+  /* ---------- Radius ---------- */
+  --r-xs:    4px;
+  --r-sm:    8px;
+  --r-md:   12px;
+  --r-lg:   14px;
+  --r-xl:   20px;
+  --r-pill: 999px;
+
+  /* ---------- Borders (signature 1.5px) ---------- */
+  --border:        1.5px solid var(--gray-300);
+  --border-strong: 1.5px solid var(--slate);
+  --border-hair:   1px   solid var(--gray-100);
+  --border-rule:   1px   solid var(--gray-300);
+
+  /* ---------- Shadows (warm low-spread) ---------- */
+  --shadow-sm:         0 1px 2px  rgba(20, 20, 19, 0.06);
+  --shadow-md:         0 4px 14px rgba(20, 20, 19, 0.08);
+  --shadow-lg:         0 12px 28px rgba(20, 20, 19, 0.12);
+  --shadow-card-hover: 0 10px 30px rgba(20, 20, 19, 0.10);
+
+  /* ---------- Motion ---------- */
+  --t-fast:   120ms;
+  --t-base:   150ms;
+  --t-slow:   300ms;
+  --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --ease-pop: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* ---------- Layout ---------- */
+  --content-narrow:  820px;
+  --content-default: 920px;
+  --content-wide:   1120px;
+  --page-pad-x:      24px;
+
+  /* ---------- Z-index scale ---------- */
+  --z-base:    1;
+  --z-raised: 10;
+  --z-sticky: 20;
+  --z-overlay: 30;
+  --z-modal:  50;
+
+  /* Declare both schemes so native UI follows whichever is active */
+  color-scheme: light dark;
+}
+
+/* =====================================================================
+   Dark mode — Pattern B
+   • prefers-color-scheme: dark applies UNLESS data-theme="light" is set
+   • data-theme="dark"  → forces dark regardless of OS preference
+   • data-theme="light" → forces light regardless of OS preference
+   ===================================================================== */
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+
+    --ivory: #0F1018;
+    --paper: #181A24;
+    --slate: #E8E8EE;
+    --oat:   #2B2D38;
+
+    --accent:               #7A8AD1;                 /* lifted indigo → periwinkle */
+    --accent-d:             #6273C0;
+    --accent-tint:          rgba(122, 138, 209, 0.18);
+    --accent-focus-ring:    rgba(122, 138, 209, 0.28);
+    --accent-strong-border: rgba(122, 138, 209, 0.6);
+
+    --olive:        #9CB07A;                         /* lifted */
+    --olive-tint:   rgba(156, 176, 122, 0.18);
+    --rust:         #D27468;
+    --warning:      #D9A55F;
+    --warning-tint: rgba(217, 165, 95, 0.18);
+    --info:         #7C9FD2;
+    --sky:          #85A6CB;
+
+    --gray-100: #1E1F29;
+    --gray-200: #262732;
+    --gray-300: #34363F;
+    --gray-500: #9A9AA0;
+    --gray-700: #C0C0C7;
+
+    --shadow-sm:         0 1px 2px  rgba(0, 0, 0, 0.45);
+    --shadow-md:         0 4px 14px rgba(0, 0, 0, 0.50);
+    --shadow-lg:         0 12px 28px rgba(0, 0, 0, 0.55);
+    --shadow-card-hover: 0 10px 30px rgba(0, 0, 0, 0.50);
+  }
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --ivory: #0F1018;
+  --paper: #181A24;
+  --slate: #E8E8EE;
+  --oat:   #2B2D38;
+
+  --accent:               #7A8AD1;
+  --accent-d:             #6273C0;
+  --accent-tint:          rgba(122, 138, 209, 0.18);
+  --accent-focus-ring:    rgba(122, 138, 209, 0.28);
+  --accent-strong-border: rgba(122, 138, 209, 0.6);
+
+  --olive:        #9CB07A;
+  --olive-tint:   rgba(156, 176, 122, 0.18);
+  --rust:         #D27468;
+  --warning:      #D9A55F;
+  --warning-tint: rgba(217, 165, 95, 0.18);
+  --info:         #7C9FD2;
+  --sky:          #85A6CB;
+
+  --gray-100: #1E1F29;
+  --gray-200: #262732;
+  --gray-300: #34363F;
+  --gray-500: #9A9AA0;
+  --gray-700: #C0C0C7;
+
+  --shadow-sm:         0 1px 2px  rgba(0, 0, 0, 0.45);
+  --shadow-md:         0 4px 14px rgba(0, 0, 0, 0.50);
+  --shadow-lg:         0 12px 28px rgba(0, 0, 0, 0.55);
+  --shadow-card-hover: 0 10px 30px rgba(0, 0, 0, 0.50);
+}
+
+/* =====================================================================
+   Base reset & body
+   ===================================================================== */
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  background: var(--ivory);
+  color: var(--slate);
+  font-family: var(--sans);
+  font-size: var(--t-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* =====================================================================
+   Type styles
+   ===================================================================== */
+.t-display {
+  font-family: var(--serif); font-weight: 500;
+  font-size: var(--t-display); line-height: 1.1; letter-spacing: -0.02em;
+}
+.t-h1 {
+  font-family: var(--serif); font-weight: 500;
+  font-size: var(--t-h1); line-height: 1.2; letter-spacing: -0.01em;
+}
+.t-h2 {
+  font-family: var(--serif); font-weight: 500;
+  font-size: var(--t-h2); line-height: 1.3; letter-spacing: -0.01em;
+}
+.t-h3 {
+  font-family: var(--serif); font-weight: 500;
+  font-size: var(--t-h3); line-height: 1.22; letter-spacing: -0.008em;
+}
+.t-body    { font: 430 var(--t-body)/1.55 var(--sans); }
+.t-small   { font: 430 var(--t-small)/1.5 var(--sans); color: var(--gray-700); }
+.t-caption { font: 500 var(--t-caption)/1.4 var(--sans); color: var(--gray-500); }
+
+/* Eyebrow — small uppercase mono label with leading accent rule */
+.eyebrow {
+  font-family: var(--mono);
+  font-size: var(--t-eyebrow);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--gray-500);
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+.eyebrow::before {
+  content: "";
+  width: 24px;
+  height: 1.5px;
+  background: var(--accent);
+}
+
+/* Inline elements */
+em.accent, .serif em { font-style: italic; color: var(--accent); }
+a.link {
+  color: var(--accent);
+  text-decoration-color: var(--oat);
+  text-underline-offset: 3px;
+}
+a.link:hover { text-decoration-color: var(--accent); }
+
+code, .code-inline {
+  font-family: var(--mono);
+  font-size: 0.86em;
+  background: var(--gray-100);
+  padding: 1.5px 5px;
+  border-radius: var(--r-xs);
+}
+
+/* =====================================================================
+   Components
+   ===================================================================== */
+
+/* ---------- Button ---------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 36px;
+  padding: 0 16px;
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 500;
+  border-radius: var(--r-sm);
+  border: 1.5px solid transparent;
+  cursor: pointer;
+  transition: background var(--t-fast) ease, border-color var(--t-fast) ease;
+}
+.btn-primary        { background: var(--accent); color: var(--paper); }
+.btn-primary:hover  { background: var(--accent-d); }
+.btn-secondary      { background: var(--paper); color: var(--slate); border-color: var(--gray-300); }
+.btn-secondary:hover { background: var(--gray-100); }
+.btn-ghost          { background: transparent; color: var(--gray-700); }
+.btn-ghost:hover    { background: var(--gray-100); }
+.btn-danger         { background: var(--rust); color: var(--paper); }
+.btn-danger:hover   { background: #9A3F3F; }
+
+/* ---------- Input ---------- */
+.input {
+  height: 38px;
+  padding: 0 12px;
+  font: 14px var(--sans);
+  color: var(--slate);
+  background: var(--paper);
+  border: var(--border);
+  border-radius: var(--r-sm);
+  outline: none;
+  transition: border-color var(--t-fast) ease, box-shadow var(--t-fast) ease;
+}
+.input::placeholder { color: var(--gray-500); }
+.input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-focus-ring);
+}
+
+/* ---------- Checkbox ---------- */
+.checkbox { display: inline-flex; align-items: center; gap: 10px; cursor: pointer; user-select: none; }
+.checkbox input {
+  appearance: none;
+  width: 18px; height: 18px;
+  border: var(--border);
+  border-radius: 5px;
+  background: var(--paper);
+  position: relative;
+  cursor: pointer;
+  transition: background var(--t-fast), border-color var(--t-fast);
+}
+.checkbox input:checked { background: var(--accent); border-color: var(--accent); }
+.checkbox input:checked::after {
+  content: "";
+  position: absolute;
+  left: 5px; top: 1px;
+  width: 5px; height: 10px;
+  border: solid var(--paper);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+/* ---------- Badge / Pill ---------- */
+.badge {
+  display: inline-flex; align-items: center;
+  height: 22px; padding: 0 9px;
+  font-size: 12px; font-weight: 500;
+  border-radius: var(--r-pill);
+}
+.badge-neutral { background: var(--gray-100);    color: var(--gray-700); }
+.badge-accent  { background: var(--accent-tint); color: var(--accent); }
+.badge-success { background: var(--olive-tint);  color: var(--olive); }
+.badge-warning { background: var(--warning-tint); color: #A06A2A; }
+.badge-danger  { background: var(--rust); color: var(--paper); }
+
+/* ---------- Card ---------- */
+.card {
+  background: var(--paper);
+  border: var(--border);
+  border-radius: var(--r-lg);
+  padding: var(--sp-5);
+  transition: transform var(--t-base) ease,
+              box-shadow var(--t-base) ease,
+              border-color var(--t-base) ease;
+}
+.card.is-link { display: flex; flex-direction: column; text-decoration: none; color: inherit; cursor: pointer; }
+.card.is-link:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-card-hover);
+  border-color: var(--slate);
+}
+
+/* ---------- Stat card ---------- */
+.stat-card {
+  background: var(--paper);
+  border: var(--border);
+  border-radius: var(--r-md);
+  padding: 20px 22px 18px;
+}
+.stat-card.warn { border-left: 4px solid var(--accent); padding-left: 19px; }
+.stat-num   { font: 500 44px/1 var(--serif); margin-bottom: 8px; color: var(--slate); }
+.stat-label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--gray-500); }
+.stat-delta { font-family: var(--mono); font-size: 11px; margin-top: 6px; }
+.stat-delta.up   { color: var(--olive); }
+.stat-delta.down { color: var(--rust); }
+.stat-delta.flat { color: var(--gray-500); }
+
+/* ---------- Table ---------- */
+.tbl {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: var(--paper);
+  border: var(--border);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+.tbl thead th {
+  text-align: left;
+  font: 600 11px/1 var(--sans);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--gray-500);
+  background: var(--gray-100);
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--gray-300);
+}
+.tbl tbody td {
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--gray-100);
+  font-size: 14px;
+}
+.tbl tbody tr:last-child td { border-bottom: none; }
+
+/* ---------- Dark TL;DR / callout panel ---------- */
+.tldr {
+  background: var(--slate);
+  color: var(--ivory);
+  border-radius: var(--r-md);
+  padding: 22px 26px;
+}
+.tldr-label {
+  font: 500 var(--t-eyebrow)/1 var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--oat);
+  margin-bottom: 10px;
+}
+.tldr code {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--ivory);
+}
+
+/* ---------- Severity pill ---------- */
+.pill {
+  display: inline-flex; align-items: baseline; gap: 6px;
+  font: 600 12px/1 var(--sans);
+  border-radius: var(--r-pill);
+  padding: 5px 12px;
+}
+.pill.sev      { background: var(--accent); color: var(--paper); letter-spacing: 0.03em; }
+.pill.resolved { background: var(--olive);  color: var(--paper); }
+.pill.neutral  { background: var(--gray-100); color: var(--gray-700); border: var(--border); }
+.pill.neutral .v { font-family: var(--mono); }
+
+/* ---------- Timeline ---------- */
+.timeline { position: relative; padding: 4px 0 4px 16px; }
+.timeline::before {
+  content: "";
+  position: absolute;
+  left: 16px; top: 8px; bottom: 8px;
+  width: 2px;
+  background: var(--gray-300);
+}
+.tl-entry { position: relative; padding: 0 0 22px 28px; }
+.tl-entry::before {
+  content: "";
+  position: absolute;
+  left: -7px; top: 4px;
+  width: 14px; height: 14px;
+  border-radius: 50%;
+  background: var(--paper);
+  border: 2px solid var(--accent);
+}
+
+/* ---------- Section header ---------- */
+.sec-head { display: flex; align-items: baseline; gap: 16px; margin-bottom: 10px; }
+.sec-head .idx {
+  font: 600 13px/1 var(--mono);
+  color: var(--accent);
+  width: 34px;
+  flex-shrink: 0;
+}
+.sec-head h2 { margin: 0; font-family: var(--serif); font-weight: 500; font-size: 27px; letter-spacing: -0.012em; }
+.sec-head .count {
+  font: 11px/1 var(--mono);
+  color: var(--gray-500);
+  background: var(--gray-100);
+  padding: 2px 8px;
+  border-radius: var(--r-pill);
+}
+
+/* ---------- TOC pill nav ---------- */
+.toc { display: flex; flex-wrap: wrap; gap: 8px; }
+.toc a {
+  font-size: 12.5px;
+  padding: 7px 14px;
+  border: var(--border);
+  border-radius: var(--r-pill);
+  text-decoration: none;
+  color: var(--gray-700);
+  background: var(--paper);
+  transition: border-color var(--t-fast), color var(--t-fast), background var(--t-fast);
+  display: inline-flex; align-items: center; gap: 7px;
+}
+.toc a .n { font: 10px/1 var(--mono); color: var(--gray-500); }
+.toc a:hover { border-color: var(--slate); color: var(--slate); }
+.toc a:hover .n { color: var(--accent); }
+
+/* ---------- Avatar (PR-style monogram) ---------- */
+.avatar {
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: var(--oat);
+  color: var(--slate);
+  display: inline-flex; align-items: center; justify-content: center;
+  font: 600 13px/1 var(--sans);
+  letter-spacing: 0.02em;
+  border: var(--border);
+}
+
+/* ---------- Risk chip (with status dot) ---------- */
+.chip-dot {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 8px 12px;
+  border-radius: var(--r-sm);
+  border: var(--border);
+  font: 12.5px var(--mono);
+  color: var(--slate);
+  background: var(--paper);
+}
+.chip-dot .dot { width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; }
+.chip-dot.safe      { background: var(--olive-tint); border-color: rgba(120,140,93,0.45); }
+.chip-dot.safe .dot      { background: var(--olive); }
+.chip-dot.medium    { background: var(--oat); }
+.chip-dot.medium .dot    { background: var(--gray-500); }
+.chip-dot.attention { background: var(--accent-tint); border-color: var(--accent-strong-border); }
+.chip-dot.attention .dot { background: var(--accent); }
+
+/* =====================================================================
+   Layout helpers
+   ===================================================================== */
+.wrap         { max-width: var(--content-default); margin: 0 auto; padding: 0 var(--page-pad-x); }
+.wrap-narrow  { max-width: var(--content-narrow);  margin: 0 auto; padding: 0 var(--page-pad-x); }
+.wrap-wide    { max-width: var(--content-wide);    margin: 0 auto; padding: 0 var(--page-pad-x); }
+hr.rule       { border: none; border-top: var(--border-rule); margin: 0 0 22px; }
+
+/* =====================================================================
+   Accessibility
+   ===================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+*:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--r-xs);
+}

--- a/lib/quadrants.ts
+++ b/lib/quadrants.ts
@@ -2,20 +2,27 @@ import type { QuadrantId } from "@/lib/types";
 
 export type RedesignQuadrantKey = "q1" | "q2" | "q3" | "q4";
 
-/** Canonical accent hex per quadrant — single source of truth for charts, panes, and inline styles. */
+/**
+ * Canonical accent per quadrant — single source of truth for charts, panes,
+ * and inline styles. Values are CSS custom-property references so the actual
+ * color tracks light/dark mode (defined in app/globals.css :root and .dark).
+ *
+ * Dark variants are deliberately extra-lifted so labels clear WCAG AA (4.5:1)
+ * over the 20%-wash header band. The band tint carries quadrant identity.
+ */
 export const QUADRANT_ACCENT: Record<RedesignQuadrantKey, string> = {
-  q1: "#c2410c",
-  q2: "#1d4ed8",
-  q3: "#15803d",
-  q4: "#854d0e",
+  q1: "var(--q1)",
+  q2: "var(--q2)",
+  q3: "var(--q3)",
+  q4: "var(--q4)",
 };
 
 /** Same palette keyed by QuadrantId for components that reference the long-form id. */
 export const QUADRANT_ACCENT_BY_ID: Record<QuadrantId, string> = {
-  "urgent-important": "#c2410c",
-  "not-urgent-important": "#1d4ed8",
-  "urgent-not-important": "#15803d",
-  "not-urgent-not-important": "#854d0e",
+  "urgent-important": "var(--q1)",
+  "not-urgent-important": "var(--q2)",
+  "urgent-not-important": "var(--q3)",
+  "not-urgent-not-important": "var(--q4)",
 };
 export type RedesignIconKey = "flame" | "calendar" | "users" | "trash";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.1.0",
+	"version": "9.2.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '9.1.0';
+const CACHE_VERSION = '9.2.0';
 const CACHE_NAME = `gsd-cache-v${CACHE_VERSION}`;
 const OFFLINE_ASSETS = [
 	"/",

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -41,3 +41,12 @@ Project-specific learnings, gotchas, and patterns. Review at the start of every 
 - Pinned `canvas-confetti` from `^1.9.4` to exact `1.9.4`.
 - Migrated `.parse()` to `.safeParse()` in user-input paths (import, create).
 - Refactored `clearIndexedDB()` and `checkAndNotify()` for function length compliance.
+
+## Inkwell Design System Migration (2026-05-08)
+
+- **Token-bridging is the right move when adopting a new palette.** The app has 71 component files referencing GSD's existing token names (`bg-background`, `text-foreground`, `border-border`, etc.). Replacing token *values* in `app/globals.css` while keeping token *names* unchanged migrates the entire utility surface in one file. Vanilla-class adoption would have been a 71-file rewrite for no functional gain.
+- **Don't `@import inkwell.css` directly.** Inkwell's stylesheet ships its own `body { background: var(--ivory) }` and a `prefers-color-scheme: dark` block keyed on `:root:not([data-theme="light"])`. Both fight `next-themes`'s class-based dark mode and produce flicker. Cherry-pick utility classes (`.t-h1`, `.eyebrow`) into `globals.css` under `@layer utilities` instead.
+- **Hard-coded hex inside scoped blocks won't follow root token swaps.** `.redesign-scope { --q1: #c2410c; ... }` lives in the v9 matrix surface. Forgetting to update it would have left the most-visible UI showing old colors while the rest of the app went Inkwell — visible inconsistency.
+- **Concatenated alpha hex (`${a}14`) breaks when `a` becomes a CSS var.** `lib/quadrants.ts` exported hex values like `#c2410c`, then components did `backgroundColor: \`${a}14\`` for alpha tinting. Switching `a` to `var(--q1)` makes that string an invalid `var(--q1)14`. Fix: `color-mix(in srgb, ${a} 8%, transparent)` — accepts CSS vars and is the modern equivalent.
+- **WCAG AA on tinted bands needs mode-specific accent values.** Light mode quadrant labels need *deeper* hues (`#9A3F3F`, `#3D5577`) to clear 4.5:1 against the soft tint headers; dark mode needs *brighter* lifted hues (`#E89788`, `#9CB8DA`) over the 20%-wash dark headers. A single hex value that "looks right" can't win both contests — split into `:root` vs `.dark` `--qN` definitions.
+- **Tokens must be defined globally if matrix code reads them globally.** `--q1`..`--q4` were originally only inside `.redesign-scope`, but the v9 matrix grid lives outside that scope. Inline `style={{ color: 'var(--q1)' }}` returned empty without a global definition. Add to `:root` and `.dark`, not just to scoped blocks.


### PR DESCRIPTION
## Summary

Phase 1 of the Inkwell migration — a **token-bridging swap** that adopts Inkwell's Indigo & Cloud palette as the default look-and-feel without rewriting any components.

GSD's existing Tailwind utility surface (`bg-background`, `text-foreground`, `border-border`, etc., referenced in **71 files**) stays unchanged; only the *underlying token values* in `app/globals.css` flip to Inkwell's palette. Total touch list: 1 stylesheet + 3 component patches + 1 lib + version bump + screenshot ignore.

### What changes visually

- **Light mode:** cool-stone ivory page surface (`#F4F4F0`), pure-white card surfaces, deep indigo `#3B4A8C` accent, slate-cool text — quiet editorial palette in place of the prior warm-paper / indigo-700 look.
- **Dark mode:** deep charcoal (`#0F1018`) page, paper-dark cards (`#181A24`), lifted periwinkle `#7A8AD1` accent — hue-preserved, luminance-lifted per Inkwell's Pattern B.
- **Quadrants:** rust / sky / olive / warning replace saturated orange / blue / green / amber. Inkwell's anti-patterns explicitly forbid saturated semantic colors; if the new feel reads as washed-out, the `--q1..--q4` tokens in `app/globals.css` are the single point to retune.
- **Typography:** editorial-serif (Instrument Serif) headlines stay where they were already wired (matrix empty states, dashboard, settings); new `.t-h1` / `.t-h2` / `.t-h3` / `.eyebrow` utilities available for adoption in Phase 2.

### Why token bridging vs full rewrite

Inkwell ships a vanilla-CSS class system (`.btn`, `.card`, `.stat-card`, `.tbl`). Adopting it directly would mean rewriting 71 component files, each currently styled with Tailwind utilities. Token bridging gets ~95% of the visual benefit with ~5% of the diff. Phase 2 can adopt Inkwell's structural classes (1.5px hairline borders, serif headings by default, mono metadata) component-by-component.

### Implementation notes (a11y + correctness)

- **Quadrant accents promoted to global mode-aware CSS tokens** (`--q1..--q4` at `:root` and `.dark`). Light values are deeper saturations (`#9A3F3F`, `#3D5577`, `#3F5034`, `#85581A`) that hit ≥5.2:1 against the soft tint header bands. Dark values are extra-lifted (`#E89788`, `#9CB8DA`, `#B5C497`, `#E8C58B`) that clear ≥6.4:1 over the 20%-wash dark header bands. WCAG AA verified in-browser via computed-style probe + luminance math; results: q1 5.49/6.40, q2 6.39/6.76, q3 7.33/7.04, q4 5.22/7.72 (light/dark).
- **`lib/quadrants.ts`** previously exported plain hex (`#c2410c` etc.) used inline-style for every quadrant label, dashed CTA button, and chart series. Hex doesn't switch with mode, so dark mode displayed old saturated colors on Inkwell's desaturated tints. Now exports `var(--qN)` references.
- **`color-mix` replaces hex+alpha string concatenation.** `${a}14` no longer works once `a` is a CSS var. Two sites patched: `edit-drawer.tsx:215` (active-quadrant chip) and `capture-bar.tsx:157` (quadrant pill).
- **`.redesign-scope` quadrant literals** (lines 521-543 of `globals.css`) updated to Inkwell rust/info/olive/warning so the v9 matrix grid stays consistent with the rest of the app.
- **Did not `@import inkwell.css` directly.** Inkwell ships its own `body { background: var(--ivory) }` and a `prefers-color-scheme: dark` block keyed on `:root:not([data-theme="light"])` — both fight `next-themes`'s class-based dark mode. Cherry-picked typography utilities into `globals.css @layer utilities` instead.

### Out of scope (Phase 2 follow-ups)

- Adopting Inkwell's signature 1.5px hairline borders on existing panels
- Replacing Tailwind utility classes with Inkwell vanilla components (`.btn`, `.card`, `.stat-card`, `.tbl`)
- Moving heading defaults to serif globally
- Wiring three-state Auto/Light/Dark toggle from Inkwell preview

## Test plan

- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] `bun run test` — 1825 passed, 1 skipped (matches baseline)
- [x] `bun run build` — all 9 static routes generated
- [x] Browser smoke: matrix view (empty state) verified in light + dark, dashboard verified in dark
- [x] WCAG AA contrast measured for all 4 quadrant header labels in both modes (all pass)
- [ ] Stakeholder visual review — confirm quadrant desaturation reads as editorial-quiet vs washed-out
- [ ] Settings page + Archive page visual smoke (token-only changes, no component logic touched, but worth eyeballing)

Bumps version `9.1.0 → 9.2.0`.