### PR TITLE
test(e2e): Playwright suite for v9 single-matrix UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ dist
 *.swp
 
 # Testing and coverage
+playwright-report/
+test-results/
+debug-screenshot.png
 
 # AI files
 .kiro

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ These packages are not self-explanatory from their names alone:
 ### Navigation & UI
 - Use `useViewTransition()` hook for client-side navigation with View Transitions API
 - Button component variants: "primary" | "subtle" | "ghost" (no size prop)
-- Smart view shortcuts (1-9, 0) use `useSmartViewShortcuts` with typing detection
+- Smart view shortcuts and pinning UI were removed in v9 (see ADR 0011). The `smartViews` Dexie table is retained for data continuity but has no UI surface in the v9 shell.
 
 ### Cloud Sync
 - **PocketBase Admin**: `https://api.vinny.io/_/` for collection management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,9 @@ GSD Task Manager is a privacy-first Eisenhower matrix task manager built with Ne
 - `bun run test:watch` - Run Vitest in watch mode
 - `bun run test -- --coverage` - Generate coverage report (target: ≥80%)
 - `bun lint` - Run ESLint
+- `bun run test:e2e` - Run Playwright end-to-end tests
+- `bun run test:e2e:ui` - Run Playwright tests with UI mode
+- `bun run test:e2e:debug` - Run Playwright tests in debug mode
 
 ### Build & Deployment
 - `bun run build` - Build production bundle
@@ -115,8 +118,25 @@ Logic in `lib/quadrants.ts` with `resolveQuadrantId()` and `quadrantOrder`.
 
 ## Testing Guidelines
 - UI tests in `tests/ui/`, data logic in `tests/data/`
-- Use `@testing-library/react` and `@testing-library/jest-dom`
+- E2E tests in `tests/e2e/` using Playwright
+- Use `@testing-library/react` and `@testing-library/jest-dom` for unit tests
 - Coverage thresholds: 80% statements, 80% lines, 80% functions, 75% branches
+
+### E2E Testing
+- **Framework**: Playwright with TypeScript support
+- **Configuration**: `playwright.config.ts` with auto-starting dev server
+- **Test Location**: `tests/e2e/` directory
+- **Browser Support**: Chromium, Firefox, WebKit
+- **Key Features**:
+  - Automatic IndexedDB cleanup between tests
+  - Page Object Model for maintainable tests
+  - Handles app redirect (root → about page) automatically
+  - Tests core user workflows: CRUD, navigation, search, settings
+- **Data Attributes**: Components use `data-testid` attributes for reliable selector targeting
+- **Running Tests**:
+  - `bun run test:e2e` - Run all e2e tests
+  - `bun run test:e2e:ui` - Run with interactive UI
+  - `bun run test:e2e:debug` - Run in debug mode with step-through
 
 ## Code Style
 - **TypeScript strict mode** with Next.js typed routes

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "zod": "4.3.6",
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "4.2.2",
         "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "6.9.1",
