### PR TITLE
fix(security): tranche 2 — MCP server hardening (setup, hostname, bulk-delete)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -62,12 +62,12 @@
     },
     "packages/mcp-server": {
       "name": "gsd-mcp-server",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "bin": {
         "gsd-mcp-server": "dist/index.js",
       },
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.27.1",
+        "@modelcontextprotocol/sdk": "1.29.0",
         "pocketbase": "0.26.8",
         "zod": "4.3.6",
       },
@@ -86,12 +86,15 @@
     "brace-expansion": ">=5.0.5",
     "esbuild": ">=0.25.0",
     "express-rate-limit": ">=8.2.2",
+    "fast-uri": ">=3.1.2",
     "flatted": ">=3.4.2",
     "hono": ">=4.12.18",
+    "ip-address": ">=10.2.0",
     "js-yaml": ">=4.1.1",
     "minimatch": ">=3.1.3",
     "path-to-regexp": ">=8.4.0",
     "picomatch": ">=4.0.4",
+    "postcss": ">=8.5.14",
     "qs": ">=6.14.2",
     "rollup": ">=4.59.0",
     "undici": ">=7.24.0",
@@ -329,7 +332,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
@@ -973,7 +976,7 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -1079,7 +1082,7 @@
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
-    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
@@ -1333,7 +1336,7 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -1659,8 +1662,6 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@tailwindcss/postcss/postcss": ["postcss@8.5.13", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag=="],
-
     "@testing-library/jest-dom/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
@@ -1729,8 +1730,6 @@
 
     "make-dir/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
-    "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
-
     "path-scurry/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
@@ -1744,8 +1743,6 @@
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
-
-    "vite/postcss": ["postcss@8.5.13", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag=="],
 
     "vitest/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
@@ -1762,8 +1759,6 @@
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
-
-    "@tailwindcss/postcss/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "@vitest/ui/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@4.0.18", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw=="],
 
@@ -1797,14 +1792,6 @@
 
     "gsd-mcp-server/vitest/tinyrainbow": ["tinyrainbow@3.0.3", "", {}, "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="],
 
-    "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
-    "vite/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
-    "vitest/vite/postcss": ["postcss@8.5.13", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag=="],
-
     "vitest/vite/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
-
-    "vitest/vite/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.1.4",
+	"version": "9.1.5",
 	"private": true,
 	"type": "module",
 	"scripts": {
@@ -95,7 +95,10 @@
 		"flatted": ">=3.4.2",
 		"express-rate-limit": ">=8.2.2",
 		"path-to-regexp": ">=8.4.0",
-		"picomatch": ">=4.0.4"
+		"picomatch": ">=4.0.4",
+		"fast-uri": ">=3.1.2",
+		"ip-address": ">=10.2.0",
+		"postcss": ">=8.5.14"
 	},
 	"license": "MIT"
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-mcp-server",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "MCP server for GSD Task Manager — 20 tools for task CRUD, analytics, and diagnostics over PocketBase. Validated inputs, dry-run support, JWT-aware token health, and dependency-safe deletes.",
   "type": "module",
   "main": "dist/index.js",
@@ -75,7 +75,7 @@
     "url": "https://github.com/vscarpenter/gsd-task-manager/issues"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.27.1",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "pocketbase": "0.26.8",
     "zod": "4.3.6"
   },

