### PR TITLE
fix(security): tranche 5 — defensive hardening (WebMCP, import, render cap)

### DIFF
--- a/components/import-dialog.tsx
+++ b/components/import-dialog.tsx
@@ -22,16 +22,37 @@ export function ImportDialog({ open, onOpenChange, fileContents, existingTaskCou
   const [isImporting, setIsImporting] = useState(false);
   const [importTaskCount, setImportTaskCount] = useState<number | null>(null);
 
-  // Parse the file to get task count when fileContents changes
+  // Parse the file to get task count when fileContents changes.
+  //
+  // We only need the count for the dialog copy ("Importing 5 tasks") — the
+  // real validation runs later in `importFromJson` via `importPayloadSchema`.
+  // Tri-state result:
+  //   number  — known count (valid array, or valid JSON without tasks key → 0)
+  //   null    — couldn't determine (parse error, or `tasks` is the wrong type)
+  // Avoids a misleading count for malformed payloads like `{ "tasks": "AAAA" }`
+  // where the old `parsed.tasks?.length ?? 0` would have reported `4`.
   useEffect(() => {
-    if (fileContents) {
-      try {
-        const parsed = JSON.parse(fileContents);
-        setImportTaskCount(parsed.tasks?.length ?? 0);
-      } catch {
+    if (!fileContents) {
+      setImportTaskCount(null);
+      return;
+    }
+    try {
+      const parsed: unknown = JSON.parse(fileContents);
+      if (parsed === null || typeof parsed !== 'object') {
+        setImportTaskCount(null);
+        return;
+      }
+      const tasks = (parsed as { tasks?: unknown }).tasks;
+      if (tasks === undefined) {
+        // Valid JSON, no tasks key — definitively 0 tasks to import.
+        setImportTaskCount(0);
+      } else if (Array.isArray(tasks)) {
+        setImportTaskCount(tasks.length);
+      } else {
+        // Malformed: tasks key present but not an array.
         setImportTaskCount(null);
       }
-    } else {
+    } catch {
       setImportTaskCount(null);
     }
   }, [fileContents]);

--- a/components/webmcp-register.tsx
+++ b/components/webmcp-register.tsx
@@ -40,6 +40,9 @@ const TOOLS: WebMCPToolDefinition[] = [
 		inputSchema: {
 			type: "object",
 			required: ["title"],
+			// Reject unknown fields so an AI cannot smuggle subtasks/dependencies/etc.
+			// past the JSON Schema layer and rely on `execute` whitelist alone.
+			additionalProperties: false,
 			properties: {
 				title: {
 					type: "string",
@@ -68,7 +71,11 @@ const TOOLS: WebMCPToolDefinition[] = [
 				tags: {
 					type: "array",
 					items: { type: "string", minLength: 1, maxLength: 32 },
-					description: "Optional list of lowercase, kebab-case tags.",
+					// maxItems mirrors the Zod constraint in createTask so the AI
+					// sees the same limit the validator will enforce. Without it,
+					// >20 tags pass JSON Schema and hit a confusing Zod error.
+					maxItems: SCHEMA_LIMITS.MAX_TAGS,
+					description: "Optional list of lowercase, kebab-case tags (max 20).",
 				},
 			},
 		},

--- a/lib/task-links.ts
+++ b/lib/task-links.ts
@@ -1,3 +1,5 @@
+import { SCHEMA_LIMITS } from "@/lib/constants/schema";
+
 export type DescriptionSegment =
   | { type: "text"; text: string }
   | { type: "link"; text: string; href: string };
@@ -6,6 +8,9 @@ const URL_CANDIDATE_PATTERN = /\bhttps?:\/\/[^\s<>"'`{}|\\^]+/giu;
 const TRAILING_URL_PUNCTUATION_PATTERN = /[),.!?;:]+$/u;
 const MAX_URL_LENGTH = 2048;
 const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+// Defensive ceiling for getDescriptionSegments — see comment on the cap there.
+const MAX_DESCRIPTION_RENDER_LENGTH = SCHEMA_LIMITS.TASK_DESCRIPTION_MAX_LENGTH * 2;
 
 export function sanitizeHttpUrl(candidate: string): string | null {
   const value = candidate.trim();
@@ -36,6 +41,16 @@ export function sanitizeHttpUrl(candidate: string): string | null {
 }
 
 export function getDescriptionSegments(description: string): DescriptionSegment[] {
+  // Zod bounds description at TASK_DESCRIPTION_MAX_LENGTH at the write
+  // boundary. This defensive slice protects the regex/iteration cost if a
+  // future bypass (e.g. a sync-pull mapper change) ever lets an oversize
+  // string reach the renderer. Doubled to leave headroom for legacy data
+  // that may predate the cap.
+  const safeDescription =
+    description.length > MAX_DESCRIPTION_RENDER_LENGTH
+      ? description.slice(0, MAX_DESCRIPTION_RENDER_LENGTH)
+      : description;
+
   const segments: DescriptionSegment[] = [];
   let lastIndex = 0;
   const pushText = (text: string) => {
@@ -50,7 +65,7 @@ export function getDescriptionSegments(description: string): DescriptionSegment[
     segments.push({ type: "text", text });
   };
 
-  for (const match of description.matchAll(URL_CANDIDATE_PATTERN)) {
+  for (const match of safeDescription.matchAll(URL_CANDIDATE_PATTERN)) {
     const rawMatch = match[0];
     const matchIndex = match.index ?? 0;
     const trimmedCandidate = rawMatch.replace(TRAILING_URL_PUNCTUATION_PATTERN, "");
@@ -62,7 +77,7 @@ export function getDescriptionSegments(description: string): DescriptionSegment[
     }
 
     if (matchIndex > lastIndex) {
-      pushText(description.slice(lastIndex, matchIndex));
+      pushText(safeDescription.slice(lastIndex, matchIndex));
     }
 
     segments.push({ type: "link", text: trimmedCandidate, href });
@@ -70,9 +85,9 @@ export function getDescriptionSegments(description: string): DescriptionSegment[
     lastIndex = matchIndex + rawMatch.length;
   }
 
-  if (lastIndex < description.length) {
-    pushText(description.slice(lastIndex));
+  if (lastIndex < safeDescription.length) {
+    pushText(safeDescription.slice(lastIndex));
   }
 
-  return segments.length > 0 ? segments : [{ type: "text", text: description }];
+  return segments.length > 0 ? segments : [{ type: "text", text: safeDescription }];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.1.7",
+	"version": "9.1.8",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '9.1.7';
+const CACHE_VERSION = '9.1.8';
 const CACHE_NAME = `gsd-cache-v${CACHE_VERSION}`;
 const OFFLINE_ASSETS = [
 	"/",

--- a/tests/data/task-links.test.ts
+++ b/tests/data/task-links.test.ts
@@ -38,4 +38,17 @@ describe("task link sanitization", () => {
       { type: "text", text: "<img src=x onerror=alert(1)> javascript:alert(1)" },
     ]);
   });
+
+  it("caps oversize descriptions to protect the renderer", () => {
+    // Defense in depth: Zod bounds description length at the write boundary,
+    // but if a future sync-pull bypass ever ships an oversize string, the
+    // renderer must not iterate it unbounded.
+    const oversize = "x".repeat(10_000);
+    const segments = getDescriptionSegments(oversize);
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0].type).toBe("text");
+    // Cap is 2x SCHEMA_LIMITS.TASK_DESCRIPTION_MAX_LENGTH (600) = 1200 chars.
+    expect(segments[0].text.length).toBeLessThanOrEqual(1200);
+  });
 });


### PR DESCRIPTION
## Summary

Final tranche of 5 from the [May 2026 security review](../blob/main/tasks/security-review-2026-05-12.md). All P3 defensive items in one bundle. Low-risk, low-LOC.

- **P2-12**: WebMCP `create_task` JSON Schema declares `additionalProperties: false` and `maxItems: SCHEMA_LIMITS.MAX_TAGS`. Makes the model's view match the Zod validator's view; eliminates confusing post-call validation errors when the AI exceeds 20 tags.
- **P3-7**: `import-dialog.tsx` validates the parsed JSON shape before reading `.length`. Tri-state result: a real count (array), `0` (valid JSON without `tasks` key), or `null` (malformed — e.g. `tasks` is a string). Closes the misleading-count case where `{"tasks": "AAAA"}` would have rendered as "Importing 4 tasks".
- **P3-8**: `getDescriptionSegments` defensively caps input at 2× `TASK_DESCRIPTION_MAX_LENGTH` (1200 chars) before iterating with the URL regex. Defense-in-depth for the renderer if a future sync-pull bypass ever ships an oversize string.

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun run test` — 1830 pass (+1 new task-links cap test; updated 1 import-dialog test to assert new tri-state semantics; same 5 pre-existing e2e config failures as `main`)
- [x] `bun run build` — static export builds cleanly

## Behavioral changes

- **import-dialog**: a file like `{"version": "1.0"}` (valid JSON, no tasks) now still shows "0 tasks" — unchanged. A file like `{"tasks": "AAAA"}` (malformed) used to render "Importing 4 tasks"; now renders "Importing these tasks". The real validator catches the malformed case later regardless.
- **WebMCP**: an AI calling `create_task` with extra fields or >20 tags now gets a clear JSON Schema error instead of falling through to a Zod error inside `createTask()`.
- **task descriptions**: oversize descriptions (>1200 chars) are sliced before rendering. No user-visible change — Zod already enforces 600 chars at the write boundary.

## Closing the May 2026 review

This concludes the remediation. All P1, P2, P3 findings from `tasks/security-review-2026-05-12.md` are now addressed across:

- PR #270 — Tranche 1 (deps + logger)
- PR #271 — Tranche 2 (MCP server)
- PR #272 — Tranche 3 (sync layer)
- PR #273 — Tranche 4 (headers + IaC)
- This PR — Tranche 5 (defensive hardening)

## Merge order

Independent of Tranches 1-4. Trivial conflicts on `package.json` (version) and `public/sw.js` (cache version).