### PR TITLE
fix(sync): LWW guard for stale push writes (Codex finding #1)

### DIFF
--- a/lib/sync/pb-push.ts
+++ b/lib/sync/pb-push.ts
@@ -11,7 +11,7 @@ import { taskRecordToPocketBase } from './task-mapper';
 import { createLogger } from '@/lib/logger';
 import { THROTTLE_MS, delay, getDeviceId, getCurrentUserId, fetchRemoteTaskIndex } from './pb-sync-helpers';
 import { sanitizeSyncError } from './error-categorizer';
-import type { SyncQueueItem } from './types';
+import type { SyncQueueItem, RemoteTaskIndexEntry } from './types';
 
 const logger = createLogger('SYNC_ENGINE');
 
@@ -59,36 +59,112 @@ async function upsertRemoteTask(
 }
 
 /**
+ * Outcome of processing one queue item. Distinguishes a real network write
+ * from an LWW-skipped dequeue so the caller can report accurate stats.
+ */
+type PushItemOutcome = 'pushed' | 'skipped' | 'index_unavailable';
+
+/**
  * Process a single queue item: create, update, or delete the remote record.
- * Returns true if the item was successfully dequeued.
+ *
+ * LWW guard: before writing or deleting, compare the queued payload's
+ * `updatedAt` (or the queue item's `timestamp` for deletes) against the
+ * remote record's `client_updated_at`. If the remote is strictly newer,
+ * the queued op is stale — skip the write and dequeue. The next pull will
+ * deliver the newer remote version, restoring correctness on this device.
  */
 async function pushSingleItem(
   item: SyncQueueItem,
-  remoteIndex: Map<string, string>,
+  remoteIndex: Map<string, RemoteTaskIndexEntry>,
   indexFetchSucceeded: boolean,
   ownerId: string,
   deviceId: string,
-): Promise<boolean> {
+): Promise<PushItemOutcome> {
   const pb = getPocketBase();
   const queue = getSyncQueue();
-  const pbRecordId = remoteIndex.get(item.taskId);
+  const remote = remoteIndex.get(item.taskId);
 
-  if ((item.operation === 'create' || item.operation === 'update') && item.payload) {
-    const recordId = await upsertRemoteTask(item.payload, pbRecordId, ownerId, deviceId);
-    remoteIndex.set(item.taskId, recordId);
-  } else if (item.operation === 'delete') {
-    if (pbRecordId) {
-      await pb.collection('tasks').delete(pbRecordId);
-      remoteIndex.delete(item.taskId);
-    } else if (!indexFetchSucceeded) {
-      logger.warn('Skipping delete dequeue: remote index unavailable', { taskId: item.taskId });
-      await queue.recordAttemptFailure(item.id, 'Remote task index unavailable for delete verification');
-      return false;
+  if (item.operation === 'create' || item.operation === 'update') {
+    if (!item.payload) {
+      // Invalid queue state — payload is required for create/update.
+      await queue.dequeue(item.id);
+      return 'skipped';
     }
+
+    // If the index fetch failed AND we have no remote entry, we cannot
+    // verify whether the queued write would clobber newer remote data.
+    // Refuse to push and let the next attempt retry once the index is
+    // available again. Mirrors the symmetric guard in the delete path.
+    if (!remote && !indexFetchSucceeded) {
+      logger.warn('Skipping upsert dequeue: remote index unavailable', {
+        taskId: item.taskId,
+        operation: item.operation,
+      });
+      await queue.recordAttemptFailure(
+        item.id,
+        'Remote task index unavailable for upsert LWW verification',
+      );
+      return 'index_unavailable';
+    }
+
+    if (remote?.clientUpdatedAt && isRemoteNewer(remote.clientUpdatedAt, item.payload.updatedAt)) {
+      logger.info('Skipping stale push: remote is newer', {
+        taskId: item.taskId,
+        operation: item.operation,
+        remoteAt: remote.clientUpdatedAt,
+        localAt: item.payload.updatedAt,
+      });
+      await queue.dequeue(item.id);
+      return 'skipped';
+    }
+
+    const recordId = await upsertRemoteTask(item.payload, remote?.pbRecordId, ownerId, deviceId);
+    remoteIndex.set(item.taskId, {
+      pbRecordId: recordId,
+      clientUpdatedAt: item.payload.updatedAt,
+    });
+    await queue.dequeue(item.id);
+    return 'pushed';
   }
 
+  // item.operation === 'delete'
+  if (remote) {
+    const deletionIntent = new Date(item.timestamp).toISOString();
+    if (remote.clientUpdatedAt && isRemoteNewer(remote.clientUpdatedAt, deletionIntent)) {
+      logger.info('Skipping stale delete: remote modified after delete was queued', {
+        taskId: item.taskId,
+        remoteAt: remote.clientUpdatedAt,
+        deletionQueuedAt: deletionIntent,
+      });
+      await queue.dequeue(item.id);
+      return 'skipped';
+    }
+    await pb.collection('tasks').delete(remote.pbRecordId);
+    remoteIndex.delete(item.taskId);
+    await queue.dequeue(item.id);
+    return 'pushed';
+  }
+
+  if (!indexFetchSucceeded) {
+    logger.warn('Skipping delete dequeue: remote index unavailable', { taskId: item.taskId });
+    await queue.recordAttemptFailure(item.id, 'Remote task index unavailable for delete verification');
+    return 'index_unavailable';
+  }
+
+  // Remote record is already gone and index fetch succeeded — local delete is a no-op.
   await queue.dequeue(item.id);
-  return true;
+  return 'pushed';
+}
+
+/**
+ * Compare two ISO timestamps. Returns true iff remote is strictly newer than local.
+ * Returns false for any NaN/invalid input — never skip a write because of bad data.
+ */
+function isRemoteNewer(remoteIso: string, localIso: string): boolean {
+  const r = new Date(remoteIso).getTime();
+  const l = new Date(localIso).getTime();
+  if (Number.isNaN(r) || Number.isNaN(l)) return false;
+  return r > l;
 }
 
 /**
@@ -111,19 +187,22 @@ export async function pushLocalChanges(): Promise<PushResult> {
   const { index: remoteIndex, fetchSucceeded } = await fetchRemoteTaskIndex(ownerId);
   let pushedCount = 0;
   let failedCount = 0;
+  let skippedCount = 0;
   let lastError: string | null = null;
 
   for (const item of pending) {
     try {
-      const succeeded = await pushSingleItem(item, remoteIndex, fetchSucceeded, ownerId, deviceId);
-      if (succeeded) {
+      const outcome = await pushSingleItem(item, remoteIndex, fetchSucceeded, ownerId, deviceId);
+      if (outcome === 'pushed') {
         pushedCount++;
+      } else if (outcome === 'skipped') {
+        skippedCount++;
       } else {
         failedCount++;
         lastError = 'remote_index_unavailable';
       }
 
-      if (pushedCount + failedCount < pending.length) {
+      if (pushedCount + failedCount + skippedCount < pending.length) {
         await delay(THROTTLE_MS);
       }
     } catch (error) {
@@ -146,13 +225,14 @@ export async function pushLocalChanges(): Promise<PushResult> {
         logger.warn('Aborting push loop due to rate limit (429)', {
           pushedCount,
           failedCount,
-          remaining: pending.length - (pushedCount + failedCount),
+          skippedCount,
+          remaining: pending.length - (pushedCount + failedCount + skippedCount),
         });
         break;
       }
     }
   }
 
-  logger.info('Push completed', { pushedCount, failedCount, total: pending.length });
+  logger.info('Push completed', { pushedCount, failedCount, skippedCount, total: pending.length });
   return { pushedCount, failedCount, lastError, authenticated: true };
 }

--- a/lib/sync/pb-sync-helpers.ts
+++ b/lib/sync/pb-sync-helpers.ts
@@ -5,7 +5,7 @@
 import { getPocketBase, getCurrentUserId } from './pocketbase-client';
 import { getDb } from '@/lib/db';
 import { createLogger } from '@/lib/logger';
-import type { PBSyncConfig } from './types';
+import type { PBSyncConfig, RemoteTaskIndexEntry } from './types';
 
 const logger = createLogger('SYNC_ENGINE');
 
@@ -53,21 +53,28 @@ export async function getDeviceId(): Promise<string> {
 export { getCurrentUserId };
 
 /**
- * Fetch all existing remote task_ids for the current user in one request.
- * Returns a Map of task_id -> PocketBase record id for efficient lookups.
+ * Fetch all existing remote task records for the current user in one request.
+ * Returns a Map of task_id -> { pbRecordId, clientUpdatedAt } for efficient
+ * lookups + LWW timestamp comparison in the push path.
  */
-export async function fetchRemoteTaskIndex(ownerId: string): Promise<{ index: Map<string, string>; fetchSucceeded: boolean }> {
+export async function fetchRemoteTaskIndex(ownerId: string): Promise<{
+  index: Map<string, RemoteTaskIndexEntry>;
+  fetchSucceeded: boolean;
+}> {
   assertSafeRecordId(ownerId, 'ownerId');
   const pb = getPocketBase();
-  const index = new Map<string, string>();
+  const index = new Map<string, RemoteTaskIndexEntry>();
 
   try {
     const records = await pb.collection('tasks').getFullList({
       filter: `owner = "${escapeFilterValue(ownerId)}"`,
-      fields: 'id,task_id',
+      fields: 'id,task_id,client_updated_at',
     });
     for (const r of records) {
-      index.set(r['task_id'] as string, r.id);
+      index.set(r['task_id'] as string, {
+        pbRecordId: r.id,
+        clientUpdatedAt: (r['client_updated_at'] as string) ?? null,
+      });
     }
     return { index, fetchSucceeded: true };
   } catch {

--- a/lib/sync/types.ts
+++ b/lib/sync/types.ts
@@ -69,6 +69,16 @@ export interface SyncQueueItem {
 }
 
 // ============================================================================
+// Remote task index entry (used by fetchRemoteTaskIndex for push LWW guard)
+// ============================================================================
+
+/** One row of the remote task index used by push/pull pre-fetch. */
+export interface RemoteTaskIndexEntry {
+  pbRecordId: string;
+  clientUpdatedAt: string | null;
+}
+
+// ============================================================================
 // Device info
 // ============================================================================
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.1.9",
+	"version": "9.1.10",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/data/sync/pb-push.test.ts
+++ b/tests/data/sync/pb-push.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getDb } from '@/lib/db';
+import { getSyncQueue } from '@/lib/sync/queue';
+import type { TaskRecord } from '@/lib/types';
+
+vi.mock('@/lib/sync/pocketbase-client', () => ({
+  getPocketBase: vi.fn(),
+  getCurrentUserId: vi.fn(() => 'user-1'),
+}));
+
+const { fetchRemoteTaskIndexMock } = vi.hoisted(() => ({
+  fetchRemoteTaskIndexMock: vi.fn(),
+}));
+
+vi.mock('@/lib/sync/pb-sync-helpers', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/sync/pb-sync-helpers')>(
+    '@/lib/sync/pb-sync-helpers',
+  );
+  return {
+    ...actual,
+    fetchRemoteTaskIndex: fetchRemoteTaskIndexMock,
+    getCurrentUserId: vi.fn(() => 'user-1'),
+    getDeviceId: vi.fn(async () => 'dev-1'),
+    // Use zero throttle to keep tests fast.
+    THROTTLE_MS: 0,
+    delay: vi.fn(async () => {}),
+  };
+});
+
+import { pushLocalChanges } from '@/lib/sync/pb-push';
+import { getPocketBase } from '@/lib/sync/pocketbase-client';
+
+function makeTask(id: string, updatedAt: string): TaskRecord {
+  return {
+    id,
+    title: 'T',
+    description: '',
+    urgent: false,
+    important: false,
+    quadrant: 'not-urgent-not-important',
+    completed: false,
+    createdAt: updatedAt,
+    updatedAt,
+    recurrence: 'none',
+    tags: [],
+    subtasks: [],
+    dependencies: [],
+  };
+}
+
+describe('pushLocalChanges LWW guard', () => {
+  beforeEach(async () => {
+    await getDb().syncQueue.clear();
+    fetchRemoteTaskIndexMock.mockReset();
+  });
+
+  it('skips a queued update whose payload is older than the remote record', async () => {
+    const stalePayload = makeTask('t1', '2026-05-18T08:00:00.000Z');
+    await getSyncQueue().enqueue('update', 't1', stalePayload);
+
+    fetchRemoteTaskIndexMock.mockResolvedValue({
+      index: new Map([
+        ['t1', { pbRecordId: 'rec-1', clientUpdatedAt: '2026-05-18T10:00:00.000Z' }],
+      ]),
+      fetchSucceeded: true,
+    });
+
+    const updateSpy = vi.fn(async () => ({ id: 'rec-1' }));
+    const createSpy = vi.fn();
+    const deleteSpy = vi.fn();
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({ create: createSpy, update: updateSpy, delete: deleteSpy }),
+    });
+
+    const result = await pushLocalChanges();
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(result.pushedCount).toBe(0);
+    expect(result.failedCount).toBe(0);
+    // Stale item is dequeued — the LWW outcome is final.
+    expect(await getSyncQueue().getPendingCount()).toBe(0);
+  });
+
+  it('skips a queued delete when the remote record is newer than the queued op', async () => {
+    await getSyncQueue().enqueue('delete', 't1', null);
+
+    // Override the auto-stamped timestamp to a known past instant.
+    const queue = await getDb().syncQueue.toArray();
+    await getDb().syncQueue.update(queue[0].id, {
+      timestamp: new Date('2026-05-18T08:00:00.000Z').getTime(),
+    });
+
+    fetchRemoteTaskIndexMock.mockResolvedValue({
+      index: new Map([
+        ['t1', { pbRecordId: 'rec-1', clientUpdatedAt: '2026-05-18T10:00:00.000Z' }],
+      ]),
+      fetchSucceeded: true,
+    });
+
+    const deleteSpy = vi.fn();
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({ create: vi.fn(), update: vi.fn(), delete: deleteSpy }),
+    });
+
+    const result = await pushLocalChanges();
+
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(result.pushedCount).toBe(0);
+    expect(result.failedCount).toBe(0);
+    expect(await getSyncQueue().getPendingCount()).toBe(0);
+  });
+
+  it('proceeds with the write when the payload is newer than the remote record', async () => {
+    const freshPayload = makeTask('t1', '2026-05-18T12:00:00.000Z');
+    await getSyncQueue().enqueue('update', 't1', freshPayload);
+
+    fetchRemoteTaskIndexMock.mockResolvedValue({
+      index: new Map([
+        ['t1', { pbRecordId: 'rec-1', clientUpdatedAt: '2026-05-18T10:00:00.000Z' }],
+      ]),
+      fetchSucceeded: true,
+    });
+
+    const updateSpy = vi.fn(async () => ({ id: 'rec-1' }));
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({ create: vi.fn(), update: updateSpy, delete: vi.fn() }),
+    });
+
+    const result = await pushLocalChanges();
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(result.pushedCount).toBe(1);
+    expect(await getSyncQueue().getPendingCount()).toBe(0);
+  });
+
+  it('does not push an upsert when the remote index fetch failed (LWW unverifiable)', async () => {
+    const payload = makeTask('t1', '2026-05-18T12:00:00.000Z');
+    await getSyncQueue().enqueue('update', 't1', payload);
+
+    // Index fetch failed — we have no remote timestamp to compare against,
+    // so we cannot verify whether the queued write would clobber newer data.
+    fetchRemoteTaskIndexMock.mockResolvedValue({
+      index: new Map(),
+      fetchSucceeded: false,
+    });
+
+    const updateSpy = vi.fn();
+    const createSpy = vi.fn();
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({ create: createSpy, update: updateSpy, delete: vi.fn() }),
+    });
+
+    const result = await pushLocalChanges();
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(result.pushedCount).toBe(0);
+    expect(result.failedCount).toBe(1);
+    expect(result.lastError).toBe('remote_index_unavailable');
+    // Item should NOT be dequeued — recordAttemptFailure keeps it pending for a future retry.
+    expect(await getSyncQueue().getPendingCount()).toBe(1);
+  });
+
+  it('proceeds with the write when the remote record has null client_updated_at', async () => {
+    const payload = makeTask('t1', '2026-05-18T12:00:00.000Z');
+    await getSyncQueue().enqueue('update', 't1', payload);
+
+    // Remote record exists but has no client_updated_at (legacy or test data).
+    // The LWW guard's `remote?.clientUpdatedAt && ...` short-circuit must let
+    // this through to the upsert — there's nothing to compare against.
+    fetchRemoteTaskIndexMock.mockResolvedValue({
+      index: new Map([
+        ['t1', { pbRecordId: 'rec-1', clientUpdatedAt: null }],
+      ]),
+      fetchSucceeded: true,
+    });
+
+    const updateSpy = vi.fn(async () => ({ id: 'rec-1' }));
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({ create: vi.fn(), update: updateSpy, delete: vi.fn() }),
+    });
+
+    const result = await pushLocalChanges();
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(result.pushedCount).toBe(1);
+    expect(await getSyncQueue().getPendingCount()).toBe(0);
+  });
+
+  it('refreshes the in-memory index after upsert so a later stale delete is skipped', async () => {
+    // Same task: queue an update (payload.updatedAt = T2), then a delete queued at T1 < T2.
+    // Initial remote index has clientUpdatedAt T0 < T1 < T2, so the update proceeds
+    // and bumps the in-memory index entry to { clientUpdatedAt: T2 }. The subsequent
+    // delete (intent timestamp T1) must then be skipped because T2 > T1.
+    const T0 = '2026-05-18T08:00:00.000Z';
+    const T_update_enqueue = new Date('2026-05-18T08:30:00.000Z').getTime();
+    const T1 = new Date('2026-05-18T09:00:00.000Z').getTime();
+    const T2 = '2026-05-18T10:00:00.000Z';
+
+    const payload = makeTask('t1', T2);
+    await getSyncQueue().enqueue('update', 't1', payload);
+    await getSyncQueue().enqueue('delete', 't1', null);
+
+    // Pin both queue items' timestamps so the loop processes update -> delete,
+    // and the delete's "intent" timestamp (T1) is older than the update's payload (T2).
+    const pending = await getDb().syncQueue.orderBy('timestamp').toArray();
+    const updateItem = pending.find(i => i.operation === 'update')!;
+    const deleteItem = pending.find(i => i.operation === 'delete')!;
+    await getDb().syncQueue.update(updateItem.id, { timestamp: T_update_enqueue });
+    await getDb().syncQueue.update(deleteItem.id, { timestamp: T1 });
+
+    fetchRemoteTaskIndexMock.mockResolvedValue({
+      index: new Map([
+        ['t1', { pbRecordId: 'rec-1', clientUpdatedAt: T0 }],
+      ]),
+      fetchSucceeded: true,
+    });
+
+    const updateSpy = vi.fn(async () => ({ id: 'rec-1' }));
+    const deleteSpy = vi.fn();
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({ create: vi.fn(), update: updateSpy, delete: deleteSpy }),
+    });
+
+    const result = await pushLocalChanges();
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(result.pushedCount).toBe(1); // update only — delete was LWW-skipped
+    expect(await getSyncQueue().getPendingCount()).toBe(0);
+  });
+
+  it('fails open and proceeds with the write when remote clientUpdatedAt is unparseable', async () => {
+    // NaN contract: isRemoteNewer returns false on parse failure, so the
+    // write must proceed rather than silently dropping the user's edit.
+    const payload = makeTask('t1', '2026-05-18T12:00:00.000Z');
+    await getSyncQueue().enqueue('update', 't1', payload);
+
+    fetchRemoteTaskIndexMock.mockResolvedValue({
+      index: new Map([
+        ['t1', { pbRecordId: 'rec-1', clientUpdatedAt: 'garbage-not-an-iso-date' }],
+      ]),
+      fetchSucceeded: true,
+    });
+
+    const updateSpy = vi.fn(async () => ({ id: 'rec-1' }));
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({ create: vi.fn(), update: updateSpy, delete: vi.fn() }),
+    });
+
+    const result = await pushLocalChanges();
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(result.pushedCount).toBe(1);
+    expect(await getSyncQueue().getPendingCount()).toBe(0);
+  });
+});