--- a/packages/mcp-server/src/__tests__/api/client.test.ts
+++ b/packages/mcp-server/src/__tests__/api/client.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
+import type { GsdConfig } from '../../types.js';
+
+// Mock retry so we can throw and inspect the error message.
+vi.mock('../../api/retry.js', async () => {
+  const actual = await vi.importActual<typeof import('../../api/retry.js')>(
+    '../../api/retry.js'
+  );
+  return {
+    ...actual,
+    fetchWithRetry: vi.fn(),
+  };
+});
+
+import { apiRequest, redactPocketBaseHost } from '../../api/client.js';
+import { fetchWithRetry } from '../../api/retry.js';
+
+const schema = z.object({ ok: z.boolean() });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('redactPocketBaseHost', () => {
+  it('redacts the hostname from an https URL', () => {
+    expect(redactPocketBaseHost('https://api.vinny.io')).toBe(
+      'https://[pocketbase-host]'
+    );
+  });
+
+  it('redacts the hostname and port from an http URL', () => {
+    expect(redactPocketBaseHost('http://localhost:8090')).toBe(
+      'http://[pocketbase-host]'
+    );
+  });
+
+  it('returns a stable placeholder if the URL is unparseable', () => {
+    expect(redactPocketBaseHost('not a url')).toBe('[pocketbase-host]');
+  });
+});
+
+describe('apiRequest error messages', () => {
+  it('redacts the PocketBase host in network-error messages', async () => {
+    vi.mocked(fetchWithRetry).mockRejectedValueOnce(new Error('connect ECONNREFUSED'));
+
+    const config: GsdConfig = {
+      pocketBaseUrl: 'https://api.vinny.io',
+      authToken: 'fake',
+    } as GsdConfig;
+
+    await expect(apiRequest(config, '/api/health', schema)).rejects.toThrow(
+      /\[pocketbase-host\]/
+    );
+    await expect(apiRequest(config, '/api/health', schema)).rejects.not.toThrow(
+      /api\.vinny\.io/
+    );
+  });
+
+  it('redacts the PocketBase host in non-2xx error messages', async () => {
+    vi.mocked(fetchWithRetry).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => 'server error',
+    } as Response);
+
+    const config: GsdConfig = {
+      pocketBaseUrl: 'https://api.vinny.io',
+      authToken: 'fake',
+    } as GsdConfig;
+
+    // The endpoint path is fine to leak — only the host is sensitive.
+    const error = await apiRequest(config, '/api/collections/tasks/records', schema).catch(
+      (e: Error) => e
+    );
+    expect((error as Error).message).not.toContain('api.vinny.io');
+  });
+});

