### PR TITLE
fix(import): replace import queues remote deletes

### DIFF
--- a/lib/tasks/import-export.ts
+++ b/lib/tasks/import-export.ts
@@ -120,14 +120,34 @@ export async function importTasks(payload: ImportPayload, mode: "replace" | "mer
   if (parsed.tasks.length > MAX_IMPORT_TASKS) {
     throw new Error(`Import exceeds maximum of ${MAX_IMPORT_TASKS.toLocaleString()} tasks. Please split into smaller files.`);
   }
-  let tasksEnqueuedForSync: TaskRecord[] = [];
 
-  await db.transaction("rw", db.tasks, async () => {
+  // Resolve sync modules BEFORE opening the transaction so we don't introduce
+  // unrelated awaits that could detach the Dexie transaction context.
+  const { getSyncConfig } = await import("@/lib/sync/config");
+  const { getSyncQueue } = await import("@/lib/sync/queue");
+  const { scheduleSyncAfterChange } = await import("@/lib/tasks/crud/helpers");
+  const syncConfig = await getSyncConfig();
+  const syncEnabled = !!syncConfig?.enabled;
+  const queue = getSyncQueue();
+
+  let tasksToCreate: TaskRecord[] = [];
+  let taskIdsToDelete: string[] = [];
+
+  await db.transaction("rw", [db.tasks, db.syncQueue], async () => {
     if (mode === "replace") {
-      // Replace mode: clear existing and add imported tasks
+      // Replace mode: clear existing and add imported tasks.
+      // Capture the pre-import IDs so we can queue remote deletes for tasks
+      // that are not present in the imported payload — without this, the next
+      // pull would resurrect them from the server.
+      const existingIds = new Set(
+        (await db.tasks.toCollection().primaryKeys()) as string[],
+      );
+      const importedIds = new Set(parsed.tasks.map(t => t.id));
+      taskIdsToDelete = [...existingIds].filter(id => !importedIds.has(id));
+
       await db.tasks.clear();
       await db.tasks.bulkAdd(parsed.tasks);
-      tasksEnqueuedForSync = parsed.tasks;
+      tasksToCreate = parsed.tasks;
     } else {
       // Merge mode: keep existing, add imported with regenerated IDs if needed
       const existingTasks = await db.tasks.toArray();
@@ -135,20 +155,22 @@ export async function importTasks(payload: ImportPayload, mode: "replace" | "mer
       const { tasks: regeneratedTasks, idMap } = regenerateConflictingIds(parsed.tasks, existingIds);
       const tasksToImport = remapTaskReferences(regeneratedTasks, idMap);
       await db.tasks.bulkAdd(tasksToImport);
-      tasksEnqueuedForSync = tasksToImport;
+      tasksToCreate = tasksToImport;
+    }
+
+    // Enqueue sync operations inside the same transaction so the local mutation
+    // and the queued remote intent are atomically committed together.
+    if (syncEnabled) {
+      for (const id of taskIdsToDelete) {
+        await queue.enqueue('delete', id, null);
+      }
+      for (const task of tasksToCreate) {
+        await queue.enqueue('create', task.id, task);
+      }
     }
   });
 
-  // Enqueue imported tasks for sync (if sync is enabled)
-  const { getSyncConfig } = await import("@/lib/sync/config");
-  const { getSyncQueue } = await import("@/lib/sync/queue");
-  const { scheduleSyncAfterChange } = await import("@/lib/tasks/crud/helpers");
-  const syncConfig = await getSyncConfig();
-  if (syncConfig?.enabled) {
-    const queue = getSyncQueue();
-    for (const task of tasksEnqueuedForSync) {
-      await queue.enqueue('create', task.id, task);
-    }
+  if (syncEnabled) {
     scheduleSyncAfterChange();
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.1.9",
+	"version": "9.1.10",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/data/import-export-sync.test.ts
+++ b/tests/data/import-export-sync.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getDb } from '@/lib/db';
+import { importTasks } from '@/lib/tasks/import-export';
+import { getSyncQueue } from '@/lib/sync/queue';
+import type { ImportPayload, TaskRecord } from '@/lib/types';
+
+function makeTask(id: string, title: string): TaskRecord {
+  return {
+    id,
+    title,
+    description: '',
+    urgent: false,
+    important: false,
+    quadrant: 'not-urgent-not-important',
+    completed: false,
+    createdAt: '2026-05-01T00:00:00.000Z',
+    updatedAt: '2026-05-01T00:00:00.000Z',
+    recurrence: 'none',
+    tags: [],
+    subtasks: [],
+    dependencies: [],
+    notificationEnabled: false,
+    notificationSent: false,
+  };
+}
+
+describe('importTasks replace mode with sync enabled', () => {
+  beforeEach(async () => {
+    const db = getDb();
+    await db.tasks.clear();
+    await db.syncQueue.clear();
+    await db.syncMetadata.clear();
+    await db.syncMetadata.put({
+      key: 'sync_config',
+      enabled: true,
+      userId: 'user-1',
+      deviceId: 'dev-1',
+      deviceName: 'Test',
+      email: null,
+      provider: null,
+      lastSyncAt: null,
+      lastSuccessfulSyncAt: null,
+      consecutiveFailures: 0,
+      lastFailureAt: null,
+      lastFailureReason: null,
+      nextRetryAt: null,
+    });
+  });
+
+  it('enqueues delete operations for local tasks absent from the imported payload', async () => {
+    const db = getDb();
+    await db.tasks.bulkAdd([makeTask('keep-1', 'Keep'), makeTask('remove-1', 'Removed')]);
+
+    const payload: ImportPayload = {
+      tasks: [makeTask('keep-1', 'Keep'), makeTask('new-1', 'New')],
+      exportedAt: '2026-05-18T00:00:00.000Z',
+      version: '1.0.0',
+    };
+
+    await importTasks(payload, 'replace');
+
+    const queue = await getSyncQueue().getPending();
+    const deletes = queue.filter(q => q.operation === 'delete').map(q => q.taskId);
+    const creates = queue.filter(q => q.operation === 'create').map(q => q.taskId);
+
+    expect(deletes).toEqual(['remove-1']);
+    expect(creates.sort()).toEqual(['keep-1', 'new-1']);
+  });
+
+  it('does not enqueue deletes when sync is disabled', async () => {
+    const db = getDb();
+    await db.syncMetadata.put({
+      key: 'sync_config',
+      enabled: false,
+      userId: null,
+      deviceId: 'dev-1',
+      deviceName: 'Test',
+      email: null,
+      provider: null,
+      lastSyncAt: null,
+      lastSuccessfulSyncAt: null,
+      consecutiveFailures: 0,
+      lastFailureAt: null,
+      lastFailureReason: null,
+      nextRetryAt: null,
+    });
+    await db.tasks.bulkAdd([makeTask('remove-1', 'Removed')]);
+
+    await importTasks(
+      {
+        tasks: [makeTask('new-1', 'New')],
+        exportedAt: '2026-05-18T00:00:00.000Z',
+        version: '1.0.0',
+      },
+      'replace',
+    );
+
+    const queue = await getSyncQueue().getPending();
+    expect(queue).toHaveLength(0);
+  });
+});

--- a/tests/data/tasks/import-export.test.ts
+++ b/tests/data/tasks/import-export.test.ts
@@ -86,6 +86,13 @@ describe('Task Import/Export Operations', () => {
         toArray: vi.fn(),
         clear: vi.fn(),
         bulkAdd: vi.fn(),
+        toCollection: vi.fn(() => ({
+          primaryKeys: vi.fn().mockResolvedValue([]),
+        })),
+      },
+      syncQueue: {
+        add: vi.fn(),
+        clear: vi.fn(),
       },
       syncMetadata: {
         get: vi.fn().mockResolvedValue(null),
@@ -308,7 +315,7 @@ describe('Task Import/Export Operations', () => {
 
       expect(mockDb.transaction).toHaveBeenCalledWith(
         'rw',
-        mockDb.tasks,
+        [mockDb.tasks, mockDb.syncQueue],
         expect.any(Function)
       );
     });


### PR DESCRIPTION
Closes Codex adversarial review finding #4. See plan: docs/superpowers/plans/2026-05-18-codex-adversarial-review-fixes.md

## Summary
- Replace-mode import now computes `idsToDelete = existingIds − importedIds` and enqueues a `delete` op for each, ensuring tasks removed by the replace are propagated to PocketBase.
- The Dexie transaction now includes `db.syncQueue` alongside `db.tasks` so the local mutation and the queued remote intents commit atomically.
- Sync module dynamic imports moved before the transaction to avoid async gaps that could detach the transaction context.
- Merge-mode behavior is unchanged.

## Test plan
- [x] New file `tests/data/import-export-sync.test.ts`: sync-enabled replace enqueues delete for missing IDs and creates for imported ones; sync-disabled replace enqueues nothing.
- [x] `bun run test -- tests/data/import.test.ts tests/data/tasks/import-export.test.ts tests/data/import-export-sync.test.ts` — all 34 tests pass.
- [x] `bun typecheck` clean.
- [x] `bun lint` clean.
- [ ] Manual: enable sync on two devices, do a replace import on device A that removes a task, verify device B no longer sees the resurrected task after the next pull.