### PR TITLE
fix(sync): clamp pull cursor against bogus future timestamps

### DIFF
--- a/lib/sync/pb-pull.ts
+++ b/lib/sync/pb-pull.ts
@@ -14,10 +14,46 @@ import type { RecordModel } from 'pocketbase';
 
 const logger = createLogger('SYNC_ENGINE');
 
+/** Five minutes — anything further into the future is treated as clock skew. */
+const FUTURE_TIMESTAMP_CLAMP_MS = 5 * 60 * 1000;
+
+/** Overlap window subtracted from the persisted cursor to avoid boundary misses. */
+const CURSOR_OVERLAP_MS = 30 * 1000;
+
+/**
+ * Clamp a client-supplied timestamp so it cannot exceed `now + 5min`.
+ * Anything further into the future is treated as clock skew, not a real event.
+ * A NaN/malformed input falls back to the current time.
+ */
+function clampFutureTimestamp(iso: string): string {
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return new Date().toISOString();
+  const ceiling = Date.now() + FUTURE_TIMESTAMP_CLAMP_MS;
+  return ts > ceiling ? new Date(ceiling).toISOString() : iso;
+}
+
+/** Find the max client_updated_at across records that were successfully applied. */
+function findMaxAppliedTimestamp(appliedRecords: RecordModel[]): string | null {
+  let max: string | null = null;
+  for (const record of appliedRecords) {
+    const raw = record['client_updated_at'] as string | undefined;
+    if (!raw) continue;
+    const clamped = clampFutureTimestamp(raw);
+    if (!max || clamped > max) max = clamped;
+  }
+  return max;
+}
+
 /**
  * Apply fetched remote records to local IndexedDB using LWW resolution.
+ * Returns the records that were actually applied (post-validation, post-LWW)
+ * so the caller can compute a cursor from real, persisted events only.
  */
