### PR TITLE
fix(security): tranche 4 — headers, COOP, CloudFront IaC

### DIFF
--- a/cloudfront-function-url-rewrite.cjs
+++ b/cloudfront-function-url-rewrite.cjs
@@ -21,6 +21,20 @@ function handler(event) {
   var uri = request.uri;
   var headers = request.headers;
 
+  // 0. Path-safety guard. Bail to the root index for URIs containing control
+  //    characters, null bytes, or path-traversal sequences. CloudFront and
+  //    S3 reject most of these downstream, but a cheap defense-in-depth check
+  //    here prevents any chance of CRLF injection into the rewritten URI.
+  if (
+    uri.indexOf('\r') !== -1 ||
+    uri.indexOf('\n') !== -1 ||
+    uri.indexOf('\0') !== -1 ||
+    uri.indexOf('..') !== -1
+  ) {
+    request.uri = '/index.html';
+    return request;
+  }
+
   // 1. Resolve trailing-slash and extensionless paths to their `index.html`.
   if (uri.endsWith('/')) {
     request.uri = uri + 'index.html';

--- a/cloudfront/response-headers-policy.json
+++ b/cloudfront/response-headers-policy.json
@@ -1,0 +1,51 @@
+{
+  "Comment": "Security headers for gsd.vinny.dev — CSP, HSTS, COOP/CORP, Permissions-Policy, frame protection.",
+  "Name": "gsd-security-headers",
+  "SecurityHeadersConfig": {
+    "XSSProtection": {
+      "Override": true,
+      "Protection": false
+    },
+    "FrameOptions": {
+      "Override": true,
+      "FrameOption": "DENY"
+    },
+    "ReferrerPolicy": {
+      "Override": true,
+      "ReferrerPolicy": "strict-origin-when-cross-origin"
+    },
+    "ContentSecurityPolicy": {
+      "Override": true,
+      "ContentSecurityPolicy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://api.vinny.io https://accounts.google.com https://github.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://accounts.google.com https://github.com; object-src 'none'; manifest-src 'self'; worker-src 'self';"
+    },
+    "ContentTypeOptions": {
+      "Override": true
+    },
+    "StrictTransportSecurity": {
+      "Override": true,
+      "IncludeSubdomains": true,
+      "Preload": true,
+      "AccessControlMaxAgeSec": 63072000
+    }
+  },
+  "CustomHeadersConfig": {
+    "Quantity": 3,
+    "Items": [
+      {
+        "Header": "Cross-Origin-Opener-Policy",
+        "Value": "same-origin-allow-popups",
+        "Override": true
+      },
+      {
+        "Header": "Cross-Origin-Resource-Policy",
+        "Value": "same-origin",
+        "Override": true
+      },
+      {
+        "Header": "Permissions-Policy",
+        "Value": "accelerometer=(), autoplay=(), bluetooth=(), browsing-topics=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), hid=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), serial=(), usb=()",
+        "Override": true
+      }
+    ]
+  }
+}

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -22,13 +22,28 @@
 
 	# Security headers
 	header {
-		X-Content-Type-Options    "nosniff"
-		X-Frame-Options           "DENY"
-		Referrer-Policy           "strict-origin-when-cross-origin"
-		Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
-		Permissions-Policy        "geolocation=(), microphone=(), camera=(), payment=()"
-		Content-Security-Policy   "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://accounts.google.com https://github.com;"
+		X-Content-Type-Options       "nosniff"
+		X-Frame-Options              "DENY"
+		Referrer-Policy              "strict-origin-when-cross-origin"
+		Strict-Transport-Security    "max-age=63072000; includeSubDomains; preload"
+
+		# COOP is required for OAuth popup-flow safety (`window.opener`
+		# isolation, tabnabbing defense). COEP intentionally omitted —
+		# enabling it would break OAuth popup `postMessage`.
+		Cross-Origin-Opener-Policy   "same-origin-allow-popups"
+		Cross-Origin-Resource-Policy "same-origin"
+
+		# Permissions-Policy: deny everything the app does not use. Modern
+		# directives (browsing-topics, interest-cohort, display-capture,
+		# etc.) close future-feature gaps that the original 4-directive
+		# allowlist did not cover.
+		Permissions-Policy           "accelerometer=(), autoplay=(), bluetooth=(), browsing-topics=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), hid=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), serial=(), usb=()"
+
+		Content-Security-Policy      "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://accounts.google.com https://github.com; object-src 'none'; manifest-src 'self'; worker-src 'self';"
+
+		# Hide server / upstream framework banners.
 		-Server
+		-X-Powered-By
 	}
 
 	# ---- PocketBase reverse proxy ----

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.1.6",
+	"version": "9.1.7",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '9.1.4';
+const CACHE_VERSION = '9.1.7';
 const CACHE_NAME = `gsd-cache-v${CACHE_VERSION}`;
 const OFFLINE_ASSETS = [
 	"/",

--- a/scripts/deploy-cloudfront-function.sh
+++ b/scripts/deploy-cloudfront-function.sh
@@ -3,6 +3,11 @@
 # Deploy CloudFront Functions for URL rewriting and agent-discovery response headers.
 # This script publishes both functions and attaches them to the distribution
 # (viewer-request and viewer-response respectively).
+#
+# Note: security headers (CSP, HSTS, COOP/CORP, Permissions-Policy, frame
+# protection) are managed by the separate `deploy-cloudfront-response-headers-policy.sh`
+# script using the JSON definition in `cloudfront/response-headers-policy.json`.
+# Run that script whenever the policy file changes.
 
 set -euo pipefail
 

--- a/scripts/deploy-cloudfront-response-headers-policy.sh
+++ b/scripts/deploy-cloudfront-response-headers-policy.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Apply the gsd-security-headers Response Headers Policy from version control.
+#
+# This script keeps the authoritative production security headers
+# (CSP, HSTS, COOP/CORP, Permissions-Policy, frame protection) in
+# `cloudfront/response-headers-policy.json` instead of letting them
+# drift in the AWS console. Run it whenever the policy file changes.
+#
+# Idempotent: creates the policy if it does not exist, updates it
+# (ETag-aware) if it does.
+#
+# Environment variables:
+#   POLICY_NAME  Defaults to 'gsd-security-headers' (matches what the
+#                CloudFront distribution references).
+
+set -euo pipefail
+
+export AWS_PAGER=""
+export AWS_REGION="${AWS_REGION:-us-east-1}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+POLICY_FILE="$PROJECT_ROOT/cloudfront/response-headers-policy.json"
+POLICY_NAME="${POLICY_NAME:-gsd-security-headers}"
+
+for cmd in aws jq; do
+  command -v "$cmd" >/dev/null 2>&1 || {
+    echo "❌ Required tool not found on PATH: $cmd" >&2
+    exit 1
+  }
+done
+
+[[ -f "$POLICY_FILE" ]] || {
+  echo "❌ Policy file missing: $POLICY_FILE" >&2
+  exit 1
+}
+
+# Sanity-check that the JSON parses before we send it to AWS.
+jq -e . "$POLICY_FILE" > /dev/null
+
+# Use a private temp dir with cleanup on exit.
+TMPDIR_LOCAL="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_LOCAL"' EXIT
+
+echo "🔍 Checking for existing policy: $POLICY_NAME"
+
+# Find an existing policy by name. The list endpoint paginates, but the
+# `--query` filter handles that for our scale.
+EXISTING_ID=$(aws cloudfront list-response-headers-policies \
+  --type custom \
+  --query "ResponseHeadersPolicyList.Items[?ResponseHeadersPolicy.ResponseHeadersPolicyConfig.Name=='$POLICY_NAME'].ResponseHeadersPolicy.Id" \
+  --output text 2>/dev/null || true)
+
+if [[ -z "$EXISTING_ID" || "$EXISTING_ID" == "None" ]]; then
+  echo "✨ Creating new Response Headers Policy: $POLICY_NAME"
+  aws cloudfront create-response-headers-policy \
+    --response-headers-policy-config "file://$POLICY_FILE" \
+    --query 'ResponseHeadersPolicy.Id' \
+    --output text
+else
+  echo "📝 Updating existing Response Headers Policy: $POLICY_NAME (id=$EXISTING_ID)"
+
+  # ETag is required for update; fetch the current ETag.
+  ETAG=$(aws cloudfront get-response-headers-policy \
+    --id "$EXISTING_ID" \
+    --query 'ETag' \
+    --output text)
+
+  aws cloudfront update-response-headers-policy \
+    --id "$EXISTING_ID" \
+    --if-match "$ETAG" \
+    --response-headers-policy-config "file://$POLICY_FILE" \
+    --query 'ResponseHeadersPolicy.Id' \
+    --output text
+fi
+
+echo ""
+echo "✅ Policy applied. Distribution must reference it by id in its DefaultCacheBehavior."
+echo "    To verify: aws cloudfront get-distribution-config --id \$CLOUDFRONT_DISTRIBUTION_ID \\"
+echo "      | jq '.DistributionConfig.DefaultCacheBehavior.ResponseHeadersPolicyId'"

--- a/tests/data/cloudfront-functions.test.ts
+++ b/tests/data/cloudfront-functions.test.ts
@@ -59,6 +59,33 @@ describe('cloudfront-function-url-rewrite (viewer-request)', () => {
 		const out = urlRewrite({ request: req }) as CFRequest;
 		expect(out.uri).toBe('/about/index.html');
 	});
+
+	describe('path safety', () => {
+		it('rejects URIs containing carriage returns', () => {
+			const req = makeRequest('/about\r/');
+			const out = urlRewrite({ request: req }) as CFRequest;
+			// Should fall back to /index.html, not propagate the CR.
+			expect(out.uri).not.toContain('\r');
+		});
+
+		it('rejects URIs containing newlines (CRLF injection defense)', () => {
+			const req = makeRequest('/about\n/');
+			const out = urlRewrite({ request: req }) as CFRequest;
+			expect(out.uri).not.toContain('\n');
+		});
+
+		it('rejects URIs containing null bytes', () => {
+			const req = makeRequest('/about\0/');
+			const out = urlRewrite({ request: req }) as CFRequest;
+			expect(out.uri).not.toContain('\0');
+		});
+
+		it('rejects URIs containing path traversal sequences', () => {
+			const req = makeRequest('/about/../../etc/passwd');
+			const out = urlRewrite({ request: req }) as CFRequest;
+			expect(out.uri).not.toContain('..');
+		});
+	});
 });
 
 describe('cloudfront-function-response-headers (viewer-response)', () => {


### PR DESCRIPTION
## Summary

Tranche 4 of 5 from the [May 2026 security review](../blob/main/tasks/security-review-2026-05-12.md). Scope: deployment-layer security headers and CloudFront infrastructure drift.

- **P1-9**: COOP (`same-origin-allow-popups`) + CORP (`same-origin`) added to **both** Caddyfile and the new CloudFront policy file. OAuth popup-flow defense against tabnabbing.
- **P2-13**: CloudFront Response Headers Policy is now in version control at `cloudfront/response-headers-policy.json`. New `scripts/deploy-cloudfront-response-headers-policy.sh` applies it idempotently. The drift problem (production CSP lived only in the AWS console) is solved.
- **P3-9**: `cloudfront-function-url-rewrite.cjs` short-circuits to `/index.html` for URIs containing `\r`, `\n`, `\0`, or `..` — defense-in-depth against CRLF injection / path traversal.
- **P3-10**: Permissions-Policy expanded from 4 directives to 18 (locks down USB, serial, HID, bluetooth, accelerometer, gyroscope, magnetometer, midi, browsing-topics, interest-cohort, display-capture, encrypted-media, autoplay).
- **P3-12**: Caddyfile strips `X-Powered-By` in addition to existing `Server` strip.

CSP also strengthened (rolled in since the policy was already being rewritten): both Caddyfile and CloudFront CSP now include `object-src 'none'`, `manifest-src 'self'`, `worker-src 'self'`. The CloudFront CSP `connect-src` allowlists `https://api.vinny.io`, `https://accounts.google.com`, and `https://github.com` explicitly.

## Test plan

- [x] `node --check cloudfront-function-url-rewrite.cjs` — syntax OK
- [x] `jq -e . cloudfront/response-headers-policy.json` — JSON valid
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun run test` — 1833 pass (1829 baseline + 4 new path-safety tests for the URL-rewrite function)
- [x] `bun run build` — static export builds cleanly
- [ ] **Manual post-merge**: run `bash scripts/deploy-cloudfront-response-headers-policy.sh` and verify with `curl -I https://gsd.vinny.dev`:
  - `Cross-Origin-Opener-Policy: same-origin-allow-popups`
  - `Cross-Origin-Resource-Policy: same-origin`
  - Expanded `Permissions-Policy` (18 directives)
  - CSP includes `object-src 'none'; manifest-src 'self'; worker-src 'self';`
- [ ] **Manual post-merge**: OAuth popup round-trip (Google AND GitHub) against the new COOP value to confirm `postMessage` still works
- [ ] **Manual post-merge**: redeploy self-hosted Docker and confirm the Caddyfile parses (run `docker compose up` and check for header presence on a `curl -I` against the container)

## Operational notes

- The new deploy script is not committed with the executable bit (chmod was blocked in the sandbox). Run via `bash scripts/deploy-cloudfront-response-headers-policy.sh`, or `chmod +x` locally before first invocation.
- The Caddyfile is not validated by CI today; if there's a typo it will only be caught at container start. Worth adding a Caddy validate step to CI in a follow-up.
- COEP intentionally omitted — enabling it would break OAuth popup `postMessage` and is not needed for this app.

## Merge order

Independent of Tranches 1, 2, 3. Conflicts on `package.json` (version) and `public/sw.js` (cache version) are trivial.