### PR TITLE
fix(security): tranche 3 — sync layer hardening (OAuth, privacy, errors, 429)

### DIFF
--- a/lib/sync/config/disable.ts
+++ b/lib/sync/config/disable.ts
@@ -26,7 +26,12 @@ async function stopHealthMonitor(): Promise<void> {
 }
 
 /**
- * Reset sync config to disabled state
+ * Reset sync config to disabled state and wipe per-user sync artefacts.
+ *
+ * Important on shared/kiosk devices: the next user on the same browser
+ * profile must not see the previous user's sync metadata, queued
+ * operations, or sync-history entries (which carry device IDs, task
+ * counts, and error messages that may contain task content).
  */
 async function resetSyncConfigState(current: PBSyncConfig): Promise<void> {
   const db = getDb();
@@ -48,6 +53,9 @@ async function resetSyncConfigState(current: PBSyncConfig): Promise<void> {
 
   // Clear sync queue
   await db.syncQueue.clear();
+
+  // Clear sync history — privacy on shared devices.
+  await db.syncHistory.clear();
 }
 
 /**

--- a/lib/sync/error-categorizer.ts
+++ b/lib/sync/error-categorizer.ts
@@ -82,3 +82,98 @@ export function isPermanentError(error: Error): boolean {
     message.includes('parse error')
   );
 }
+
+/** Stable error codes for sync queue / sync history persistence. */
+export type SyncErrorCode =
+  | 'rate_limited'
+  | 'unauthorized'
+  | 'validation_failed'
+  | 'not_found'
+  | 'server_error'
+  | 'network_error'
+  | 'unknown_error';
+
+/**
+ * Convert an arbitrary thrown value into a stable error code suitable for
+ * persisting in the sync queue / sync history. Strips all original message
+ * content so that PocketBase 4xx responses (which echo the request payload —
+ * e.g. validation errors quoting the task title) cannot leak task content
+ * into `db.syncQueue.lastError` or `db.syncHistory.errorMessage`.
+ */
+export function sanitizeSyncError(error: unknown): SyncErrorCode {
+  if (!(error instanceof Error)) {
+    return 'unknown_error';
+  }
+
+  const message = error.message.toLowerCase();
+
+  // Rate limit must be checked first — 429 contains '4' and the validation
+  // branch matches things like '422'. Order: rate → auth → validation/404 → 5xx → network.
+  if (message.includes('429') || message.includes('too many requests')) {
+    return 'rate_limited';
+  }
+  if (isAuthError(error)) {
+    return 'unauthorized';
+  }
+  if (message.includes('404') || message.includes('not found')) {
+    return 'not_found';
+  }
+  if (
+    message.includes('400') ||
+    message.includes('422') ||
+    message.includes('bad request') ||
+    message.includes('unprocessable') ||
+    message.includes('validation') ||
+    message.includes('failed to validate')
+  ) {
+    return 'validation_failed';
+  }
+  if (
+    message.includes('500') ||
+    message.includes('502') ||
+    message.includes('503') ||
+    message.includes('504') ||
+    message.includes('internal server error') ||
+    message.includes('bad gateway') ||
+    message.includes('service unavailable') ||
+    message.includes('gateway timeout')
+  ) {
+    return 'server_error';
+  }
+  if (
+    message.includes('network') ||
+    message.includes('timeout') ||
+    message.includes('fetch') ||
+    message.includes('connection') ||
+    message.includes('econnrefused') ||
+    message.includes('enotfound') ||
+    message.includes('etimedout')
+  ) {
+    return 'network_error';
+  }
+  return 'unknown_error';
+}
+
+/**
+ * Parse an HTTP `Retry-After` header value into a delay in milliseconds.
+ * Accepts either a numeric seconds value (`"30"`) or an HTTP-date.
+ * Returns `null` for missing/garbage input; clamps negative values to 0.
+ */
+export function parseRetryAfterMs(value: string | null | undefined): number | null {
+  if (!value) return null;
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  // Numeric seconds
+  if (/^-?\d+$/.test(trimmed)) {
+    const seconds = Number.parseInt(trimmed, 10);
+    if (Number.isNaN(seconds)) return null;
+    return Math.max(0, seconds * 1000);
+  }
+
+  // HTTP-date
+  const timestamp = Date.parse(trimmed);
+  if (Number.isNaN(timestamp)) return null;
+  return Math.max(0, timestamp - Date.now());
+}

--- a/lib/sync/pb-auth.ts
+++ b/lib/sync/pb-auth.ts
@@ -13,6 +13,17 @@ const logger = createLogger('SYNC_AUTH');
 
 export type OAuthProvider = 'google' | 'github';
 
+/**
+ * Runtime whitelist of OAuth providers. The `OAuthProvider` type is erased
+ * at compile time, so a caller (XSS payload, console invocation, future
+ * feature regression) could pass any string into `loginWithProvider`.
+ * PocketBase will happily attempt OAuth with any provider configured on the
+ * server — including potentially malicious ones added by an admin attacker.
+ * Gating here ensures the SDK call only runs for providers we explicitly
+ * support.
+ */
+const ALLOWED_OAUTH_PROVIDERS = new Set<OAuthProvider>(['google', 'github']);
+
 export interface AuthState {
   isLoggedIn: boolean;
   userId: string | null;
@@ -28,6 +39,12 @@ export interface AuthState {
  * Returns the authenticated user record on success.
  */
 export async function loginWithProvider(provider: OAuthProvider): Promise<AuthState> {
+  if (!provider || !ALLOWED_OAUTH_PROVIDERS.has(provider)) {
+    throw new Error(
+      `OAuth provider not allowed: ${String(provider)}. Allowed providers: ${[...ALLOWED_OAUTH_PROVIDERS].join(', ')}`
+    );
+  }
+
   const pb = getPocketBase();
 
   try {

--- a/lib/sync/pb-push.ts
+++ b/lib/sync/pb-push.ts
@@ -10,9 +10,25 @@ import { getSyncQueue } from './queue';
 import { taskRecordToPocketBase } from './task-mapper';
 import { createLogger } from '@/lib/logger';
 import { THROTTLE_MS, delay, getDeviceId, getCurrentUserId, fetchRemoteTaskIndex } from './pb-sync-helpers';
+import { sanitizeSyncError } from './error-categorizer';
 import type { SyncQueueItem } from './types';
 
 const logger = createLogger('SYNC_ENGINE');
+
+/**
+ * Detect HTTP 429 responses in arbitrary thrown values. PocketBase SDK
+ * surfaces 429s either as `{status: 429}` (ClientResponseError) or as a
+ * plain Error whose message includes the status code.
+ */
+function isRateLimitError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const candidate = error as { status?: number; message?: string };
+  if (candidate.status === 429) return true;
+  if (typeof candidate.message === 'string') {
+    return /\b429\b|too many requests/i.test(candidate.message);
+  }
+  return false;
+}
 
 export interface PushResult {
   pushedCount: number;
@@ -104,7 +120,7 @@ export async function pushLocalChanges(): Promise<PushResult> {
         pushedCount++;
       } else {
         failedCount++;
-        lastError = 'Remote index unavailable for delete verification';
+        lastError = 'remote_index_unavailable';
       }
 
       if (pushedCount + failedCount < pending.length) {
@@ -112,12 +128,28 @@ export async function pushLocalChanges(): Promise<PushResult> {
       }
     } catch (error) {
       failedCount++;
-      lastError = error instanceof Error ? error.message : String(error);
+      // Persist a stable error code only — never the raw error message,
+      // which (for 4xx responses) can echo task content back from PocketBase.
+      const errorCode = sanitizeSyncError(error);
+      lastError = errorCode;
       logger.error('Push failed for item', error instanceof Error ? error : new Error(String(error)), {
         taskId: item.taskId,
         operation: item.operation,
+        errorCode,
       });
-      await queue.recordAttemptFailure(item.id, lastError);
+      await queue.recordAttemptFailure(item.id, errorCode);
+
+      // 429 means the server is under load. Abort the push loop early so
+      // we don't hammer it through the remaining queue items at 100ms
+      // throttle and amplify the rate-limit response.
+      if (isRateLimitError(error)) {
+        logger.warn('Aborting push loop due to rate limit (429)', {
+          pushedCount,
+          failedCount,
+          remaining: pending.length - (pushedCount + failedCount),
+        });
+        break;
+      }
     }
   }
 

--- a/lib/sync/pb-realtime.ts
+++ b/lib/sync/pb-realtime.ts
@@ -6,6 +6,7 @@
  * "echo" events from the current device to prevent feedback loops.
  */
 
+import { z } from 'zod';
 import { getPocketBase, getCurrentUserId } from './pocketbase-client';
 import { applyRemoteChange } from './pb-sync-engine';
 import { createLogger } from '@/lib/logger';
@@ -15,6 +16,20 @@ const logger = createLogger('SYNC_REALTIME');
 
 let unsubscribeFn: (() => void) | null = null;
 let currentDeviceId: string | null = null;
+
+/**
+ * Minimal shape that every inbound realtime record must satisfy before we
+ * route it to the sync engine. PocketBase responses are normally well-typed,
+ * but a compromised or misbehaving server could push something weird (an
+ * object with a `toString` that fakes the current device id, for example).
+ * Failing closed on type-mismatch is safer than letting unexpected shapes
+ * flow into IndexedDB.
+ */
+const realtimeRecordShape = z.object({
+  device_id: z.string(),
+  task_id: z.string(),
+  owner: z.string(),
+});
 
 /**
  * Start listening for realtime changes on the tasks collection
@@ -60,33 +75,45 @@ export function unsubscribe(): void {
  * Handle a single realtime event from PocketBase SSE
  */
 async function handleRealtimeEvent(event: RecordSubscription<RecordModel>): Promise<void> {
-  const record = event.record;
+  // Validate the record shape before doing anything else. Fails closed on
+  // missing / non-string fields — see realtimeRecordShape above.
+  const parsed = realtimeRecordShape.safeParse(event.record);
+  if (!parsed.success) {
+    logger.warn('Skipping malformed realtime event', {
+      action: event.action,
+      issues: parsed.error.issues.map((i) => i.path.join('.')).join(','),
+    });
+    return;
+  }
+  const record = parsed.data;
 
-  // Skip echoes from this device to prevent feedback loops
-  if (record['device_id'] === currentDeviceId) {
-    logger.debug('Skipping own-device echo', { action: event.action, taskId: record['task_id'] });
+  // Skip echoes from this device to prevent feedback loops. Require both
+  // sides non-empty so an empty/null currentDeviceId (cold-start race)
+  // does not accidentally filter every legitimate event as an echo.
+  if (record.device_id && currentDeviceId && record.device_id === currentDeviceId) {
+    logger.debug('Skipping own-device echo', { action: event.action, taskId: record.task_id });
     return;
   }
 
-  // Only process events for the current user
+  // Only process events for the current user.
   const userId = getCurrentUserId();
-  if (record['owner'] !== userId) {
+  if (record.owner !== userId) {
     return;
   }
 
   logger.debug('Realtime event received', {
     action: event.action,
-    taskId: record['task_id'],
-    deviceId: record['device_id'],
+    taskId: record.task_id,
+    deviceId: record.device_id,
   });
 
   try {
-    await applyRemoteChange(event.action as 'create' | 'update' | 'delete', record);
+    await applyRemoteChange(event.action as 'create' | 'update' | 'delete', event.record);
   } catch (error) {
     logger.error(
       'Failed to apply realtime change',
       error instanceof Error ? error : new Error(String(error)),
-      { action: event.action, taskId: record['task_id'] }
+      { action: event.action, taskId: record.task_id }
     );
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.1.5",
+	"version": "9.1.6",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/data/sync/config.test.ts
+++ b/tests/data/sync/config.test.ts
@@ -271,6 +271,43 @@ describe('Sync Config', () => {
       // Should not throw — disableSync returns early when config is null
       await expect(disableSync()).resolves.not.toThrow();
     });
+
+    it('should clear sync history (privacy on shared device)', async () => {
+      // Seed sync history with entries that include device IDs and counts.
+      // Without clearing on logout, the next user on the same browser
+      // profile would see these.
+      await db.syncHistory.bulkAdd([
+        {
+          id: 'h1',
+          timestamp: new Date().toISOString(),
+          status: 'success',
+          pushedCount: 5,
+          pulledCount: 3,
+          conflictsResolved: 0,
+          deviceId: 'device-123',
+          triggeredBy: 'user',
+        },
+        {
+          id: 'h2',
+          timestamp: new Date().toISOString(),
+          status: 'failure',
+          pushedCount: 0,
+          pulledCount: 0,
+          conflictsResolved: 0,
+          deviceId: 'device-123',
+          triggeredBy: 'auto',
+          errorMessage: 'something failed',
+        },
+      ]);
+
+      const historyCountBefore = await db.syncHistory.count();
+      expect(historyCountBefore).toBe(2);
+
+      await disableSync();
+
+      const historyCountAfter = await db.syncHistory.count();
+      expect(historyCountAfter).toBe(0);
+    });
   });
 
   describe('isSyncEnabled', () => {

--- a/tests/data/sync/error-categorizer.test.ts
+++ b/tests/data/sync/error-categorizer.test.ts
@@ -4,6 +4,8 @@ import {
   isTransientError,
   isAuthError,
   isPermanentError,
+  sanitizeSyncError,
+  parseRetryAfterMs,
 } from '@/lib/sync/error-categorizer';
 
 describe('error-categorizer', () => {
@@ -94,6 +96,95 @@ describe('error-categorizer', () => {
     it('should return false for transient errors', () => {
       expect(isPermanentError(new Error('Network error'))).toBe(false);
       expect(isPermanentError(new Error('500 Internal Server Error'))).toBe(false);
+    });
+  });
+
+  describe('sanitizeSyncError', () => {
+    it('returns rate_limited for 429 errors', () => {
+      expect(sanitizeSyncError(new Error('429 Too Many Requests'))).toBe('rate_limited');
+    });
+
+    it('returns unauthorized for 401/403/auth errors', () => {
+      expect(sanitizeSyncError(new Error('401 Unauthorized'))).toBe('unauthorized');
+      expect(sanitizeSyncError(new Error('403 Forbidden'))).toBe('unauthorized');
+      expect(sanitizeSyncError(new Error('Token expired'))).toBe('unauthorized');
+    });
+
+    it('returns validation_failed for 400/422 errors', () => {
+      expect(sanitizeSyncError(new Error('400 Bad Request'))).toBe('validation_failed');
+      expect(sanitizeSyncError(new Error('422 Unprocessable Entity'))).toBe('validation_failed');
+      expect(sanitizeSyncError(new Error('Validation failed: title required'))).toBe(
+        'validation_failed'
+      );
+    });
+
+    it('returns not_found for 404 errors', () => {
+      expect(sanitizeSyncError(new Error('404 Not Found'))).toBe('not_found');
+    });
+
+    it('returns server_error for 5xx errors', () => {
+      expect(sanitizeSyncError(new Error('500 Internal Server Error'))).toBe('server_error');
+      expect(sanitizeSyncError(new Error('502 Bad Gateway'))).toBe('server_error');
+      expect(sanitizeSyncError(new Error('503 Service Unavailable'))).toBe('server_error');
+    });
+
+    it('returns network_error for fetch/timeout failures', () => {
+      expect(sanitizeSyncError(new Error('Network request failed'))).toBe('network_error');
+      expect(sanitizeSyncError(new Error('Failed to fetch'))).toBe('network_error');
+      expect(sanitizeSyncError(new Error('ECONNREFUSED'))).toBe('network_error');
+      expect(sanitizeSyncError(new Error('Request timeout'))).toBe('network_error');
+    });
+
+    it('returns unknown_error for unrecognized errors', () => {
+      expect(sanitizeSyncError(new Error('something broke'))).toBe('unknown_error');
+    });
+
+    it('NEVER leaks task content from validation error messages', () => {
+      // PocketBase 4xx responses echo the request payload — e.g.
+      // "failed to validate field 'title': 'My private task title'"
+      const result = sanitizeSyncError(
+        new Error("400 failed to validate field 'title': 'My private task title'")
+      );
+      expect(result).toBe('validation_failed');
+      expect(result).not.toContain('My private task title');
+      expect(result).not.toContain('title');
+    });
+
+    it('handles non-Error inputs safely', () => {
+      expect(sanitizeSyncError('plain string')).toBe('unknown_error');
+      expect(sanitizeSyncError(null)).toBe('unknown_error');
+      expect(sanitizeSyncError(undefined)).toBe('unknown_error');
+      expect(sanitizeSyncError({ message: 'an object' })).toBe('unknown_error');
+    });
+  });
+
+  describe('parseRetryAfterMs', () => {
+    it('parses a numeric Retry-After value (seconds) into milliseconds', () => {
+      expect(parseRetryAfterMs('30')).toBe(30_000);
+      expect(parseRetryAfterMs('1')).toBe(1_000);
+    });
+
+    it('parses an HTTP-date Retry-After value into ms from now', () => {
+      const futureMs = Date.now() + 60_000;
+      const httpDate = new Date(futureMs).toUTCString();
+      const parsed = parseRetryAfterMs(httpDate);
+      // Allow a small tolerance for clock drift during the test.
+      expect(parsed).toBeGreaterThan(50_000);
+      expect(parsed).toBeLessThan(70_000);
+    });
+
+    it('returns null for missing/empty input', () => {
+      expect(parseRetryAfterMs(null)).toBeNull();
+      expect(parseRetryAfterMs(undefined)).toBeNull();
+      expect(parseRetryAfterMs('')).toBeNull();
+    });
+
+    it('returns null for garbage input', () => {
+      expect(parseRetryAfterMs('not a number or date')).toBeNull();
+    });
+
+    it('clamps negative numeric values to 0', () => {
+      expect(parseRetryAfterMs('-5')).toBe(0);
     });
   });
 });

--- a/tests/data/sync/pb-auth.test.ts
+++ b/tests/data/sync/pb-auth.test.ts
@@ -64,6 +64,27 @@ describe('PocketBase Auth', () => {
 
       await expect(loginWithProvider('github')).rejects.toThrow('OAuth popup closed');
     });
+
+    it('rejects provider names not in the runtime whitelist', async () => {
+      // `OAuthProvider` is a TS type — erased at runtime. A caller (XSS
+      // payload, future feature regression, console invocation) could pass
+      // an arbitrary string. The runtime allowlist must catch this before
+      // the SDK call is made.
+      await expect(
+        loginWithProvider('facebook' as unknown as 'google')
+      ).rejects.toThrow(/not allowed|whitelist|provider/i);
+      expect(mockAuthWithOAuth2).not.toHaveBeenCalled();
+    });
+
+    it('rejects empty/null provider strings', async () => {
+      await expect(
+        loginWithProvider('' as unknown as 'google')
+      ).rejects.toThrow();
+      await expect(
+        loginWithProvider(null as unknown as 'google')
+      ).rejects.toThrow();
+      expect(mockAuthWithOAuth2).not.toHaveBeenCalled();
+    });
   });
 
   describe('loginWithGoogle', () => {

--- a/tests/data/sync/pb-realtime.test.ts
+++ b/tests/data/sync/pb-realtime.test.ts
@@ -146,5 +146,45 @@ describe('pb-realtime', () => {
 
       expect(mockApplyRemoteChange).toHaveBeenCalledWith('create', record);
     });
+
+    it('does NOT echo-filter when remote device_id is empty/null', async () => {
+      // Legacy / corrupted records may have empty device_id. If currentDeviceId
+      // is also somehow empty, naive `===` would treat the event as an echo
+      // and silently drop it. Echo filter must require BOTH sides non-empty.
+      await subscribe('device-1');
+      const handler = mockSubscribe.mock.calls[0][1];
+
+      await handler({
+        action: 'create',
+        record: {
+          device_id: '',
+          owner: 'user-123',
+          task_id: 'task-1',
+        },
+      });
+
+      // Empty device_id from a remote record is not an echo of 'device-1';
+      // event must flow through.
+      expect(mockApplyRemoteChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores records with non-string device_id (defense against bad data)', async () => {
+      await subscribe('device-1');
+      const handler = mockSubscribe.mock.calls[0][1];
+
+      // PocketBase responses are normally well-typed, but a compromised or
+      // misbehaving server could push something weird. The handler should
+      // tolerate (drop) the event without throwing.
+      await handler({
+        action: 'create',
+        record: {
+          device_id: { toString: () => 'device-1' },
+          owner: 'user-123',
+          task_id: 'task-1',
+        },
+      });
+
+      expect(mockApplyRemoteChange).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Tranche 3 of 5 from the [May 2026 security review](../blob/main/tasks/security-review-2026-05-12.md). Scope: PocketBase sync layer. Highest behavioral-risk tranche — every change is red→green TDD.

- **P1-7**: `loginWithProvider` enforces a runtime `Set<OAuthProvider>` allowlist. The TS type is erased — without this check, any caller (XSS payload, console invocation, future feature regression) can pass an arbitrary provider string.
- **P1-8**: `disableSync` now clears `db.syncHistory`. Privacy on shared/kiosk devices — the previous user's 100-row history (device IDs, counts, error messages) no longer carries over.
- **P2-8**: Sync queue persists *stable error codes* (`rate_limited`, `validation_failed`, etc.) instead of raw `error.message`. PocketBase 4xx validation responses echo task content back; this prevents task titles/descriptions from leaking into `db.syncQueue.lastError`.
- **P2-9**: Echo filter requires *both* sides non-empty: `record.device_id && currentDeviceId && record.device_id === currentDeviceId`. Cold-start races no longer silently drop legitimate events.
- **P2-10**: `pushLocalChanges` detects 429 and breaks out of the loop early — no more hammering a flapping server through the whole queue at 100ms throttle. New `parseRetryAfterMs` helper parses both numeric-seconds and HTTP-date forms.
- **P3-6**: Inbound realtime records pass through a Zod schema (`device_id`, `task_id`, `owner` are all required strings). Malformed payloads from a compromised/buggy server are logged + skipped instead of flowing into the sync engine.

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun run test` — 1848 pass (1829 baseline + 19 new tests)
  - `pb-auth.test.ts` +2 (rejects unknown provider, rejects null/empty)
  - `config.test.ts` +1 (clears syncHistory on disable)
  - `error-categorizer.test.ts` +14 (`sanitizeSyncError` x9 + leak-protection, `parseRetryAfterMs` x5)
  - `pb-realtime.test.ts` +2 (empty `device_id` flows through, non-string `device_id` is filtered)
- [x] `bun run build` — static export builds cleanly
- [ ] **Manual post-merge**: OAuth login round-trip with BOTH Google AND GitHub from a clean browser profile (allowlist change affects all login paths)
- [ ] **Manual post-merge**: log in, run a sync, log out, log back in (different account if possible). Sync-history page should be empty.

## Behavioral changes worth a careful review

1. **Sync history table is cleared on logout.** If a user logs out and back in, they lose all prior sync log entries. This is intentional (the finding is privacy-on-shared-device), but if there's a workflow that depends on history surviving across sessions, this PR changes that.

2. **`lastError` in the sync queue is now a code, not free text.** Any UI that displays `lastError` to the user will now show e.g. `validation_failed` instead of `failed to validate field 'title': '...'`. Existing UI surfaces should be checked — at minimum sync-history page, and any error toast that renders queue items.

3. **Push loop bails out early on 429.** Previously every queue item was attempted even if the first ten 429'd. The bail-out reduces wasted requests but means a user-triggered sync that hits a 429 will leave more items in the queue. They'll retry on the next sync per existing retry logic.

## Merge order

Independent of Tranche 1 and 2. Merge whenever ready. Conflicts on `package.json` (version + lockfile) are trivial.