@@ -361,6 +362,8 @@
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -1322,6 +1325,10 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
     "pocketbase": ["pocketbase@0.26.8", "", {}, "sha512-aQ/ewvS7ncvAE8wxoW10iAZu6ElgbeFpBhKPnCfvRovNzm2gW8u/sQNPGN6vNgVEagz44kK//C61oKjfa+7Low=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
@@ -1725,6 +1732,8 @@
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 

--- a/components/matrix-simplified/capture-bar.tsx
+++ b/components/matrix-simplified/capture-bar.tsx
@@ -126,6 +126,7 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
 
   return (
     <form
+      data-testid="capture-bar"
       onSubmit={submit}
       className={cn(
         "flex items-center gap-3 rounded-2xl border border-border bg-card px-4 py-3.5",
@@ -138,6 +139,7 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
         style={{ color: text.trim() ? accent : "color-mix(in srgb, var(--gray-500) 70%, transparent)" }}
       />
       <input
+        data-testid="capture-input"
         ref={internalRef}
         value={text}
         onChange={(e) => setText(e.target.value)}
@@ -149,6 +151,7 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
       {text.trim() ? (
         <>
           <button
+            data-testid="quadrant-toggle"
             key={effectiveKey}
             type="button"
             onClick={cycleQuadrant}
@@ -168,6 +171,7 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
           </button>
           {onMoreOptions ? (
             <button
+              data-testid="more-options"
               type="button"
               onClick={() => {
                 const flags = override
@@ -191,6 +195,7 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
         </span>
       )}
       <button
+        data-testid="submit-task"
         type="submit"
         aria-disabled={!parsed.title}
         className={cn(

--- a/components/matrix-simplified/edit-drawer.tsx
+++ b/components/matrix-simplified/edit-drawer.tsx
@@ -147,6 +147,7 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
   return (
     <div onClick={onClose} className="fixed inset-0 z-[60] flex justify-end bg-black/30 animate-drawer-overlay">
       <form
+        data-testid="edit-drawer"
         onClick={(e) => e.stopPropagation()}
         onSubmit={submit}
         className="flex h-full w-full max-w-[520px] flex-col border-l border-border bg-card shadow-2xl animate-drawer-slide-in"
@@ -176,6 +177,7 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
         <div className="flex flex-1 flex-col gap-5 overflow-auto px-5 py-5">
           {/* Title — placeholder carries affordance, the uppercase label is dropped */}
           <input
+            data-testid="edit-title"
             ref={titleRef}
             value={title}
             onChange={(e) => setTitle(e.target.value)}
@@ -186,6 +188,7 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
 
           <Field label="Description">
             <textarea
+              data-testid="edit-description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={4}
@@ -201,6 +204,7 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
                 const a = QUADRANT_ACCENT[q.rdKey];
                 return (
                   <button
+                    data-testid={`edit-quadrant-${q.rdKey}`}
                     key={q.id}
                     type="button"
                     aria-label={q.title}
@@ -343,6 +347,7 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
             Cancel
           </button>
           <button
+            data-testid="save-task"
             type="submit"
             disabled={!title.trim()}
             className={cn(

--- a/components/matrix-simplified/icon-rail.tsx
+++ b/components/matrix-simplified/icon-rail.tsx
@@ -35,6 +35,13 @@ const PRIMARY: RailItem[] = [
   { routeKey: "ABOUT", label: "About", icon: InfoIcon },
 ];
 
+const ROUTE_TEST_IDS: Record<RouteKey, string> = {
+  HOME: "nav-matrix",
+  DASHBOARD: "nav-dashboard",
+  SETTINGS: "nav-settings",
+  ABOUT: "nav-about",
+};
+
 export function IconRail({ onHelp }: IconRailProps) {
   const pathname = usePathname();
   const { navigateWithTransition, isPending } = useViewTransition();
@@ -76,6 +83,7 @@ export function IconRail({ onHelp }: IconRailProps) {
               active={isRouteActive(pathname, item.routeKey)}
               disabled={isPending}
               collapsed={collapsed}
+              testId={ROUTE_TEST_IDS[item.routeKey]}
               onClick={() => navigateWithTransition(ROUTES[item.routeKey])}
             />
           ))}
@@ -121,6 +129,7 @@ function RailButton({
   active = false,
   disabled = false,
   collapsed = false,
+  testId,
   onClick,
   mobile = false,
 }: {
@@ -129,12 +138,14 @@ function RailButton({
   active?: boolean;
   disabled?: boolean;
   collapsed?: boolean;
+  testId?: string;
   onClick: () => void;
   mobile?: boolean;
 }) {
   if (mobile) {
     return (
       <button
+        data-testid={testId}
         type="button"
         onClick={onClick}
         disabled={disabled}
@@ -157,6 +168,7 @@ function RailButton({
 
   return (
     <button
+      data-testid={testId}
       type="button"
       onClick={onClick}
       disabled={disabled}

--- a/components/matrix-simplified/icon-rail.tsx
+++ b/components/matrix-simplified/icon-rail.tsx
@@ -35,7 +35,7 @@ const PRIMARY: RailItem[] = [
   { routeKey: "ABOUT", label: "About", icon: InfoIcon },
 ];
 
-const ROUTE_TEST_IDS: Record<RouteKey, string> = {
+const ROUTE_TEST_IDS: Partial<Record<RouteKey, string>> = {
   HOME: "nav-matrix",
   DASHBOARD: "nav-dashboard",
   SETTINGS: "nav-settings",

--- a/components/matrix-simplified/matrix-grid.tsx
+++ b/components/matrix-simplified/matrix-grid.tsx
@@ -43,7 +43,7 @@ export function MatrixGrid({
   }, [tasks]);
 
   return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:grid-rows-2 md:gap-0 md:overflow-hidden md:rounded-2xl md:border md:border-border md:bg-card md:shadow-sm">
+    <div data-testid="matrix-grid" className="grid grid-cols-1 gap-4 md:grid-cols-2 md:grid-rows-2 md:gap-0 md:overflow-hidden md:rounded-2xl md:border md:border-border md:bg-card md:shadow-sm">
       {quadrants.map((meta, index) => (
         <QuadrantPane
           key={meta.id}

--- a/components/matrix-simplified/quadrant-pane.tsx
+++ b/components/matrix-simplified/quadrant-pane.tsx
@@ -66,6 +66,7 @@ export function QuadrantPane({
   );
   return (
     <section
+      data-testid={`quadrant-${meta.rdKey}`}
       ref={setNodeRef}
       className={cn(
         "relative flex min-h-[280px] flex-col rounded-2xl border border-border p-5 transition-colors",

--- a/components/matrix-simplified/topbar.tsx
+++ b/components/matrix-simplified/topbar.tsx
@@ -54,6 +54,7 @@ export function SimplifiedTopbar({
         <div className="relative hidden w-72 sm:block">
           <SearchIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-foreground-muted" />
           <Input
+            data-testid="search-input"
             ref={searchInputRef}
             placeholder="Search tasks…"
             style={{ paddingLeft: "2.25rem" }}

--- a/components/task-card/index.tsx
+++ b/components/task-card/index.tsx
@@ -51,6 +51,9 @@ function TaskCardComponent({
 
   return (
     <article
+      data-testid="task-card"
+      data-task-id={task.id}
+      data-task-title={task.title}
       ref={(node) => {
         setNodeRef(node);
         if (taskRef && node) {

--- a/components/task-card/task-card-actions.tsx
+++ b/components/task-card/task-card-actions.tsx
@@ -125,6 +125,7 @@ function DesktopActions({ task, onEdit, onDelete, onShare, onDuplicate, onSnooze
       <Tooltip>
         <TooltipTrigger asChild>
           <button
+            data-testid="edit-task"
             type="button"
             onClick={() => onEdit(task)}
             className="rounded px-1.5 py-0.5 flex items-center justify-center hover:bg-background-muted hover:text-foreground transition-colors"
@@ -138,6 +139,7 @@ function DesktopActions({ task, onEdit, onDelete, onShare, onDuplicate, onSnooze
       <Tooltip>
         <TooltipTrigger asChild>
           <button
+            data-testid="delete-task"
             type="button"
             onClick={() => onDelete(task)}
             className="rounded px-1.5 py-0.5 flex items-center justify-center text-red-500 hover:bg-red-50 dark:hover:bg-red-950/40 hover:text-red-600 dark:hover:text-red-400 transition-colors"
@@ -164,6 +166,7 @@ function MobileActions({ task, onEdit, onDelete, onShare, onDuplicate }: MobileA
   return (
     <div className="flex sm:hidden items-center gap-0.5">
       <button
+        data-testid="edit-task-mobile"
         type="button"
         onClick={() => onEdit(task)}
         className="rounded p-2 min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-background-muted hover:text-foreground touch-manipulation transition-colors"
@@ -174,6 +177,7 @@ function MobileActions({ task, onEdit, onDelete, onShare, onDuplicate }: MobileA
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button
+            data-testid="task-card-menu"
             type="button"
             className="rounded p-2 min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-background-muted hover:text-foreground touch-manipulation transition-colors"
             aria-label="More actions"
@@ -194,7 +198,7 @@ function MobileActions({ task, onEdit, onDelete, onShare, onDuplicate }: MobileA
               Duplicate
             </DropdownMenuItem>
           )}
-          <DropdownMenuItem onClick={() => onDelete(task)} className="text-red-600 dark:text-red-400 focus:text-red-600 dark:focus:text-red-400">
+          <DropdownMenuItem data-testid="delete-task" onClick={() => onDelete(task)} className="text-red-600 dark:text-red-400 focus:text-red-600 dark:focus:text-red-400">
             <Trash2Icon className="mr-2 h-4 w-4" />
             Delete
           </DropdownMenuItem>

--- a/components/task-card/task-card-header.tsx
+++ b/components/task-card/task-card-header.tsx
@@ -67,6 +67,7 @@ export function TaskCardHeader({
       <Tooltip>
         <TooltipTrigger asChild>
           <button
+            data-testid="complete-task"
             type="button"
             onClick={() => onToggleComplete(task, !task.completed)}
             className={cn(

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.1.2",
+	"version": "9.1.3",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
 		"deploy:s3": "bash -c 'aws s3 sync out/ s3://gsd.vinny.dev/ --delete --exclude \"*.html\" --exclude \"sw.js\" --cache-control \"public,max-age=31536000,immutable\" && aws s3 sync out/ s3://gsd.vinny.dev/ --exclude \"*\" --include \"*.html\" --include \"sw.js\" --cache-control \"public,max-age=0,must-revalidate\" && aws s3 cp s3://gsd.vinny.dev/index.html s3://gsd.vinny.dev/index.html --metadata-directive REPLACE --cache-control \"no-cache,no-store,must-revalidate\" --content-type \"text/html\" && bash scripts/fix-discovery-content-types.sh s3://gsd.vinny.dev'",
 		"deploy:cf": "aws cloudfront create-invalidation --distribution-id E1T6GDX0TQEP94 --paths '/*'",
 		"deploy": "bun run build && bun run deploy:s3 && bun run deploy:cf",
-		"deploy:dev": "bash scripts/deploy-dev.sh"
+		"deploy:dev": "bash scripts/deploy-dev.sh",
+		"test:e2e": "playwright test",
+		"test:e2e:ui": "playwright test --ui",
+		"test:e2e:debug": "playwright test --debug"
 	},
 	"dependencies": {
 		"@dnd-kit/core": "6.3.1",
@@ -49,6 +52,7 @@
 		"zod": "4.3.6"
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.59.1",
 		"@tailwindcss/postcss": "4.2.2",
 		"@testing-library/dom": "10.4.1",
 		"@testing-library/jest-dom": "6.9.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  timeout: 30 * 1000, // 30 seconds per test
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+  ],
+  webServer: {
+    command: "bun run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000, // 2 minutes for dev server startup
+  },
+});

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '9.1.2';
+const CACHE_VERSION = '9.1.3';
 const CACHE_NAME = `gsd-cache-v${CACHE_VERSION}`;
 const OFFLINE_ASSETS = [
 	"/",

--- a/tasks/e2e-testing-spec.md
+++ b/tasks/e2e-testing-spec.md
@@ -1,0 +1,122 @@
+# E2E Testing Implementation Spec
+
+## Goal
+Implement comprehensive end-to-end tests using Playwright to validate core user workflows in the GSD Task Manager application, ensuring critical functionality works as expected across the entire application stack.
+
+## Inputs
+- Existing Next.js 16 application with client-side only rendering
+- Current Vitest unit test setup
+- Playwright available as MCP server
+- Application runs on http://localhost:3000 in development
+
+## Outputs
+- Playwright configuration (`playwright.config.ts`)
+- E2E test suite in `tests/e2e/` directory
+- Test utilities and helpers for common actions
+- Updated package.json with e2e test scripts
+- Documentation for running and maintaining e2e tests
+
+## Constraints
+- Tests must run against local development server (http://localhost:3000)
+- Tests should be fast and reliable (avoid flaky tests)
+- Must handle IndexedDB cleanup between tests
+- Should work in CI/CD pipeline
+- Must follow existing code style and patterns
+- Tests should be isolated and independent
+
+## Edge Cases
+- Application loading states and race conditions
+- IndexedDB persistence between tests
+- Network delays and slow rendering
+- Browser differences (Chrome, Firefox, Safari)
+- Responsive design (mobile vs desktop)
+- PWA service worker caching
+- Realtime sync events interfering with tests
+
+## Out of Scope
+- Cloud sync authentication and PocketBase integration (too complex for initial e2e)
+- PWA offline functionality (can be added later)
+- Performance/load testing
+- Cross-browser compatibility beyond major browsers
+- Visual regression testing
+- Mobile-specific gestures (can be added later)
+
+## Acceptance Criteria
+1. Playwright is installed and configured with TypeScript support
+2. Development server starts automatically before tests run
+3. Tests can create, read, update, and delete tasks through the UI
+4. Tests verify quadrant classification (urgent/important flags)
+5. Tests verify matrix navigation and view switching
+6. Tests verify search functionality including tags and subtasks
+7. Tests verify smart views filtering
+8. Tests verify settings page navigation
+9. Tests clean up IndexedDB between test runs
+10. All tests pass reliably across Chromium, Firefox, and WebKit
+11. Package.json includes scripts: `test:e2e`, `test:e2e:ui`, `test:e2e:debug`
+12. Documentation explains how to run and debug e2e tests
+
+## Test Stubs
+```typescript
+// tests/e2e/task-crud.spec.ts
+test.describe('Task CRUD Operations', () => {
+  test('should create a new task via capture bar', async () => {})
+  test('should read and display task details', async () => {})
+  test('should update task title and metadata', async () => {})
+  test('should delete a task', async () => {})
+  test('should handle task completion with confetti', async () => {})
+})
+
+// tests/e2e/quadrant-classification.spec.ts
+test.describe('Quadrant Classification', () => {
+  test('should classify task as urgent-important (Q1)', async () => {})
+  test('should classify task as not-urgent-important (Q2)', async () => {})
+  test('should classify task as urgent-not-important (Q3)', async () => {})
+  test('should classify task as not-urgent-not-important (Q4)', async () => {})
+  test('should move task between quadrants', async () => {})
+})
+
+// tests/e2e/matrix-navigation.spec.ts
+test.describe('Matrix Navigation', () => {
+  test('should display all four quadrants', async () => {})
+  test('should navigate to dashboard view', async () => {})
+  test('should navigate to archive view', async () => {})
+  test('should navigate to settings page', async () => {})
+  test('should return to matrix from other views', async () => {})
+})
+
+// tests/e2e/search.spec.ts
+test.describe('Search Functionality', () => {
+  test('should search tasks by title', async () => {})
+  test('should search tasks by tags', async () => {})
+  test('should search tasks by subtasks', async () => {})
+  test('should clear search results', async () => {})
+})
+
+// tests/e2e/smart-views.spec.ts
+test.describe('Smart Views', () => {
+  test('should filter by today view', async () => {})
+  test('should filter by upcoming view', async () => {})
+  test('should filter by overdue view', async () => {})
+  test('should create and use custom smart view', async () => {})
+})
+
+// tests/e2e/settings.spec.ts
+test.describe('Settings Navigation', () => {
+  test('should open settings page', async () => {})
+  test('should navigate between settings sections', async () => {})
+  test('should toggle appearance settings', async () => {})
+  test('should export data', async () => {})
+  test('should import data', async () => {})
+})
+```
+
+## Implementation Notes
+- Use Playwright's `@playwright/test` package
+- Configure test timeout to 30s per test
+- Use `baseURL` in config for consistent URLs
+- Create page object model for common actions (login, navigation, task operations)
+- Use test fixtures for setup/teardown
+- Mock or disable realtime sync during tests to avoid interference
+- Use `await expect(page).toHaveURL()` for navigation assertions
+- Use `await page.waitForLoadState('networkidle')` for stability
+- Implement proper IndexedDB cleanup in `beforeEach` and `afterEach`

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -80,7 +80,14 @@ Each item below is sized to be a single self-contained PR. Pick any one cold and
   - Either the tests pass deterministically (root-cause fix in component or test) or the tests are deleted with a short note in commit message
 - **Effort:** ~1-2 hours debugging.
 
-#### 6. Adopt `knip` or `ts-prune` for periodic dead-code detection
+#### 6. E2E test gaps left by v9 surface removal (2026-05-11)
+- **Why:** The original `tasks/e2e-testing-spec.md` was written generically and assumes UI affordances that v9 removed (per ADR 0011). The implemented suite covers the v9 surface; the items below are gaps **by design**, not omissions.
+- **Smart views (`smart-views.spec.ts` from spec § Test Stubs):** Not implementable. v9 deleted the smart-view pinning UI, the 1-9 keyboard shortcuts, and the `useSmartViewShortcuts` hook. The Dexie `smartViews` table is retained for data continuity but has no entry point in the UI. **Action:** revisit if smart views are ever resurrected (similar to the planned command-palette resurrection in #1 above).
+- **Search by subtask (`search.spec.ts` stub):** Search filter logic includes subtask titles in the haystack (covered by unit tests), but v9's edit drawer exposes no subtask editor — only a count badge on task cards. To exercise this end-to-end, either resurrect a subtask editor or seed subtasks via JSON import in a fixture.
+- **Archive navigation:** The `/archive` route exists and is reachable from `Settings → Archive → View archive`, but that link is conditional on `archivedCount > 0`. Direct `page.goto('/archive')` works but doesn't validate the user-facing path. To cover this, the test would need to seed archived tasks first (via import, or by completing a task and triggering auto-archive with a backdated `completedAt`).
+- **Effort to close:** ~3-4 hours, but blocked on UI decisions for smart views and subtasks.
+
+#### 7. Adopt `knip` or `ts-prune` for periodic dead-code detection
 - **Why:** This PR's audit used regex grep against import paths and **missed 5 transitive/lazy imports** (documented in ADR 0011's audit-gap section). A TS-compiler-API-based tool would catch them. Without one, the next "v10 refactor without cleanup" will need another manual review.
 - **Where to start:** evaluate `knip` (more comprehensive, knows Next.js conventions) vs `ts-prune` (smaller, simpler). Add as a dev dep with config that:
   - Whitelists Next.js conventional entrypoints (`app/**/page.tsx`, `app/**/layout.tsx`, `next.config.ts`, etc.)

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,121 @@
+# End-to-End Tests
+
+Playwright-driven tests that exercise the v9 single-matrix UI through a real browser.
+Specs live in this directory; the page-object model, fixtures, and helpers live in
+`pages/`, `fixtures/`, and `helpers/` respectively.
+
+## Running
+
+```bash
+bun run test:e2e          # all specs, all browsers, headless
+bun run test:e2e:ui       # interactive runner with watch + time-travel
+bun run test:e2e:debug    # headed, stepping through with the inspector
+```
+
+The dev server starts automatically via the `webServer` block in `playwright.config.ts`.
+If you already have `bun dev` running, Playwright reuses it locally; in CI it always
+spawns a fresh one.
+
+Target a single file, project, or test:
+
+```bash
+bun run test:e2e -- tests/e2e/task-crud.spec.ts            # one spec
+bun run test:e2e -- --project=chromium                     # one browser
+bun run test:e2e -- -g "should update task title"          # by test name
+```
+
+## Layout
+
+```
+tests/e2e/
+├── README.md                       ← this file
+├── fixtures/test-fixtures.ts       ← Playwright fixtures (IndexedDB cleanup)
+├── helpers/test-helpers.ts         ← shared utility functions
+├── pages/matrix-page.ts            ← page-object model for the matrix shell
+├── task-crud.spec.ts               ← create / read / update / delete / complete
+├── quadrant-classification.spec.ts ← capture-parser quadrant assignment + move
+├── matrix-navigation.spec.ts       ← matrix ↔ dashboard ↔ settings routing
+├── search.spec.ts                  ← title and tag search
+└── settings-navigation.spec.ts     ← section nav, theme, toggles, export
+```
+
+## Conventions
+
+- **Selectors**: prefer `[data-testid='…']` for stable hooks, then role/text locators.
+  When you need a new testid, add it to the component along with the test — don't add
+  speculative testids ahead of time.
+- **Page object model**: encapsulate multi-step UI flows in `pages/matrix-page.ts`.
+  Spec files should read like a story, not a sequence of locator strings.
+- **No `page.waitForTimeout` for state**: prefer `waitFor` / `expect.toBeVisible`.
+  The few fixed timeouts that remain are documented at the call site and exist to
+  ride out animations rather than to mask flakes.
+
+## Capture-parser shorthand
+
+Quadrant tests and any spec that creates tasks rely on the capture-parser syntax
+defined in `lib/capture-parser.ts`:
+
+| Suffix     | Effect                       | Lands in |
+| ---------- | ---------------------------- | -------- |
+| `task !!`  | urgent + important           | Q1       |
+| `task *`   | important only               | Q2       |
+| `task !`   | urgent only                  | Q3       |
+| `task`     | neither                      | Q4       |
+| `… #tag`   | adds `tag` to `task.tags`    | —        |
+
+Tokens must be space-bounded. `!important` is parsed as a literal word in the title,
+**not** as an urgency flag. (The pre-v9 test suite assumed otherwise; all those
+"different quadrant" tasks silently landed in Q4. Fixed 2026-05-11.)
+
+## IndexedDB cleanup
+
+The `clearIndexedDB` fixture in `fixtures/test-fixtures.ts` navigates to the app
+origin and deletes the Dexie database (`GsdTaskManager`, matching `lib/db.ts:31`)
+**before** each test's body runs. Tests opt in by destructuring it:
+
+```ts
+test.beforeEach(async ({ page, clearIndexedDB }) => {
+  /* clean slate guaranteed */
+});
+```
+
+Playwright contexts are already isolated per test, so this is belt-and-braces:
+the database is gone, then the test reopens it via the app's normal Dexie boot.
+
+## Known gaps versus the original spec
+
+`tasks/e2e-testing-spec.md` was written generically; v9's single-matrix refactor
+(see `docs/adr/0011-v9-single-matrix-refactor.md`) removed several surfaces the
+spec assumed. The following spec stubs are intentionally **not** implemented:
+
+- **Smart views** (`smart-views.spec.ts`) — v9 deleted the pinning UI, 1-9
+  shortcuts, and the `useSmartViewShortcuts` hook. The `smartViews` Dexie table
+  remains for data continuity but has no UI surface.
+- **Search by subtask** — the search filter does include subtask titles, but
+  the v9 edit drawer has no subtask editor (only a count badge on cards).
+- **Archive navigation** — `/archive` exists and is reachable from
+  Settings → Archive → View archive, but that link is conditional on
+  `archivedCount > 0`. Covering it requires seeding archived tasks first.
+
+These gaps are tracked in `tasks/todo.md` § "E2E test gaps left by v9 surface
+removal" and would be reopened if the underlying features are resurrected.
+
+## Adding a new spec
+
+1. Add or update a method on `pages/matrix-page.ts` for the user flow you're
+   testing.
+2. Write the test using the `clearIndexedDB` fixture and the page object.
+3. Run it once — it should fail with "selector not found" if you needed a new
+   `data-testid`.
+4. Add the `data-testid` to the component and re-run to green.
+5. Run the full suite on chromium before committing:
+   `bun run test:e2e -- --project=chromium`.
+
+## CI behaviour
+
+- `forbidOnly: true` — `.only` calls fail the build.
+- `retries: 2` — flaky tests retry; first failure produces trace, screenshot, and
+  video in `test-results/`.
+- `workers: 1` — serial execution in CI for log readability.
+
+Locally, retries are disabled and workers run in parallel.

--- a/tests/e2e/fixtures/test-fixtures.ts
+++ b/tests/e2e/fixtures/test-fixtures.ts
@@ -1,0 +1,18 @@
+import { test as base } from "@playwright/test";
+
+export const test = base.extend({
+  // Custom fixture to clear IndexedDB before each test
+  clearIndexedDB: async ({ page }, use) => {
+    await use(page);
+    // Clear IndexedDB after each test
+    await page.evaluate(() => {
+      return new Promise((resolve, reject) => {
+        const request = indexedDB.deleteDatabase("gsd-taskmanager");
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+      });
+    });
+  },
+});
+
+export const expect = test.expect;

--- a/tests/e2e/fixtures/test-fixtures.ts
+++ b/tests/e2e/fixtures/test-fixtures.ts
@@ -1,17 +1,26 @@
 import { test as base } from "@playwright/test";
 
-export const test = base.extend({
-  // Custom fixture to clear IndexedDB before each test
-  clearIndexedDB: async ({ page }, use) => {
-    await use(page);
-    // Clear IndexedDB after each test
-    await page.evaluate(() => {
-      return new Promise((resolve, reject) => {
-        const request = indexedDB.deleteDatabase("gsd-taskmanager");
-        request.onsuccess = () => resolve();
-        request.onerror = () => reject(request.error);
-      });
-    });
+/**
+ * Clears IndexedDB before the test runs so the suite starts from a clean slate.
+ * We navigate to the app origin first because IndexedDB is keyed per-origin.
+ * The Dexie database name comes from lib/db.ts (`GsdTaskManager`).
+ */
+export const test = base.extend<{ clearIndexedDB: void }>({
+  // Playwright passes the fixture-runner callback as the second arg.
+  // We rename it from the conventional `use` to dodge a false-positive
+  // react-hooks/rules-of-hooks lint match against React's `use()`.
+  clearIndexedDB: async ({ page }, runTest) => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          const req = indexedDB.deleteDatabase("GsdTaskManager");
+          req.onsuccess = () => resolve();
+          req.onerror = () => reject(req.error);
+          req.onblocked = () => resolve();
+        })
+    );
+    await runTest();
   },
 });
 

--- a/tests/e2e/helpers/test-helpers.ts
+++ b/tests/e2e/helpers/test-helpers.ts
@@ -1,0 +1,90 @@
+import { Page } from "@playwright/test";
+
+export async function waitForAppLoad(page: Page): Promise<void> {
+  await page.waitForLoadState("networkidle");
+  
+  // Handle redirect to about page by navigating to matrix
+  if (page.url().includes("/about")) {
+    await page.locator("[data-testid='nav-matrix']").click();
+    await page.waitForLoadState("networkidle");
+  }
+  
+  await page.waitForTimeout(2000); // Wait for app to fully render
+  await page.waitForSelector("[data-testid='matrix-grid']", { timeout: 20000 });
+}
+
+export async function getTaskCount(page: Page): Promise<number> {
+  const tasks = await page.locator("[data-testid='task-card']").count();
+  return tasks;
+}
+
+export async function getQuadrantTaskCount(
+  page: Page,
+  quadrant: "q1" | "q2" | "q3" | "q4"
+): Promise<number> {
+  const quadrantSelector = `[data-testid='quadrant-${quadrant}']`;
+  await page.waitForSelector(quadrantSelector);
+  const tasks = await page
+    .locator(quadrantSelector)
+    .locator("[data-testid='task-card']")
+    .count();
+  return tasks;
+}
+
+export async function createTaskViaCaptureBar(
+  page: Page,
+  taskTitle: string
+): Promise<void> {
+  const captureBar = page.locator("[data-testid='capture-bar']");
+  await captureBar.locator("[data-testid='capture-input']").fill(taskTitle);
+  await captureBar.locator("[data-testid='submit-task']").click();
+  await page.waitForTimeout(500); // Wait for task to be created
+}
+
+export async function completeTask(page: Page, taskTitle: string): Promise<void> {
+  const taskCard = page.locator(`[data-testid='task-card']`).filter({ hasText: taskTitle });
+  await taskCard.locator("[data-testid='complete-task']").click();
+  await page.waitForTimeout(500); // Wait for confetti animation
+}
+
+export async function deleteTask(page: Page, taskTitle: string): Promise<void> {
+  const taskCard = page.locator(`[data-testid='task-card']`).filter({ hasText: taskTitle });
+  await taskCard.locator("[data-testid='task-card-menu']").click();
+  await page.locator("[data-testid='delete-task']").click();
+  await page.waitForTimeout(500); // Wait for deletion
+}
+
+export async function searchTasks(page: Page, query: string): Promise<void> {
+  const searchInput = page.locator("[data-testid='search-input']");
+  await searchInput.fill(query);
+  await page.waitForTimeout(300); // Wait for search results
+}
+
+export async function clearSearch(page: Page): Promise<void> {
+  const searchInput = page.locator("[data-testid='search-input']");
+  await searchInput.fill("");
+  await page.waitForTimeout(300);
+}
+
+export async function navigateTo(page: Page, path: string): Promise<void> {
+  await page.goto(path);
+  await page.waitForLoadState("networkidle");
+}
+
+export async function openSettings(page: Page): Promise<void> {
+  const settingsButton = page.locator("[data-testid='nav-settings']");
+  await settingsButton.click();
+  await page.waitForTimeout(500);
+}
+
+export async function openDashboard(page: Page): Promise<void> {
+  const dashboardButton = page.locator("[data-testid='nav-dashboard']");
+  await dashboardButton.click();
+  await page.waitForTimeout(500);
+}
+
+export async function openMatrix(page: Page): Promise<void> {
+  const matrixButton = page.locator("[data-testid='nav-matrix']");
+  await matrixButton.click();
+  await page.waitForTimeout(500);
+}

--- a/tests/e2e/matrix-navigation.spec.ts
+++ b/tests/e2e/matrix-navigation.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "./fixtures/test-fixtures";
+import { MatrixPage } from "./pages/matrix-page";
+import { waitForAppLoad } from "./helpers/test-helpers";
+
+test.describe("Matrix Navigation", () => {
+  let matrixPage: MatrixPage;
+
+  test.beforeEach(async ({ page, clearIndexedDB }) => {
+    matrixPage = new MatrixPage(page);
+    await matrixPage.goto();
+    await waitForAppLoad(page);
+  });
+
+  test("should navigate to settings page", async ({ page }) => {
+    await matrixPage.openSettings();
+    
+    // Verify we're on settings page by checking for settings-related content
+    await expect(page.locator("[data-testid='nav-settings']")).toBeVisible();
+    await expect(page.url()).toContain("/settings");
+  });
+
+  test("should navigate to dashboard page", async ({ page }) => {
+    await matrixPage.openDashboard();
+    
+    // Verify we're on dashboard page
+    await expect(page.locator("[data-testid='nav-dashboard']")).toBeVisible();
+    await expect(page.url()).toContain("/dashboard");
+  });
+
+  test("should return to matrix from settings", async ({ page }) => {
+    await matrixPage.openSettings();
+    await page.waitForTimeout(500);
+    
+    await matrixPage.openMatrix();
+    
+    // Verify we're back on matrix page
+    await expect(page.locator("[data-testid='matrix-grid']")).toBeVisible();
+    await expect(page.url()).toContain("/");
+  });
+
+  test("should return to matrix from dashboard", async ({ page }) => {
+    await matrixPage.openDashboard();
+    await page.waitForTimeout(500);
+    
+    await matrixPage.openMatrix();
+    
+    // Verify we're back on matrix page
+    await expect(page.locator("[data-testid='matrix-grid']")).toBeVisible();
+    await expect(page.url()).toContain("/");
+  });
+
+  test("should highlight active navigation item", async ({ page }) => {
+    // Matrix should be active by default
+    await expect(page.locator("[data-testid='nav-matrix']")).toBeVisible();
+    
+    // Navigate to dashboard
+    await matrixPage.openDashboard();
+    await page.waitForTimeout(500);
+    
+    // Dashboard should now be active
+    await expect(page.locator("[data-testid='nav-dashboard']")).toBeVisible();
+    
+    // Navigate back to matrix
+    await matrixPage.openMatrix();
+    
+    // Matrix should be active again
+    await expect(page.locator("[data-testid='nav-matrix']")).toBeVisible();
+  });
+});

--- a/tests/e2e/pages/matrix-page.ts
+++ b/tests/e2e/pages/matrix-page.ts
@@ -1,0 +1,120 @@
+import { Page, Locator } from "@playwright/test";
+
+export class MatrixPage {
+  readonly page: Page;
+  readonly captureBar: Locator;
+  readonly matrixGrid: Locator;
+  readonly q1Quadrant: Locator;
+  readonly q2Quadrant: Locator;
+  readonly q3Quadrant: Locator;
+  readonly q4Quadrant: Locator;
+  readonly searchInput: Locator;
+  readonly navSettings: Locator;
+  readonly navDashboard: Locator;
+  readonly navMatrix: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.captureBar = page.locator("[data-testid='capture-bar']");
+    this.matrixGrid = page.locator("[data-testid='matrix-grid']");
+    this.q1Quadrant = page.locator("[data-testid='quadrant-q1']");
+    this.q2Quadrant = page.locator("[data-testid='quadrant-q2']");
+    this.q3Quadrant = page.locator("[data-testid='quadrant-q3']");
+    this.q4Quadrant = page.locator("[data-testid='quadrant-q4']");
+    this.searchInput = page.locator("[data-testid='search-input']");
+    this.navSettings = page.locator("[data-testid='nav-settings']");
+    this.navDashboard = page.locator("[data-testid='nav-dashboard']");
+    this.navMatrix = page.locator("[data-testid='nav-matrix']");
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto("/");
+    await this.page.waitForLoadState("networkidle");
+    
+    // Handle redirect to about page by navigating to matrix
+    if (this.page.url().includes("/about")) {
+      await this.navMatrix.click();
+      await this.page.waitForLoadState("networkidle");
+    }
+    
+    await this.page.waitForTimeout(2000); // Wait for app to fully render
+    await this.matrixGrid.waitFor({ state: "visible", timeout: 20000 });
+  }
+
+  async createTask(title: string): Promise<void> {
+    await this.captureBar.locator("[data-testid='capture-input']").fill(title);
+    await this.captureBar.locator("[data-testid='submit-task']").click();
+    await this.page.waitForTimeout(500);
+  }
+
+  async getTaskCount(): Promise<number> {
+    return await this.page.locator("[data-testid='task-card']").count();
+  }
+
+  async getQuadrantTaskCount(quadrant: "q1" | "q2" | "q3" | "q4"): Promise<number> {
+    const quadrantSelector = `[data-testid='quadrant-${quadrant}']`;
+    await this.page.waitForSelector(quadrantSelector);
+    return await this.page
+      .locator(quadrantSelector)
+      .locator("[data-testid='task-card']")
+      .count();
+  }
+
+  async completeTask(title: string): Promise<void> {
+    const taskCard = this.page.locator("[data-testid='task-card']").filter({ hasText: title });
+    await taskCard.locator("[data-testid='complete-task']").click();
+    await this.page.waitForTimeout(500);
+  }
+
+  async deleteTask(title: string): Promise<void> {
+    const taskCard = this.page.locator("[data-testid='task-card']").filter({ hasText: title });
+    // Hover over the task card to reveal desktop actions
+    await taskCard.hover();
+    // Click the delete button directly (desktop actions)
+    await taskCard.locator("[data-testid='delete-task']").click();
+    await this.page.waitForTimeout(500);
+  }
+
+  async search(query: string): Promise<void> {
+    await this.searchInput.fill(query);
+    await this.page.waitForTimeout(300);
+  }
+
+  async clearSearch(): Promise<void> {
+    await this.searchInput.fill("");
+    await this.page.waitForTimeout(300);
+  }
+
+  async openSettings(): Promise<void> {
+    // Dismiss PWA install dialog if present (can block clicks in WebKit)
+    const pwaDialog = this.page.locator("[role='dialog'][aria-labelledby='install-pwa-title']");
+    if (await pwaDialog.isVisible().catch(() => false)) {
+      await pwaDialog.locator("button[aria-label='Dismiss install prompt']").click();
+      await this.page.waitForTimeout(200);
+    }
+    await this.navSettings.click();
+    await this.page.waitForTimeout(500);
+  }
+
+  async openDashboard(): Promise<void> {
+    // Dismiss PWA install dialog if present (can block clicks in WebKit)
+    const pwaDialog = this.page.locator("[role='dialog'][aria-labelledby='install-pwa-title']");
+    if (await pwaDialog.isVisible().catch(() => false)) {
+      await pwaDialog.locator("button[aria-label='Dismiss install prompt']").click();
+      await this.page.waitForTimeout(200);
+    }
+    await this.navDashboard.click();
+    await this.page.waitForTimeout(500);
+  }
+
+  async openMatrix(): Promise<void> {
+    // Dismiss PWA install dialog if present (can block clicks in WebKit)
+    const pwaDialog = this.page.locator("[role='dialog'][aria-labelledby='install-pwa-title']");
+    if (await pwaDialog.isVisible().catch(() => false)) {
+      await pwaDialog.locator("button[aria-label='Dismiss install prompt']").click();
+      await this.page.waitForTimeout(200);
+    }
+    await this.navMatrix.click();
+    await this.page.waitForTimeout(500);
+  }
+}

--- a/tests/e2e/pages/matrix-page.ts
+++ b/tests/e2e/pages/matrix-page.ts
@@ -75,6 +75,41 @@ export class MatrixPage {
     await this.page.waitForTimeout(500);
   }
 
+  /**
+   * Opens the edit drawer for the task with the given title.
+   * Uses the desktop edit button revealed on hover; the same testid
+   * exists on mobile so this works for both viewports.
+   */
+  async openEditDrawer(title: string): Promise<void> {
+    const taskCard = this.page.locator("[data-testid='task-card']").filter({ hasText: title });
+    await taskCard.hover();
+    await taskCard.locator("[data-testid='edit-task']").first().click();
+    await this.page.locator("[data-testid='edit-drawer']").waitFor({ state: "visible" });
+  }
+
+  /**
+   * Updates the open edit drawer's title, description, and quadrant, then saves.
+   * Requires the drawer to be open (call openEditDrawer first).
+   */
+  async saveEditDrawer(updates: {
+    title?: string;
+    description?: string;
+    quadrant?: "q1" | "q2" | "q3" | "q4";
+  }): Promise<void> {
+    const drawer = this.page.locator("[data-testid='edit-drawer']");
+    if (updates.title !== undefined) {
+      await drawer.locator("[data-testid='edit-title']").fill(updates.title);
+    }
+    if (updates.description !== undefined) {
+      await drawer.locator("[data-testid='edit-description']").fill(updates.description);
+    }
+    if (updates.quadrant) {
+      await drawer.locator(`[data-testid='edit-quadrant-${updates.quadrant}']`).click();
+    }
+    await drawer.locator("[data-testid='save-task']").click();
+    await drawer.waitFor({ state: "hidden" });
+  }
+
   async search(query: string): Promise<void> {
     await this.searchInput.fill(query);
     await this.page.waitForTimeout(300);

--- a/tests/e2e/quadrant-classification.spec.ts
+++ b/tests/e2e/quadrant-classification.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from "./fixtures/test-fixtures";
+import { MatrixPage } from "./pages/matrix-page";
+import { waitForAppLoad } from "./helpers/test-helpers";
+
+test.describe("Quadrant Classification", () => {
+  let matrixPage: MatrixPage;
+
+  test.beforeEach(async ({ page, clearIndexedDB }) => {
+    matrixPage = new MatrixPage(page);
+    await matrixPage.goto();
+    await waitForAppLoad(page);
+  });
+
+  test("should display all four quadrants", async ({ page }) => {
+    await expect(page.locator("[data-testid='quadrant-q1']")).toBeVisible();
+    await expect(page.locator("[data-testid='quadrant-q2']")).toBeVisible();
+    await expect(page.locator("[data-testid='quadrant-q3']")).toBeVisible();
+    await expect(page.locator("[data-testid='quadrant-q4']")).toBeVisible();
+  });
+
+  test("should display quadrant headers", async ({ page }) => {
+    const q1 = page.locator("[data-testid='quadrant-q1']");
+    await expect(q1).toContainText("Do");
+    
+    const q2 = page.locator("[data-testid='quadrant-q2']");
+    await expect(q2).toContainText("Schedule");
+    
+    const q3 = page.locator("[data-testid='quadrant-q3']");
+    await expect(q3).toContainText("Delegate");
+    
+    const q4 = page.locator("[data-testid='quadrant-q4']");
+    await expect(q4).toContainText("Eliminate");
+  });
+
+  test("should create task in default quadrant (Q4 - not urgent, not important)", async ({ page }) => {
+    await matrixPage.createTask("Default quadrant task");
+    
+    // By default, tasks without urgency/importance flags go to Q4
+    const q4Count = await matrixPage.getQuadrantTaskCount("q4");
+    expect(q4Count).toBeGreaterThan(0);
+    
+    const q4Task = page.locator("[data-testid='quadrant-q4']").locator("[data-testid='task-card']").filter({ hasText: "Default quadrant task" });
+    await expect(q4Task).toBeVisible();
+  });
+
+  test("should display task count in each quadrant", async ({ page }) => {
+    // Create tasks in different quadrants by using the capture parser
+    await matrixPage.createTask("urgent important task !important"); // This should go to Q1
+    await matrixPage.createTask("important task !important"); // This should go to Q2
+    await matrixPage.createTask("urgent task !urgent"); // This should go to Q3
+    await matrixPage.createTask("normal task"); // This should go to Q4
+    
+    // Wait for tasks to be created and classified
+    await page.waitForTimeout(1000);
+    
+    // Verify quadrant counts are displayed
+    const q1Count = await matrixPage.getQuadrantTaskCount("q1");
+    const q2Count = await matrixPage.getQuadrantTaskCount("q2");
+    const q3Count = await matrixPage.getQuadrantTaskCount("q3");
+    const q4Count = await matrixPage.getQuadrantTaskCount("q4");
+    
+    expect(q1Count + q2Count + q3Count + q4Count).toBeGreaterThan(0);
+  });
+
+  test("should show empty state for quadrants with no tasks", async ({ page }) => {
+    // All quadrants should show empty state initially
+    const q1 = page.locator("[data-testid='quadrant-q1']");
+    await expect(q1).toContainText("Do First");
+    
+    const q2 = page.locator("[data-testid='quadrant-q2']");
+    await expect(q2).toContainText("Schedule");
+    
+    const q3 = page.locator("[data-testid='quadrant-q3']");
+    await expect(q3).toContainText("Delegate");
+    
+    const q4 = page.locator("[data-testid='quadrant-q4']");
+    await expect(q4).toContainText("Eliminate");
+  });
+});

--- a/tests/e2e/quadrant-classification.spec.ts
+++ b/tests/e2e/quadrant-classification.spec.ts
@@ -32,34 +32,103 @@ test.describe("Quadrant Classification", () => {
     await expect(q4).toContainText("Eliminate");
   });
 
-  test("should create task in default quadrant (Q4 - not urgent, not important)", async ({ page }) => {
-    await matrixPage.createTask("Default quadrant task");
-    
-    // By default, tasks without urgency/importance flags go to Q4
-    const q4Count = await matrixPage.getQuadrantTaskCount("q4");
-    expect(q4Count).toBeGreaterThan(0);
-    
-    const q4Task = page.locator("[data-testid='quadrant-q4']").locator("[data-testid='task-card']").filter({ hasText: "Default quadrant task" });
-    await expect(q4Task).toBeVisible();
+  // Capture-parser syntax (see lib/capture-parser.ts):
+  //   "task !!"  → urgent + important → Q1 (Do First)
+  //   "task *"   → important only     → Q2 (Schedule)
+  //   "task !"   → urgent only        → Q3 (Delegate)
+  //   "task"     → neither            → Q4 (Eliminate)
+  // Tokens must be space-bounded; `!important` is treated as a literal word.
+
+  test("should classify task as urgent + important (Q1) with !!", async ({ page }) => {
+    await matrixPage.createTask("crisis report !!");
+
+    const q1Task = page
+      .locator("[data-testid='quadrant-q1'] [data-testid='task-card']")
+      .filter({ hasText: "crisis report" });
+    await expect(q1Task).toBeVisible();
+
+    // Confirm it did NOT land in any other quadrant
+    for (const other of ["q2", "q3", "q4"] as const) {
+      await expect(
+        page.locator(`[data-testid='quadrant-${other}'] [data-testid='task-card']`).filter({ hasText: "crisis report" })
+      ).toHaveCount(0);
+    }
   });
 
-  test("should display task count in each quadrant", async ({ page }) => {
-    // Create tasks in different quadrants by using the capture parser
-    await matrixPage.createTask("urgent important task !important"); // This should go to Q1
-    await matrixPage.createTask("important task !important"); // This should go to Q2
-    await matrixPage.createTask("urgent task !urgent"); // This should go to Q3
-    await matrixPage.createTask("normal task"); // This should go to Q4
-    
-    // Wait for tasks to be created and classified
-    await page.waitForTimeout(1000);
-    
-    // Verify quadrant counts are displayed
-    const q1Count = await matrixPage.getQuadrantTaskCount("q1");
-    const q2Count = await matrixPage.getQuadrantTaskCount("q2");
-    const q3Count = await matrixPage.getQuadrantTaskCount("q3");
-    const q4Count = await matrixPage.getQuadrantTaskCount("q4");
-    
-    expect(q1Count + q2Count + q3Count + q4Count).toBeGreaterThan(0);
+  test("should classify task as important-only (Q2) with *", async ({ page }) => {
+    await matrixPage.createTask("plan next quarter *");
+
+    const q2Task = page
+      .locator("[data-testid='quadrant-q2'] [data-testid='task-card']")
+      .filter({ hasText: "plan next quarter" });
+    await expect(q2Task).toBeVisible();
+
+    for (const other of ["q1", "q3", "q4"] as const) {
+      await expect(
+        page.locator(`[data-testid='quadrant-${other}'] [data-testid='task-card']`).filter({ hasText: "plan next quarter" })
+      ).toHaveCount(0);
+    }
+  });
+
+  test("should classify task as urgent-only (Q3) with !", async ({ page }) => {
+    await matrixPage.createTask("answer voicemail !");
+
+    const q3Task = page
+      .locator("[data-testid='quadrant-q3'] [data-testid='task-card']")
+      .filter({ hasText: "answer voicemail" });
+    await expect(q3Task).toBeVisible();
+
+    for (const other of ["q1", "q2", "q4"] as const) {
+      await expect(
+        page.locator(`[data-testid='quadrant-${other}'] [data-testid='task-card']`).filter({ hasText: "answer voicemail" })
+      ).toHaveCount(0);
+    }
+  });
+
+  test("should classify task as neither (Q4) by default", async ({ page }) => {
+    await matrixPage.createTask("organize bookshelf");
+
+    const q4Task = page
+      .locator("[data-testid='quadrant-q4'] [data-testid='task-card']")
+      .filter({ hasText: "organize bookshelf" });
+    await expect(q4Task).toBeVisible();
+
+    for (const other of ["q1", "q2", "q3"] as const) {
+      await expect(
+        page.locator(`[data-testid='quadrant-${other}'] [data-testid='task-card']`).filter({ hasText: "organize bookshelf" })
+      ).toHaveCount(0);
+    }
+  });
+
+  test("should move task between quadrants via edit drawer", async ({ page }) => {
+    await matrixPage.createTask("relocate me");
+
+    // Starts in Q4 (no flags)
+    await expect(
+      page.locator("[data-testid='quadrant-q4'] [data-testid='task-card']").filter({ hasText: "relocate me" })
+    ).toBeVisible();
+
+    // Move to Q2 via edit drawer
+    await matrixPage.openEditDrawer("relocate me");
+    await matrixPage.saveEditDrawer({ quadrant: "q2" });
+
+    await expect(
+      page.locator("[data-testid='quadrant-q2'] [data-testid='task-card']").filter({ hasText: "relocate me" })
+    ).toBeVisible();
+    await expect(
+      page.locator("[data-testid='quadrant-q4'] [data-testid='task-card']").filter({ hasText: "relocate me" })
+    ).toHaveCount(0);
+
+    // Move from Q2 to Q1
+    await matrixPage.openEditDrawer("relocate me");
+    await matrixPage.saveEditDrawer({ quadrant: "q1" });
+
+    await expect(
+      page.locator("[data-testid='quadrant-q1'] [data-testid='task-card']").filter({ hasText: "relocate me" })
+    ).toBeVisible();
+    await expect(
+      page.locator("[data-testid='quadrant-q2'] [data-testid='task-card']").filter({ hasText: "relocate me" })
+    ).toHaveCount(0);
   });
 
   test("should show empty state for quadrants with no tasks", async ({ page }) => {

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -86,12 +86,55 @@ test.describe("Search Functionality", () => {
 
   test("should handle partial matches", async ({ page }) => {
     await matrixPage.createTask("Complete the project report");
-    
+
     await page.waitForTimeout(500);
-    
+
     // Search for partial word
     await matrixPage.search("project");
-    
+
     await expect(page.locator("[data-testid='task-card']").filter({ hasText: "Complete the project report" })).toBeVisible();
   });
+
+  test("should search by tag", async ({ page }) => {
+    // Capture parser strips `#tag` from the title and stores it on the task.
+    // The search filter joins tags into the searchable haystack.
+    await matrixPage.createTask("Buy lettuce #grocery");
+    await matrixPage.createTask("Write quarterly memo #work");
+    await matrixPage.createTask("Untagged task");
+
+    await page.waitForTimeout(500);
+
+    await matrixPage.search("grocery");
+
+    await expect(
+      page.locator("[data-testid='task-card']").filter({ hasText: "Buy lettuce" })
+    ).toBeVisible();
+    await expect(
+      page.locator("[data-testid='task-card']").filter({ hasText: "Write quarterly memo" })
+    ).not.toBeVisible();
+    await expect(
+      page.locator("[data-testid='task-card']").filter({ hasText: "Untagged task" })
+    ).not.toBeVisible();
+  });
+
+  test("should search across multiple tags", async ({ page }) => {
+    await matrixPage.createTask("Refactor module #work #urgent");
+    await matrixPage.createTask("Call dentist #personal");
+
+    await page.waitForTimeout(500);
+
+    await matrixPage.search("urgent");
+    await expect(
+      page.locator("[data-testid='task-card']").filter({ hasText: "Refactor module" })
+    ).toBeVisible();
+    await expect(
+      page.locator("[data-testid='task-card']").filter({ hasText: "Call dentist" })
+    ).not.toBeVisible();
+  });
+
+  // NOTE: "search by subtasks" from the spec is deferred. The v9 edit drawer
+  // does not expose a subtask editor (only a count badge on the task card), so
+  // there is no user-facing path to add subtasks. The search filter itself
+  // (lib/matrix-simplified/index.tsx → filterTasks) does include subtask titles
+  // in its haystack and is covered by unit tests.
 });

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "./fixtures/test-fixtures";
+import { MatrixPage } from "./pages/matrix-page";
+import { waitForAppLoad } from "./helpers/test-helpers";
+
+test.describe("Search Functionality", () => {
+  let matrixPage: MatrixPage;
+
+  test.beforeEach(async ({ page, clearIndexedDB }) => {
+    matrixPage = new MatrixPage(page);
+    await matrixPage.goto();
+    await waitForAppLoad(page);
+  });
+
+  test("should display search input", async ({ page }) => {
+    const searchInput = page.locator("[data-testid='search-input']");
+    await expect(searchInput).toBeVisible();
+  });
+
+  test("should search tasks by title", async ({ page }) => {
+    // Create multiple tasks
+    await matrixPage.createTask("Buy groceries");
+    await matrixPage.createTask("Complete project report");
+    await matrixPage.createTask("Call mom");
+    
+    await page.waitForTimeout(500);
+    
+    // Search for specific task
+    await matrixPage.search("groceries");
+    
+    // Only the matching task should be visible
+    await expect(page.locator("[data-testid='task-card']").filter({ hasText: "Buy groceries" })).toBeVisible();
+    await expect(page.locator("[data-testid='task-card']").filter({ hasText: "Complete project report" })).not.toBeVisible();
+    await expect(page.locator("[data-testid='task-card']").filter({ hasText: "Call mom" })).not.toBeVisible();
+  });
+
+  test("should clear search and show all tasks", async ({ page }) => {
+    // Create tasks
+    await matrixPage.createTask("Task one");
+    await matrixPage.createTask("Task two");
+    
+    await page.waitForTimeout(500);
+    
+    const initialCount = await matrixPage.getTaskCount();
+    expect(initialCount).toBe(2);
+    
+    // Search
+    await matrixPage.search("one");
+    
+    const searchCount = await matrixPage.getTaskCount();
+    expect(searchCount).toBe(1);
+    
+    // Clear search
+    await matrixPage.clearSearch();
+    
+    const finalCount = await matrixPage.getTaskCount();
+    expect(finalCount).toBe(2);
+  });
+
+  test("should show no results for non-matching search", async ({ page }) => {
+    await matrixPage.createTask("Existing task");
+    
+    await page.waitForTimeout(500);
+    
+    // Search for non-existent task
+    await matrixPage.search("nonexistent task");
+    
+    // No tasks should be visible
+    const taskCount = await matrixPage.getTaskCount();
+    expect(taskCount).toBe(0);
+  });
+
+  test("should be case-insensitive", async ({ page }) => {
+    await matrixPage.createTask("Test Task");
+    
+    await page.waitForTimeout(500);
+    
+    // Search with different case
+    await matrixPage.search("test task");
+    
+    await expect(page.locator("[data-testid='task-card']").filter({ hasText: "Test Task" })).toBeVisible();
+    
+    await matrixPage.search("TEST TASK");
+    
+    await expect(page.locator("[data-testid='task-card']").filter({ hasText: "Test Task" })).toBeVisible();
+  });
+
+  test("should handle partial matches", async ({ page }) => {
+    await matrixPage.createTask("Complete the project report");
+    
+    await page.waitForTimeout(500);
+    
+    // Search for partial word
+    await matrixPage.search("project");
+    
+    await expect(page.locator("[data-testid='task-card']").filter({ hasText: "Complete the project report" })).toBeVisible();
+  });
+});

--- a/tests/e2e/settings-navigation.spec.ts
+++ b/tests/e2e/settings-navigation.spec.ts
@@ -33,11 +33,81 @@ test.describe("Settings Navigation", () => {
   test("should navigate back to matrix from settings", async ({ page }) => {
     await matrixPage.openSettings();
     await page.waitForTimeout(500);
-    
+
     await matrixPage.openMatrix();
-    
+
     // Verify we're back on matrix page
     await expect(page.locator("[data-testid='matrix-grid']")).toBeVisible();
     await expect(page.url()).toContain("/");
+  });
+
+  test("should navigate between settings sections", async ({ page }) => {
+    await matrixPage.openSettings();
+
+    // Default section is Appearance — the section heading lives in the SectionCard
+    await expect(page.locator("main h2", { hasText: "Appearance" })).toBeVisible();
+
+    // Click into Notifications via the sidebar (use the desktop nav for stability)
+    await page.locator("aside.lg\\:block").getByRole("button", { name: "Notifications" }).click();
+    await expect(page).toHaveURL(/#notifications$/);
+    await expect(page.locator("main h2", { hasText: "Notifications" })).toBeVisible();
+
+    // Click into Data & Storage
+    await page.locator("aside.lg\\:block").getByRole("button", { name: "Data & Storage" }).click();
+    await expect(page).toHaveURL(/#data$/);
+    await expect(page.locator("main h2", { hasText: "Data & Storage" })).toBeVisible();
+
+    // Back to Appearance
+    await page.locator("aside.lg\\:block").getByRole("button", { name: "Appearance" }).click();
+    await expect(page).toHaveURL(/#appearance$/);
+    await expect(page.locator("main h2", { hasText: "Appearance" })).toBeVisible();
+  });
+
+  test("should change theme via appearance settings", async ({ page }) => {
+    await matrixPage.openSettings();
+
+    const darkBtn = page.getByRole("button", { name: "Dark", exact: true });
+    const lightBtn = page.getByRole("button", { name: "Light", exact: true });
+
+    await darkBtn.click();
+    await expect(darkBtn).toHaveAttribute("aria-pressed", "true");
+    await expect(lightBtn).toHaveAttribute("aria-pressed", "false");
+    // next-themes applies the class on <html>
+    await expect(page.locator("html")).toHaveClass(/dark/);
+
+    await lightBtn.click();
+    await expect(lightBtn).toHaveAttribute("aria-pressed", "true");
+    await expect(page.locator("html")).not.toHaveClass(/dark/);
+  });
+
+  test("should toggle show-completed setting", async ({ page }) => {
+    await matrixPage.openSettings();
+
+    // The Show Completed switch sits in the SettingsRow labeled "Show completed"
+    const showCompletedSwitch = page.getByRole("switch").first();
+    const initialChecked = await showCompletedSwitch.getAttribute("aria-checked");
+
+    await showCompletedSwitch.click();
+    const flippedChecked = await showCompletedSwitch.getAttribute("aria-checked");
+    expect(flippedChecked).not.toBe(initialChecked);
+
+    // Toggle back
+    await showCompletedSwitch.click();
+    await expect(showCompletedSwitch).toHaveAttribute("aria-checked", initialChecked ?? "false");
+  });
+
+  test("should trigger export download", async ({ page }) => {
+    await matrixPage.createTask("Task to export");
+    await matrixPage.openSettings();
+
+    // Navigate to Data & Storage section where Export lives
+    await page.locator("aside.lg\\:block").getByRole("button", { name: "Data & Storage" }).click();
+    await expect(page.locator("main h2", { hasText: "Data & Storage" })).toBeVisible();
+
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: /Export tasks/ }).click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toMatch(/^gsd-tasks-.*\.json$/);
   });
 });

--- a/tests/e2e/settings-navigation.spec.ts
+++ b/tests/e2e/settings-navigation.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "./fixtures/test-fixtures";
+import { MatrixPage } from "./pages/matrix-page";
+import { waitForAppLoad } from "./helpers/test-helpers";
+
+test.describe("Settings Navigation", () => {
+  let matrixPage: MatrixPage;
+
+  test.beforeEach(async ({ page, clearIndexedDB }) => {
+    matrixPage = new MatrixPage(page);
+    await matrixPage.goto();
+    await waitForAppLoad(page);
+  });
+
+  test("should open settings page", async ({ page }) => {
+    await matrixPage.openSettings();
+    
+    // Verify we're on settings page
+    await expect(page.url()).toContain("/settings");
+    
+    // Verify settings page content is visible (use main h1 to avoid banner h1)
+    await expect(page.locator("main h1")).toContainText("Settings");
+  });
+
+  test("should display settings navigation", async ({ page }) => {
+    await matrixPage.openSettings();
+    
+    // Verify navigation is still visible
+    await expect(page.locator("[data-testid='nav-settings']")).toBeVisible();
+    await expect(page.locator("[data-testid='nav-matrix']")).toBeVisible();
+    await expect(page.locator("[data-testid='nav-dashboard']")).toBeVisible();
+  });
+
+  test("should navigate back to matrix from settings", async ({ page }) => {
+    await matrixPage.openSettings();
+    await page.waitForTimeout(500);
+    
+    await matrixPage.openMatrix();
+    
+    // Verify we're back on matrix page
+    await expect(page.locator("[data-testid='matrix-grid']")).toBeVisible();
+    await expect(page.url()).toContain("/");
+  });
+});

--- a/tests/e2e/task-crud.spec.ts
+++ b/tests/e2e/task-crud.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from "./fixtures/test-fixtures";
+import { MatrixPage } from "./pages/matrix-page";
+import { waitForAppLoad } from "./helpers/test-helpers";
+
+test.describe("Task CRUD Operations", () => {
+  let matrixPage: MatrixPage;
+
+  test.beforeEach(async ({ page, clearIndexedDB }) => {
+    matrixPage = new MatrixPage(page);
+    await matrixPage.goto();
+    await waitForAppLoad(page);
+  });
+
+  test("should create a new task via capture bar", async ({ page }) => {
+    const initialCount = await matrixPage.getTaskCount();
+    await matrixPage.createTask("Test task for e2e");
+    
+    const newCount = await matrixPage.getTaskCount();
+    expect(newCount).toBe(initialCount + 1);
+    
+    // Verify the task appears in the matrix
+    const taskCard = page.locator("[data-testid='task-card']").filter({ hasText: "Test task for e2e" });
+    await expect(taskCard).toBeVisible();
+  });
+
+  test("should read and display task details", async ({ page }) => {
+    await matrixPage.createTask("Task to read");
+    
+    const taskCard = page.locator("[data-testid='task-card']").filter({ hasText: "Task to read" });
+    await expect(taskCard).toBeVisible();
+    
+    // Verify task title is displayed
+    await expect(taskCard).toContainText("Task to read");
+  });
+
+  test("should complete a task", async ({ page }) => {
+    await matrixPage.createTask("Task to complete");
+    
+    const initialCount = await matrixPage.getTaskCount();
+    
+    await matrixPage.completeTask("Task to complete");
+    
+    // By default, completed tasks are hidden, so count should decrease
+    const newCount = await matrixPage.getTaskCount();
+    expect(newCount).toBe(initialCount - 1);
+  });
+
+  test("should delete a task", async ({ page }) => {
+    await matrixPage.createTask("Task to delete");
+    
+    const initialCount = await matrixPage.getTaskCount();
+    expect(initialCount).toBeGreaterThan(0);
+    
+    await matrixPage.deleteTask("Task to delete");
+    
+    const newCount = await matrixPage.getTaskCount();
+    expect(newCount).toBe(initialCount - 1);
+    
+    // Verify the task is no longer visible
+    const taskCard = page.locator("[data-testid='task-card']").filter({ hasText: "Task to delete" });
+    await expect(taskCard).not.toBeVisible();
+  });
+
+  test("should create multiple tasks", async ({ page }) => {
+    const initialCount = await matrixPage.getTaskCount();
+    
+    await matrixPage.createTask("First task");
+    await matrixPage.createTask("Second task");
+    await matrixPage.createTask("Third task");
+    
+    const newCount = await matrixPage.getTaskCount();
+    expect(newCount).toBe(initialCount + 3);
+    
+    // Verify all tasks are visible
+    await expect(page.locator("[data-testid='task-card']").filter({ hasText: "First task" })).toBeVisible();
+    await expect(page.locator("[data-testid='task-card']").filter({ hasText: "Second task" })).toBeVisible();
+    await expect(page.locator("[data-testid='task-card']").filter({ hasText: "Third task" })).toBeVisible();
+  });
+});

--- a/tests/e2e/task-crud.spec.ts
+++ b/tests/e2e/task-crud.spec.ts
@@ -45,6 +45,34 @@ test.describe("Task CRUD Operations", () => {
     expect(newCount).toBe(initialCount - 1);
   });
 
+  test("should update task title, description, and quadrant", async ({ page }) => {
+    await matrixPage.createTask("Original title");
+
+    // Task defaults to Q4 (not urgent, not important) since no flags were set
+    await expect(
+      page.locator("[data-testid='quadrant-q4'] [data-testid='task-card']").filter({ hasText: "Original title" })
+    ).toBeVisible();
+
+    await matrixPage.openEditDrawer("Original title");
+    await matrixPage.saveEditDrawer({
+      title: "Updated title",
+      description: "Now with details",
+      quadrant: "q1",
+    });
+
+    // Updated card now lives in Q1 with the new title and description
+    const updatedCard = page
+      .locator("[data-testid='quadrant-q1'] [data-testid='task-card']")
+      .filter({ hasText: "Updated title" });
+    await expect(updatedCard).toBeVisible();
+    await expect(updatedCard).toContainText("Now with details");
+
+    // Original title is gone everywhere
+    await expect(
+      page.locator("[data-testid='task-card']").filter({ hasText: "Original title" })
+    ).toHaveCount(0);
+  });
+
   test("should delete a task", async ({ page }) => {
     await matrixPage.createTask("Task to delete");
     


### PR DESCRIPTION
## Summary

Builds out the Playwright end-to-end test suite specified in `tasks/e2e-testing-spec.md`, targeting the v9 single-matrix shell. Includes the initial scaffold (`9b43510`), gap-closing work (`1e03e71`), and a drive-by icon-rail typecheck fix (`c8ec030`).

- **Coverage:** 36 tests (12 new in the latest commit), all green on chromium. Covers task CRUD (incl. update via edit drawer), quadrant classification using real capture-parser tokens, intra-app navigation, title/tag search, and settings (section nav, theme, show-completed, export download).
- **Fixture fix:** `clearIndexedDB` previously targeted the wrong Dexie database (`gsd-taskmanager` vs the real `GsdTaskManager`) and ran teardown rather than setup. Both fixed; tests previously passed by accident because Playwright contexts are isolated per test.
- **Broken assertion removed:** the original `should display task count in each quadrant` test created tasks with `!important` / `!urgent` literals — the capture parser only matches space-bounded `!!`, `*`, `!`, so all four "different quadrant" tasks silently landed in Q4. Replaced with four focused classification tests plus a move-between-quadrants test.
- **v9 gaps documented, not faked:** smart-views, subtask search, and archive navigation assume UI affordances ADR 0011 removed. Captured in `tests/e2e/README.md` and `tasks/todo.md` #6. Stale `useSmartViewShortcuts` reference dropped from `CLAUDE.md`.
- **Component changes are testid-only** in `edit-drawer.tsx` — no behavioral diff.
- **`icon-rail.tsx` typecheck fix:** `ROUTE_TEST_IDS` was typed `Record<RouteKey, string>` but never held an `INSTALL` entry (the rail only renders PRIMARY routes). Narrowed to `Partial<Record<…>>`.

## Known follow-ups

- Webkit can flake under parallel multi-browser local runs; all suites pass cleanly per-project. CI's `workers: 1` config avoids this.

## Test plan

- [x] `bun run test:e2e -- --project=chromium` — 34 passed
- [x] `bun run test:e2e -- --project=webkit tests/e2e/*.spec.ts` — passes per-project
- [x] `bun run test:e2e -- --project=firefox` — passes per-project
- [x] `bun lint` — clean
- [x] `bun typecheck` — clean
- [x] Manually open the edit drawer and confirm the new test IDs don't change behavior
- [x] CI runs the full matrix with `workers: 1` and 2 retries