--- a/tests/data/sync/pb-sync-helpers.test.ts
+++ b/tests/data/sync/pb-sync-helpers.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/sync/pocketbase-client', () => ({
+  getPocketBase: vi.fn(),
+  getCurrentUserId: vi.fn(() => 'user-1'),
+}));
+
+import { fetchRemoteTaskIndex } from '@/lib/sync/pb-sync-helpers';
+import { getPocketBase } from '@/lib/sync/pocketbase-client';
+
+describe('fetchRemoteTaskIndex', () => {
+  it('returns task_id -> { pbRecordId, clientUpdatedAt } map', async () => {
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({
+        getFullList: vi.fn(async () => [
+          { id: 'rec-1', task_id: 't1', client_updated_at: '2026-05-18T10:00:00.000Z' },
+          { id: 'rec-2', task_id: 't2', client_updated_at: '2026-05-18T11:00:00.000Z' },
+        ]),
+      }),
+    });
+
+    const { index, fetchSucceeded } = await fetchRemoteTaskIndex('user-1');
+    expect(fetchSucceeded).toBe(true);
+    expect(index.get('t1')).toEqual({
+      pbRecordId: 'rec-1',
+      clientUpdatedAt: '2026-05-18T10:00:00.000Z',
+    });
+    expect(index.get('t2')?.pbRecordId).toBe('rec-2');
+    expect(index.get('t2')?.clientUpdatedAt).toBe('2026-05-18T11:00:00.000Z');
+  });
+
+  it('falls back to an empty map and fetchSucceeded=false when PB throws', async () => {
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({
+        getFullList: vi.fn(async () => {
+          throw new Error('boom');
+        }),
+      }),
+    });
+
+    const { index, fetchSucceeded } = await fetchRemoteTaskIndex('user-1');
+    expect(fetchSucceeded).toBe(false);
+    expect(index.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Closes Codex adversarial review finding #1 (critical) — silent data loss on cross-device LWW pushes.

`pushSingleItem` previously updated or deleted a PocketBase record solely on the presence of `task_id` in the remote index, never checking the remote `client_updated_at`. A stale queued update (e.g., offline device coming back online after a newer edit landed elsewhere) would silently overwrite the newer remote data before the pull-side LWW comparison ever got a chance.

This PR extends the batched remote index to carry `client_updated_at` and compares it against the queued payload (for `create`/`update`) or the queue item timestamp (for `delete`) before writing. Stale ops are skipped and dequeued — the LWW outcome is final, and the next pull delivers the newer remote version.

- `fetchRemoteTaskIndex` now returns `Map<string, RemoteTaskIndexEntry>` (`{ pbRecordId, clientUpdatedAt }`) instead of `Map<string, string>`.
- `pushSingleItem` applies the LWW guard via a new `isRemoteNewer(remoteIso, localIso)` helper and a `PushItemOutcome` discriminator (`'pushed' | 'skipped' | 'index_unavailable'`).
- `skippedCount` is tracked in the push loop so LWW-skipped items no longer inflate `pushedCount`.

A narrow race between the batched index fetch and the per-item write remains — accepted as out of scope, same race the pull side already accepts per [ADR 0003](docs/adr/0003-lww-conflict-resolution.md). Realtime SSE + the next pull converge it. Option (a) per-item fresh fetch may follow later if telemetry shows the window matters.

## Strategy decision
Option (b) from the plan: index-cached timestamps + accept narrow race. See `docs/superpowers/plans/2026-05-18-codex-adversarial-review-fixes.md` PR4 for the full rationale.

## Test plan
- [x] `bun run test -- tests/data/sync/pb-push.test.ts tests/data/sync/pb-sync-helpers.test.ts` — 5 new tests pass (stale update skip, stale delete skip, fresh update proceeds, index shape, error fallback)
- [x] `bun run test -- tests/data/sync/ tests/sync/` — full sync suite (335 tests) green
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [ ] Manual two-device scenario: device A edits task X to "A version" and syncs; device B (offline) edits task X to "B version" then comes online — verify B's stale update is dropped from the queue and pull delivers A's version.