### PR TITLE
feat(matrix): restore per-task share dialog dropped in v9 cleanup

### DIFF
--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -21,6 +21,7 @@ import {
 import type { TaskRecord } from "@/lib/types";
 import { quadrantByRdKey, type RedesignQuadrantKey } from "@/lib/quadrants";
 import { TaskCard } from "@/components/task-card";
+import { ShareTaskDialog } from "@/components/share-task-dialog";
 import { AppShell } from "./app-shell";
 import { CaptureBar, type CapturePayload } from "./capture-bar";
 import { MatrixGrid } from "./matrix-grid";
@@ -65,6 +66,7 @@ export function MatrixSimplified() {
   const [createDrawerOpen, setCreateDrawerOpen] = useState(false);
   const [createInitial, setCreateInitial] = useState<Partial<EditDraft> | undefined>(undefined);
   const [showCompleted, setShowCompleted] = useState<boolean>(readShowCompleted);
+  const [sharingTask, setSharingTask] = useState<TaskRecord | null>(null);
 
   useEffect(() => {
     const handler = (e: Event) => {
@@ -199,6 +201,10 @@ export function MatrixSimplified() {
 
   const handleEditOpen = useCallback((task: TaskRecord) => setEditingTask(task), []);
   const handleEditClose = useCallback(() => setEditingTask(null), []);
+  const handleShareOpen = useCallback((task: TaskRecord) => setSharingTask(task), []);
+  const handleShareOpenChange = useCallback((next: boolean) => {
+    if (!next) setSharingTask(null);
+  }, []);
 
   const handleOpenCreateDrawer = useCallback((payload?: CapturePayload) => {
     if (payload) {
@@ -294,9 +300,16 @@ export function MatrixSimplified() {
           onEdit={handleEditOpen}
           onToggleComplete={handleToggle}
           onDelete={handleDelete}
+          onShare={handleShareOpen}
           onAddInQuadrant={handleAddInQuadrant}
         />
       </AppShell>
+
+      <ShareTaskDialog
+        task={sharingTask}
+        open={Boolean(sharingTask)}
+        onOpenChange={handleShareOpenChange}
+      />
 
       <EditDrawer
         open={Boolean(editingTask)}

--- a/components/matrix-simplified/matrix-grid.tsx
+++ b/components/matrix-simplified/matrix-grid.tsx
@@ -11,6 +11,7 @@ interface MatrixGridProps {
   onEdit: (task: TaskRecord) => void;
   onToggleComplete: (task: TaskRecord, completed: boolean) => void | Promise<void>;
   onDelete: (task: TaskRecord) => void | Promise<void>;
+  onShare: (task: TaskRecord) => void;
   onAddInQuadrant: (key: RedesignQuadrantKey) => void;
 }
 
@@ -20,6 +21,7 @@ export function MatrixGrid({
   onEdit,
   onToggleComplete,
   onDelete,
+  onShare,
   onAddInQuadrant,
 }: MatrixGridProps) {
   const grouped = useMemo(() => {
@@ -54,6 +56,7 @@ export function MatrixGrid({
           onEdit={onEdit}
           onToggleComplete={onToggleComplete}
           onDelete={onDelete}
+          onShare={onShare}
           onAddInQuadrant={onAddInQuadrant}
         />
       ))}

--- a/components/matrix-simplified/quadrant-pane.tsx
+++ b/components/matrix-simplified/quadrant-pane.tsx
@@ -44,6 +44,7 @@ interface QuadrantPaneProps {
   onEdit: (task: TaskRecord) => void;
   onToggleComplete: (task: TaskRecord, completed: boolean) => void | Promise<void>;
   onDelete: (task: TaskRecord) => void | Promise<void>;
+  onShare: (task: TaskRecord) => void;
   onAddInQuadrant: (key: RedesignQuadrantKey) => void;
 }
 
@@ -55,6 +56,7 @@ export function QuadrantPane({
   onEdit,
   onToggleComplete,
   onDelete,
+  onShare,
   onAddInQuadrant,
 }: QuadrantPaneProps) {
   const { setNodeRef, isOver } = useDroppable({ id: meta.id });
@@ -135,6 +137,7 @@ export function QuadrantPane({
                 allTasks={allTasks}
                 onEdit={onEdit}
                 onDelete={onDelete}
+                onShare={onShare}
                 onToggleComplete={onToggleComplete}
               />
             ))

--- a/components/share-task-dialog/format-task-details.ts
+++ b/components/share-task-dialog/format-task-details.ts
@@ -1,0 +1,61 @@
+import type { TaskRecord } from "@/lib/types";
+import { formatDueDate } from "@/lib/utils";
+
+export function canUseWebShare(): boolean {
+  return typeof navigator !== "undefined" && typeof navigator.share === "function";
+}
+
+export function formatTaskHeader(task: TaskRecord): string[] {
+  return [`Task: ${task.title}`, ""];
+}
+
+export function formatTaskDescription(task: TaskRecord): string[] {
+  if (!task.description) return [];
+  return ["Description:", task.description, ""];
+}
+
+export function formatTaskMetadata(task: TaskRecord): string[] {
+  const lines: string[] = ["Details:"];
+  lines.push(`Status: ${task.completed ? "Completed" : "To Do"}`);
+
+  const priority = task.urgent && task.important
+    ? "Urgent & Important"
+    : task.urgent ? "Urgent" : task.important ? "Important" : "Low Priority";
+  lines.push(`Priority: ${priority}`);
+
+  if (task.dueDate) {
+    lines.push(`Due: ${formatDueDate(task.dueDate)}`);
+  }
+  if (task.tags.length > 0) {
+    lines.push(`Tags: ${task.tags.join(", ")}`);
+  }
+  return lines;
+}
+
+export function formatTaskSubtasks(task: TaskRecord): string[] {
+  if (task.subtasks.length === 0) return [];
+  const lines = ["", "Subtasks:"];
+  task.subtasks.forEach((subtask) => {
+    lines.push(`  ${subtask.completed ? "☑" : "☐"} ${subtask.title}`);
+  });
+  return lines;
+}
+
+export function formatTaskFooter(task: TaskRecord): string[] {
+  return [
+    "",
+    `Created: ${new Date(task.createdAt).toLocaleDateString()}`,
+    "",
+    "Sent from GSD Task Manager (https://gsd.vinny.dev)",
+  ];
+}
+
+export function formatTaskDetails(task: TaskRecord): string {
+  return [
+    ...formatTaskHeader(task),
+    ...formatTaskDescription(task),
+    ...formatTaskMetadata(task),
+    ...formatTaskSubtasks(task),
+    ...formatTaskFooter(task),
+  ].join("\n");
+}

--- a/components/share-task-dialog/index.tsx
+++ b/components/share-task-dialog/index.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState } from "react";
+import { MailIcon, CopyIcon, Share2Icon } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/toast";
+import type { TaskRecord } from "@/lib/types";
+import { TOAST_DURATION } from "@/lib/constants";
+import { createLogger } from "@/lib/logger";
+import {
+  canUseWebShare,
+  formatTaskDetails,
+} from "@/components/share-task-dialog/format-task-details";
+import {
+  ShareTabButtons,
+  ShareTabContent,
+  type ShareTab,
+} from "@/components/share-task-dialog/share-tab-content";
+
+const logger = createLogger("UI");
+
+interface ShareTaskDialogProps {
+  task: TaskRecord | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ShareTaskDialog({ task, open, onOpenChange }: ShareTaskDialogProps) {
+  const [activeTab, setActiveTab] = useState<ShareTab>(() =>
+    canUseWebShare() ? "native" : "email"
+  );
+  const [recipientEmail, setRecipientEmail] = useState("");
+  const { showToast } = useToast();
+
+  if (!task) return null;
+
+  const taskDetails = formatTaskDetails(task);
+  const emailSubject = `Task: ${task.title}`;
+  const emailBody = encodeURIComponent(taskDetails);
+
+  const handleOpenEmailClient = () => {
+    const mailto = recipientEmail
+      ? `mailto:${recipientEmail}?subject=${encodeURIComponent(emailSubject)}&body=${emailBody}`
+      : `mailto:?subject=${encodeURIComponent(emailSubject)}&body=${emailBody}`;
+
+    const anchor = document.createElement("a");
+    anchor.href = mailto;
+    anchor.target = "_blank";
+    anchor.rel = "noopener noreferrer";
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+
+    onOpenChange(false);
+  };
+
+  const handleCopyDetails = async () => {
+    try {
+      await navigator.clipboard.writeText(taskDetails);
+      showToast("Task details copied to clipboard", undefined, TOAST_DURATION.SHORT);
+      onOpenChange(false);
+    } catch {
+      showToast("Failed to copy to clipboard", undefined, TOAST_DURATION.SHORT);
+    }
+  };
+
+  const handleNativeShare = async () => {
+    try {
+      await navigator.share({
+        title: `Task: ${task.title}`,
+        text: taskDetails,
+      });
+      showToast("Task shared successfully", undefined, TOAST_DURATION.SHORT);
+      onOpenChange(false);
+    } catch (error) {
+      if ((error as Error).name !== "AbortError") {
+        logger.error(
+          "Failed to share task",
+          error instanceof Error ? error : new Error(String(error))
+        );
+        showToast("Failed to share task", undefined, TOAST_DURATION.SHORT);
+      }
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg" data-testid="share-task-dialog">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Share2Icon className="h-5 w-5" aria-hidden />
+            Share Task: {task.title}
+          </DialogTitle>
+          <DialogDescription>
+            {canUseWebShare()
+              ? "Share this task to any app, via email, or copy to clipboard."
+              : "Share this task via email or copy the details to your clipboard."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <ShareTabButtons activeTab={activeTab} onTabChange={setActiveTab} />
+
+          <ShareTabContent
+            activeTab={activeTab}
+            taskDetails={taskDetails}
+            recipientEmail={recipientEmail}
+            onRecipientEmailChange={setRecipientEmail}
+          />
+
+          <div className="flex items-center justify-end gap-2 pt-2">
+            <Button variant="subtle" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            {activeTab === "native" ? (
+              <Button onClick={handleNativeShare} className="gap-2">
+                <Share2Icon className="h-4 w-4" aria-hidden />
+                Share
+              </Button>
+            ) : activeTab === "email" ? (
+              <Button onClick={handleOpenEmailClient} className="gap-2">
+                <MailIcon className="h-4 w-4" aria-hidden />
+                Open Email Client
+              </Button>
+            ) : (
+              <Button onClick={handleCopyDetails} className="gap-2">
+                <CopyIcon className="h-4 w-4" aria-hidden />
+                Copy Details
+              </Button>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/share-task-dialog/share-tab-content.tsx
+++ b/components/share-task-dialog/share-tab-content.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { MailIcon, CopyIcon, Share2Icon } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { canUseWebShare } from "@/components/share-task-dialog/format-task-details";
+
+type ShareTab = "native" | "email" | "copy";
+
+interface TaskDetailsPreviewProps {
+  label: string;
+  taskDetails: string;
+}
+
+function TaskDetailsPreview({ label, taskDetails }: TaskDetailsPreviewProps) {
+  return (
+    <div className="space-y-1">
+      <p className="text-sm font-medium text-foreground">{label}</p>
+      <div className="rounded-md border border-border bg-background-muted p-3 max-h-64 overflow-y-auto">
+        <pre className="text-xs font-mono whitespace-pre-wrap text-foreground">
+          {taskDetails}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+interface ShareTabButtonsProps {
+  activeTab: ShareTab;
+  onTabChange: (tab: ShareTab) => void;
+}
+
+export function ShareTabButtons({ activeTab, onTabChange }: ShareTabButtonsProps) {
+  const tabClass = (tab: ShareTab) =>
+    `flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors border-b-2 ${
+      activeTab === tab
+        ? "border-accent text-accent"
+        : "border-transparent text-foreground-muted hover:text-foreground"
+    }`;
+
+  return (
+    <div role="tablist" className="flex gap-2 border-b border-border">
+      {canUseWebShare() && (
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === "native"}
+          onClick={() => onTabChange("native")}
+          className={tabClass("native")}
+        >
+          <Share2Icon className="h-4 w-4" aria-hidden />
+          Share
+        </button>
+      )}
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeTab === "email"}
+        onClick={() => onTabChange("email")}
+        className={tabClass("email")}
+      >
+        <MailIcon className="h-4 w-4" aria-hidden />
+        Email
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeTab === "copy"}
+        onClick={() => onTabChange("copy")}
+        className={tabClass("copy")}
+      >
+        <CopyIcon className="h-4 w-4" aria-hidden />
+        Copy Details
+      </button>
+    </div>
+  );
+}
+
+interface ShareTabContentProps {
+  activeTab: ShareTab;
+  taskDetails: string;
+  recipientEmail: string;
+  onRecipientEmailChange: (email: string) => void;
+}
+
+export function ShareTabContent({
+  activeTab,
+  taskDetails,
+  recipientEmail,
+  onRecipientEmailChange,
+}: ShareTabContentProps) {
+  if (activeTab === "native") {
+    return (
+      <div className="space-y-3">
+        <TaskDetailsPreview label="Task Details" taskDetails={taskDetails} />
+        <p className="text-xs text-foreground-muted">
+          Share this task to WhatsApp, Messages, Slack, email, or any installed app on your device.
+        </p>
+      </div>
+    );
+  }
+
+  if (activeTab === "email") {
+    return (
+      <div className="space-y-3">
+        <div className="space-y-1">
+          <label htmlFor="recipient-email" className="text-sm font-medium text-foreground">
+            Recipient Email (optional)
+          </label>
+          <Input
+            id="recipient-email"
+            type="email"
+            placeholder="Enter email address…"
+            value={recipientEmail}
+            onChange={(e) => onRecipientEmailChange(e.target.value)}
+          />
+        </div>
+        <TaskDetailsPreview label="Email Preview" taskDetails={taskDetails} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <TaskDetailsPreview label="Task Details" taskDetails={taskDetails} />
+      <p className="text-xs text-foreground-muted">
+        Click &ldquo;Copy Details&rdquo; to copy this text to your clipboard.
+      </p>
+    </div>
+  );
+}
+
+export type { ShareTab };

--- a/tests/data/format-task-details.test.ts
+++ b/tests/data/format-task-details.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  canUseWebShare,
+  formatTaskDescription,
+  formatTaskDetails,
+  formatTaskHeader,
+  formatTaskMetadata,
+  formatTaskSubtasks,
+} from "@/components/share-task-dialog/format-task-details";
+import { createMockTask } from "@/tests/fixtures";
+
+describe("format-task-details", () => {
+  describe("formatTaskHeader", () => {
+    it("emits a Task: <title> line followed by a blank line", () => {
+      const task = createMockTask({ title: "Ship the share dialog" });
+      expect(formatTaskHeader(task)).toEqual(["Task: Ship the share dialog", ""]);
+    });
+  });
+
+  describe("formatTaskDescription", () => {
+    it("returns nothing when there is no description", () => {
+      const task = createMockTask({ description: "" });
+      expect(formatTaskDescription(task)).toEqual([]);
+    });
+
+    it("emits a labeled block when description is present", () => {
+      const task = createMockTask({ description: "Notes go here" });
+      expect(formatTaskDescription(task)).toEqual(["Description:", "Notes go here", ""]);
+    });
+  });
+
+  describe("formatTaskMetadata", () => {
+    it("labels priority as Urgent & Important when both flags are set", () => {
+      const task = createMockTask({ urgent: true, important: true });
+      expect(formatTaskMetadata(task)).toContain("Priority: Urgent & Important");
+    });
+
+    it("labels priority as Low Priority when neither flag is set", () => {
+      const task = createMockTask({ urgent: false, important: false });
+      expect(formatTaskMetadata(task)).toContain("Priority: Low Priority");
+    });
+
+    it("omits the due-date line when there is no due date", () => {
+      const task = createMockTask({ dueDate: undefined });
+      expect(formatTaskMetadata(task).some((line) => line.startsWith("Due:"))).toBe(false);
+    });
+
+    it("renders status as Completed when the task is done", () => {
+      const task = createMockTask({ completed: true });
+      expect(formatTaskMetadata(task)).toContain("Status: Completed");
+    });
+
+    it("renders tags joined by commas when present", () => {
+      const task = createMockTask({ tags: ["work", "urgent"] });
+      expect(formatTaskMetadata(task)).toContain("Tags: work, urgent");
+    });
+  });
+
+  describe("formatTaskSubtasks", () => {
+    it("returns nothing when there are no subtasks", () => {
+      const task = createMockTask({ subtasks: [] });
+      expect(formatTaskSubtasks(task)).toEqual([]);
+    });
+
+    it("renders subtasks with completion glyphs", () => {
+      const task = createMockTask({
+        subtasks: [
+          { id: "1", title: "Open", completed: false },
+          { id: "2", title: "Done", completed: true },
+        ],
+      });
+      const out = formatTaskSubtasks(task);
+      expect(out).toContain("  ☐ Open");
+      expect(out).toContain("  ☑ Done");
+    });
+  });
+
+  describe("formatTaskDetails", () => {
+    it("composes all sections into a single string", () => {
+      const task = createMockTask({
+        title: "T",
+        description: "D",
+        tags: ["a"],
+        subtasks: [{ id: "s1", title: "s", completed: false }],
+      });
+      const text = formatTaskDetails(task);
+      expect(text).toContain("Task: T");
+      expect(text).toContain("Description:");
+      expect(text).toContain("Priority:");
+      expect(text).toContain("Subtasks:");
+      expect(text).toContain("Sent from GSD Task Manager");
+    });
+  });
+
+  describe("canUseWebShare", () => {
+    const original = Object.getOwnPropertyDescriptor(navigator, "share");
+
+    afterEach(() => {
+      if (original) {
+        Object.defineProperty(navigator, "share", original);
+      } else {
+        // jsdom doesn't ship navigator.share; remove anything we added.
+        delete (navigator as unknown as { share?: unknown }).share;
+      }
+    });
+
+    beforeEach(() => {
+      delete (navigator as unknown as { share?: unknown }).share;
+    });
+
+    it("returns false when navigator.share is unavailable", () => {
+      expect(canUseWebShare()).toBe(false);
+    });
+
+    it("returns true when navigator.share is a function", () => {
+      Object.defineProperty(navigator, "share", {
+        configurable: true,
+        value: () => Promise.resolve(),
+      });
+      expect(canUseWebShare()).toBe(true);
+    });
+  });
+});

--- a/tests/ui/matrix-simplified.test.tsx
+++ b/tests/ui/matrix-simplified.test.tsx
@@ -208,6 +208,21 @@ describe("<MatrixSimplified>", () => {
       );
     });
 
+    it("opens the share dialog with the target task when its share button is clicked", async () => {
+      const user = userEvent.setup();
+      tasksFixture.current = [makeTask({ id: "shareable", title: "Shareable thing" })];
+      render(<MatrixSimplified />);
+
+      // Dialog is closed until the user clicks Share.
+      expect(screen.queryByTestId("share-task-dialog")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /share task/i }));
+
+      const dialog = await screen.findByTestId("share-task-dialog");
+      expect(dialog).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /share task: shareable thing/i })).toBeInTheDocument();
+    });
+
     it("opens the create drawer pre-set to a quadrant when its empty-state pill is clicked (polish v0.9.2 — item 3)", async () => {
       const user = userEvent.setup();
       tasksFixture.current = [];


### PR DESCRIPTION
## Summary

The per-task share dialog was removed in 8755e8f (v8 cleanup, April 2026) as part of the broader v8 surface trim. The TaskCard layer still has `onShare?` wired through to the desktop tooltip button and the mobile overflow menu — the dialog component and the host wiring were the only missing pieces.

- Restored `components/share-task-dialog/` (formatter, tab content, dialog shell — three tabs: native Web Share API, email-via-mailto, copy-to-clipboard).
- Threaded `onShare` through `MatrixGrid` → `QuadrantPane` → `TaskCard`.
- Added share state + `ShareTaskDialog` render in `MatrixSimplified`.

### Notes on the restore

- The original initialized `activeTab` via `useState(canUseWebShare() ? "native" : "email")`. Replaced with a lazy initializer — `canUseWebShare()` is already SSR-safe (returns `false` when `navigator` is undefined), so the server renders `"email"` and the client picks `"native"` on capable devices. The component returns `null` while `task` is null, so there's no hydration mismatch surface.

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun run test` — 1870 passed / 1 skipped (the 5 e2e file failures are pre-existing: vitest picking up Playwright specs)
- [x] New `tests/data/format-task-details.test.ts` — 13 tests covering the six formatter helpers + `canUseWebShare` detection
- [x] New wiring test in `tests/ui/matrix-simplified.test.tsx` — confirms clicking a task's Share button opens the dialog with the correct task title
- [x] Manual smoke in browser (not run — no browser available in this environment): open a task's Share button on desktop and mobile; verify native share, mailto, and clipboard tabs each fire the expected action

https://claude.ai/code/session_01Am4UU1FV4Rqe4VtypVcpEy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Am4UU1FV4Rqe4VtypVcpEy)_