--- a/packages/mcp-server/src/__tests__/server/config.test.ts
+++ b/packages/mcp-server/src/__tests__/server/config.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { configSchema } from '../../server/config.js';
+
+const validToken = 'a'.repeat(40);
+
+describe('configSchema URL validation', () => {
+  describe('accepts safe URLs', () => {
+    it('accepts https URLs', () => {
+      const result = configSchema.safeParse({
+        pocketBaseUrl: 'https://api.example.com',
+        authToken: validToken,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts http://localhost', () => {
+      const result = configSchema.safeParse({
+        pocketBaseUrl: 'http://localhost',
+        authToken: validToken,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts http://localhost with a port', () => {
+      const result = configSchema.safeParse({
+        pocketBaseUrl: 'http://localhost:8090',
+        authToken: validToken,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts http://127.0.0.1', () => {
+      const result = configSchema.safeParse({
+        pocketBaseUrl: 'http://127.0.0.1',
+        authToken: validToken,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts http://127.0.0.1 with a port', () => {
+      const result = configSchema.safeParse({
+        pocketBaseUrl: 'http://127.0.0.1:8090',
+        authToken: validToken,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts http://[::1] (IPv6 loopback)', () => {
+      const result = configSchema.safeParse({
+        pocketBaseUrl: 'http://[::1]:8090',
+        authToken: validToken,
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('rejects DNS subdomain bypass attempts', () => {
+    it('rejects http://localhost.attacker.com', () => {
+      const result = configSchema.safeParse({
+        pocketBaseUrl: 'http://localhost.attacker.com',
+        authToken: validToken,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects http://127.0.0.1.attacker.com', () => {
+      const result = configSchema.safeParse({
+        pocketBaseUrl: 'http://127.0.0.1.attacker.com',
+        authToken: validToken,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects http://localhost@attacker.com (userinfo trick)', () => {
+      const result = configSchema.safeParse({
+        pocketBaseUrl: 'http://localhost@attacker.com',
+        authToken: validToken,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects http://attacker.com#localhost (fragment trick)', () => {
+      const result = configSchema.safeParse({
+        pocketBaseUrl: 'http://attacker.com#localhost',
+        authToken: validToken,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('rejects plain http to non-loopback hosts', () => {
+    it('rejects http://api.example.com', () => {
+      const result = configSchema.safeParse({
+        pocketBaseUrl: 'http://api.example.com',
+        authToken: validToken,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects http://192.168.1.1 (private network, not loopback)', () => {
+      const result = configSchema.safeParse({
+        pocketBaseUrl: 'http://192.168.1.1',
+        authToken: validToken,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/packages/mcp-server/src/__tests__/tools/input-schemas.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/input-schemas.test.ts
@@ -126,6 +126,16 @@ describe('validateToolArgs', () => {
         })
       ).toThrow(/taskIds/);
     });
+
+    it('rejects caller-supplied maxTasks (policy lives server-side, not in input)', () => {
+      expect(() =>
+        validateToolArgs('bulk_update_tasks', {
+          taskIds: ['id1'],
+          operation: { type: 'delete' },
+          maxTasks: 9999,
+        })
+      ).toThrow(/maxTasks/);
+    });
   });
 
   describe('list_tasks', () => {

--- a/packages/mcp-server/src/__tests__/write-ops/bulk-operations.test.ts
+++ b/packages/mcp-server/src/__tests__/write-ops/bulk-operations.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { GsdConfig, Task } from '../../types.js';
+
+vi.mock('../../write-ops/helpers.js', async () => {
+  const actual = await vi.importActual<typeof import('../../write-ops/helpers.js')>(
+    '../../write-ops/helpers.js'
+  );
+  return {
+    ...actual,
+    getAuthInfo: vi.fn().mockResolvedValue({ ownerId: 'owner-1', deviceId: 'device-1' }),
+    fetchPBRecordIdsForTasks: vi.fn().mockResolvedValue(new Map()),
+    updateTaskInPBById: vi.fn().mockResolvedValue(undefined),
+    deleteTaskInPBById: vi.fn().mockResolvedValue(undefined),
+    sleep: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('../../tools/list-tasks.js', () => ({
+  listTasks: vi.fn(),
+}));
+
+vi.mock('../../cache.js', () => ({
+  getTaskCache: () => ({ invalidate: vi.fn() }),
+}));
+
+import { bulkUpdateTasks } from '../../write-ops/bulk-operations.js';
+
+const config: GsdConfig = {
+  pocketbaseUrl: 'http://example.invalid',
+  authToken: 'fake',
+} as GsdConfig;
+
+function makeTask(id: string): Task {
+  return {
+    id,
+    title: `task ${id}`,
+    description: '',
+    urgent: false,
+    important: false,
+    quadrant: 'not-urgent-not-important',
+    completed: false,
+    tags: [],
+    subtasks: [],
+    recurrence: 'none',
+    dependencies: [],
+    createdAt: '2026-04-01T00:00:00Z',
+    updatedAt: '2026-04-01T00:00:00Z',
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('bulkUpdateTasks — delete safety', () => {
+  it('defaults dryRun to true for delete operations when not specified', async () => {
+    const { listTasks } = await import('../../tools/list-tasks.js');
+    const helpers = await import('../../write-ops/helpers.js');
+    vi.mocked(listTasks).mockResolvedValueOnce([makeTask('t1'), makeTask('t2')]);
+
+    const result = await bulkUpdateTasks(config, ['t1', 't2'], { type: 'delete' });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.deleted).toBe(2);
+    expect(helpers.deleteTaskInPBById).not.toHaveBeenCalled();
+  });
+
+  it('actually deletes when dryRun is explicitly false', async () => {
+    const { listTasks } = await import('../../tools/list-tasks.js');
+    const helpers = await import('../../write-ops/helpers.js');
+    vi.mocked(listTasks).mockResolvedValueOnce([makeTask('t1')]);
+    vi.mocked(helpers.fetchPBRecordIdsForTasks).mockResolvedValueOnce(
+      new Map([['t1', 'pb-rec-1']])
+    );
+
+    const result = await bulkUpdateTasks(
+      config,
+      ['t1'],
+      { type: 'delete' },
+      { dryRun: false }
+    );
+
+    expect(result.dryRun).toBe(false);
+    expect(result.deleted).toBe(1);
+    expect(helpers.deleteTaskInPBById).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps delete operations at 10 tasks per call', async () => {
+    const ids = Array.from({ length: 11 }, (_, i) => `t${i}`);
+
+    await expect(
+      bulkUpdateTasks(config, ids, { type: 'delete' }, { dryRun: false })
+    ).rejects.toThrow(/delete/i);
+  });
+
+  it('allows up to 10 deletes per call', async () => {
+    const { listTasks } = await import('../../tools/list-tasks.js');
+    const ids = Array.from({ length: 10 }, (_, i) => `t${i}`);
+    vi.mocked(listTasks).mockResolvedValueOnce(ids.map((id) => makeTask(id)));
+
+    // dryRun stays true by default — proves the cap is not exceeded
+    const result = await bulkUpdateTasks(config, ids, { type: 'delete' });
+    expect(result.dryRun).toBe(true);
+    expect(result.deleted).toBe(10);
+  });
+
+  it('does not apply the 10-cap to non-delete operations (50-cap still applies via schema)', async () => {
+    const { listTasks } = await import('../../tools/list-tasks.js');
+    const helpers = await import('../../write-ops/helpers.js');
+    const ids = Array.from({ length: 11 }, (_, i) => `t${i}`);
+    const recordMap = new Map(ids.map((id) => [id, `rec-${id}`]));
+    vi.mocked(listTasks).mockResolvedValueOnce(ids.map((id) => makeTask(id)));
+    vi.mocked(helpers.fetchPBRecordIdsForTasks).mockResolvedValueOnce(recordMap);
+
+    const result = await bulkUpdateTasks(
+      config,
+      ids,
+      { type: 'complete', completed: true },
+      { dryRun: false }
+    );
+
+    expect(result.dryRun).toBe(false);
+    expect(result.updated).toBe(11);
+  });
+});

--- a/packages/mcp-server/src/api/client.ts
+++ b/packages/mcp-server/src/api/client.ts
@@ -3,6 +3,21 @@ import type { GsdConfig } from '../types.js';
 import { fetchWithRetry, DEFAULT_RETRY_CONFIG, type RetryConfig } from './retry.js';
 
 /**
+ * Replace the hostname (and port) in a PocketBase URL with a stable
+ * `[pocketbase-host]` placeholder so error messages can be safely shared
+ * (chat logs, screenshots, bug reports) without leaking a private
+ * self-hosted endpoint. The user's local config still has the real URL.
+ */
+export function redactPocketBaseHost(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//[pocketbase-host]`;
+  } catch {
+    return '[pocketbase-host]';
+  }
+}
+
+/**
  * Make authenticated API request to PocketBase
  */
 export async function apiRequest<T>(
@@ -49,12 +64,13 @@ async function fetchWithErrorHandling(
       retryConfig
     );
   } catch (error) {
+    const redactedHost = redactPocketBaseHost(config.pocketBaseUrl);
     throw new Error(
-      `Failed to connect to ${config.pocketBaseUrl}\n\n` +
+      `Failed to connect to ${redactedHost}\n\n` +
         `Network error: ${error instanceof Error ? error.message : 'Unknown error'}\n\n` +
         `Please check:\n` +
         `  1. Your internet connection\n` +
-        `  2. GSD_POCKETBASE_URL is correct (${config.pocketBaseUrl})\n` +
+        `  2. GSD_POCKETBASE_URL is correct\n` +
         `  3. PocketBase server is running\n\n` +
         `Run: npx gsd-mcp-server --validate`
     );

--- a/packages/mcp-server/src/cli/index.ts
+++ b/packages/mcp-server/src/cli/index.ts
@@ -120,29 +120,70 @@ export async function prompt(question: string, defaultValue?: string): Promise<s
 }
 
 /**
- * Prompt for password (hidden input)
+ * Prompt for password with echo suppressed.
+ *
+ * Implementation note: in a TTY we put stdin into raw mode and consume bytes
+ * one at a time, never writing the character back to stdout. This is the only
+ * portable way to suppress echo for password input in Node — readline.question
+ * always echoes, and `setRawMode(false)` is cooked mode (the default) which
+ * also echoes.
+ *
+ * When stdin is not a TTY (CI pipeline, scripted input) we fall back to a
+ * regular line read; echo behavior is whatever the caller's environment does.
  */
 export async function promptPassword(question: string): Promise<string> {
-  const rl = createReadline();
+  process.stdout.write(`${question}: `);
 
-  return new Promise((resolve) => {
-    // Disable echo for password input
-    // Node.js typings don't expose all Readable methods consistently across versions;
-    // safe to cast since process.stdin is always a Readable TTY stream at runtime.
-    const stdin = process.stdin as unknown as {
-      setEncoding: (enc: string) => void;
-      isTTY: boolean;
-      setRawMode: (mode: boolean) => boolean;
-    };
-    const originalMode = stdin.isTTY && stdin.setRawMode ? stdin.setRawMode(false) : null;
+  const stdin = process.stdin as NodeJS.ReadStream;
 
-    rl.question(`${question}: `, (answer: string) => {
-      rl.close();
-      if (originalMode !== null && stdin.isTTY) {
-        stdin.setRawMode(originalMode);
-      }
-      console.log(); // New line after password input
-      resolve(answer.trim());
+  if (!stdin.isTTY || typeof stdin.setRawMode !== 'function') {
+    // Non-TTY fallback (CI, piped input). Read one line via readline.
+    const rl = createReadline();
+    return new Promise<string>((resolve) => {
+      rl.question('', (answer: string) => {
+        rl.close();
+        process.stdout.write('\n');
+        resolve(answer.trim());
+      });
     });
+  }
+
+  stdin.setRawMode(true);
+  stdin.resume();
+  stdin.setEncoding('utf8');
+
+  return new Promise<string>((resolve) => {
+    let buffer = '';
+    const onData = (chunk: string) => {
+      for (const char of chunk) {
+        const code = char.charCodeAt(0);
+        if (char === '\n' || char === '\r' || code === 4) {
+          // Enter or Ctrl-D — finalize input
+          stdin.setRawMode(false);
+          stdin.pause();
+          stdin.removeListener('data', onData);
+          process.stdout.write('\n');
+          resolve(buffer.trim());
+          return;
+        }
+        if (code === 3) {
+          // Ctrl-C — abort
+          stdin.setRawMode(false);
+          stdin.pause();
+          process.stdout.write('\n');
+          process.exit(130);
+        }
+        if (code === 127 || code === 8) {
+          // Backspace
+          if (buffer.length > 0) {
+            buffer = buffer.slice(0, -1);
+          }
+          continue;
+        }
+        // Append printable byte to buffer; do NOT echo to stdout.
+        buffer += char;
+      }
+    };
+    stdin.on('data', onData);
   });
 }

--- a/packages/mcp-server/src/cli/setup-wizard.ts
+++ b/packages/mcp-server/src/cli/setup-wizard.ts
@@ -3,6 +3,9 @@
  * Guides users through PocketBase URL and auth token setup
  */
 
+import { writeFileSync, chmodSync, unlinkSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import type { GsdConfig } from '../tools.js';
 import { getSyncStatus, listTasks } from '../tools.js';
 import { prompt, promptPassword, getClaudeConfigPath } from './index.js';
@@ -78,13 +81,16 @@ async function testTaskAccess(pbUrl: string, authToken: string): Promise<void> {
   }
 }
 
-/**
- * Display generated configuration JSON
- */
-function displayConfiguration(pbUrl: string, authToken: string): void {
-  console.log('Step 3/4: Generated Configuration');
-  console.log(`Add this to ${getClaudeConfigPath()}:\n`);
+/** Where the wizard writes the generated config snippet (mode 0600). */
+const GENERATED_CONFIG_PATH = join(homedir(), '.gsd-mcp-setup.json');
 
+/**
+ * Write the generated config snippet to a chmod-600 file. The token is never
+ * printed to stdout (no terminal scrollback, no screenshot leak, no shell
+ * history if the output is piped). The user reads the file to copy the
+ * config into Claude Desktop, then deletes it.
+ */
+function writeConfigurationFile(pbUrl: string, authToken: string): string {
   const configJson = {
     mcpServers: {
       'gsd-tasks': {
@@ -98,7 +104,52 @@ function displayConfiguration(pbUrl: string, authToken: string): void {
     },
   };
 
-  console.log(JSON.stringify(configJson, null, 2));
+  // Write first, then chmod — avoids a brief window where the file is
+  // world-readable on POSIX. Use writeFileSync with mode option for the
+  // initial write, and chmodSync as belt-and-braces (mode is honored on
+  // Linux/macOS; on Windows the chmod is a no-op but the file lives in
+  // the user's home directory under the user's ACLs).
+  writeFileSync(GENERATED_CONFIG_PATH, JSON.stringify(configJson, null, 2), {
+    mode: 0o600,
+  });
+  chmodSync(GENERATED_CONFIG_PATH, 0o600);
+  return GENERATED_CONFIG_PATH;
+}
+
+/**
+ * Display configuration step. Writes the JSON to a chmod-600 file and prints
+ * only a redacted preview to the terminal so the token never lives in
+ * scrollback, screenshots, or shell history.
+ */
+function displayConfiguration(pbUrl: string, authToken: string): void {
+  const configPath = writeConfigurationFile(pbUrl, authToken);
+  const tokenPreview =
+    authToken.length > 6
+      ? `${authToken.slice(0, 3)}…${authToken.slice(-3)} (${authToken.length} chars)`
+      : `(${authToken.length} chars)`;
+
+  console.log('Step 3/4: Generated Configuration');
+  console.log(`Written to: ${configPath}  (mode 0600, owner-only)`);
+  console.log();
+  console.log('Preview (token redacted — full token is in the file above):\n');
+  console.log(
+    JSON.stringify(
+      {
+        mcpServers: {
+          'gsd-tasks': {
+            command: 'npx',
+            args: ['-y', 'gsd-mcp-server'],
+            env: {
+              GSD_POCKETBASE_URL: pbUrl,
+              GSD_AUTH_TOKEN: `<see ${configPath}>  // ${tokenPreview}`,
+            },
+          },
+        },
+      },
+      null,
+      2
+    )
+  );
   console.log();
 }
 
@@ -107,13 +158,26 @@ function displayConfiguration(pbUrl: string, authToken: string): void {
  */
 function displayNextSteps(): void {
   console.log('Step 4/4: Next Steps');
-  console.log('1. Copy the config above');
-  console.log(`2. Open ${getClaudeConfigPath()}`);
-  console.log('3. Add the configuration to the "mcpServers" section');
-  console.log('4. Restart Claude Desktop');
-  console.log("5. Ask Claude: \"What's my GSD sync status?\"");
+  console.log(`1. Open the generated file:  cat ${GENERATED_CONFIG_PATH}`);
+  console.log(`2. Open Claude Desktop config: ${getClaudeConfigPath()}`);
+  console.log('3. Merge the "mcpServers" section into the Claude config');
+  console.log(`4. Delete the generated file:  rm ${GENERATED_CONFIG_PATH}`);
+  console.log('5. Restart Claude Desktop');
+  console.log("6. Ask Claude: \"What's my GSD sync status?\"");
   console.log();
   console.log('✓ Setup complete! Need help? Run: npx gsd-mcp-server --help');
+}
+
+/**
+ * Best-effort cleanup of the generated config file on wizard failure so a
+ * partial setup does not leave a token in the user's home directory.
+ */
+function cleanupGeneratedConfigOnError(): void {
+  try {
+    unlinkSync(GENERATED_CONFIG_PATH);
+  } catch {
+    // File may not exist yet — ignore.
+  }
 }
 
 /**
@@ -146,6 +210,7 @@ Welcome! This wizard will help you configure the MCP server for Claude Desktop.
     // Step 4: Next Steps
     displayNextSteps();
   } catch (error) {
+    cleanupGeneratedConfigOnError();
     console.error('\n✗ Setup failed:', error instanceof Error ? error.message : 'Unknown error');
     process.exit(1);
   }

--- a/packages/mcp-server/src/server/config.ts
+++ b/packages/mcp-server/src/server/config.ts
@@ -4,14 +4,41 @@ import { createMcpLogger } from '../utils/logger.js';
 
 const logger = createMcpLogger('CONFIG');
 
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
+
+/**
+ * Validate that a URL either uses HTTPS, or uses HTTP only when targeting a
+ * loopback hostname. Uses exact hostname matching after parsing so that
+ * `http://localhost.attacker.com` and `http://localhost@attacker.com` are
+ * correctly rejected (a `startsWith` check is bypassable).
+ */
+function isSafePocketBaseUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol === 'https:') {
+    return true;
+  }
+  if (parsed.protocol !== 'http:') {
+    return false;
+  }
+  // URL.hostname for `[::1]` is `[::1]` (with brackets); strip them.
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
+  return LOOPBACK_HOSTNAMES.has(hostname);
+}
+
 /**
  * Configuration schema for GSD MCP Server (PocketBase)
  */
 export const configSchema = z.object({
-  pocketBaseUrl: z.string().url().refine(
-    (url) => url.startsWith('https://') || url.startsWith('http://localhost') || url.startsWith('http://127.0.0.1'),
-    { message: 'PocketBase URL must use HTTPS (except localhost for local development)' }
-  ),
+  pocketBaseUrl: z.string().url().refine(isSafePocketBaseUrl, {
+    message:
+      'PocketBase URL must use HTTPS (or http://localhost / http://127.0.0.1 / http://[::1] for local development)',
+  }),
   authToken: z.string().min(1),
 });
 

--- a/packages/mcp-server/src/tools/handlers/input-schemas.ts
+++ b/packages/mcp-server/src/tools/handlers/input-schemas.ts
@@ -149,7 +149,6 @@ export const bulkUpdateTasksArgsSchema = z
   .object({
     taskIds: z.array(z.string().min(1)).min(1).max(50),
     operation: bulkOperationSchema,
-    maxTasks: z.number().int().positive().optional(),
     dryRun: z.boolean().optional(),
   })
   .strict();

--- a/packages/mcp-server/src/tools/handlers/write-handlers.ts
+++ b/packages/mcp-server/src/tools/handlers/write-handlers.ts
@@ -158,10 +158,9 @@ export async function handleDeleteTask(config: GsdConfig, args: { id: string; dr
 
 export async function handleBulkUpdateTasks(
   config: GsdConfig,
-  args: { taskIds: string[]; operation: BulkOperation; maxTasks?: number; dryRun?: boolean }
+  args: { taskIds: string[]; operation: BulkOperation; dryRun?: boolean }
 ): Promise<McpToolResponse> {
   const result = await bulkUpdateTasks(config, args.taskIds, args.operation, {
-    maxTasks: args.maxTasks,
     dryRun: args.dryRun,
   });
 

--- a/packages/mcp-server/src/tools/schemas/write-tools.ts
+++ b/packages/mcp-server/src/tools/schemas/write-tools.ts
@@ -217,7 +217,7 @@ export const deleteTaskTool: Tool = {
 export const bulkUpdateTasksTool: Tool = {
   name: 'bulk_update_tasks',
   description:
-    'Update multiple tasks at once. Supports completing, moving quadrants, adding/removing tags, setting due dates, and deleting. Limited to 50 tasks per operation for safety. Use dryRun=true to preview changes.',
+    'Update multiple tasks at once. Supports completing, moving quadrants, adding/removing tags, setting due dates, and deleting. Limited to 50 tasks per operation (10 for deletes) for safety. Destructive deletes default to dryRun=true — pass dryRun=false explicitly to apply.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -260,13 +260,10 @@ export const bulkUpdateTasksTool: Tool = {
         },
         required: ['type'],
       },
-      maxTasks: {
-        type: 'number',
-        description: 'Safety limit (default: 50)',
-      },
       dryRun: {
         type: 'boolean',
-        description: 'If true, validate and show what would change without actually saving',
+        description:
+          'If true, preview changes without saving. Defaults to true for delete operations — pass dryRun=false to actually delete.',
       },
     },
     required: ['taskIds', 'operation'],

--- a/packages/mcp-server/src/write-ops/bulk-operations.ts
+++ b/packages/mcp-server/src/write-ops/bulk-operations.ts
@@ -72,21 +72,42 @@ function applyOperation(task: Task, operation: BulkOperation, now: string): Task
   throw new Error(`Unknown operation type: ${(operation as { type: string }).type}`);
 }
 
+/**
+ * Server-side policy ceilings for bulk operations. Not caller-controllable
+ * (see input-schemas.ts — `maxTasks` is intentionally absent from the input
+ * schema so an over-eager LLM cannot raise the limit).
+ */
+const BULK_MAX_TASKS = 50;
+const BULK_MAX_DELETES = 10;
+
 export async function bulkUpdateTasks(
   config: GsdConfig,
   taskIds: string[],
   operation: BulkOperation,
-  options?: { maxTasks?: number; dryRun?: boolean }
+  options?: { dryRun?: boolean }
 ): Promise<{ updated: number; deleted: number; errors: string[]; dryRun: boolean }> {
-  const isDryRun = options?.dryRun ?? false;
-  const maxTasks = options?.maxTasks ?? 50;
+  // Destructive deletes default to dryRun=true. Callers must pass
+  // `dryRun: false` explicitly to actually delete.
+  const isDryRun =
+    operation.type === 'delete' ? options?.dryRun !== false : options?.dryRun ?? false;
 
-  if (taskIds.length > maxTasks) {
+  if (taskIds.length > BULK_MAX_TASKS) {
     throw new Error(
       `Bulk operation limit exceeded\n\n` +
         `Requested: ${taskIds.length} tasks\n` +
-        `Maximum: ${maxTasks} tasks\n\n` +
+        `Maximum: ${BULK_MAX_TASKS} tasks\n\n` +
         `Please reduce the number of tasks or split into multiple operations.`
+    );
+  }
+
+  if (operation.type === 'delete' && taskIds.length > BULK_MAX_DELETES) {
+    throw new Error(
+      `Bulk delete limit exceeded\n\n` +
+        `Requested: ${taskIds.length} deletes\n` +
+        `Maximum: ${BULK_MAX_DELETES} deletes per call\n\n` +
+        `Delete operations are capped lower than other bulk operations to limit ` +
+        `accidental data loss from an LLM-driven call. Split into multiple ` +
+        `delete calls of ${BULK_MAX_DELETES} or fewer task ids each.`
     );
   }
 


### PR DESCRIPTION
## Summary

Tranche 2 of 5 from the [May 2026 security review](../blob/main/tasks/security-review-2026-05-12.md). Scope: MCP server attack surface. The common thread is **misuse-of-trust failures** where the local user (or an LLM acting on their behalf) is the threat actor, not a remote attacker.

- **P1-3**: Setup wizard writes config snippet to `~/.gsd-mcp-setup.json` (mode `0600`) instead of printing the token to stdout. Stdout shows a redacted preview only — the token never lives in scrollback, screenshots, or shell history.
- **P1-4**: `promptPassword` actually suppresses echo. The old `setRawMode(false)` call is *cooked mode* (echoes input); replaced with proper raw-mode byte-level handling.
- **P1-10**: `configSchema.pocketBaseUrl` exact-matches hostname against `{localhost, 127.0.0.1, ::1}`. `http://localhost.attacker.com` and userinfo tricks are now rejected.
- **P2-11**: `bulk_update_tasks` no longer accepts caller-supplied `maxTasks`. Delete operations default `dryRun: true` and are capped at 10/call (vs 50 for other ops) to limit accidental LLM-driven data loss.
- **P3-11**: `apiRequest` redacts the PocketBase host in error messages — private self-hosted URLs no longer leak in shared chat logs.

Also bumps `@modelcontextprotocol/sdk` 1.27.1 → 1.29.0 and adds `fast-uri`/`ip-address`/`postcss` overrides to clear transitive moderate/high CVEs.

## Test plan

- [x] `cd packages/mcp-server && bun run test` — 106 pass (15 new tests across `config`, `bulk-operations`, `client`, `input-schemas`)
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun run test` — 1829 unit/data tests pass (5 pre-existing e2e config failures unchanged from `main`)
- [x] `bun run build` — static export builds cleanly
- [x] `cd packages/mcp-server && bun run build` — tsc compiles cleanly
- [x] `bun audit` — 22 vulns → 18. **Note**: the 7 remaining `high` advisories are all Next.js — they clear when [Tranche 1 (#270)](./270) merges into `main` and this branch is rebased
- [ ] After merge: manually exercise `npx gsd-mcp-server --setup` end-to-end to confirm the new flow (token-to-file + masked stdout) on macOS

## TDD discipline

Every behavioral change has a red→green test pair:
- `config.test.ts` — 12 tests covering hostname allowlist (`localhost.attacker.com` bypass, IPv6 `[::1]`, userinfo tricks)
- `bulk-operations.test.ts` — 5 tests covering delete dry-run default, 10-cap, and non-delete ops unaffected
- `client.test.ts` — 5 tests covering `redactPocketBaseHost` + error-message redaction
- `input-schemas.test.ts` — +1 test asserting `maxTasks` is rejected

The setup-wizard and promptPassword changes are TTY-interaction code where raw-mode behavior isn't portably mockable; covered by code review + the existing manual post-build flow.

## Merge order

Recommended: merge Tranche 1 (#270) first, then rebase this branch onto `main` before review. That gives reviewers a clean `bun audit` (zero high) and avoids confusing the Next.js advisories with the MCP changes.