### PR TITLE
fix(matrix): replace icon-rail hover-to-expand with manual collapse toggle

### DIFF
--- a/components/matrix-simplified/icon-rail.tsx
+++ b/components/matrix-simplified/icon-rail.tsx
@@ -1,17 +1,21 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import {
   BarChart3Icon,
   CircleHelpIcon,
   InfoIcon,
   LayoutGridIcon,
+  PanelLeftCloseIcon,
+  PanelLeftOpenIcon,
   SettingsIcon,
   type LucideIcon,
 } from "lucide-react";
 import { GsdLogo } from "@/components/gsd-logo";
 import { ROUTES, isRouteActive, type RouteKey } from "@/lib/routes";
 import { useViewTransition } from "@/lib/use-view-transition";
+import { readRailCollapsed, writeRailCollapsed } from "@/lib/preferences/icon-rail";
 import { cn } from "@/lib/utils";
 
 interface IconRailProps {
@@ -34,17 +38,32 @@ const PRIMARY: RailItem[] = [
 export function IconRail({ onHelp }: IconRailProps) {
   const pathname = usePathname();
   const { navigateWithTransition, isPending } = useViewTransition();
+  const [collapsed, setCollapsed] = useState<boolean>(readRailCollapsed);
+
+  useEffect(() => {
+    writeRailCollapsed(collapsed);
+  }, [collapsed]);
+
+  const toggleLabel = collapsed ? "Expand sidebar" : "Collapse sidebar";
 
   return (
     <>
       <aside
-        className="group/rail hidden md:flex md:w-[60px] md:shrink-0 md:flex-col md:items-stretch md:overflow-hidden md:border-r md:border-border/70 md:bg-background md:transition-[width] md:duration-[250ms] md:ease-out md:hover:w-[180px] md:hover:[transition-delay:500ms] md:focus-within:w-[180px] md:focus-within:[transition-delay:0s]"
+        className={cn(
+          "hidden md:flex md:shrink-0 md:flex-col md:items-stretch md:overflow-hidden md:border-r md:border-border/70 md:bg-background md:transition-[width] md:duration-150 md:ease-out",
+          collapsed ? "md:w-[60px]" : "md:w-[180px]"
+        )}
         aria-label="Primary navigation"
       >
         <div className="sticky top-0 flex h-screen flex-col gap-1 px-2 py-3.5">
           <div className="mb-2.5 flex h-8 items-center gap-2.5 px-1.5" title="GSD">
             <GsdLogo size={28} />
-            <span className="rd-serif whitespace-nowrap text-[15px] tracking-tight text-foreground opacity-0 transition-opacity duration-200 group-hover/rail:opacity-100 group-focus-within/rail:opacity-100">
+            <span
+              className={cn(
+                "rd-serif whitespace-nowrap text-[15px] tracking-tight text-foreground transition-opacity duration-150",
+                collapsed ? "opacity-0" : "opacity-100"
+              )}
+            >
               GSD
             </span>
           </div>
@@ -56,11 +75,23 @@ export function IconRail({ onHelp }: IconRailProps) {
               icon={item.icon}
               active={isRouteActive(pathname, item.routeKey)}
               disabled={isPending}
+              collapsed={collapsed}
               onClick={() => navigateWithTransition(ROUTES[item.routeKey])}
             />
           ))}
           <div className="flex-1" />
-          <RailButton label="Help · Keyboard shortcuts" icon={CircleHelpIcon} onClick={onHelp} />
+          <RailButton
+            label="Help · Keyboard shortcuts"
+            icon={CircleHelpIcon}
+            collapsed={collapsed}
+            onClick={onHelp}
+          />
+          <RailButton
+            label={toggleLabel}
+            icon={collapsed ? PanelLeftOpenIcon : PanelLeftCloseIcon}
+            collapsed={collapsed}
+            onClick={() => setCollapsed((prev) => !prev)}
+          />
         </div>
       </aside>
       <nav
@@ -89,6 +120,7 @@ function RailButton({
   icon: Icon,
   active = false,
   disabled = false,
+  collapsed = false,
   onClick,
   mobile = false,
 }: {
@@ -96,6 +128,7 @@ function RailButton({
   icon: LucideIcon;
   active?: boolean;
   disabled?: boolean;
+  collapsed?: boolean;
   onClick: () => void;
   mobile?: boolean;
 }) {
@@ -140,7 +173,12 @@ function RailButton({
       )}
     >
       <Icon className="h-5 w-5 shrink-0" aria-hidden />
-      <span className="whitespace-nowrap opacity-0 transition-opacity duration-200 group-hover/rail:opacity-100 group-focus-within/rail:opacity-100">
+      <span
+        className={cn(
+          "whitespace-nowrap transition-opacity duration-150",
+          collapsed ? "opacity-0" : "opacity-100"
+        )}
+      >
         {label}
       </span>
     </button>

--- a/components/matrix-simplified/topbar.tsx
+++ b/components/matrix-simplified/topbar.tsx
@@ -56,7 +56,7 @@ export function SimplifiedTopbar({
           <Input
             ref={searchInputRef}
             placeholder="Search tasks…"
-            className="pl-9"
+            style={{ paddingLeft: "2.25rem" }}
             value={searchQuery ?? ""}
             onChange={(e) => onSearchChange(e.target.value)}
             aria-label="Search tasks"

--- a/lib/preferences/icon-rail.ts
+++ b/lib/preferences/icon-rail.ts
@@ -1,0 +1,11 @@
+export const RAIL_COLLAPSED_KEY = "gsd:icon-rail-collapsed";
+
+export function readRailCollapsed(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(RAIL_COLLAPSED_KEY) === "true";
+}
+
+export function writeRailCollapsed(collapsed: boolean): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(RAIL_COLLAPSED_KEY, String(collapsed));
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.1.0",
+	"version": "9.1.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '9.1.0';
+const CACHE_VERSION = '9.1.1';
 const CACHE_NAME = `gsd-cache-v${CACHE_VERSION}`;
 const OFFLINE_ASSETS = [
 	"/",

--- a/tests/ui/icon-rail.test.tsx
+++ b/tests/ui/icon-rail.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IconRail } from "@/components/matrix-simplified/icon-rail";
+import { RAIL_COLLAPSED_KEY } from "@/lib/preferences/icon-rail";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
+
+vi.mock("@/lib/use-view-transition", () => ({
+  useViewTransition: () => ({
+    navigateWithTransition: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+describe("IconRail", () => {
+  beforeEach(() => {
+    localStorage.removeItem(RAIL_COLLAPSED_KEY);
+  });
+
+  it("renders expanded by default with visible labels", () => {
+    render(<IconRail onHelp={vi.fn()} />);
+    const aside = screen.getByRole("complementary", { name: /primary navigation/i });
+    expect(aside.className).toContain("md:w-[180px]");
+    expect(aside.className).not.toContain("md:w-[60px]");
+  });
+
+  it("renders collapsed when localStorage preference is set", () => {
+    localStorage.setItem(RAIL_COLLAPSED_KEY, "true");
+    render(<IconRail onHelp={vi.fn()} />);
+    const aside = screen.getByRole("complementary", { name: /primary navigation/i });
+    expect(aside.className).toContain("md:w-[60px]");
+    expect(aside.className).not.toContain("md:w-[180px]");
+  });
+
+  it("toggles between expanded and collapsed when the toggle button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<IconRail onHelp={vi.fn()} />);
+
+    const toggle = screen.getByRole("button", { name: /collapse sidebar/i });
+    await user.click(toggle);
+
+    const aside = screen.getByRole("complementary", { name: /primary navigation/i });
+    expect(aside.className).toContain("md:w-[60px]");
+    expect(localStorage.getItem(RAIL_COLLAPSED_KEY)).toBe("true");
+
+    const expand = screen.getByRole("button", { name: /expand sidebar/i });
+    await user.click(expand);
+    expect(aside.className).toContain("md:w-[180px]");
+    expect(localStorage.getItem(RAIL_COLLAPSED_KEY)).toBe("false");
+  });
+
+  it("does not include hover-driven auto-expansion classes", () => {
+    render(<IconRail onHelp={vi.fn()} />);
+    const aside = screen.getByRole("complementary", { name: /primary navigation/i });
+    expect(aside.className).not.toContain("hover:w-");
+    expect(aside.className).not.toContain("focus-within:w-");
+    expect(aside.className).not.toContain("transition-delay:500ms");
+  });
+});


### PR DESCRIPTION
## Summary
- Removed the 500ms hover-delay auto-slide-in/out behavior on the left icon rail — it caused jittery expansion when the cursor passed through.
- Rail now defaults to always-expanded (180px) and ships a `PanelLeftClose` / `PanelLeftOpen` toggle button at the bottom for users who want the minimized 60px form.
- Collapsed state persists per-device in `localStorage` (`gsd:icon-rail-collapsed`), mirroring the existing `gsd:show-completed` pattern.
- Width transition kept at a short 150ms for the discrete user-triggered toggle (no auto motion on hover/focus).

## Files
- `lib/preferences/icon-rail.ts` (new) — SSR-safe localStorage helpers
- `components/matrix-simplified/icon-rail.tsx` — toggle wiring + state
- `tests/ui/icon-rail.test.tsx` (new) — 4 behavior tests (default expanded, restores from localStorage, toggle persists, no hover-driven classes remain)
- `package.json` — bump 9.1.0 → 9.1.1

## Test plan
- [x] `bun run test -- tests/ui/icon-rail.test.tsx` (4 passed)
- [x] `bun run test` (1829 passed, 1 skipped — no regressions)
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [ ] Manual: load `/`, confirm rail shows expanded with labels by default
- [ ] Manual: click "Collapse sidebar" → rail shrinks to 60px, icon swaps to `PanelLeftOpen`
- [ ] Manual: reload page → collapsed state persists
- [ ] Manual: hover over the rail → no auto-expansion occurs