### PR TITLE
fix(security): tranche 1 — bump next/hono, harden logger sanitizer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
         "dexie-react-hooks": "4.4.0",
         "lucide-react": "1.7.0",
         "nanoid": "5.1.7",
-        "next": "16.2.3",
+        "next": "16.2.6",
         "next-themes": "0.4.6",
         "pocketbase": "0.26.8",
         "react": "19.2.4",
@@ -34,7 +34,7 @@
         "zod": "4.3.6",
       },
       "devDependencies": {
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "4.2.2",
         "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "6.9.1",
@@ -48,7 +48,7 @@
         "@vitest/coverage-v8": "4.1.2",
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "9.39.4",
-        "eslint-config-next": "16.2.3",
+        "eslint-config-next": "16.2.6",
         "eslint-plugin-react-hooks": "7.0.1",
         "fake-indexeddb": "6.2.5",
         "jsdom": "29.0.1",
@@ -87,7 +87,7 @@
     "esbuild": ">=0.25.0",
     "express-rate-limit": ">=8.2.2",
     "flatted": ">=3.4.2",
-    "hono": ">=4.12.14",
+    "hono": ">=4.12.18",
     "js-yaml": ">=4.1.1",
     "minimatch": ">=3.1.3",
     "path-to-regexp": ">=8.4.0",
@@ -333,25 +333,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
-    "@next/env": ["@next/env@16.2.3", "", {}, "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA=="],
+    "@next/env": ["@next/env@16.2.6", "", {}, "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw=="],
 
-    "@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.2.3", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-nE/b9mht28XJxjTwKs/yk7w4XTaU3t40UHVAky6cjiijdP/SEy3hGsnQMPxmXPTpC7W4/97okm6fngKnvCqVaA=="],
+    "@next/eslint-plugin-next": ["@next/eslint-plugin-next@16.2.6", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-Z8l6o4JWKUl755x4R+wogD86KPeU+Ckw4K+SYG4kHeOJtRenDeK+OSbGcqZpDtbwn9DsJVdir2UxmwXuinUbUw=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.3", "", { "os": "win32", "cpu": "x64" }, "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -363,7 +363,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
 
-    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
+    "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -917,7 +917,7 @@
 
     "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
 
-    "eslint-config-next": ["eslint-config-next@16.2.3", "", { "dependencies": { "@next/eslint-plugin-next": "16.2.3", "eslint-import-resolver-node": "^0.3.6", "eslint-import-resolver-typescript": "^3.5.2", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-hooks": "^7.0.0", "globals": "16.4.0", "typescript-eslint": "^8.46.0" }, "peerDependencies": { "eslint": ">=9.0.0", "typescript": ">=3.3.1" }, "optionalPeers": ["typescript"] }, "sha512-Dnkrylzjof/Az7iNoIQJqD18zTxQZcngir19KJaiRsMnnjpQSVoa6aEg/1Q4hQC+cW90uTlgQYadwL1CYNwFWA=="],
+    "eslint-config-next": ["eslint-config-next@16.2.6", "", { "dependencies": { "@next/eslint-plugin-next": "16.2.6", "eslint-import-resolver-node": "^0.3.6", "eslint-import-resolver-typescript": "^3.5.2", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsx-a11y": "^6.10.0", "eslint-plugin-react": "^7.37.0", "eslint-plugin-react-hooks": "^7.0.0", "globals": "16.4.0", "typescript-eslint": "^8.46.0" }, "peerDependencies": { "eslint": ">=9.0.0", "typescript": ">=3.3.1" }, "optionalPeers": ["typescript"] }, "sha512-z2ELYSkyrrJ6cuunTU8vhsT/RpouPkjaSah06nVW6Rg2Hpg0Vs8s497/e5s8G8qtdp4ccsiovz5P1rv+5VSW2Q=="],
 
     "eslint-import-resolver-node": ["eslint-import-resolver-node@0.3.9", "", { "dependencies": { "debug": "^3.2.7", "is-core-module": "^2.13.0", "resolve": "^1.22.4" } }, "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g=="],
 
@@ -1053,7 +1053,7 @@
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
-    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
+    "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
@@ -1263,7 +1263,7 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
-    "next": ["next@16.2.3", "", { "dependencies": { "@next/env": "16.2.3", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.3", "@next/swc-darwin-x64": "16.2.3", "@next/swc-linux-arm64-gnu": "16.2.3", "@next/swc-linux-arm64-musl": "16.2.3", "@next/swc-linux-x64-gnu": "16.2.3", "@next/swc-linux-x64-musl": "16.2.3", "@next/swc-win32-arm64-msvc": "16.2.3", "@next/swc-win32-x64-msvc": "16.2.3", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA=="],
+    "next": ["next@16.2.6", "", { "dependencies": { "@next/env": "16.2.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.6", "@next/swc-darwin-x64": "16.2.6", "@next/swc-linux-arm64-gnu": "16.2.6", "@next/swc-linux-arm64-musl": "16.2.6", "@next/swc-linux-x64-gnu": "16.2.6", "@next/swc-linux-x64-musl": "16.2.6", "@next/swc-win32-arm64-msvc": "16.2.6", "@next/swc-win32-x64-msvc": "16.2.6", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
@@ -1325,9 +1325,9 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
-    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
 
-    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
 
     "pocketbase": ["pocketbase@0.26.8", "", {}, "sha512-aQ/ewvS7ncvAE8wxoW10iAZu6ElgbeFpBhKPnCfvRovNzm2gW8u/sQNPGN6vNgVEagz44kK//C61oKjfa+7Low=="],
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN node scripts/generate-build-info.cjs \
     && bash -c 'source .build-env.sh && bunx --bun next build'
 
 # Download PocketBase in the Debian-based builder (avoids Alpine TLS issues)
-ARG POCKETBASE_VERSION=0.26.1
+ARG POCKETBASE_VERSION=0.26.9
 ARG TARGETARCH
 RUN apt-get update && apt-get install -y --no-install-recommends unzip curl ca-certificates \
     && curl -fsSL -o /tmp/pb.zip \

--- a/docker/README.md
+++ b/docker/README.md
@@ -95,7 +95,7 @@ Caddy will obtain and renew certificates from Let's Encrypt automatically.
 Override the default PocketBase version at build time:
 
 ```bash
-docker compose build --build-arg POCKETBASE_VERSION=0.25.6
+docker compose build --build-arg POCKETBASE_VERSION=0.26.9
 ```
 
 ## Data Persistence

--- a/docker/docker-setup-and-run.md
+++ b/docker/docker-setup-and-run.md
@@ -134,7 +134,7 @@ No more certificate warnings — the browser trusts the mkcert-issued certificat
 Override the default PocketBase version at build time:
 
 ```bash
-docker compose build --build-arg POCKETBASE_VERSION=0.25.6
+docker compose build --build-arg POCKETBASE_VERSION=0.26.9
 ```
 
 ## Data Persistence & Backups

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -136,6 +136,7 @@ function sanitizeMetadata(metadata?: LogMetadata): LogMetadata | undefined {
   const sensitivePatterns = [
     'token', 'password', 'secret', 'apikey', 'authorization',
     'passphrase', 'email', 'credential', 'cookie', 'session',
+    'jwt', 'refresh', 'access', 'bearer',
   ];
   for (const key of Object.keys(sanitized)) {
     const lower = key.toLowerCase();

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.1.3",
+	"version": "9.1.4",
 	"private": true,
 	"type": "module",
 	"scripts": {
@@ -41,7 +41,7 @@
 		"dexie-react-hooks": "4.4.0",
 		"lucide-react": "1.7.0",
 		"nanoid": "5.1.7",
-		"next": "16.2.3",
+		"next": "16.2.6",
 		"next-themes": "0.4.6",
 		"pocketbase": "0.26.8",
 		"react": "19.2.4",
@@ -52,7 +52,7 @@
 		"zod": "4.3.6"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.59.1",
+		"@playwright/test": "^1.60.0",
 		"@tailwindcss/postcss": "4.2.2",
 		"@testing-library/dom": "10.4.1",
 		"@testing-library/jest-dom": "6.9.1",
@@ -66,7 +66,7 @@
 		"@vitest/coverage-v8": "4.1.2",
 		"babel-plugin-react-compiler": "1.0.0",
 		"eslint": "9.39.4",
-		"eslint-config-next": "16.2.3",
+		"eslint-config-next": "16.2.6",
 		"eslint-plugin-react-hooks": "7.0.1",
 		"fake-indexeddb": "6.2.5",
 		"jsdom": "29.0.1",
@@ -90,7 +90,7 @@
 		"qs": ">=6.14.2",
 		"minimatch": ">=3.1.3",
 		"rollup": ">=4.59.0",
-		"hono": ">=4.12.14",
+		"hono": ">=4.12.18",
 		"undici": ">=7.24.0",
 		"flatted": ">=3.4.2",
 		"express-rate-limit": ">=8.2.2",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '9.1.3';
+const CACHE_VERSION = '9.1.4';
 const CACHE_NAME = `gsd-cache-v${CACHE_VERSION}`;
 const OFFLINE_ASSETS = [
 	"/",

--- a/tasks/security-review-2026-05-12.md
+++ b/tasks/security-review-2026-05-12.md
@@ -1,0 +1,392 @@
+# Security Review — May 2026 (Post-Inkwell)
+
+**Date:** 2026-05-12
+**Reviewer:** Claude Opus 4.7 (7-agent parallel audit + advisor reconcile)
+**Scope:** Full codebase since commit `e69591e` (May 6 security fix). Covers new Inkwell design system (#266), bookmarklet share-capture (#264), and current state of every attack surface.
+**Baseline:** All 10 findings from `security-review-may2026.md` confirmed fixed and intact.
+
+---
+
+## Executive Summary
+
+| Severity | Count | Notes |
+|---|---|---|
+| Critical | 0 | |
+| High (P1) | 7 | Includes 7 high-severity CVEs in `next` (single dep bump) |
+| Medium (P2) | 8 | |
+| Low (P3) | 9 | |
+| Informational | 4 | Accepted trade-offs / verification clears |
+
+The audit found **no critical vulnerabilities** and **no XSS sinks** in the application. All identified High items are either dependency CVEs (mechanical fix), MCP setup flow gaps that leak the auth token to the user's own terminal (no remote attacker required), or sync-layer privacy regressions on shared devices.
+
+---
+
+## P1 · High — Fix Before Next Release
+
+### P1-3 · MCP setup wizard echoes the auth token to stdout in plaintext
+
+**File:** `packages/mcp-server/src/cli/setup-wizard.ts:88-102`
+
+After `promptPassword` collects the token, the wizard prints the full JSON config block — including `GSD_AUTH_TOKEN` in plaintext — to stdout so the user can paste it into Claude Desktop config. The token then lives in terminal scrollback, in `script`/`tmux` logs, in any screen-share/screen-recording of the setup flow, and in `bash` history if redirected. The PocketBase token grants 14–30 days of full read/write/delete access to all of the user's tasks.
+
+**Fix:** Write the config snippet to `~/.gsd-mcp-setup.json` with `chmod 600` and tell the user to copy it. Or display the JSON with the token field redacted plus a separate "token is N chars, starts with X…" verification line.
+
+---
+
+### P1-4 · MCP `promptPassword` does not actually suppress echo
+
+**File:** `packages/mcp-server/src/cli/index.ts:137`
+
+```ts
+const originalMode = stdin.isTTY && stdin.setRawMode ? stdin.setRawMode(false) : null;
+```
+
+`setRawMode(false)` puts stdin into **cooked mode**, which is the mode that echoes characters as the user types. The comment claiming this disables echo is incorrect about Node.js TTY behavior. `rl.question()` does not suppress echo on its own. Combined with P1-3, the token is exposed twice in the same setup session.
+
+**Fix:** Replace with a real hidden-input implementation:
+```ts
+stdin.setRawMode(true);
+// then handle keypresses manually, print '*' (or nothing), break on '\r'
+```
+Or add `@inquirer/prompts` and use its `type: 'password'` input.
+
+---
+
+### P1-5 · `next@16.2.3` has 7 high-severity CVEs
+
+**File:** `package.json:44`
+
+`bun audit` reports SSRF, DoS, and middleware-bypass advisories for the pinned version. Even though this app is a static export (no server runtime), the dev server, build process, and any contributor running `bun dev` is exposed.
+
+**Fix:** Bump `next` to `16.2.6` (or current latest 16.2.x). Run `bun audit` after to confirm clearance.
+
+---
+
+### P1-6 · `hono` override is too loose; 5 advisories still apply
+
+**File:** `package.json:overrides`
+
+```jsonc
+"hono": ">=4.12.14"   // still vulnerable
+```
+
+Current resolution does not pull in the patch for JWT date-validation and cache-leak advisories.
+
+**Fix:** Tighten the override to `">=4.12.18"` (or latest 4.12.x). Run `bun install && bun audit`.
+
+---
+
+### P1-7 · OAuth provider has no runtime whitelist
+
+**File:** `lib/sync/pb-auth.ts:30-34`
+
+```ts
+export async function loginWithProvider(provider: OAuthProvider): Promise<AuthState> {
+  const authData = await pb.collection('users').authWithOAuth2({ provider });
+```
+
+`OAuthProvider` is a TypeScript type — erased at runtime. Any caller (XSS payload, future feature regression, console invocation) can pass an arbitrary provider string. The PocketBase server may have additional providers configured.
+
+**Fix:**
+```ts
+const ALLOWED_PROVIDERS = new Set<OAuthProvider>(['google', 'github']);
+if (!ALLOWED_PROVIDERS.has(provider)) {
+  throw new Error(`OAuth provider not allowed: ${provider}`);
+}
+```
+
+---
+
+### P1-8 · Sync history retained across logout (privacy leak on shared device)
+
+**File:** `lib/sync/config/disable.ts:31-51`
+
+`disableSync()` clears the sync queue and auth state but never touches `db.syncHistory`. After logout, the next user on the same browser sees up to 100 prior sync entries — timestamps, device IDs, push/pull counts, and error messages (which may contain task IDs via `recordAttemptFailure`). Important for self-hosted/kiosk deployments.
+
+**Fix:** Add to `resetSyncConfigState`:
+```ts
+const { clearHistory } = await import('@/lib/sync-history');
+await clearHistory();
+```
+
+---
+
+### P1-9 · Missing Cross-Origin-Opener-Policy for OAuth popup
+
+**File:** `docker/Caddyfile:24-32` (and CloudFront Response Headers Policy, not in repo)
+
+OAuth uses popup-based flow. Without `Cross-Origin-Opener-Policy: same-origin-allow-popups`, the popup retains a `window.opener` reference vulnerable to tabnabbing and cross-origin manipulation.
+
+**Fix:**
+```caddy
+header {
+    # ...existing headers
+    Cross-Origin-Opener-Policy "same-origin-allow-popups"
+    Cross-Origin-Resource-Policy "same-origin"
+}
+```
+Skip COEP — it would break OAuth popup `postMessage`. Apply equivalent change in the CloudFront policy.
+
+---
+
+### P1-10 · MCP `pocketBaseUrl` validator uses `startsWith` — bypassable
+
+**File:** `packages/mcp-server/src/server/config.ts:11-14`
+
+```ts
+url.startsWith('http://localhost') || url.startsWith('http://127.0.0.1')
+```
+
+`http://localhost.attacker.com` and `http://127.0.0.1.attacker.com` (DNS-resolvable on public infra) both pass the prefix check. If a user is tricked into setting `GSD_POCKETBASE_URL` to such a value, the auth token and all task content exfiltrates on every tool call.
+
+**Fix:**
+```ts
+.refine((u) => {
+  const parsed = new URL(u);
+  if (parsed.protocol === 'https:') return true;
+  return parsed.protocol === 'http:' &&
+    ['localhost', '127.0.0.1', '::1'].includes(parsed.hostname);
+}, { message: 'PocketBase URL must use HTTPS (except localhost for local dev)' })
+```
+
+---
+
+## P2 · Medium
+
+### P2-7 · Logger sanitizer misses `jwt`, `refresh`, `access`, `bearer` patterns
+
+**File:** `lib/logger.ts:136`
+
+`sensitivePatterns` covers `token`, `password`, `secret`, `apiKey`, `authorization`, `cookie` — but a metadata key named `jwt`, `refreshToken`, `accessToken`, or `bearerToken` would pass through. Recursion and case-insensitive matching are correct; only the keyword list is incomplete.
+
+**Fix:** Add `'jwt'`, `'refresh'`, `'access'`, `'bearer'` to the array. Verify with a test case.
+
+---
+
+### P2-8 · Sync queue persists raw error messages with task content
+
+**File:** `lib/sync/queue.ts:102-131` (writer), `lib/sync/pb-push.ts:115` (source)
+
+`recordAttemptFailure` writes `error.message` directly into `db.syncQueue.lastError` up to 500 chars. PocketBase 4xx responses echo the request payload back (e.g. validation messages including field values), so task titles/descriptions can land in the persisted error field.
+
+**Fix:** Replace raw `error.message` with the categorized code from `error-categorizer.ts` (e.g. `'validation_failed'`, `'unauthorized'`, `'rate_limited'`).
+
+---
+
+### P2-9 · Echo filter fails closed if `currentDeviceId` is null
+
+**File:** `lib/sync/pb-realtime.ts:66`, `lib/sync/pb-sync-helpers.ts:49`
+
+If the realtime subscription opens before `currentDeviceId` is set (race during cold start), and a remote record has empty/null `device_id` (legacy data), the strict-equality check filters all events as echoes, silently breaking realtime sync.
+
+**Fix:**
+```ts
+if (record.device_id && currentDeviceId && record.device_id === currentDeviceId) {
+  // skip own-device echo
+}
+```
+Also assert `currentDeviceId` is non-null before calling `subscribe`.
+
+---
+
+### P2-10 · No max-retry cap on user-triggered sync (429 amplification)
+
+**File:** `lib/sync/retry-manager.ts:71-78`, `lib/sync/sync-coordinator.ts:58-72`
+
+`shouldRetry()` blocks auto-sync after `MAX_RETRIES`, but user-triggered syncs bypass that gate. A 429-flapping server lets a user retry repeatedly, each attempt running a full queue push at 100ms throttle.
+
+**Fix:** Detect HTTP 429 in `pb-push.ts`, parse `Retry-After`, abort the push loop early. Apply the auto-sync retry cap to user-triggered syncs after N consecutive 429s.
+
+---
+
+### P2-11 · `bulk_update_tasks` accepts caller-supplied `maxTasks` and has no dry-run default for deletes
+
+**File:** `packages/mcp-server/src/write-ops/bulk-operations.ts:82`, `packages/mcp-server/src/tools/handlers/input-schemas.ts:148-155`
+
+`maxTasks` is an open positive integer in the input schema. `bulkUpdateTasks` uses `options?.maxTasks ?? 50` as the ceiling — the caller (LLM) controls the limit it would be compared against. The 50-id Zod cap on `taskIds` saves the day today, but the design puts the policy ceiling in the wrong place. Additionally, destructive `operation.type === 'delete'` has no `dryRun: true` default, so a confused LLM call can wipe up to 50 tasks per invocation with no preview.
+
+**Fix:**
+1. Remove `maxTasks` from the tool input schema; make it a server-side constant.
+2. Default `dryRun: true` for deletes; require explicit `dryRun: false` to actually delete.
+3. Cap deletes at 10 per call.
+
+---
+
+### P2-12 · WebMCP `create_task` schema missing `maxItems` on tags and `additionalProperties: false`
+
+**File:** `components/webmcp-register.tsx:68-72`
+
+```ts
+tags: { type: "array", items: { type: "string", minLength: 1, maxLength: 32 } }
+// no maxItems
+// inputSchema lacks additionalProperties: false at root
+```
+
+The Zod schema in `createTask()` enforces `MAX_TAGS = 20`, but the WebMCP JSON Schema doesn't declare it. AI will generate >20 tags and hit a Zod error instead of a clear schema constraint. Same pattern as P3-4 in the previous review.
+
+**Fix:** Add `maxItems: SCHEMA_LIMITS.MAX_TAGS` and `additionalProperties: false` to `inputSchema`.
+
+---
+
+### P2-13 · CloudFront Response Headers Policy not in version control (drift risk)
+
+**File:** `cloudfront-function-response-headers.cjs:18-20` (references external `gsd-security-headers` policy)
+
+The authoritative production CSP/HSTS/etc. lives in an AWS-managed Response Headers Policy that is not in the repo and not deployed by `scripts/deploy-cloudfront-function.sh`. No mechanism exists to diff CloudFront's live policy against the Caddyfile or `SECURITY.md` to detect drift.
+
+**Fix:** Codify in `deploy-cloudfront-function.sh` via `aws cloudfront create-response-headers-policy --response-headers-policy-config file://...`, or move to CDK/Terraform. Add a CI assertion comparing the two configurations.
+
+---
+
+### P2-14 · Docker `POCKETBASE_VERSION` lags client SDK
+
+**File:** `docker/Dockerfile:28`
+
+`ARG POCKETBASE_VERSION=0.26.1` while the client SDK in `package.json` is `0.26.8` (and 0.26.9 is available). Patch-level drift can produce subtle auth/realtime bugs in self-hosted deployments.
+
+**Fix:** Bump to `0.26.9`. Verify against PocketBase changelog. Also update `docker/README.md` and `docker/docker-setup-and-run.md` examples that still show `0.25.6`.
+
+---
+
+## P3 · Low
+
+### P3-6 · `device_id` not validated on inbound realtime records
+
+`lib/sync/pb-realtime.ts:66-92` — Zod schema should include `device_id: z.string()`.
+
+### P3-7 · `import-dialog.tsx` re-parses JSON without size guard
+
+`components/import-dialog.tsx:26-37` — practical exposure is small (caller `settings-page` enforces 10MB) but the dialog is a public component with no documented precondition. Call `importPayloadSchema.safeParse` (or `Array.isArray(parsed.tasks)`) before reading `.length`.
+
+### P3-8 · `getDescriptionSegments` no defensive length cap
+
+`lib/task-description.tsx` (`getDescriptionSegments`) — Zod bounds the field at `TASK_DESCRIPTION_MAX_LENGTH`, but a defensive `description.slice(0, MAX)` at the top of the segmenter protects against any future bypass.
+
+### P3-9 · CloudFront URL rewrite: no `..` / control-char validation
+
+`cloudfront-function-url-rewrite.cjs:25-29` — defensive validation is cheap. Reject URIs containing `\r`, `\n`, `\0`, or `..` before appending `/index.html`.
+
+### P3-10 · `Permissions-Policy` underspecified
+
+`docker/Caddyfile:29` — locks 4 directives; should also disable `usb, serial, hid, bluetooth, accelerometer, gyroscope, magnetometer, midi, browsing-topics, interest-cohort, display-capture, encrypted-media, autoplay`.
+
+### P3-11 · MCP error messages echo full PocketBase URL
+
+`packages/mcp-server/src/api/client.ts:52-60`, `tools/list-tasks.ts:72-80` — for users with private self-hosted PocketBase URLs, errors leak the host verbatim. If MCP error output is ever forwarded outside the user's machine (shared chat logs), the URL is disclosed. Redact host in user-facing error strings.
+
+### P3-12 · Caddy `-X-Powered-By` header not stripped
+
+`docker/Caddyfile:31` — Caddy strips `Server` but upstream PocketBase may add `X-Powered-By`. Cosmetic; add `-X-Powered-By` to the header block.
+
+### P3-13 · Service worker SPA fallback returns `/` for any failed path
+
+`public/sw.js:96-108` — acceptable for this app (no sensitive paths), flagged only for future codebase reuse.
+
+### P3-14 · Service worker network-first HTML cache lacks `response.type === 'basic'` check
+
+`public/sw.js:81-93` — opaque/cors HTML cannot currently reach this path (sw skips cross-origin on line 62), so this is defensive hardening only.
+
+---
+
+## Informational — Verified Clean
+
+- **No XSS sinks anywhere.** No raw-HTML injection sinks, no `eval`, no dynamic `Function()` constructor, no string-form `setTimeout`, no `srcDoc`, no `javascript:` href injection. URL allowlist (`sanitizeHttpUrl`) is consistently applied in `task-links.ts`, `share-capture.ts`, `capture-parser.ts`. The bookmarklet feature (#264) uses the existing allowlist correctly. Double-filtered: capture-time and render-time.
+- **No prototype pollution vector.** Every `JSON.parse` user-input path is wrapped by `importPayloadSchema.safeParse`. Zod produces a fresh object graph; spread operators in `regenerateConflictingIds` operate on already-validated records.
+- **No ReDoS.** All regexes (`URL_CANDIDATE_PATTERN`, tag/bang/star matchers) use single negated-character-class repetitions with no nested quantifiers.
+- **No shell-command injection in the MCP server.** No subprocess invocations, no `eval`, no dynamic `require` paths. The single `node:readline` import is a static module specifier.
+- **Owner enforcement is sound.** PocketBase API rules (`scripts/setup-pocketbase-collections.sh:49-53`) enforce `owner = @request.auth.id` on every operation. `taskRecordToPocketBase` writes `owner` from `getCurrentUserId()`, not from the local record. Forged owners on JSON import cannot bypass the server check.
+- **No secrets in working tree.** `.env.local` is gitignored; sample data files contain only fictional content.
+
+---
+
+## Findings the audit considered but did NOT carry forward
+
+These were raised by individual sub-agents but rejected after verification or as out-of-scope per architecture:
+
+- **Caddyfile `connect-src 'self'`** — intentional for the documented single-origin Docker/Caddy setup. Not a vulnerability.
+- **SW HTML cache lifetime** — static-export HTML has no per-user data. Informational only (covered as P3-14 defensive note).
+- **SPA fallback to `/`** — acceptable for this app.
+- **gitleaks historic JWT** — `exp 2025-10-22` (already expired). PII (email in payload) is the only residual concern, and the working tree is clean. Decision logged below; no code change.
+
+---
+
+## Open Decision: Historic JWT in Git History
+
+A `gitleaks-report.json` from October 2025 flagged a real JWT for `vscarpenter@gmail.com` in commit `f3e5edf`. The token is expired (`exp 2025-10-22`); the working tree is clean (file was renamed to `.example`). Three options:
+
+1. **Accept and document** — add an allowlist entry to `.gitleaksignore` documenting the expired token. Lowest effort, residual: email PII in git history.
+2. **Rewrite history** with `git filter-repo` — removes the expired token and 34 other historical findings, but rewrites every commit hash after `f3e5edf`. High coordination cost (every clone needs to re-clone). Recommended only if there's a separate reason to rewrite (e.g. a never-expired credential).
+3. **Public-disclosure note in `SECURITY.md`** — acknowledge the history publicly with a date and an "expired, no action needed" line.
+
+Recommended: **Option 1**. Token is expired; PII risk is acceptable for a public personal repo where the maintainer's email is already in `git log` author headers.
+
+---
+
+## Remediation Plan (Tranches)
+
+Suggested order and grouping. Each tranche is a self-contained PR with its own test pass.
+
+### Tranche 1 — Dependencies & Logger (no behavioral risk)
+- P1-5: Bump `next` to `16.2.6`
+- P1-6: Tighten `hono` override to `>=4.12.18`
+- P2-14: Bump Docker `POCKETBASE_VERSION` to `0.26.9`
+- P2-7: Add `jwt|refresh|access|bearer` to `lib/logger.ts` sensitive patterns + test
+
+**Risk:** very low. Run `bun audit`, `bun typecheck`, `bun lint`, `bun run test`. Build verifies static export.
+
+### Tranche 2 — MCP Server (single package, well-tested surface)
+- P1-3: Setup wizard writes config file with `chmod 600` instead of stdout
+- P1-4: Real hidden-input password prompt
+- P1-10: Hostname pinning (`URL.hostname` exact match for localhost)
+- P2-11: Remove caller-supplied `maxTasks`; default `dryRun: true` for deletes; delete cap = 10
+- P3-11: Redact PB URL in user-facing MCP errors
+
+**Risk:** isolated to `packages/mcp-server`. Add tests for the new validators.
+
+### Tranche 3 — Sync Layer (behavioral changes — needs thorough testing)
+- P1-7: OAuth provider runtime whitelist (`Set<OAuthProvider>`)
+- P1-8: Clear `syncHistory` on logout
+- P2-8: Replace raw `error.message` with categorized codes in sync queue
+- P2-9: Strengthen echo filter against null/empty `device_id`
+- P2-10: 429 handling — parse `Retry-After`, cap user-triggered retries
+- P3-6: Add `device_id: z.string()` to inbound Zod schema
+
+**Risk:** highest. OAuth flow change especially needs a manual end-to-end test with Google and GitHub. The error-message change has a downstream user-facing impact on sync history display.
+
+### Tranche 4 — Headers & Infrastructure
+- P1-9: Add COOP/CORP to `docker/Caddyfile` and CloudFront policy
+- P2-13: Codify CloudFront Response Headers Policy in deploy script (or CDK)
+- P3-9: CloudFront URL rewrite path validation
+- P3-10: Expand `Permissions-Policy` directives
+- P3-12: Strip `X-Powered-By`
+
+**Risk:** changes touch deployment infrastructure. COOP needs a real OAuth popup test post-deploy.
+
+### Tranche 5 — Defensive Hardening (P3 cleanups; bundle as one)
+- P2-12: WebMCP `maxItems` + `additionalProperties: false`
+- P3-7: Validate JSON shape in `import-dialog.tsx` before reading `.length`
+- P3-8: Defensive `slice` in `getDescriptionSegments`
+- P3-13, P3-14: SW comments / documentation
+
+**Risk:** low.
+
+---
+
+## Validation Commands
+
+```bash
+bun audit                       # zero high after Tranche 1
+bun typecheck                   # passes after every tranche
+bun lint                        # passes after every tranche
+bun run test                    # full suite + new tests for each tranche
+bun run build                   # static export builds clean
+cd packages/mcp-server && bun audit   # zero high
+```
+
+Manual verification after Tranche 3: OAuth login with Google AND GitHub from a clean browser profile. Manual verification after Tranche 4: confirm CSP/COOP headers in deployed environment using `curl -I`.
+
+---
+
+## Acknowledgments
+
+7 parallel sub-agents covered: prior-finding verification, XSS surface, MCP server, sync/auth, headers/deployment, import/export parsing, and dependencies/secrets. Advisor reconciliation flagged 3 findings to downgrade (kept here as informational rejects) and 2 to verify before treating as High (both confirmed real after direct file inspection).

--- a/tests/data/logger.test.ts
+++ b/tests/data/logger.test.ts
@@ -375,6 +375,57 @@ describe("Logger module", () => {
 			expect(metadata.passphrase).toBe("***");
 		});
 
+		it("should redact fields containing 'jwt'", () => {
+			const logger = createLogger("AUTH", "debug");
+			logger.info("auth event", { jwt: "eyJhbGciOiJIUzI1NiJ9.payload.sig" });
+
+			const logObject = consoleLogSpy.mock.calls[0][1] as Record<
+				string,
+				unknown
+			>;
+			const metadata = logObject.metadata as Record<string, unknown>;
+			expect(metadata.jwt).toBe("***");
+		});
+
+		it("should redact fields containing 'refresh' (standalone, e.g. refreshExpiry)", () => {
+			const logger = createLogger("AUTH", "debug");
+			// 'refreshExpiry' does NOT contain 'token' — must match on 'refresh' alone
+			logger.info("oauth", { refreshExpiry: "rfsh-abc-123" });
+
+			const logObject = consoleLogSpy.mock.calls[0][1] as Record<
+				string,
+				unknown
+			>;
+			const metadata = logObject.metadata as Record<string, unknown>;
+			expect(metadata.refreshExpiry).toBe("***");
+		});
+
+		it("should redact fields containing 'access' (standalone, e.g. accessGrant)", () => {
+			const logger = createLogger("AUTH", "debug");
+			// 'accessGrant' does NOT contain 'token' — must match on 'access' alone
+			logger.info("oauth", { accessGrant: "acc-xyz-789" });
+
+			const logObject = consoleLogSpy.mock.calls[0][1] as Record<
+				string,
+				unknown
+			>;
+			const metadata = logObject.metadata as Record<string, unknown>;
+			expect(metadata.accessGrant).toBe("***");
+		});
+
+		it("should redact fields containing 'bearer' (standalone, e.g. bearerScheme)", () => {
+			const logger = createLogger("AUTH", "debug");
+			// 'bearerScheme' does NOT contain 'token' — must match on 'bearer' alone
+			logger.info("header", { bearerScheme: "abc-bearer-value" });
+
+			const logObject = consoleLogSpy.mock.calls[0][1] as Record<
+				string,
+				unknown
+			>;
+			const metadata = logObject.metadata as Record<string, unknown>;
+			expect(metadata.bearerScheme).toBe("***");
+		});
+
 		it("should perform case-insensitive key matching for sanitization", () => {
 			const logger = createLogger("AUTH", "debug");
 			logger.info("mixed case", {


### PR DESCRIPTION
## Summary

Tranche 1 of 5 from the [May 2026 security review](../blob/fix/security-tranche-1-deps-logger/tasks/security-review-2026-05-12.md). Scope: dependency CVEs and logger sanitizer. No behavioral changes; lowest-risk tranche to land first.

- **P1-5**: Bump `next` 16.2.3 → 16.2.6 (clears 7 high-severity advisories: SSRF, DoS, middleware bypass)
- **P1-6**: Tighten `hono` override `>=4.12.14` → `>=4.12.18` (clears JWT date-validation + cache-leak advisories)
- **P2-7**: Add `jwt`, `refresh`, `access`, `bearer` to `lib/logger.ts` sensitive-pattern list so OAuth artefact key names are redacted (TDD: 4 red tests, then green)
- **P2-14**: Bump Docker `POCKETBASE_VERSION` 0.26.1 → 0.26.9 to match the 0.26.8 client SDK; `docker/README.md` and `docker/docker-setup-and-run.md` examples updated in lockstep

`bun audit` went from **22 vulns (9 high)** to **4 vulns (2 high, 2 moderate)**. The two remaining `high`s (`fast-uri`, `ip-address`) are transitive via `@modelcontextprotocol/sdk` and ship with Tranche 2 alongside the MCP server hardening.

The full security review and the 4-tranche remediation plan are in `tasks/security-review-2026-05-12.md`.

## Test plan

- [x] `bun audit` — confirmed reduction from 22 → 4 vulns; zero `next`/`hono` advisories remain
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun run test` — 1833 unit/data tests pass (5 pre-existing e2e config failures unchanged from `main`; the 4 new logger sanitizer tests pass)
- [x] `bun run build` — static export builds cleanly under `next 16.2.6`
- [ ] Reviewer: confirm `next-env.d.ts` path drift (`/.next/dev/types/` → `/.next/types/`) is acceptable; this was already pending in the working tree before this PR
- [ ] After merge: run `bun audit` on `main` to confirm parity