### PR TITLE
[codex] Implement Inkwell design system

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,129 +2,55 @@
 @config "../tailwind.config.ts";
 
 :root {
-  color-scheme: light;
+  /* App bridge aliases. Inkwell owns the canonical tokens loaded from /css/inkwell.css. */
+  --background: var(--ivory);
+  --background-muted: var(--gray-100);
+  --background-accent: var(--oat);
+  --foreground: var(--slate);
+  --foreground-muted: var(--gray-500);
+  --border-muted: var(--gray-100);
+  --accent-hover: var(--accent-d);
+  --accent-muted: var(--accent-tint);
+  --card-background: var(--paper);
+  --card-border: var(--gray-300);
 
-  /* Surfaces — warm paper */
-  --background: 246 245 241;           /* #f6f5f1 */
-  --background-muted: 239 237 231;     /* #efede7 */
-  --background-accent: 235 232 224;    /* #ebe8e0 */
+  --quadrant-focus: color-mix(in srgb, var(--rust) 12%, var(--paper));
+  --quadrant-schedule: color-mix(in srgb, var(--accent) 12%, var(--paper));
+  --quadrant-delegate: color-mix(in srgb, var(--olive) 12%, var(--paper));
+  --quadrant-eliminate: color-mix(in srgb, var(--warning) 14%, var(--paper));
+  --q1: var(--rust);
+  --q2: var(--accent);
+  --q3: var(--olive);
+  --q4: var(--warning);
 
-  /* Text */
-  --foreground: 24 24 27;              /* #18181b */
-  --foreground-muted: 113 113 122;     /* #71717a — AA on paper 4.8:1 */
+  --shadow-card: var(--shadow-sm);
+  --shadow-column: var(--shadow-sm);
+  --shadow-fab: 0 8px 30px var(--accent-focus-ring);
 
-  /* Borders — warm */
-  --border: 230 227 219;               /* #e6e3db */
-  --border-muted: 239 237 231;         /* #efede7 */
+  /* Solid color slots retained for existing chart/quadrant call sites. */
+  --gradient-focus: var(--rust);
+  --gradient-schedule: var(--accent);
+  --gradient-delegate: var(--olive);
+  --gradient-eliminate: var(--warning);
+  --chart-series-2: var(--sky);
 
-  /* Accent */
-  --accent: 67 56 202;                  /* #4338ca — indigo-700, AA on paper 7.1:1 */
-  --accent-hover: 79 70 229;           /* #4f46e5 */
-  --accent-muted: 199 210 254;         /* #c7d2fe */
+  --status-overdue: var(--rust);
+  --status-overdue-muted: color-mix(in srgb, var(--rust) 14%, var(--paper));
+  --status-blocked: var(--warning);
+  --status-blocked-muted: var(--warning-tint);
+  --status-blocking: var(--sky);
+  --status-blocking-muted: color-mix(in srgb, var(--sky) 14%, var(--paper));
+  --status-success: var(--olive);
+  --status-success-muted: var(--olive-tint);
 
-  /* Quadrant tint pairs (match redesign scope) */
-  --quadrant-focus: 253 241 231;       /* #fdf1e7 */
-  --quadrant-schedule: 238 242 253;    /* #eef2fd */
-  --quadrant-delegate: 232 242 236;    /* #e8f2ec */
-  --quadrant-eliminate: 245 239 223;   /* #f5efdf */
-
-  /* Quadrant washes — ~5% accent for pane backgrounds (v9 simplified) */
-  --q1-wash: 194 65 12;        /* #c2410c */
-  --q2-wash: 29 78 216;        /* #1d4ed8 */
-  --q3-wash: 21 128 61;        /* #15803d */
-  --q4-wash: 133 77 14;        /* #854d0e */
-
-  /* Card */
-  --card-background: 251 250 246;      /* #fbfaf6 — paper */
-  --card-border: 230 227 219;          /* matches --border */
-
-  --overlay: 0 0 0;
-
-  /* Shadows — softer for paper */
-  --shadow-card: 0 1px 0 rgba(24, 24, 27, 0.04), 0 1px 2px rgba(24, 24, 27, 0.04);
-  --shadow-card-hover: 0 1px 0 rgba(24, 24, 27, 0.04), 0 6px 18px -8px rgba(24, 24, 27, 0.12);
-  --shadow-column: 0 1px 2px rgba(24, 24, 27, 0.05), 0 1px 0 rgba(24, 24, 27, 0.04);
-  --shadow-fab: 0 8px 30px rgba(67, 56, 202, 0.35);
-
-  /* Quadrant solid gradients — used by dashboard donut, etc. */
-  --gradient-focus: linear-gradient(135deg, #c2410c, #ea580c);
-  --gradient-schedule: linear-gradient(135deg, #1d4ed8, #3b82f6);
-  --gradient-delegate: linear-gradient(135deg, #15803d, #22c55e);
-  --gradient-eliminate: linear-gradient(135deg, #854d0e, #ca8a04);
-
-  /* Chart palette — series 1 uses --accent; series 2+ are tokenized here. */
-  --chart-series-2: 59 130 246;        /* blue-500 */
-
-  /* Semantic status colors */
-  --status-overdue: 220 38 38;          /* red-600 */
-  --status-overdue-muted: 254 226 226;  /* red-100 */
-  --status-blocked: 217 119 6;          /* amber-600 */
-  --status-blocked-muted: 254 243 199;  /* amber-100 */
-  --status-blocking: 37 99 235;         /* blue-600 */
-  --status-blocking-muted: 219 234 254; /* blue-100 */
-  --status-success: 22 163 74;          /* green-600 */
-  --status-success-muted: 220 252 231;  /* green-100 */
-
-  /* Motion tokens */
-  --duration-fast: 150ms;
-  --duration-normal: 250ms;
-}
-
-.dark {
-  color-scheme: dark;
-
-  --background: 12 12 13;              /* #0c0c0d */
-  --background-muted: 23 23 26;        /* #17171a */
-  --background-accent: 31 31 34;       /* #1f1f22 */
-
-  --foreground: 244 244 245;           /* #f4f4f5 */
-  --foreground-muted: 161 161 170;     /* #a1a1aa — AA 5.5:1 */
-
-  --border: 39 39 42;                  /* #27272a */
-  --border-muted: 31 31 34;            /* #1f1f22 */
-
-  --accent: 129 140 248;               /* #818cf8 */
-  --accent-hover: 165 180 252;         /* #a5b4fc */
-  --accent-muted: 165 180 252;         /* #a5b4fc — lighter for dark mode readability */
-
-  --quadrant-focus: 42 22 9;           /* #2a1609 */
-  --quadrant-schedule: 15 26 58;       /* #0f1a3a */
-  --quadrant-delegate: 11 36 26;       /* #0b241a */
-  --quadrant-eliminate: 44 32 9;       /* #2c2009 */
-
-  /* Wash channels reused; opacity bumped at use-site for dark legibility */
-  --q1-wash: 194 65 12;
-  --q2-wash: 29 78 216;
-  --q3-wash: 21 128 61;
-  --q4-wash: 133 77 14;
-
-  --card-background: 26 26 29;         /* #1a1a1d */
-  --card-border: 39 39 42;
-
-  --overlay: 0 0 0;
-
-  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
-  --shadow-card-hover: 0 10px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.3);
-  --shadow-column: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -2px rgba(0, 0, 0, 0.2);
-  --shadow-fab: 0 8px 30px rgba(129, 140, 248, 0.35);
-
-  --chart-series-2: 96 165 250;        /* blue-400 — slightly lighter for dark mode */
-
-  /* Semantic status colors — dark */
-  --status-overdue: 248 113 113;        /* red-400 */
-  --status-overdue-muted: 69 10 10;     /* red-950/50 */
-  --status-blocked: 251 191 36;         /* amber-400 */
-  --status-blocked-muted: 69 26 3;      /* amber-950/50 */
-  --status-blocking: 96 165 250;        /* blue-400 */
-  --status-blocking-muted: 23 37 84;    /* blue-950/50 */
-  --status-success: 74 222 128;         /* green-400 */
-  --status-success-muted: 5 46 22;      /* green-950/50 */
+  --duration-fast: var(--t-fast);
+  --duration-normal: var(--t-slow);
 }
 
 body {
-  font-family: var(--font-sans, 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
-  background: rgb(var(--background));
-  color: rgb(var(--foreground));
+  font-family: var(--sans);
+  background: var(--ivory);
+  color: var(--slate);
   min-height: 100vh;
   overflow-y: scroll;
   /* iOS safe area support - respect notch and home indicator */
@@ -144,7 +70,7 @@ main {
 }
 
 ::-webkit-scrollbar-thumb {
-  background-color: rgb(var(--foreground-muted) / 0.3);
+  background-color: color-mix(in srgb, var(--gray-500) 30%, transparent);
   border-radius: 9999px;
 }
 
@@ -155,7 +81,7 @@ main {
 /* Firefox scrollbar */
 * {
   scrollbar-width: thin;
-  scrollbar-color: rgb(var(--foreground-muted) / 0.3) transparent;
+  scrollbar-color: color-mix(in srgb, var(--gray-500) 30%, transparent) transparent;
 }
 
 /* Hide scrollbar utility for horizontal scroll containers */
@@ -221,16 +147,16 @@ main {
 
   /* Subtle quadrant gradient glow — adds depth without overwhelming content */
   .matrix-card.bg-quadrant-focus {
-    background-image: radial-gradient(ellipse at top left, rgb(var(--quadrant-focus) / 0.15), transparent 60%);
+    background-color: color-mix(in srgb, var(--rust) 8%, var(--paper));
   }
   .matrix-card.bg-quadrant-schedule {
-    background-image: radial-gradient(ellipse at top left, rgb(var(--quadrant-schedule) / 0.15), transparent 60%);
+    background-color: color-mix(in srgb, var(--accent) 8%, var(--paper));
   }
   .matrix-card.bg-quadrant-delegate {
-    background-image: radial-gradient(ellipse at top left, rgb(var(--quadrant-delegate) / 0.15), transparent 60%);
+    background-color: color-mix(in srgb, var(--olive) 8%, var(--paper));
   }
   .matrix-card.bg-quadrant-eliminate {
-    background-image: radial-gradient(ellipse at top left, rgb(var(--quadrant-eliminate) / 0.15), transparent 60%);
+    background-color: color-mix(in srgb, var(--warning) 10%, var(--paper));
   }
 
   .matrix-card__header {
@@ -245,25 +171,25 @@ main {
     @apply text-sm text-foreground-muted;
   }
 
-  .quadrant-wash-q1 { background-color: rgb(var(--q1-wash) / 0.045); }
-  .quadrant-wash-q2 { background-color: rgb(var(--q2-wash) / 0.045); }
-  .quadrant-wash-q3 { background-color: rgb(var(--q3-wash) / 0.05); }
-  .quadrant-wash-q4 { background-color: rgb(var(--q4-wash) / 0.055); }
+  .quadrant-wash-q1 { background-color: color-mix(in srgb, var(--rust) 5%, transparent); }
+  .quadrant-wash-q2 { background-color: color-mix(in srgb, var(--accent) 5%, transparent); }
+  .quadrant-wash-q3 { background-color: color-mix(in srgb, var(--olive) 6%, transparent); }
+  .quadrant-wash-q4 { background-color: color-mix(in srgb, var(--warning) 7%, transparent); }
 
-  .dark .quadrant-wash-q1 { background-color: rgb(var(--q1-wash) / 0.14); }
-  .dark .quadrant-wash-q2 { background-color: rgb(var(--q2-wash) / 0.14); }
-  .dark .quadrant-wash-q3 { background-color: rgb(var(--q3-wash) / 0.15); }
-  .dark .quadrant-wash-q4 { background-color: rgb(var(--q4-wash) / 0.16); }
+  .dark .quadrant-wash-q1 { background-color: color-mix(in srgb, var(--rust) 15%, transparent); }
+  .dark .quadrant-wash-q2 { background-color: color-mix(in srgb, var(--accent) 15%, transparent); }
+  .dark .quadrant-wash-q3 { background-color: color-mix(in srgb, var(--olive) 16%, transparent); }
+  .dark .quadrant-wash-q4 { background-color: color-mix(in srgb, var(--warning) 17%, transparent); }
 
-  .quadrant-header-q1 { background-color: rgb(var(--q1-wash) / 0.07); }
-  .quadrant-header-q2 { background-color: rgb(var(--q2-wash) / 0.07); }
-  .quadrant-header-q3 { background-color: rgb(var(--q3-wash) / 0.075); }
-  .quadrant-header-q4 { background-color: rgb(var(--q4-wash) / 0.08); }
+  .quadrant-header-q1 { background-color: color-mix(in srgb, var(--rust) 8%, transparent); }
+  .quadrant-header-q2 { background-color: color-mix(in srgb, var(--accent) 8%, transparent); }
+  .quadrant-header-q3 { background-color: color-mix(in srgb, var(--olive) 9%, transparent); }
+  .quadrant-header-q4 { background-color: color-mix(in srgb, var(--warning) 10%, transparent); }
 
-  .dark .quadrant-header-q1 { background-color: rgb(var(--q1-wash) / 0.20); }
-  .dark .quadrant-header-q2 { background-color: rgb(var(--q2-wash) / 0.20); }
-  .dark .quadrant-header-q3 { background-color: rgb(var(--q3-wash) / 0.21); }
-  .dark .quadrant-header-q4 { background-color: rgb(var(--q4-wash) / 0.22); }
+  .dark .quadrant-header-q1 { background-color: color-mix(in srgb, var(--rust) 21%, transparent); }
+  .dark .quadrant-header-q2 { background-color: color-mix(in srgb, var(--accent) 21%, transparent); }
+  .dark .quadrant-header-q3 { background-color: color-mix(in srgb, var(--olive) 22%, transparent); }
+  .dark .quadrant-header-q4 { background-color: color-mix(in srgb, var(--warning) 23%, transparent); }
 }
 
 /* View Transitions */
@@ -370,10 +296,10 @@ main {
 
   @keyframes new-task-glow {
     0%, 100% {
-      box-shadow: 0 0 0 0 rgba(var(--accent), 0.4);
+      box-shadow: 0 0 0 0 var(--accent-focus-ring);
     }
     50% {
-      box-shadow: 0 0 0 6px rgba(var(--accent), 0);
+      box-shadow: 0 0 0 6px transparent;
     }
   }
 
@@ -405,10 +331,10 @@ main {
   /* Drop zone pulse when drag is over */
   @keyframes drop-zone-pulse {
     0%, 100% {
-      box-shadow: 0 0 0 0 rgba(var(--accent), 0.2);
+      box-shadow: 0 0 0 0 var(--accent-focus-ring);
     }
     50% {
-      box-shadow: 0 0 0 8px rgba(var(--accent), 0);
+      box-shadow: 0 0 0 8px transparent;
     }
   }
 
@@ -506,22 +432,21 @@ main {
 /* ─────────────────────────────────────────────── */
 
 .redesign-scope {
-  --bg: rgb(var(--background));
-  --bg-inset: rgb(var(--background-muted));
-  --paper: rgb(var(--card-background));
-  --ink: rgb(var(--foreground));
-  --ink-2: rgb(var(--foreground) / 0.75);
-  --ink-3: rgb(var(--foreground-muted));
-  --ink-4: rgb(var(--foreground-muted) / 0.6);
-  --line: rgb(var(--border));
-  --line-soft: rgb(var(--border-muted));
-  --rd-accent: rgb(var(--accent));
-  --rd-accent-soft: rgb(var(--accent-muted) / 0.25);
+  --bg: var(--ivory);
+  --bg-inset: var(--gray-100);
+  --ink: var(--slate);
+  --ink-2: color-mix(in srgb, var(--slate) 75%, transparent);
+  --ink-3: var(--gray-500);
+  --ink-4: color-mix(in srgb, var(--gray-500) 60%, transparent);
+  --line: var(--gray-300);
+  --line-soft: var(--gray-100);
+  --rd-accent: var(--accent);
+  --rd-accent-soft: var(--accent-tint);
 
-  --q1: #c2410c; --q1-soft: #fdf1e7; --q1-tint: #faebdd;
-  --q2: #1d4ed8; --q2-soft: #eef2fd; --q2-tint: #e3e9fb;
-  --q3: #15803d; --q3-soft: #e8f2ec; --q3-tint: #dbebe1;
-  --q4: #854d0e; --q4-soft: #f5efdf; --q4-tint: #ede4cd;
+  --q1-soft: color-mix(in srgb, var(--rust) 10%, var(--paper)); --q1-tint: color-mix(in srgb, var(--rust) 16%, var(--paper));
+  --q2-soft: color-mix(in srgb, var(--accent) 10%, var(--paper)); --q2-tint: color-mix(in srgb, var(--accent) 16%, var(--paper));
+  --q3-soft: color-mix(in srgb, var(--olive) 10%, var(--paper)); --q3-tint: color-mix(in srgb, var(--olive) 16%, var(--paper));
+  --q4-soft: color-mix(in srgb, var(--warning) 12%, var(--paper)); --q4-tint: color-mix(in srgb, var(--warning) 18%, var(--paper));
 
   --rd-radius: 14px;
   --rd-radius-sm: 10px;
@@ -532,36 +457,29 @@ main {
 
   background: var(--bg);
   color: var(--ink);
-  font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+  font-family: var(--sans);
   font-feature-settings: "ss01", "cv11";
-}
-
-.dark .redesign-scope {
-  --q1-soft: #2a1609; --q1-tint: #3a1e0c;
-  --q2-soft: #0f1a3a; --q2-tint: #152350;
-  --q3-soft: #0b241a; --q3-tint: #0f2e22;
-  --q4-soft: #2c2009; --q4-tint: #3a2a0d;
 }
 
 /* Editorial serif utility — global so dashboard and settings pages can use
  * the same display typography as the redesign scope without duplicating
  * the font-family fallback chain inline. */
 .rd-serif {
-  font-family: var(--font-instrument-serif, ui-serif, Georgia, serif);
+  font-family: var(--serif);
   font-weight: 400;
   letter-spacing: -0.01em;
 }
 
 .redesign-scope .rd-mono {
-  font-family: var(--font-mono, ui-monospace, monospace);
+  font-family: var(--mono);
 }
 
 .redesign-scope kbd {
-  font-family: var(--font-mono, ui-monospace, monospace);
+  font-family: var(--mono);
   font-size: 11px;
   padding: 2px 6px;
   border-radius: 5px;
-  border: 1px solid var(--line);
+  border: var(--border);
   background: var(--paper);
   color: var(--ink-2);
   box-shadow: 0 1px 0 var(--line);
@@ -742,7 +660,7 @@ main {
 /* RdButton variants — split out of inline styles so :hover rules can attach
  * and so `prefers-reduced-motion` gating works consistently. */
 .redesign-scope .rd-button-default {
-  border: 1px solid var(--line);
+  border: var(--border);
   background: var(--paper);
   color: var(--ink);
 }
@@ -751,7 +669,7 @@ main {
   border-color: var(--ink-3);
 }
 .redesign-scope .rd-button-primary {
-  border: 1px solid var(--ink);
+  border: var(--border-strong);
   background: var(--ink);
   color: var(--paper);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,10 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono, Instrument_Serif } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { ToastProvider } from "@/components/ui/toast";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "sonner";
 import "./globals.css";
-import { cn } from "@/lib/utils";
 import { PwaRegister } from "@/components/pwa-register";
 import { WebMcpRegister } from "@/components/webmcp-register";
 import { InstallPwaPrompt } from "@/components/install-pwa-prompt";
@@ -15,25 +13,9 @@ import { ClientLayout } from "@/components/client-layout";
 import { QueryProvider } from "@/components/query-provider";
 import { FirstTimeRedirect } from "@/components/first-time-redirect";
 
-const geist = Geist({
-  subsets: ["latin"],
-  variable: "--font-sans",
-  display: "swap",
-});
-
-const geistMono = Geist_Mono({
-  subsets: ["latin"],
-  variable: "--font-mono",
-  display: "swap",
-});
-
-const instrumentSerif = Instrument_Serif({
-  subsets: ["latin"],
-  weight: "400",
-  style: ["normal", "italic"],
-  variable: "--font-instrument-serif",
-  display: "swap",
-});
+const scriptSrc = process.env.NODE_ENV === "development"
+  ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+  : "script-src 'self' 'unsafe-inline'";
 
 const contentSecurityPolicy = [
   "default-src 'self'",
@@ -43,7 +25,7 @@ const contentSecurityPolicy = [
   "frame-ancestors 'none'",
   "img-src 'self' data: blob:",
   "font-src 'self' data:",
-  "script-src 'self' 'unsafe-inline'",
+  scriptSrc,
   "style-src 'self' 'unsafe-inline'",
   "connect-src 'self' https: wss:",
   "worker-src 'self' blob:",
@@ -102,8 +84,10 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <head>
         <meta httpEquiv="Content-Security-Policy" content={contentSecurityPolicy} />
+        {/* eslint-disable-next-line @next/next/no-css-tags -- Inkwell is installed as canonical static CSS. */}
+        <link rel="stylesheet" href="/css/inkwell.css" />
       </head>
-      <body className={cn(geist.variable, geistMono.variable, instrumentSerif.variable, "font-sans bg-background text-foreground antialiased")}>
+      <body className="font-sans bg-background text-foreground antialiased">
         <ErrorBoundary>
           <ThemeProvider>
             <ToastProvider>

--- a/components/dashboard/completion-chart.tsx
+++ b/components/dashboard/completion-chart.tsx
@@ -51,7 +51,7 @@ export function CompletionChart({ data }: CompletionChartProps) {
               backgroundImage: "linear-gradient(to right, currentColor 50%, transparent 50%)",
               backgroundSize: "4px 2px",
               backgroundColor: "transparent",
-              color: "rgb(var(--accent))",
+              color: "var(--accent)",
             }}
           />
           <span className="text-xs font-medium text-foreground-muted">Created</span>
@@ -83,31 +83,31 @@ export function CompletionChart({ data }: CompletionChartProps) {
           />
           <Tooltip
             contentStyle={{
-              backgroundColor: "rgb(var(--card-background))",
-              border: "1px solid rgb(var(--border))",
+              backgroundColor: "var(--paper)",
+              border: "var(--border)",
               borderRadius: "10px",
               fontSize: "13px",
-              color: "rgb(var(--foreground))",
+              color: "var(--slate)",
               boxShadow: "var(--shadow-card-hover)",
             }}
-            cursor={{ stroke: "rgb(var(--foreground-muted))", strokeOpacity: 0.3 }}
+            cursor={{ stroke: "var(--gray-500)", strokeOpacity: 0.3 }}
           />
           <Line
             type="monotone"
             dataKey="Completed"
-            stroke="rgb(var(--status-success))"
+            stroke="var(--status-success)"
             strokeWidth={2}
             dot={false}
-            activeDot={{ r: 5, fill: "rgb(var(--status-success))", stroke: "#fff", strokeWidth: 2 }}
+            activeDot={{ r: 5, fill: "var(--status-success)", stroke: "var(--paper)", strokeWidth: 2 }}
           />
           <Line
             type="monotone"
             dataKey="Created"
-            stroke="rgb(var(--accent))"
+            stroke="var(--accent)"
             strokeWidth={1.6}
             strokeDasharray="3 3"
             dot={false}
-            activeDot={{ r: 5, fill: "rgb(var(--accent))", stroke: "#fff", strokeWidth: 2 }}
+            activeDot={{ r: 5, fill: "var(--accent)", stroke: "var(--paper)", strokeWidth: 2 }}
           />
         </LineChart>
       </ResponsiveContainer>

--- a/components/gsd-logo.tsx
+++ b/components/gsd-logo.tsx
@@ -14,10 +14,10 @@ export function GsdLogo({ className, size = 28 }: GsdLogoProps) {
       className={className}
       aria-hidden="true"
     >
-      <rect x="2" y="2" width="7" height="7" rx="1.6" fill="#1d4ed8" opacity="0.32" />
-      <rect x="11" y="2" width="7" height="7" rx="1.6" fill="#c2410c" />
-      <rect x="2" y="11" width="7" height="7" rx="1.6" fill="#15803d" opacity="0.32" />
-      <rect x="11" y="11" width="7" height="7" rx="1.6" fill="#854d0e" opacity="0.32" />
+      <rect x="2" y="2" width="7" height="7" rx="1.6" fill="var(--accent)" opacity="0.32" />
+      <rect x="11" y="2" width="7" height="7" rx="1.6" fill="var(--rust)" />
+      <rect x="2" y="11" width="7" height="7" rx="1.6" fill="var(--olive)" opacity="0.32" />
+      <rect x="11" y="11" width="7" height="7" rx="1.6" fill="var(--warning)" opacity="0.32" />
     </svg>
   );
 }

--- a/components/matrix-simplified/capture-bar.tsx
+++ b/components/matrix-simplified/capture-bar.tsx
@@ -135,14 +135,14 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
       <ZapIcon
         aria-hidden
         className="h-4 w-4 shrink-0 transition-colors"
-        style={{ color: text.trim() ? accent : "rgb(var(--foreground-muted) / 0.7)" }}
+        style={{ color: text.trim() ? accent : "color-mix(in srgb, var(--gray-500) 70%, transparent)" }}
       />
       <input
         ref={internalRef}
         value={text}
         onChange={(e) => setText(e.target.value)}
         onKeyDown={onInputKey}
-        placeholder="Capture a task… use ! urgent  * important  #tag"
+        placeholder="Capture a task..."
         aria-label="Capture a task"
         className="min-w-0 flex-1 border-0 bg-transparent text-[15px] leading-snug text-foreground outline-none placeholder:text-foreground-muted"
       />
@@ -154,7 +154,10 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
             onClick={cycleQuadrant}
             title="Tab to cycle quadrant"
             className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[11px] font-medium animate-quadrant-pill-in"
-            style={{ backgroundColor: `${accent}33`, color: accent }}
+            style={{
+              backgroundColor: `color-mix(in srgb, ${accent} 20%, transparent)`,
+              color: accent,
+            }}
           >
             <span
               className="h-[5px] w-[5px] rounded-full bg-current"
@@ -193,7 +196,7 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
         className={cn(
           "inline-flex h-9 items-center gap-1.5 rounded-lg px-4 text-[14px] font-semibold transition-colors duration-[120ms]",
           parsed.title
-            ? "bg-accent text-white hover:bg-accent-hover"
+            ? "bg-accent text-card hover:bg-accent-hover"
             : "bg-accent/15 text-accent hover:bg-accent/20"
         )}
       >

--- a/components/matrix-simplified/edit-drawer.tsx
+++ b/components/matrix-simplified/edit-drawer.tsx
@@ -112,7 +112,7 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
   const isCreateMode = !task;
 
   const activeQuadrant = quadrants.find((q) => q.urgent === urgent && q.important === important);
-  const accent = activeQuadrant ? QUADRANT_ACCENT[activeQuadrant.rdKey] : "#c2410c";
+  const accent = activeQuadrant ? QUADRANT_ACCENT[activeQuadrant.rdKey] : "var(--rust)";
 
   const submit = (e?: FormEvent) => {
     e?.preventDefault();

--- a/components/matrix-simplified/help-drawer.tsx
+++ b/components/matrix-simplified/help-drawer.tsx
@@ -31,7 +31,7 @@ export function HelpDrawer({ open, onClose }: HelpDrawerProps) {
         <header
           style={{
             padding: "20px 52px 16px 24px",
-            borderBottom: "1px solid var(--line)",
+            borderBottom: "var(--border-hair)",
             display: "flex",
             alignItems: "flex-start",
             gap: 12,
@@ -270,11 +270,11 @@ const bodyStyle: React.CSSProperties = {
 };
 
 const codeStyle: React.CSSProperties = {
-  fontFamily: "var(--font-mono, ui-monospace, monospace)",
+  fontFamily: "var(--mono)",
   fontSize: 12,
   padding: "2px 8px",
   borderRadius: 6,
-  border: "1px solid var(--line)",
+  border: "var(--line)",
   background: "var(--bg-inset)",
   color: "var(--ink)",
 };

--- a/components/reset-everything-dialog.tsx
+++ b/components/reset-everything-dialog.tsx
@@ -112,7 +112,7 @@ export function ResetEverythingDialog({
 		<Dialog open={open} onOpenChange={handleClose}>
 			<DialogContent className="sm:max-w-lg">
 				<DialogHeader>
-					<DialogTitle className="flex items-center gap-2 text-red-600">
+					<DialogTitle className="flex items-center gap-2 text-status-overdue">
 						<AlertTriangleIcon className="h-5 w-5" />
 						Reset Everything
 					</DialogTitle>
@@ -123,11 +123,11 @@ export function ResetEverythingDialog({
 
 				<div className="space-y-4">
 					{/* Data Summary */}
-					<div className="rounded-lg border border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950/20 p-4">
-						<h4 className="font-semibold text-red-900 dark:text-red-100 mb-2">
+					<div className="rounded-lg border border-status-overdue/35 bg-status-overdue-muted p-4">
+						<h4 className="mb-2 font-semibold text-status-overdue">
 							What will be deleted:
 						</h4>
-						<ul className="space-y-1 text-sm text-red-800 dark:text-red-200">
+						<ul className="space-y-1 text-sm text-status-overdue">
 							<li>• {totalTasks} task{totalTasks !== 1 ? "s" : ""} ({activeTasks} active, {completedTasks} completed)</li>
 							<li>• All custom smart views</li>
 							<li>• All notification settings</li>
@@ -136,8 +136,8 @@ export function ResetEverythingDialog({
 								<li>• Cloud sync configuration (you will be logged out)</li>
 							)}
 							{pendingSync > 0 && (
-								<li className="font-semibold text-red-600 dark:text-red-400">
-									⚠️ {pendingSync} unsynchronized change{pendingSync !== 1 ? "s" : ""}
+								<li className="font-semibold text-status-overdue">
+									{pendingSync} unsynchronized change{pendingSync !== 1 ? "s" : ""}
 								</li>
 							)}
 						</ul>
@@ -187,7 +187,7 @@ export function ResetEverythingDialog({
 								</Button>
 							)}
 							{exportFirst && hasExported && (
-								<p className="text-xs text-green-600">✓ Exported successfully</p>
+								<p className="text-xs text-status-success">Exported successfully</p>
 							)}
 						</div>
 					</div>
@@ -211,7 +211,7 @@ export function ResetEverythingDialog({
 					{/* Confirmation Input */}
 					<div className="space-y-2">
 						<Label htmlFor="confirm-text" className="text-sm font-semibold">
-							Type <span className="font-mono text-red-600">RESET</span> to confirm:
+							Type <span className="font-mono text-status-overdue">RESET</span> to confirm:
 						</Label>
 						<Input
 							id="confirm-text"

--- a/components/task-timer.tsx
+++ b/components/task-timer.tsx
@@ -112,7 +112,7 @@ export function TaskTimer({
         className={cn(
           "flex items-center gap-1 rounded px-2 py-1 text-xs font-medium transition touch-manipulation",
           isRunning
-            ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300 animate-pulse"
+            ? "bg-status-success-muted text-status-success animate-pulse"
             : "bg-background-muted text-foreground-muted hover:bg-background hover:text-foreground",
           isLoading && "opacity-50 cursor-not-allowed",
           className
@@ -147,8 +147,8 @@ export function TaskTimer({
         className={cn(
           "flex h-8 w-8 items-center justify-center rounded-full transition touch-manipulation",
           isRunning
-            ? "bg-green-500 text-white hover:bg-green-600"
-            : "bg-background-muted text-foreground-muted hover:bg-accent hover:text-white",
+            ? "bg-status-success text-card hover:bg-status-success/90"
+            : "bg-background-muted text-foreground-muted hover:bg-accent hover:text-card",
           isLoading && "opacity-50 cursor-not-allowed"
         )}
         aria-label={ariaLabel}
@@ -162,13 +162,13 @@ export function TaskTimer({
 
       <div className="flex flex-col">
         {isRunning && (
-          <span className="font-mono text-sm font-medium text-green-600 dark:text-green-400">
+          <span className="font-mono text-sm font-medium text-status-success">
             {formatElapsedTime(elapsedSeconds)}
           </span>
         )}
         <div className="flex items-center gap-1 text-xs text-foreground-muted">
           <ClockIcon className="h-3 w-3" />
-          <span className={cn(isOverEstimate && "text-amber-600 dark:text-amber-400")}>
+          <span className={cn(isOverEstimate && "text-status-blocked")}>
             {formatTimeSpent(totalTimeSpent)}
           </span>
           {estimatedMinutes && (

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -10,7 +10,7 @@ interface ThemeProviderProps {
 export function ThemeProvider({ children }: ThemeProviderProps) {
   return (
     <NextThemesProvider
-      attribute="class"
+      attribute={["class", "data-theme"]}
       defaultTheme="system"
       enableSystem
       disableTransitionOnChange

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -4,10 +4,10 @@ import { cn } from "@/lib/utils";
 type BadgeVariant = "default" | "outline" | "ghost" | "accent";
 
 const variantClasses: Record<BadgeVariant, string> = {
-  default: "bg-white/10 text-white",
-  outline: "border border-white/20 text-white",
-  ghost: "bg-transparent text-white",
-  accent: "bg-accent/10 text-accent border border-accent/20"
+  default: "badge-neutral",
+  outline: "border-border bg-transparent text-foreground",
+  ghost: "bg-transparent text-foreground-muted",
+  accent: "badge-accent"
 };
 
 export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
@@ -18,6 +18,7 @@ export const Badge = ({ className, variant = "default", ...props }: BadgeProps) 
   <span
     className={cn(
       "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium uppercase tracking-wide",
+      "badge",
       variantClasses[variant],
       className
     )}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,10 +4,10 @@ import { cn } from "@/lib/utils";
 type ButtonVariant = "primary" | "subtle" | "ghost" | "destructive";
 
 const variantClasses: Record<ButtonVariant, string> = {
-  primary: "bg-accent hover:bg-accent-hover text-white shadow-md shadow-accent/20 hover:shadow-lg hover:shadow-accent/30 active:scale-[0.97]",
-  subtle: "bg-background-muted hover:bg-background-accent text-foreground border border-border hover:border-border active:scale-[0.97]",
-  ghost: "bg-transparent hover:bg-background-muted text-foreground active:scale-[0.97]",
-  destructive: "bg-red-600 hover:bg-red-700 text-white shadow-md shadow-red-600/20 hover:shadow-lg hover:shadow-red-700/30 active:scale-[0.97]"
+  primary: "btn-primary active:scale-[0.97]",
+  subtle: "btn-secondary active:scale-[0.97]",
+  ghost: "btn-ghost active:scale-[0.97]",
+  destructive: "btn-danger active:scale-[0.97]"
 };
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -20,7 +20,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       ref={ref}
       type={type}
       className={cn(
-        "inline-flex items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "btn gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         "disabled:cursor-not-allowed disabled:opacity-50",
         variantClasses[variant],
         className

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -9,7 +9,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       ref={ref}
       type={type}
       className={cn(
-        "w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-foreground-muted",
+        "input w-full",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         className
       )}

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -11,11 +11,11 @@ const Switch = React.forwardRef<
   <SwitchPrimitives.Root
     className={cn(
       "peer inline-flex h-[22px] w-[38px] shrink-0 cursor-pointer items-center rounded-full transition-colors",
-      "shadow-[inset_0_0_0_1px_rgb(var(--border))]",
+      "border border-border bg-background-accent",
       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background",
       "disabled:cursor-not-allowed disabled:opacity-50",
       "data-[state=checked]:bg-accent data-[state=checked]:shadow-none",
-      "data-[state=unchecked]:bg-border",
+      "data-[state=unchecked]:bg-background-accent",
       className
     )}
     {...props}
@@ -23,7 +23,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-[18px] w-[18px] rounded-full bg-white shadow-sm ring-0 transition-transform",
+        "pointer-events-none block h-[18px] w-[18px] rounded-full bg-card shadow-sm ring-0 transition-transform",
         "data-[state=checked]:translate-x-[18px] data-[state=unchecked]:translate-x-[2px]"
       )}
     />

--- a/lib/quadrants.ts
+++ b/lib/quadrants.ts
@@ -2,20 +2,20 @@ import type { QuadrantId } from "@/lib/types";
 
 export type RedesignQuadrantKey = "q1" | "q2" | "q3" | "q4";
 
-/** Canonical accent hex per quadrant — single source of truth for charts, panes, and inline styles. */
+/** Canonical accent token per quadrant - single source of truth for charts, panes, and inline styles. */
 export const QUADRANT_ACCENT: Record<RedesignQuadrantKey, string> = {
-  q1: "#c2410c",
-  q2: "#1d4ed8",
-  q3: "#15803d",
-  q4: "#854d0e",
+  q1: "var(--rust)",
+  q2: "var(--accent)",
+  q3: "var(--olive)",
+  q4: "var(--warning)",
 };
 
 /** Same palette keyed by QuadrantId for components that reference the long-form id. */
 export const QUADRANT_ACCENT_BY_ID: Record<QuadrantId, string> = {
-  "urgent-important": "#c2410c",
-  "not-urgent-important": "#1d4ed8",
-  "urgent-not-important": "#15803d",
-  "not-urgent-not-important": "#854d0e",
+  "urgent-important": "var(--rust)",
+  "not-urgent-important": "var(--accent)",
+  "urgent-not-important": "var(--olive)",
+  "not-urgent-not-important": "var(--warning)",
 };
 export type RedesignIconKey = "flame" | "calendar" | "users" | "trash";
 
@@ -52,10 +52,10 @@ export const quadrants: QuadrantMeta[] = [
     id: "urgent-important",
     title: "Do First",
     subtitle: "High urgency, high impact tasks",
-    accentClass: "bg-[#f9e3e0] text-[#c94b3a] dark:bg-[#763632]/55 dark:text-[#f3b2a8]",
+    accentClass: "bg-status-overdue-muted text-status-overdue",
     bgClass: "bg-quadrant-focus",
-    colorClass: "bg-[#e74f43] dark:bg-[#f08b78]",
-    iconColor: "text-[#e74f43] dark:text-[#f5b0a4]",
+    colorClass: "bg-status-overdue",
+    iconColor: "text-status-overdue",
     emptyMessage: "What needs your attention right now?",
     emptyEmoji: "🎯",
     emptyHeadline: "No urgent tasks right now",
@@ -76,10 +76,10 @@ export const quadrants: QuadrantMeta[] = [
     id: "not-urgent-important",
     title: "Schedule",
     subtitle: "Plan meaningful progress",
-    accentClass: "bg-[#e3ebff] text-[#4f73e8] dark:bg-[#374a78]/55 dark:text-[#b9c9ff]",
+    accentClass: "bg-accent-muted text-accent",
     bgClass: "bg-quadrant-schedule",
-    colorClass: "bg-[#4d74f5] dark:bg-[#7ea0ff]",
-    iconColor: "text-[#4d74f5] dark:text-[#abc1ff]",
+    colorClass: "bg-accent",
+    iconColor: "text-accent",
     emptyMessage: "What's important but not urgent?",
     emptyEmoji: "📅",
     emptyHeadline: "Nothing scheduled yet",
@@ -100,10 +100,10 @@ export const quadrants: QuadrantMeta[] = [
     id: "urgent-not-important",
     title: "Delegate",
     subtitle: "Hand off quick wins",
-    accentClass: "bg-[#e1f2e9] text-[#31996f] dark:bg-[#315548]/55 dark:text-[#a5dec2]",
+    accentClass: "bg-status-success-muted text-status-success",
     bgClass: "bg-quadrant-delegate",
-    colorClass: "bg-[#36c28a] dark:bg-[#71d4a9]",
-    iconColor: "text-[#36c28a] dark:text-[#9fe6c3]",
+    colorClass: "bg-status-success",
+    iconColor: "text-status-success",
     emptyMessage: "What can someone else handle?",
     emptyEmoji: "🤝",
     emptyHeadline: "No delegated tasks",
@@ -124,10 +124,10 @@ export const quadrants: QuadrantMeta[] = [
     id: "not-urgent-not-important",
     title: "Eliminate",
     subtitle: "Reduce noise and distractors",
-    accentClass: "bg-[#fdebcf] text-[#c07a12] dark:bg-[#6c4d21]/55 dark:text-[#ffd08a]",
+    accentClass: "bg-status-blocked-muted text-status-blocked",
     bgClass: "bg-quadrant-eliminate",
-    colorClass: "bg-[#ff9800] dark:bg-[#ffc15a]",
-    iconColor: "text-[#ff9800] dark:text-[#ffd58f]",
+    colorClass: "bg-status-blocked",
+    iconColor: "text-status-blocked",
     emptyMessage: "Anything you can let go of?",
     emptyEmoji: "🗑️",
     emptyHeadline: "Nothing to eliminate",

--- a/public/css/inkwell.css
+++ b/public/css/inkwell.css
@@ -1,0 +1,12 @@
+/* =====================================================================
+   Inkwell — brand-named alias for tokens.css.
+
+   Most projects link this file from <head>:
+       <link rel="stylesheet" href="inkwell.css">
+
+   Under the hood it re-exports tokens.css; you can link either one.
+   The branded name is recommended for brand-consistent imports —
+   "inkwell" is what your team will say in conversation.
+   ===================================================================== */
+
+@import url('tokens.css');

--- a/public/css/tokens.css
+++ b/public/css/tokens.css
@@ -1,0 +1,929 @@
+/* =====================================================================
+   Inkwell — design system tokens.
+   Default palette: Indigo & Cloud (cool stone + deep indigo).
+
+   Self-contained foundation: link from <head> (preferably via the
+   brand-named alias inkwell.css, which re-exports this file), then
+   use `var(--accent)`, `var(--ivory)`, etc. Pattern B dark mode is
+   built in (auto via prefers-color-scheme + manual override via
+   [data-theme="dark"|"light"] on <html>).
+
+   The system separates structure (borders, type scale, spacing,
+   motion, components) from brand (colors). Three alternate palettes
+   — clay, sage, burgundy — live in /variants/ as standalone files
+   that override only the brand-layer tokens.
+   ===================================================================== */
+
+:root {
+  /* ---------- Surfaces ---------- */
+  --ivory: #F4F4F0;       /* page background — cool stone, barely warm */
+  --paper: #FFFFFF;       /* card / panel surface */
+  --slate: #13141B;       /* primary text, slight cool undertone */
+  --oat:   #DDDCDF;       /* tertiary surface, hover thumbnails */
+
+  /* ---------- Accent (saturated indigo) ---------- */
+  --accent:               #3B4A8C;
+  --accent-d:             #2A3768;                /* hover/pressed */
+  --accent-tint:          rgba(59, 74, 140, 0.14); /* badge bg, periwinkle on cool paper */
+  --accent-focus-ring:    rgba(59, 74, 140, 0.18); /* input focus halo */
+  --accent-strong-border: rgba(59, 74, 140, 0.5);  /* tinted chip border */
+
+  /* ---------- Semantic ---------- */
+  --olive:        #788C5D;                         /* success, additions */
+  --olive-tint:   rgba(120, 140, 93, 0.16);
+  --rust:         #B04A3F;                         /* danger, deletions */
+  --warning:      #C78E3F;
+  --warning-tint: rgba(199, 142, 63, 0.16);
+  --info:         #5C7CA3;                         /* informational */
+  --sky:          #6A8CAF;                         /* alt info / data viz */
+
+  /* ---------- Neutral scale (cool putty) ---------- */
+  --gray-100: #EDEDEA;
+  --gray-200: #E1E1DE;
+  --gray-300: #CFCFCC;
+  --gray-500: #6F6F75;  /* WCAG AA: 5.05:1 on --paper, 4.64:1 on --ivory */
+  --gray-700: #3A3B41;
+
+  /* ---------- Typography ---------- */
+  --serif: ui-serif, Georgia, "Times New Roman", Times, serif;
+  --sans:  system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --mono:  ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale */
+  --t-display: 48px;
+  --t-h1:      32px;
+  --t-h2:      24px;
+  --t-h3:      19px;
+  --t-body:    16px;
+  --t-small:   14px;
+  --t-caption: 12px;
+  --t-eyebrow: 11px;
+
+  /* ---------- Spacing (8px base, 4px micro) ---------- */
+  --sp-1:  4px;
+  --sp-2:  8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 24px;
+  --sp-6: 32px;
+  --sp-7: 48px;
+  --sp-8: 64px;
+
+  /* ---------- Radius ---------- */
+  --r-xs:    4px;
+  --r-sm:    8px;
+  --r-md:   12px;
+  --r-lg:   14px;
+  --r-xl:   20px;
+  --r-pill: 999px;
+
+  /* ---------- Borders (signature 1.5px) ---------- */
+  --border:        1.5px solid var(--gray-300);
+  --border-strong: 1.5px solid var(--slate);
+  --border-hair:   1px   solid var(--gray-100);
+  --border-rule:   1px   solid var(--gray-300);
+
+  /* ---------- Shadows (warm low-spread) ---------- */
+  --shadow-sm:         0 1px 2px  rgba(20, 20, 19, 0.06);
+  --shadow-md:         0 4px 14px rgba(20, 20, 19, 0.08);
+  --shadow-lg:         0 12px 28px rgba(20, 20, 19, 0.12);
+  --shadow-card-hover: 0 10px 30px rgba(20, 20, 19, 0.10);
+
+  /* ---------- Motion ---------- */
+  --t-fast:   120ms;
+  --t-base:   150ms;
+  --t-slow:   300ms;
+  --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --ease-pop: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* ---------- Layout ---------- */
+  --content-narrow:  820px;
+  --content-default: 920px;
+  --content-wide:   1120px;
+  --page-pad-x:      24px;
+
+  /* ---------- Z-index scale ---------- */
+  --z-base:    1;
+  --z-raised: 10;
+  --z-sticky: 20;
+  --z-overlay: 30;
+  --z-modal:  50;
+
+  /* Declare both schemes so native UI follows whichever is active */
+  color-scheme: light dark;
+}
+
+/* =====================================================================
+   Dark mode — Pattern B
+   • prefers-color-scheme: dark applies UNLESS data-theme="light" is set
+   • data-theme="dark"  → forces dark regardless of OS preference
+   • data-theme="light" → forces light regardless of OS preference
+   ===================================================================== */
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+
+    --ivory: #0F1018;
+    --paper: #181A24;
+    --slate: #E8E8EE;
+    --oat:   #2B2D38;
+
+    --accent:               #7A8AD1;                 /* lifted indigo → periwinkle */
+    --accent-d:             #6273C0;
+    --accent-tint:          rgba(122, 138, 209, 0.18);
+    --accent-focus-ring:    rgba(122, 138, 209, 0.28);
+    --accent-strong-border: rgba(122, 138, 209, 0.6);
+
+    --olive:        #9CB07A;                         /* lifted */
+    --olive-tint:   rgba(156, 176, 122, 0.18);
+    --rust:         #D27468;
+    --warning:      #D9A55F;
+    --warning-tint: rgba(217, 165, 95, 0.18);
+    --info:         #7C9FD2;
+    --sky:          #85A6CB;
+
+    --gray-100: #1E1F29;
+    --gray-200: #262732;
+    --gray-300: #34363F;
+    --gray-500: #9A9AA0;
+    --gray-700: #C0C0C7;
+
+    --shadow-sm:         0 1px 2px  rgba(0, 0, 0, 0.45);
+    --shadow-md:         0 4px 14px rgba(0, 0, 0, 0.50);
+    --shadow-lg:         0 12px 28px rgba(0, 0, 0, 0.55);
+    --shadow-card-hover: 0 10px 30px rgba(0, 0, 0, 0.50);
+  }
+  :root:not([data-theme="light"]) .select {
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'><path d='M1 1.5L6 6.5L11 1.5' stroke='%239A9AA0' stroke-width='1.5' stroke-linecap='round'/></svg>");
+  }
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --ivory: #0F1018;
+  --paper: #181A24;
+  --slate: #E8E8EE;
+  --oat:   #2B2D38;
+
+  --accent:               #7A8AD1;
+  --accent-d:             #6273C0;
+  --accent-tint:          rgba(122, 138, 209, 0.18);
+  --accent-focus-ring:    rgba(122, 138, 209, 0.28);
+  --accent-strong-border: rgba(122, 138, 209, 0.6);
+
+  --olive:        #9CB07A;
+  --olive-tint:   rgba(156, 176, 122, 0.18);
+  --rust:         #D27468;
+  --warning:      #D9A55F;
+  --warning-tint: rgba(217, 165, 95, 0.18);
+  --info:         #7C9FD2;
+  --sky:          #85A6CB;
+
+  --gray-100: #1E1F29;
+  --gray-200: #262732;
+  --gray-300: #34363F;
+  --gray-500: #9A9AA0;
+  --gray-700: #C0C0C7;
+
+  --shadow-sm:         0 1px 2px  rgba(0, 0, 0, 0.45);
+  --shadow-md:         0 4px 14px rgba(0, 0, 0, 0.50);
+  --shadow-lg:         0 12px 28px rgba(0, 0, 0, 0.55);
+  --shadow-card-hover: 0 10px 30px rgba(0, 0, 0, 0.50);
+}
+:root[data-theme="dark"] .select {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'><path d='M1 1.5L6 6.5L11 1.5' stroke='%239A9AA0' stroke-width='1.5' stroke-linecap='round'/></svg>");
+}
+
+/* =====================================================================
+   Base reset & body
+   ===================================================================== */
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  background: var(--ivory);
+  color: var(--slate);
+  font-family: var(--sans);
+  font-size: var(--t-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* =====================================================================
+   Type styles
+   ===================================================================== */
+.t-display {
+  font-family: var(--serif); font-weight: 500;
+  font-size: var(--t-display); line-height: 1.1; letter-spacing: -0.02em;
+}
+.t-h1 {
+  font-family: var(--serif); font-weight: 500;
+  font-size: var(--t-h1); line-height: 1.2; letter-spacing: -0.01em;
+}
+.t-h2 {
+  font-family: var(--serif); font-weight: 500;
+  font-size: var(--t-h2); line-height: 1.3; letter-spacing: -0.01em;
+}
+.t-h3 {
+  font-family: var(--serif); font-weight: 500;
+  font-size: var(--t-h3); line-height: 1.22; letter-spacing: -0.008em;
+}
+.t-body    { font: 430 var(--t-body)/1.55 var(--sans); }
+.t-small   { font: 430 var(--t-small)/1.5 var(--sans); color: var(--gray-700); }
+.t-caption { font: 500 var(--t-caption)/1.4 var(--sans); color: var(--gray-500); }
+
+/* Eyebrow — small uppercase mono label with leading accent rule */
+.eyebrow {
+  font-family: var(--mono);
+  font-size: var(--t-eyebrow);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--gray-500);
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+.eyebrow::before {
+  content: "";
+  width: 24px;
+  height: 1.5px;
+  background: var(--accent);
+}
+
+/* Inline elements */
+em.accent, .serif em { font-style: italic; color: var(--accent); }
+a.link {
+  color: var(--accent);
+  text-decoration-color: var(--oat);
+  text-underline-offset: 3px;
+}
+a.link:hover { text-decoration-color: var(--accent); }
+
+code, .code-inline {
+  font-family: var(--mono);
+  font-size: 0.86em;
+  background: var(--gray-100);
+  padding: 1.5px 5px;
+  border-radius: var(--r-xs);
+}
+
+/* =====================================================================
+   Components
+   ===================================================================== */
+
+/* ---------- Button ---------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 36px;
+  padding: 0 16px;
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 500;
+  border-radius: var(--r-sm);
+  border: 1.5px solid transparent;
+  cursor: pointer;
+  transition: background var(--t-fast) ease, border-color var(--t-fast) ease;
+}
+.btn-primary        { background: var(--accent); color: var(--paper); }
+.btn-primary:hover  { background: var(--accent-d); }
+.btn-secondary      { background: var(--paper); color: var(--slate); border-color: var(--gray-300); }
+.btn-secondary:hover { background: var(--gray-100); }
+.btn-ghost          { background: transparent; color: var(--gray-700); }
+.btn-ghost:hover    { background: var(--gray-100); }
+.btn-danger         { background: var(--rust); color: var(--paper); }
+.btn-danger:hover   { background: #9A3F3F; }
+
+/* ---------- Input / Textarea / Select ---------- */
+.input,
+.textarea,
+.select {
+  padding: 0 12px;
+  font: 14px var(--sans);
+  color: var(--slate);
+  background: var(--paper);
+  border: var(--border);
+  border-radius: var(--r-sm);
+  outline: none;
+  transition: border-color var(--t-fast) ease, box-shadow var(--t-fast) ease;
+}
+.input  { height: 38px; }
+.select { height: 38px; appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'><path d='M1 1.5L6 6.5L11 1.5' stroke='%236F6F75' stroke-width='1.5' stroke-linecap='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 32px;
+}
+.textarea { padding: 10px 12px; min-height: 96px; line-height: 1.5; resize: vertical; font-family: var(--sans); }
+.input::placeholder,
+.textarea::placeholder { color: var(--gray-500); }
+.input:focus,
+.textarea:focus,
+.select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-focus-ring);
+}
+.input:disabled,
+.textarea:disabled,
+.select:disabled,
+.input.is-disabled {
+  background: var(--gray-100);
+  color: var(--gray-500);
+  cursor: not-allowed;
+}
+.input.is-error,
+.textarea.is-error,
+.select.is-error {
+  border-color: var(--rust);
+  box-shadow: 0 0 0 3px rgba(176, 74, 63, 0.18);
+}
+
+/* ---------- Field group (label + control + help/error) ---------- */
+.field { display: flex; flex-direction: column; gap: 6px; }
+.field > .input,
+.field > .textarea,
+.field > .select { width: 100%; }
+.field-label {
+  font: 500 13px/1.2 var(--sans);
+  color: var(--slate);
+}
+.field-help {
+  font: 12px/1.4 var(--sans);
+  color: var(--gray-500);
+}
+.field-error {
+  font: 500 12px/1.4 var(--sans);
+  color: var(--rust);
+}
+
+/* ---------- Checkbox ---------- */
+.checkbox { display: inline-flex; align-items: center; gap: 10px; cursor: pointer; user-select: none; }
+.checkbox input {
+  appearance: none;
+  width: 18px; height: 18px;
+  border: var(--border);
+  border-radius: 5px;
+  background: var(--paper);
+  position: relative;
+  cursor: pointer;
+  transition: background var(--t-fast), border-color var(--t-fast);
+}
+.checkbox input:checked { background: var(--accent); border-color: var(--accent); }
+.checkbox input:checked::after {
+  content: "";
+  position: absolute;
+  left: 5px; top: 1px;
+  width: 5px; height: 10px;
+  border: solid var(--paper);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+/* ---------- Radio ---------- */
+.radio { display: inline-flex; align-items: center; gap: 10px; cursor: pointer; user-select: none; }
+.radio input {
+  appearance: none;
+  width: 18px; height: 18px;
+  border: var(--border);
+  border-radius: 50%;
+  background: var(--paper);
+  position: relative;
+  cursor: pointer;
+  transition: border-color var(--t-fast);
+}
+.radio input:checked { border-color: var(--accent); }
+.radio input:checked::after {
+  content: "";
+  position: absolute;
+  left: 50%; top: 50%;
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  transform: translate(-50%, -50%);
+}
+
+/* ---------- Switch ---------- */
+.switch { display: inline-flex; align-items: center; gap: 10px; cursor: pointer; user-select: none; }
+.switch input {
+  appearance: none;
+  width: 36px; height: 20px;
+  border-radius: var(--r-pill);
+  background: var(--gray-300);
+  position: relative;
+  cursor: pointer;
+  transition: background var(--t-fast);
+}
+.switch input::after {
+  content: "";
+  position: absolute;
+  left: 2px; top: 2px;
+  width: 16px; height: 16px;
+  border-radius: 50%;
+  background: var(--paper);
+  box-shadow: var(--shadow-sm);
+  transition: left var(--t-fast) var(--ease-out);
+}
+.switch input:checked { background: var(--accent); }
+.switch input:checked::after { left: 18px; }
+
+/* ---------- Keyboard chip (<kbd>) ---------- */
+kbd, .kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  font: 500 11px/1 var(--mono);
+  color: var(--gray-700);
+  background: var(--paper);
+  border: 1px solid var(--gray-300);
+  border-bottom-width: 2px;
+  border-radius: var(--r-xs);
+  vertical-align: baseline;
+}
+
+/* ---------- Badge / Pill ---------- */
+.badge {
+  display: inline-flex; align-items: center;
+  height: 22px; padding: 0 9px;
+  font-size: 12px; font-weight: 500;
+  border-radius: var(--r-pill);
+}
+.badge-neutral { background: var(--gray-100);    color: var(--gray-700); }
+.badge-accent  { background: var(--accent-tint); color: var(--accent); }
+.badge-success { background: var(--olive-tint);  color: var(--olive); }
+.badge-warning { background: var(--warning-tint); color: #A06A2A; }
+.badge-danger  { background: var(--rust); color: var(--paper); }
+
+/* ---------- Card ---------- */
+.card {
+  background: var(--paper);
+  border: var(--border);
+  border-radius: var(--r-lg);
+  padding: var(--sp-5);
+  transition: transform var(--t-base) ease,
+              box-shadow var(--t-base) ease,
+              border-color var(--t-base) ease;
+}
+.card.is-link { display: flex; flex-direction: column; text-decoration: none; color: inherit; cursor: pointer; }
+.card.is-link:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-card-hover);
+  border-color: var(--slate);
+}
+
+/* ---------- Stat card ---------- */
+.stat-card {
+  background: var(--paper);
+  border: var(--border);
+  border-radius: var(--r-md);
+  padding: 20px 22px 18px;
+}
+.stat-card.warn { border-left: 4px solid var(--accent); padding-left: 19px; }
+.stat-num   { font: 500 44px/1 var(--serif); margin-bottom: 8px; color: var(--slate); }
+.stat-label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--gray-500); }
+.stat-delta { font-family: var(--mono); font-size: 11px; margin-top: 6px; }
+.stat-delta.up   { color: var(--olive); }
+.stat-delta.down { color: var(--rust); }
+.stat-delta.flat { color: var(--gray-500); }
+
+/* ---------- Table ---------- */
+.tbl {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: var(--paper);
+  border: var(--border);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+.tbl thead th {
+  text-align: left;
+  font: 600 11px/1 var(--sans);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--gray-500);
+  background: var(--gray-100);
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--gray-300);
+}
+.tbl tbody td {
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--gray-100);
+  font-size: 14px;
+}
+.tbl tbody tr:last-child td { border-bottom: none; }
+
+/* ---------- Dark TL;DR / callout panel ---------- */
+.tldr {
+  background: var(--slate);
+  color: var(--ivory);
+  border-radius: var(--r-md);
+  padding: 22px 26px;
+}
+.tldr-label {
+  font: 500 var(--t-eyebrow)/1 var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--oat);
+  margin-bottom: 10px;
+}
+.tldr code {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--ivory);
+}
+
+/* ---------- Severity pill ---------- */
+.pill {
+  display: inline-flex; align-items: baseline; gap: 6px;
+  font: 600 12px/1 var(--sans);
+  border-radius: var(--r-pill);
+  padding: 5px 12px;
+}
+.pill.sev      { background: var(--accent); color: var(--paper); letter-spacing: 0.03em; }
+.pill.resolved { background: var(--olive);  color: var(--paper); }
+.pill.neutral  { background: var(--gray-100); color: var(--gray-700); border: var(--border); }
+.pill.neutral .v { font-family: var(--mono); }
+
+/* ---------- Timeline ---------- */
+.timeline { position: relative; padding: 4px 0 4px 16px; }
+.timeline::before {
+  content: "";
+  position: absolute;
+  left: 16px; top: 8px; bottom: 8px;
+  width: 2px;
+  background: var(--gray-300);
+}
+.tl-entry { position: relative; padding: 0 0 22px 28px; }
+.tl-entry::before {
+  content: "";
+  position: absolute;
+  left: -7px; top: 4px;
+  width: 14px; height: 14px;
+  border-radius: 50%;
+  background: var(--paper);
+  border: 2px solid var(--accent);
+}
+
+/* ---------- Section header ---------- */
+.sec-head { display: flex; align-items: baseline; gap: 16px; margin-bottom: 10px; }
+.sec-head .idx {
+  font: 600 13px/1 var(--mono);
+  color: var(--accent);
+  width: 34px;
+  flex-shrink: 0;
+}
+.sec-head h2 { margin: 0; font-family: var(--serif); font-weight: 500; font-size: 27px; letter-spacing: -0.012em; }
+.sec-head .count {
+  font: 11px/1 var(--mono);
+  color: var(--gray-500);
+  background: var(--gray-100);
+  padding: 2px 8px;
+  border-radius: var(--r-pill);
+}
+
+/* ---------- TOC pill nav ---------- */
+.toc { display: flex; flex-wrap: wrap; gap: 8px; }
+.toc a {
+  font-size: 12.5px;
+  padding: 7px 14px;
+  border: var(--border);
+  border-radius: var(--r-pill);
+  text-decoration: none;
+  color: var(--gray-700);
+  background: var(--paper);
+  transition: border-color var(--t-fast), color var(--t-fast), background var(--t-fast);
+  display: inline-flex; align-items: center; gap: 7px;
+}
+.toc a .n { font: 10px/1 var(--mono); color: var(--gray-500); }
+.toc a:hover { border-color: var(--slate); color: var(--slate); }
+.toc a:hover .n { color: var(--accent); }
+
+/* ---------- Avatar (PR-style monogram) ---------- */
+.avatar {
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: var(--oat);
+  color: var(--slate);
+  display: inline-flex; align-items: center; justify-content: center;
+  font: 600 13px/1 var(--sans);
+  letter-spacing: 0.02em;
+  border: var(--border);
+}
+
+/* ---------- Risk chip (with status dot) ---------- */
+.chip-dot {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 8px 12px;
+  border-radius: var(--r-sm);
+  border: var(--border);
+  font: 12.5px var(--mono);
+  color: var(--slate);
+  background: var(--paper);
+}
+.chip-dot .dot { width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; }
+.chip-dot.safe      { background: var(--olive-tint); border-color: rgba(120,140,93,0.45); }
+.chip-dot.safe .dot      { background: var(--olive); }
+.chip-dot.medium    { background: var(--oat); }
+.chip-dot.medium .dot    { background: var(--gray-500); }
+.chip-dot.attention { background: var(--accent-tint); border-color: var(--accent-strong-border); }
+.chip-dot.attention .dot { background: var(--accent); }
+
+/* ---------- Alert / banner ---------- */
+.alert {
+  display: flex;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: var(--r-md);
+  border: var(--border);
+  background: var(--paper);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--slate);
+}
+.alert-title { font-weight: 600; margin: 0 0 2px; font-size: 14px; }
+.alert-body  { color: var(--gray-700); }
+.alert.is-info    { background: var(--accent-tint);  border-color: var(--accent-strong-border); }
+.alert.is-info    .alert-title { color: var(--accent); }
+.alert.is-success { background: var(--olive-tint);   border-color: rgba(120,140,93,0.45); }
+.alert.is-success .alert-title { color: var(--olive); }
+.alert.is-warning { background: var(--warning-tint); border-color: rgba(199,142,63,0.45); }
+.alert.is-warning .alert-title { color: #A06A2A; }
+.alert.is-danger  { background: rgba(176,74,63,0.10); border-color: rgba(176,74,63,0.45); }
+.alert.is-danger  .alert-title { color: var(--rust); }
+
+/* ---------- Multi-line code block ---------- */
+.code-block {
+  position: relative;
+  background: var(--gray-100);
+  border: var(--border);
+  border-radius: var(--r-md);
+  padding: 14px 16px;
+  font: 13px/1.55 var(--mono);
+  color: var(--slate);
+  overflow-x: auto;
+}
+.code-block pre,
+pre.code-block { margin: 0; font: inherit; color: inherit; white-space: pre; }
+.code-block .copy {
+  position: absolute;
+  top: 8px; right: 8px;
+  height: 26px;
+  padding: 0 10px;
+  font: 500 11px/1 var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--gray-700);
+  background: var(--paper);
+  border: var(--border);
+  border-radius: var(--r-xs);
+  cursor: pointer;
+}
+.code-block .copy:hover { border-color: var(--slate); color: var(--slate); }
+
+/* ---------- Dialog (native <dialog>) ---------- */
+.dialog {
+  background: var(--paper);
+  color: var(--slate);
+  border: var(--border);
+  border-radius: var(--r-lg);
+  padding: 0;
+  box-shadow: var(--shadow-lg);
+  max-width: 480px;
+  width: calc(100% - 32px);
+}
+.dialog::backdrop {
+  background: rgba(15, 16, 24, 0.55);
+  backdrop-filter: blur(2px);
+}
+.dialog[open] { animation: dialog-pop var(--t-base) var(--ease-pop); }
+@keyframes dialog-pop {
+  from { transform: scale(0.96); opacity: 0; }
+  to   { transform: scale(1);    opacity: 1; }
+}
+.dialog-head {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 16px;
+  padding: 18px 22px 12px;
+  border-bottom: var(--border-hair);
+}
+.dialog-head h2 { margin: 0; font: 500 18px/1.3 var(--serif); }
+.dialog-body { padding: 16px 22px; line-height: 1.55; }
+.dialog-foot {
+  display: flex; justify-content: flex-end; gap: 8px;
+  padding: 12px 22px 16px;
+  border-top: var(--border-hair);
+}
+.dialog-close {
+  background: transparent;
+  border: none;
+  width: 28px; height: 28px;
+  border-radius: var(--r-xs);
+  color: var(--gray-500);
+  font: 18px/1 var(--sans);
+  cursor: pointer;
+}
+.dialog-close:hover { background: var(--gray-100); color: var(--slate); }
+
+/* ---------- Tabs ---------- */
+.tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: var(--border-rule);
+  margin-bottom: var(--sp-5);
+}
+.tab {
+  position: relative;
+  padding: 10px 16px;
+  font: 500 14px/1 var(--sans);
+  color: var(--gray-700);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1.5px;
+  cursor: pointer;
+  transition: color var(--t-fast), border-color var(--t-fast);
+}
+.tab:hover { color: var(--slate); }
+.tab[aria-selected="true"],
+.tab.is-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+.tab-panel { display: block; }
+.tab-panel[hidden] { display: none; }
+
+/* ---------- Tooltip ([data-tooltip] on any element) ---------- */
+.tooltip { position: relative; display: inline-flex; }
+.tooltip[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--slate);
+  color: var(--ivory);
+  font: 500 11px/1.4 var(--sans);
+  padding: 5px 9px;
+  border-radius: var(--r-xs);
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--t-fast);
+  z-index: var(--z-overlay);
+}
+.tooltip[data-tooltip]:hover::after,
+.tooltip[data-tooltip]:focus-visible::after { opacity: 1; }
+
+/* ---------- Breadcrumbs ---------- */
+.breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font: 13px/1.4 var(--sans);
+  color: var(--gray-500);
+}
+.breadcrumbs li { display: inline-flex; align-items: center; gap: 8px; }
+.breadcrumbs li + li::before {
+  content: "/";
+  color: var(--gray-300);
+  font: 13px/1 var(--mono);
+}
+.breadcrumbs a {
+  color: var(--gray-700);
+  text-decoration: none;
+  transition: color var(--t-fast);
+}
+.breadcrumbs a:hover { color: var(--accent); }
+.breadcrumbs [aria-current="page"] {
+  color: var(--slate);
+  font-weight: 500;
+}
+
+/* ---------- Pagination ---------- */
+.pagination {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.pagination .page,
+.pagination a,
+.pagination button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 10px;
+  font: 500 13px/1 var(--mono);
+  color: var(--gray-700);
+  background: var(--paper);
+  border: var(--border);
+  border-radius: var(--r-sm);
+  text-decoration: none;
+  cursor: pointer;
+  transition: border-color var(--t-fast), color var(--t-fast);
+}
+.pagination a:hover,
+.pagination button:hover { border-color: var(--slate); color: var(--slate); }
+.pagination [aria-current="page"] {
+  background: var(--accent);
+  color: var(--paper);
+  border-color: var(--accent);
+}
+.pagination .ellipsis {
+  min-width: 24px;
+  border: none;
+  background: transparent;
+  color: var(--gray-500);
+  cursor: default;
+}
+
+/* ---------- Skeleton loader ---------- */
+.skeleton {
+  display: block;
+  background: linear-gradient(90deg,
+    var(--gray-100) 0%,
+    var(--gray-200) 50%,
+    var(--gray-100) 100%);
+  background-size: 200% 100%;
+  border-radius: var(--r-xs);
+  height: 12px;
+  animation: skeleton-shimmer 1.5s linear infinite;
+}
+.skeleton.is-text  { height: 14px; margin: 6px 0; }
+.skeleton.is-title { height: 24px; border-radius: var(--r-sm); }
+.skeleton.is-block { height: 80px; border-radius: var(--r-md); }
+.skeleton.is-circle { height: 36px; width: 36px; border-radius: 50%; }
+@keyframes skeleton-shimmer {
+  from { background-position: 200% 0; }
+  to   { background-position: -200% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .skeleton { animation: none; background: var(--gray-200); }
+}
+
+/* ---------- Empty state ---------- */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: var(--sp-7) var(--sp-5);
+  color: var(--gray-700);
+}
+.empty-state-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--gray-100);
+  border: var(--border);
+  display: inline-grid;
+  place-items: center;
+  margin-bottom: var(--sp-4);
+  color: var(--gray-500);
+}
+.empty-state h3 {
+  margin: 0 0 8px;
+  font: 500 19px/1.3 var(--serif);
+  color: var(--slate);
+}
+.empty-state p {
+  margin: 0 0 var(--sp-4);
+  max-width: 42ch;
+  font: var(--t-small)/1.55 var(--sans);
+}
+
+/* =====================================================================
+   Layout helpers
+   ===================================================================== */
+.wrap         { max-width: var(--content-default); margin: 0 auto; padding: 0 var(--page-pad-x); }
+.wrap-narrow  { max-width: var(--content-narrow);  margin: 0 auto; padding: 0 var(--page-pad-x); }
+.wrap-wide    { max-width: var(--content-wide);    margin: 0 auto; padding: 0 var(--page-pad-x); }
+hr.rule       { border: none; border-top: var(--border-rule); margin: 0 0 22px; }
+
+/* =====================================================================
+   Accessibility
+   ===================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+*:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--r-xs);
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,3 +1,6 @@
+const withAlpha = (value: string) =>
+  `color-mix(in srgb, ${value} calc(<alpha-value> * 100%), transparent)`;
+
 const config = {
   darkMode: "class",
   safelist: [
@@ -17,52 +20,52 @@ const config = {
     extend: {
       colors: {
         background: {
-          DEFAULT: "rgb(var(--background) / <alpha-value>)",
-          muted: "rgb(var(--background-muted) / <alpha-value>)",
-          accent: "rgb(var(--background-accent) / <alpha-value>)"
+          DEFAULT: withAlpha("var(--ivory)"),
+          muted: withAlpha("var(--gray-100)"),
+          accent: withAlpha("var(--oat)")
         },
         foreground: {
-          DEFAULT: "rgb(var(--foreground) / <alpha-value>)",
-          muted: "rgb(var(--foreground-muted) / <alpha-value>)"
+          DEFAULT: withAlpha("var(--slate)"),
+          muted: withAlpha("var(--gray-500)")
         },
         border: {
-          DEFAULT: "rgb(var(--border) / <alpha-value>)",
-          muted: "rgb(var(--border-muted) / <alpha-value>)"
+          DEFAULT: withAlpha("var(--gray-300)"),
+          muted: withAlpha("var(--gray-100)")
         },
         accent: {
-          DEFAULT: "rgb(var(--accent) / <alpha-value>)",
-          hover: "rgb(var(--accent-hover) / <alpha-value>)",
-          muted: "rgb(var(--accent-muted) / <alpha-value>)"
+          DEFAULT: withAlpha("var(--accent)"),
+          hover: withAlpha("var(--accent-d)"),
+          muted: withAlpha("var(--accent-tint)")
         },
         quadrant: {
-          focus: "rgb(var(--quadrant-focus) / <alpha-value>)",
-          schedule: "rgb(var(--quadrant-schedule) / <alpha-value>)",
-          delegate: "rgb(var(--quadrant-delegate) / <alpha-value>)",
-          eliminate: "rgb(var(--quadrant-eliminate) / <alpha-value>)"
+          focus: withAlpha("var(--quadrant-focus)"),
+          schedule: withAlpha("var(--quadrant-schedule)"),
+          delegate: withAlpha("var(--quadrant-delegate)"),
+          eliminate: withAlpha("var(--quadrant-eliminate)")
         },
         card: {
-          DEFAULT: "rgb(var(--card-background) / <alpha-value>)",
-          border: "rgb(var(--card-border) / <alpha-value>)"
+          DEFAULT: withAlpha("var(--paper)"),
+          border: withAlpha("var(--gray-300)")
         },
-        overlay: "rgb(var(--overlay) / <alpha-value>)",
+        overlay: "rgb(0 0 0 / <alpha-value>)",
         status: {
-          overdue: "rgb(var(--status-overdue) / <alpha-value>)",
-          "overdue-muted": "rgb(var(--status-overdue-muted) / <alpha-value>)",
-          blocked: "rgb(var(--status-blocked) / <alpha-value>)",
-          "blocked-muted": "rgb(var(--status-blocked-muted) / <alpha-value>)",
-          blocking: "rgb(var(--status-blocking) / <alpha-value>)",
-          "blocking-muted": "rgb(var(--status-blocking-muted) / <alpha-value>)",
-          success: "rgb(var(--status-success) / <alpha-value>)",
-          "success-muted": "rgb(var(--status-success-muted) / <alpha-value>)"
+          overdue: withAlpha("var(--status-overdue)"),
+          "overdue-muted": withAlpha("var(--status-overdue-muted)"),
+          blocked: withAlpha("var(--status-blocked)"),
+          "blocked-muted": withAlpha("var(--status-blocked-muted)"),
+          blocking: withAlpha("var(--status-blocking)"),
+          "blocking-muted": withAlpha("var(--status-blocking-muted)"),
+          success: withAlpha("var(--status-success)"),
+          "success-muted": withAlpha("var(--status-success-muted)")
         },
         // Legacy aliases for backward compatibility
         canvas: {
-          DEFAULT: "rgb(var(--background) / <alpha-value>)",
-          foreground: "rgb(var(--background-muted) / <alpha-value>)"
+          DEFAULT: withAlpha("var(--ivory)"),
+          foreground: withAlpha("var(--gray-100)")
         },
         muted: {
-          DEFAULT: "rgb(var(--foreground-muted) / <alpha-value>)",
-          foreground: "rgb(var(--foreground-muted) / <alpha-value>)"
+          DEFAULT: withAlpha("var(--gray-500)"),
+          foreground: withAlpha("var(--gray-500)")
         }
       },
       fontSize: {
@@ -74,12 +77,15 @@ const config = {
         "label": ["11px", { lineHeight: "1.45", letterSpacing: "0.04em" }]
       },
       fontFamily: {
-        sans: ["var(--font-sans)", "system-ui", "-apple-system", "BlinkMacSystemFont", "'Segoe UI'", "sans-serif"],
-        mono: ["var(--font-mono)", "ui-monospace", "SFMono-Regular", "monospace"],
-        serif: ["var(--font-instrument-serif)", "ui-serif", "Georgia", "serif"]
+        sans: ["var(--sans)"],
+        mono: ["var(--mono)"],
+        serif: ["var(--serif)"]
       },
       boxShadow: {
-        card: "0 10px 30px -12px rgba(15, 33, 50, 0.45)"
+        card: "var(--shadow-md)"
+      },
+      borderWidth: {
+        DEFAULT: "1.5px"
       }
     }
   },


### PR DESCRIPTION
## Summary

- Install the canonical Inkwell CSS files under `public/css` and load `inkwell.css` globally.
- Bridge the app's Tailwind tokens and shared UI primitives to Inkwell's surfaces, typography, accent, semantic colors, and 1.5px border system.
- Update matrix/dashboard/status surfaces to use token-driven color values and preserve dark-mode behavior through `data-theme`.

## Validation

- `bun run typecheck`
- `bun run lint`
- Playwright rendered checks for desktop, mobile, and dark mode against local dev server
- Playwright smoke test for adding a task through the capture bar

## Notes

`bun run build` was attempted, but `next build` stayed in the `Creating an optimized production build ...` phase for several minutes with no further output, so the hung process was stopped.