-async function applyRemoteRecords(records: RecordModel[]): Promise<{ pulledCount: number; skippedCount: number }> {
+async function applyRemoteRecords(records: RecordModel[]): Promise<{
+  appliedRecords: RecordModel[];
+  pulledCount: number;
+  skippedCount: number;
+}> {
   const db = getDb();
   // First pass: validate records without local state (just to filter invalid ones)
   const validRecords: RecordModel[] = [];
@@ -39,6 +75,7 @@ async function applyRemoteRecords(records: RecordModel[]): Promise<{ pulledCount
       .map(t => [t.id, t])
   );
 
+  const appliedRecords: RecordModel[] = [];
   let pulledCount = 0;
 
   for (const record of validRecords) {
@@ -49,30 +86,20 @@ async function applyRemoteRecords(records: RecordModel[]): Promise<{ pulledCount
 
     if (!localTask) {
       await db.tasks.add(remoteTask);
+      appliedRecords.push(record);
       pulledCount++;
     } else {
       const remoteTime = new Date(remoteTask.updatedAt).getTime();
       const localTime = new Date(localTask.updatedAt).getTime();
       if (remoteTime >= localTime) {
         await db.tasks.put(remoteTask);
+        appliedRecords.push(record);
         pulledCount++;
       }
     }
   }
 
-  return { pulledCount, skippedCount };
-}
-
-/** Find the maximum client_updated_at across a set of PocketBase records */
-function findMaxTimestamp(records: RecordModel[]): string | null {
-  let max: string | null = null;
-  for (const record of records) {
-    const ts = record['client_updated_at'] as string;
-    if (ts && (!max || ts > max)) {
-      max = ts;
-    }
-  }
-  return max;
+  return { appliedRecords, pulledCount, skippedCount };
 }
 
 /**
@@ -93,7 +120,10 @@ export async function pullRemoteChanges(lastSyncAt: string | null): Promise<{ pu
 
   let filter = `owner = "${escapeFilterValue(ownerId)}"`;
   if (lastSyncAt) {
-    filter += ` && client_updated_at > "${escapeFilterValue(lastSyncAt)}"`;
+    // `>=` (paired with the 30s overlap subtracted when persisting the cursor)
+    // protects against boundary misses caused by clock drift across devices.
+    // Re-fetched records are no-ops via LWW.
+    filter += ` && client_updated_at >= "${escapeFilterValue(lastSyncAt)}"`;
   }
 
   const records = await pb.collection('tasks').getFullList({
@@ -101,12 +131,18 @@ export async function pullRemoteChanges(lastSyncAt: string | null): Promise<{ pu
     sort: '-client_updated_at',
   });
 
-  const { pulledCount, skippedCount } = await applyRemoteRecords(records);
+  const { appliedRecords, pulledCount, skippedCount } = await applyRemoteRecords(records);
   if (skippedCount > 0) {
     logger.warn('Skipped invalid remote records during pull', { skippedCount });
   }
 
-  const maxObservedTimestamp = findMaxTimestamp(records);
+  // Advance the cursor only from records we actually applied — never from
+  // skipped/invalid ones — and subtract a 30s overlap window so the next
+  // pull's `>=` filter catches anything written near the boundary.
+  const maxApplied = findMaxAppliedTimestamp(appliedRecords);
+  const maxObservedTimestamp = maxApplied
+    ? new Date(new Date(maxApplied).getTime() - CURSOR_OVERLAP_MS).toISOString()
+    : null;
 
   await reconcileDeletedTasks(ownerId);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.1.9",
+	"version": "9.1.10",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/data/sync/pb-pull.test.ts
+++ b/tests/data/sync/pb-pull.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RecordModel } from 'pocketbase';
+
+vi.mock('@/lib/sync/pocketbase-client', () => ({
+  getPocketBase: vi.fn(),
+  getCurrentUserId: vi.fn(() => 'user-1'),
+}));
+
+vi.mock('@/lib/sync/pb-sync-helpers', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/sync/pb-sync-helpers')>('@/lib/sync/pb-sync-helpers');
+  return {
+    ...actual,
+    fetchRemoteTaskIndex: vi.fn(async () => ({ index: new Map(), fetchSucceeded: true })),
+    getCurrentUserId: vi.fn(() => 'user-1'),
+  };
+});
+
+import { pullRemoteChanges } from '@/lib/sync/pb-pull';
+import { getPocketBase } from '@/lib/sync/pocketbase-client';
+
+function pbRecord(taskId: string, clientUpdatedAt: string): RecordModel {
+  return {
+    id: `rec-${taskId}`,
+    collectionId: 'tasks',
+    collectionName: 'tasks',
+    created: '2026-05-18T00:00:00.000Z',
+    updated: '2026-05-18T00:00:00.000Z',
+    task_id: taskId,
+    title: 'T',
+    description: '',
+    urgent: false,
+    important: false,
+    quadrant: 'not-urgent-not-important',
+    completed: false,
+    client_updated_at: clientUpdatedAt,
+    client_created_at: '2026-05-18T00:00:00.000Z',
+    device_id: 'other-device',
+    owner: 'user-1',
+  } as unknown as RecordModel;
+}
+
+describe('pullRemoteChanges cursor clamping', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('clamps year-3000 timestamps to now+5min when computing the cursor', async () => {
+    const fiveMinFromNow = Date.now() + 5 * 60 * 1000;
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({
+        getFullList: vi.fn(async () => [pbRecord('t1', '3000-01-01T00:00:00.000Z')]),
+      }),
+    });
+
+    const { maxObservedTimestamp } = await pullRemoteChanges(null);
+    expect(maxObservedTimestamp).not.toBeNull();
+    expect(new Date(maxObservedTimestamp!).getTime()).toBeLessThanOrEqual(fiveMinFromNow + 1000);
+  });
+
+  it('does not include invalid (un-applied) records in the cursor', async () => {
+    const badRecord = pbRecord('t1', '2099-12-31T00:00:00.000Z');
+    // Force `pocketBaseToTaskRecord` to reject by stripping a required field.
+    delete (badRecord as Record<string, unknown>).title;
+
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({
+        getFullList: vi.fn(async () => [badRecord, pbRecord('t2', '2026-05-18T00:00:00.000Z')]),
+      }),
+    });
+
+    const { maxObservedTimestamp } = await pullRemoteChanges(null);
+    // The applied record's client_updated_at is 2026-05-18T00:00:00Z; the cursor
+    // is persisted with a 30s overlap subtracted so the next pull's `>=` filter
+    // can re-catch boundary records reliably across clock drift.
+    expect(maxObservedTimestamp).toBe('2026-05-17T23:59:30.000Z');
+  });
+});

--- a/tests/sync/pb-sync-engine.test.ts
+++ b/tests/sync/pb-sync-engine.test.ts
@@ -252,7 +252,9 @@ describe('pb-sync-engine', () => {
       const result = await pullRemoteChanges(null);
 
       expect(result.authenticated).toBe(true);
-      expect(result.maxObservedTimestamp).toBe('2024-06-15T12:00:00.000Z');
+      // Cursor is persisted with a 30s overlap subtracted so the next pull's
+      // `>=` filter can re-catch boundary records across clock drift.
+      expect(result.maxObservedTimestamp).toBe('2024-06-15T11:59:30.000Z');
     });
 
     it('should return null maxObservedTimestamp when no records pulled', async () => {
@@ -385,7 +387,8 @@ describe('pb-sync-engine', () => {
       const putCalls = (db.syncMetadata.put as ReturnType<typeof vi.fn>).mock.calls;
       expect(putCalls.length).toBeGreaterThan(0);
       const putCall = putCalls[0][0];
-      expect(putCall.lastSyncAt).toBe('2024-06-15T12:00:00.000Z');
+      // Cursor is persisted with a 30s overlap subtracted; see pb-pull.ts.
+      expect(putCall.lastSyncAt).toBe('2024-06-15T11:59:30.000Z');
     });
 
     it('should not call recordSuccess on partial failure', async () => {


### PR DESCRIPTION
## Summary
Closes Codex adversarial review finding #3 (cursor poisoning).

`pullRemoteChanges` previously advanced the persisted pull cursor from `findMaxTimestamp(records)` — considering ALL fetched records (including invalid ones) and trusting client-controlled `client_updated_at` literally. A bogus future timestamp (clock skew on another device, malformed remote row, malicious payload) could push `lastSyncAt` years into the future. Subsequent normal updates would then fail the `client_updated_at > lastSyncAt` filter and be silently skipped indefinitely.

This PR makes three semantic fixes:

- **Clamp future timestamps.** Cap any `client_updated_at` to `now + 5min` when computing the cursor. Anything beyond is treated as clock skew, not a real event. NaN/malformed input falls back to the current time.
- **Advance the cursor only from APPLIED records.** `applyRemoteRecords` now returns the records it actually applied (post-validation, post-LWW). The cursor is computed from that list — never from skipped or invalid records.
- **30-second overlap window.** When persisting the cursor, subtract 30s, and switch the next pull's filter from `>` to `>=`. Reapplied records are no-ops via LWW; the overlap protects against clock skew at the boundary.

See plan: `docs/superpowers/plans/2026-05-18-codex-adversarial-review-fixes.md` (PR3).

## Test plan
- [x] `bun run test -- tests/data/sync/pb-pull.test.ts` — 2 new tests pass (clamp + applied-only cursor)
- [x] `bun run test -- tests/data/sync/` — 214 tests pass
- [x] `bun run test -- tests/sync/` — 118 tests pass (2 pre-existing exact-timestamp assertions updated to account for the 30s overlap)
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [ ] Manual: simulate a peer device with skewed clock and confirm cursor stops at now+5min in app logs.