### PR TITLE
fix(mcp): preflight client_updated_at check on updateTask

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.1.9",
+	"version": "9.1.10",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-mcp-server",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "MCP server for GSD Task Manager — 20 tools for task CRUD, analytics, and diagnostics over PocketBase. Validated inputs, dry-run support, JWT-aware token health, and dependency-safe deletes.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/src/__tests__/update-task-conflict.test.ts
+++ b/packages/mcp-server/src/__tests__/update-task-conflict.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { GsdConfig } from '../types.js';
+
+import * as pbClient from '../pocketbase-client.js';
+
+// listTasks is only invoked when input.dependencies is provided. We still mock
+// it because the test path mustn't accidentally fall through to a real call.
+vi.mock('../tools/list-tasks.js', () => ({
+  listTasks: vi.fn(async () => []),
+}));
+
+import { updateTask, bulkUpdateTasks } from '../write-ops.js';
+import { ConflictError } from '../errors.js';
+
+const config: GsdConfig = {
+  pocketbaseUrl: 'http://example.invalid',
+  authToken: 'fake',
+} as unknown as GsdConfig;
+
+function pbRecord(
+  task_id: string,
+  client_updated_at: string,
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    id: `rec-${task_id}`,
+    task_id,
+    owner: 'user-1',
+    title: 'old',
+    description: '',
+    urgent: false,
+    important: false,
+    quadrant: 'not-urgent-not-important',
+    due_date: '',
+    completed: false,
+    completed_at: '',
+    recurrence: 'none',
+    tags: [],
+    subtasks: [],
+    dependencies: [],
+    notification_enabled: true,
+    notify_before: 0,
+    notification_sent: false,
+    last_notification_at: '',
+    snoozed_until: '',
+    estimated_minutes: 0,
+    time_spent: 0,
+    time_entries: [],
+    client_updated_at,
+    client_created_at: '2026-05-18T08:00:00.000Z',
+    device_id: 'dev-other',
+    created: '2026-05-18T08:00:00.000Z',
+    updated: '2026-05-18T08:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('updateTask conflict detection', () => {
+  it('throws ConflictError when client_updated_at changes between read and preflight', async () => {
+    const updateSpy = vi.fn();
+    const getFirstListItem = vi
+      .fn()
+      // 1) initial fresh read
+      .mockResolvedValueOnce(pbRecord('t1', '2026-05-18T08:00:00.000Z'))
+      // 2) preflight check just before PUT — a concurrent writer bumped it
+      .mockResolvedValueOnce(
+        pbRecord('t1', '2026-05-18T09:30:00.000Z', { title: 'changed-by-other' })
+      );
+
+    vi.spyOn(pbClient, 'getPocketBase').mockReturnValue({
+      collection: () => ({ getFirstListItem, update: updateSpy, create: vi.fn() }),
+      authStore: {
+        record: { id: 'user-1' },
+        token: 'tok',
+        isValid: true,
+      },
+    } as never);
+
+    await expect(
+      updateTask(config, { id: 't1', title: 'mine' } as never)
+    ).rejects.toBeInstanceOf(ConflictError);
+
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('writes through when client_updated_at is unchanged between read and preflight', async () => {
+    const updateSpy = vi.fn(async () => ({ id: 'rec-t1' }));
+    const stable = '2026-05-18T08:00:00.000Z';
+    const getFirstListItem = vi
+      .fn()
+      .mockResolvedValueOnce(pbRecord('t1', stable))
+      .mockResolvedValueOnce(pbRecord('t1', stable));
+
+    vi.spyOn(pbClient, 'getPocketBase').mockReturnValue({
+      collection: () => ({ getFirstListItem, update: updateSpy, create: vi.fn() }),
+      authStore: {
+        record: { id: 'user-1' },
+        token: 'tok',
+        isValid: true,
+      },
+    } as never);
+
+    const result = await updateTask(config, {
+      id: 't1',
+      title: 'mine',
+    } as never);
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(result.task.title).toBe('mine');
+  });
+
+  it('throws when the task is deleted between read and preflight', async () => {
+    const updateSpy = vi.fn();
+    // Preflight returns a 404-shaped error -> fetchSinglePBTaskFresh returns null.
+    const notFound = Object.assign(new Error('not found'), { status: 404 });
+    const getFirstListItem = vi
+      .fn()
+      .mockResolvedValueOnce(pbRecord('t1', '2026-05-18T08:00:00.000Z'))
+      .mockRejectedValueOnce(notFound);
+
+    vi.spyOn(pbClient, 'getPocketBase').mockReturnValue({
+      collection: () => ({ getFirstListItem, update: updateSpy, create: vi.fn() }),
+      authStore: {
+        record: { id: 'user-1' },
+        token: 'tok',
+        isValid: true,
+      },
+    } as never);
+
+    await expect(
+      updateTask(config, { id: 't1', title: 'mine' } as never)
+    ).rejects.toThrow(/deleted between read and write/);
+
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('propagates non-404 errors instead of misreporting as deletion', async () => {
+    const updateSpy = vi.fn();
+    // 5xx error from PocketBase must propagate — otherwise the LLM would be
+    // told the task was deleted and might try to recreate it.
+    const serverErr = Object.assign(new Error('server boom'), { status: 503 });
+    const getFirstListItem = vi
+      .fn()
+      .mockResolvedValueOnce(pbRecord('t1', '2026-05-18T08:00:00.000Z'))
+      .mockRejectedValueOnce(serverErr);
+
+    vi.spyOn(pbClient, 'getPocketBase').mockReturnValue({
+      collection: () => ({ getFirstListItem, update: updateSpy, create: vi.fn() }),
+      authStore: {
+        record: { id: 'user-1' },
+        token: 'tok',
+        isValid: true,
+      },
+    } as never);
+
+    await expect(
+      updateTask(config, { id: 't1', title: 'mine' } as never)
+    ).rejects.toThrow(/server boom/);
+
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('bulkUpdateTasks conflict detection', () => {
+  it('skips conflicted tasks, applies the rest, and surfaces ids in result.conflicts', async () => {
+    // Snapshot pre-fetch returns two tasks with timestamps T0a and T0b.
+    // Preflight returns task A unchanged, but task B has changed.
+    const snapshotA = pbRecord('a', '2026-05-18T08:00:00.000Z');
+    const snapshotB = pbRecord('b', '2026-05-18T08:00:00.000Z');
+    const preflightA = pbRecord('a', '2026-05-18T08:00:00.000Z');
+    const preflightB = pbRecord('b', '2026-05-18T09:30:00.000Z', {
+      title: 'changed-by-other',
+    });
+
+    const updateSpy = vi.fn(async (id: string) => ({ id }));
+
+    // First call: snapshot batch fetch via getFullList
+    // Subsequent calls: per-task preflight via getFirstListItem
+    const getFullList = vi.fn().mockResolvedValueOnce([snapshotA, snapshotB]);
+
+    // Preflight order matches iteration order over tasksToUpdate (a, b)
+    const getFirstListItem = vi
+      .fn()
+      .mockResolvedValueOnce(preflightA)
+      .mockResolvedValueOnce(preflightB);
+
+    vi.spyOn(pbClient, 'getPocketBase').mockReturnValue({
+      collection: () => ({
+        getFullList,
+        getFirstListItem,
+        update: updateSpy,
+        delete: vi.fn(),
+        create: vi.fn(),
+      }),
+      authStore: {
+        record: { id: 'user-1' },
+        token: 'tok',
+        isValid: true,
+      },
+    } as never);
+
+    const result = await bulkUpdateTasks(
+      config,
+      ['a', 'b'],
+      { type: 'complete', completed: true },
+      { dryRun: false }
+    );
+
+    expect(result.updated).toBe(1);
+    expect(result.conflicts).toEqual(['b']);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy.mock.calls[0]?.[0]).toBe('rec-a');
+  });
+
+  it('surfaces tasks that were deleted between snapshot and preflight as conflicts', async () => {
+    // Snapshot pre-fetch returns both tasks (a, b). Preflight for `a` succeeds
+    // (unchanged), preflight for `b` 404s — task was deleted on another device
+    // between the snapshot fetch and the per-item preflight.
+    const snapshotA = pbRecord('a', '2026-05-18T08:00:00.000Z');
+    const snapshotB = pbRecord('b', '2026-05-18T08:00:00.000Z');
+    const preflightA = pbRecord('a', '2026-05-18T08:00:00.000Z');
+    const notFound = Object.assign(new Error('not found'), { status: 404 });
+
+    const updateSpy = vi.fn(async (id: string) => ({ id }));
+    const getFullList = vi.fn().mockResolvedValueOnce([snapshotA, snapshotB]);
+    const getFirstListItem = vi
+      .fn()
+      .mockResolvedValueOnce(preflightA)
+      .mockRejectedValueOnce(notFound);
+
+    vi.spyOn(pbClient, 'getPocketBase').mockReturnValue({
+      collection: () => ({
+        getFullList,
+        getFirstListItem,
+        update: updateSpy,
+        delete: vi.fn(),
+        create: vi.fn(),
+      }),
+      authStore: {
+        record: { id: 'user-1' },
+        token: 'tok',
+        isValid: true,
+      },
+    } as never);
+
+    const result = await bulkUpdateTasks(
+      config,
+      ['a', 'b'],
+      { type: 'complete', completed: true },
+      { dryRun: false }
+    );
+
+    expect(result.updated).toBe(1);
+    expect(result.conflicts).toEqual(['b']);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy.mock.calls[0]?.[0]).toBe('rec-a');
+  });
+});

--- a/packages/mcp-server/src/__tests__/write-ops/bulk-operations.test.ts
+++ b/packages/mcp-server/src/__tests__/write-ops/bulk-operations.test.ts
@@ -8,7 +8,11 @@ vi.mock('../../write-ops/helpers.js', async () => {
   return {
     ...actual,
     getAuthInfo: vi.fn().mockResolvedValue({ ownerId: 'owner-1', deviceId: 'device-1' }),
-    fetchPBRecordIdsForTasks: vi.fn().mockResolvedValue(new Map()),
+    // Snapshot-prefetch returns fresh PB records for the whole batch in one
+    // request — bulk now sources task content from this instead of listTasks.
+    fetchPBSnapshotForTasks: vi.fn().mockResolvedValue(new Map()),
+    // Per-item preflight check just before each write.
+    fetchSinglePBTaskFresh: vi.fn().mockResolvedValue(null),
     updateTaskInPBById: vi.fn().mockResolvedValue(undefined),
     deleteTaskInPBById: vi.fn().mockResolvedValue(undefined),
     sleep: vi.fn().mockResolvedValue(undefined),
@@ -48,6 +52,48 @@ function makeTask(id: string): Task {
   };
 }
 
+/**
+ * Build a PB snapshot entry for the write path. Bulk now reads task content
+ * from PocketBase (cache bypassed) instead of `listTasks`, so write-path tests
+ * mock `fetchPBSnapshotForTasks` with one of these entries per task.
+ */
+function makeSnapshotEntry(id: string) {
+  return {
+    pbRecordId: `rec-${id}`,
+    clientUpdatedAt: '2026-04-01T00:00:00Z',
+    record: {
+      id: `rec-${id}`,
+      task_id: id,
+      owner: 'owner-1',
+      title: `task ${id}`,
+      description: '',
+      urgent: false,
+      important: false,
+      quadrant: 'not-urgent-not-important',
+      due_date: '',
+      completed: false,
+      completed_at: '',
+      recurrence: 'none',
+      tags: [],
+      subtasks: [],
+      dependencies: [],
+      notification_enabled: true,
+      notify_before: 0,
+      notification_sent: false,
+      last_notification_at: '',
+      snoozed_until: '',
+      estimated_minutes: 0,
+      time_spent: 0,
+      time_entries: [],
+      client_updated_at: '2026-04-01T00:00:00Z',
+      client_created_at: '2026-04-01T00:00:00Z',
+      device_id: 'device-1',
+      created: '2026-04-01T00:00:00Z',
+      updated: '2026-04-01T00:00:00Z',
+    },
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -66,12 +112,13 @@ describe('bulkUpdateTasks — delete safety', () => {
   });
 
   it('actually deletes when dryRun is explicitly false', async () => {
-    const { listTasks } = await import('../../tools/list-tasks.js');
     const helpers = await import('../../write-ops/helpers.js');
-    vi.mocked(listTasks).mockResolvedValueOnce([makeTask('t1')]);
-    vi.mocked(helpers.fetchPBRecordIdsForTasks).mockResolvedValueOnce(
-      new Map([['t1', 'pb-rec-1']])
+    const snapshot = makeSnapshotEntry('t1');
+    vi.mocked(helpers.fetchPBSnapshotForTasks).mockResolvedValueOnce(
+      new Map([['t1', snapshot]])
     );
+    // Preflight returns the same client_updated_at as the snapshot — no conflict.
+    vi.mocked(helpers.fetchSinglePBTaskFresh).mockResolvedValueOnce(snapshot);
 
     const result = await bulkUpdateTasks(
       config,
@@ -82,6 +129,7 @@ describe('bulkUpdateTasks — delete safety', () => {
 
     expect(result.dryRun).toBe(false);
     expect(result.deleted).toBe(1);
+    expect(result.conflicts).toEqual([]);
     expect(helpers.deleteTaskInPBById).toHaveBeenCalledTimes(1);
   });
 
@@ -105,12 +153,14 @@ describe('bulkUpdateTasks — delete safety', () => {
   });
 
   it('does not apply the 10-cap to non-delete operations (50-cap still applies via schema)', async () => {
-    const { listTasks } = await import('../../tools/list-tasks.js');
     const helpers = await import('../../write-ops/helpers.js');
     const ids = Array.from({ length: 11 }, (_, i) => `t${i}`);
-    const recordMap = new Map(ids.map((id) => [id, `rec-${id}`]));
-    vi.mocked(listTasks).mockResolvedValueOnce(ids.map((id) => makeTask(id)));
-    vi.mocked(helpers.fetchPBRecordIdsForTasks).mockResolvedValueOnce(recordMap);
+    const snapshot = new Map(ids.map((id) => [id, makeSnapshotEntry(id)]));
+    vi.mocked(helpers.fetchPBSnapshotForTasks).mockResolvedValueOnce(snapshot);
+    // Each task's preflight returns the same timestamp — no conflicts.
+    for (const id of ids) {
+      vi.mocked(helpers.fetchSinglePBTaskFresh).mockResolvedValueOnce(snapshot.get(id)!);
+    }
 
     const result = await bulkUpdateTasks(
       config,
@@ -121,5 +171,6 @@ describe('bulkUpdateTasks — delete safety', () => {
 
     expect(result.dryRun).toBe(false);
     expect(result.updated).toBe(11);
+    expect(result.conflicts).toEqual([]);
   });
 });

--- a/packages/mcp-server/src/__tests__/write-ops/task-operations-create.test.ts
+++ b/packages/mcp-server/src/__tests__/write-ops/task-operations-create.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { GsdConfig, Task } from '../../types.js';
+import type { GsdConfig } from '../../types.js';
 
 // Mock the helpers so we never touch real PocketBase.
 vi.mock('../../write-ops/helpers.js', async () => {
@@ -9,12 +9,19 @@ vi.mock('../../write-ops/helpers.js', async () => {
   return {
     ...actual,
     createTaskInPB: vi.fn().mockResolvedValue(undefined),
+    updateTaskInPB: vi.fn().mockResolvedValue(undefined),
+    updateTaskInPBById: vi.fn().mockResolvedValue(undefined),
+    fetchSinglePBTaskFresh: vi.fn().mockResolvedValue(null),
     getAuthInfo: vi.fn().mockResolvedValue({ ownerId: 'owner-1', deviceId: 'device-1' }),
   };
 });
 
 vi.mock('../../tools/list-tasks.js', () => ({
   listTasks: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../cache.js', () => ({
+  getTaskCache: () => ({ invalidate: vi.fn() }),
 }));
 
 import { createTask, updateTask } from '../../write-ops/task-operations.js';
@@ -110,24 +117,46 @@ describe('createTask URL extraction', () => {
 
 describe('updateTask URL parity', () => {
   it('does NOT extract URLs from title (mirrors webapp non-extraction on edit)', async () => {
-    const { listTasks } = await import('../../tools/list-tasks.js');
+    const helpers = await import('../../write-ops/helpers.js');
 
-    const seedTask: Task = {
-      id: 'task-1',
+    // updateTask now reads the current task via fetchSinglePBTaskFresh (bypass
+    // cache). Mock it with a PBTask shape (snake_case) that pbTaskToTask
+    // translates into the same seed as before.
+    const seedRecord = {
+      id: 'rec-task-1',
+      task_id: 'task-1',
+      owner: 'owner-1',
       title: 'Original',
       description: 'Original description',
       urgent: false,
       important: false,
       quadrant: 'not-urgent-not-important',
+      due_date: '',
       completed: false,
+      completed_at: '',
+      recurrence: 'none',
       tags: [],
       subtasks: [],
-      recurrence: 'none',
       dependencies: [],
-      createdAt: '2026-04-01T00:00:00Z',
-      updatedAt: '2026-04-01T00:00:00Z',
-    };
-    vi.mocked(listTasks).mockResolvedValueOnce([seedTask]);
+      notification_enabled: true,
+      notify_before: 0,
+      notification_sent: false,
+      last_notification_at: '',
+      snoozed_until: '',
+      estimated_minutes: 0,
+      time_spent: 0,
+      time_entries: [],
+      client_updated_at: '2026-04-01T00:00:00Z',
+      client_created_at: '2026-04-01T00:00:00Z',
+      device_id: 'device-1',
+      created: '2026-04-01T00:00:00Z',
+      updated: '2026-04-01T00:00:00Z',
+    } as never;
+    vi.mocked(helpers.fetchSinglePBTaskFresh).mockResolvedValueOnce({
+      pbRecordId: 'rec-task-1',
+      clientUpdatedAt: '2026-04-01T00:00:00Z',
+      record: seedRecord,
+    });
 
     const result = await updateTask(config, {
       id: 'task-1',

--- a/packages/mcp-server/src/errors.ts
+++ b/packages/mcp-server/src/errors.ts
@@ -1,0 +1,27 @@
+/**
+ * Typed error classes for the MCP server.
+ */
+
+/**
+ * Thrown when a precondition check (e.g., the PocketBase `client_updated_at`
+ * value has not changed between the read and the write) fails.
+ *
+ * Carries both the timestamp seen at read time and the timestamp seen
+ * immediately before the write so the caller — or the LLM — can decide how to
+ * recover (re-fetch the task and retry, surface to the user, etc.).
+ */
+export class ConflictError extends Error {
+  readonly name = 'ConflictError';
+
+  constructor(
+    readonly taskId: string,
+    readonly readClientUpdatedAt: string,
+    readonly currentClientUpdatedAt: string
+  ) {
+    super(
+      `Task ${taskId} changed between read and write ` +
+        `(read: ${readClientUpdatedAt}, current: ${currentClientUpdatedAt}). ` +
+        `Re-fetch the task and retry.`
+    );
+  }
+}

--- a/packages/mcp-server/src/tools/handlers/write-handlers.ts
+++ b/packages/mcp-server/src/tools/handlers/write-handlers.ts
@@ -183,6 +183,16 @@ export async function handleBulkUpdateTasks(
     });
   }
 
+  // Surface conflicts so the model can decide to refetch + retry. Conflicts
+  // are an expected LWW outcome (a concurrent writer changed the task between
+  // snapshot and write), not a failure — reported separately from errors.
+  if (result.conflicts && result.conflicts.length > 0) {
+    message += `\nConflicts (${result.conflicts.length} skipped — task changed during bulk operation):\n`;
+    result.conflicts.forEach((id, idx) => {
+      message += `${idx + 1}. ${id} (re-fetch and retry if you still want to apply the change)\n`;
+    });
+  }
+
   return {
     content: [
       {

--- a/packages/mcp-server/src/write-ops/bulk-operations.ts
+++ b/packages/mcp-server/src/write-ops/bulk-operations.ts
@@ -8,13 +8,15 @@
  */
 
 import type { GsdConfig, Task } from '../types.js';
+import { pbTaskToTask } from '../types.js';
 import type { BulkOperation } from './types.js';
 import { listTasks } from '../tools/list-tasks.js';
 import { getTaskCache } from '../cache.js';
 import {
   deriveQuadrant,
   getAuthInfo,
-  fetchPBRecordIdsForTasks,
+  fetchPBSnapshotForTasks,
+  fetchSinglePBTaskFresh,
   updateTaskInPBById,
   deleteTaskInPBById,
   sleep,
@@ -80,12 +82,26 @@ function applyOperation(task: Task, operation: BulkOperation, now: string): Task
 const BULK_MAX_TASKS = 50;
 const BULK_MAX_DELETES = 10;
 
+export interface BulkUpdateResult {
+  updated: number;
+  deleted: number;
+  errors: string[];
+  /**
+   * Task ids whose `client_updated_at` changed between the batch snapshot and
+   * the per-item preflight check, so the write was skipped. Distinct from
+   * `errors`: conflicts are an expected LWW outcome, not failures. Always
+   * present (empty when nothing was skipped).
+   */
+  conflicts: string[];
+  dryRun: boolean;
+}
+
 export async function bulkUpdateTasks(
   config: GsdConfig,
   taskIds: string[],
   operation: BulkOperation,
   options?: { dryRun?: boolean }
-): Promise<{ updated: number; deleted: number; errors: string[]; dryRun: boolean }> {
+): Promise<BulkUpdateResult> {
   // Destructive deletes default to dryRun=true. Callers must pass
   // `dryRun: false` explicitly to actually delete.
   const isDryRun =
@@ -112,52 +128,90 @@ export async function bulkUpdateTasks(
   }
 
   if (taskIds.length === 0) {
-    return { updated: 0, deleted: 0, errors: [], dryRun: isDryRun };
+    return { updated: 0, deleted: 0, errors: [], conflicts: [], dryRun: isDryRun };
   }
 
-  const allTasks = await listTasks(config);
-  const tasksToUpdate = allTasks.filter((t) => taskIds.includes(t.id));
-
-  if (tasksToUpdate.length === 0) {
-    return { updated: 0, deleted: 0, errors: ['No matching tasks found'], dryRun: isDryRun };
-  }
-
+  // Dry-run path: cached listTasks is fine — no PUTs will happen, so a stale
+  // snapshot only affects the preview counts.
   if (isDryRun) {
+    const allTasks = await listTasks(config);
+    const tasksToUpdate = allTasks.filter((t) => taskIds.includes(t.id));
+    if (tasksToUpdate.length === 0) {
+      return {
+        updated: 0,
+        deleted: 0,
+        errors: ['No matching tasks found'],
+        conflicts: [],
+        dryRun: true,
+      };
+    }
     const deletes = operation.type === 'delete' ? tasksToUpdate.length : 0;
     const updates = operation.type === 'delete' ? 0 : tasksToUpdate.length;
-    return { updated: updates, deleted: deletes, errors: [], dryRun: true };
+    return { updated: updates, deleted: deletes, errors: [], conflicts: [], dryRun: true };
   }
 
-  // Pre-fetch PB record ids for the whole batch in one request.
-  const [{ ownerId, deviceId }, recordIdMap] = await Promise.all([
+  // Write path: read fresh PB records (one request) so both content and the
+  // snapshot timestamps come from PocketBase, never from the cache. Closes the
+  // stale-spread hole from Codex finding #2.
+  const [{ ownerId, deviceId }, snapshot] = await Promise.all([
     getAuthInfo(config),
-    fetchPBRecordIdsForTasks(
-      config,
-      tasksToUpdate.map((t) => t.id)
-    ),
+    fetchPBSnapshotForTasks(config, taskIds),
   ]);
 
+  if (snapshot.size === 0) {
+    return {
+      updated: 0,
+      deleted: 0,
+      errors: ['No matching tasks found'],
+      conflicts: [],
+      dryRun: false,
+    };
+  }
+
+  // Iterate in the caller's requested order so the result is predictable.
+  // Note: we only carry the snapshot timestamp forward — `pbRecordId` comes
+  // from the preflight read below to avoid drifting from the freshest record.
+  const tasksToProcess: Array<{ task: Task; snapshotTimestamp: string }> = [];
+  for (const id of taskIds) {
+    const entry = snapshot.get(id);
+    if (entry) {
+      tasksToProcess.push({
+        task: pbTaskToTask(entry.record),
+        snapshotTimestamp: entry.clientUpdatedAt,
+      });
+    }
+  }
+
   const errors: string[] = [];
+  const conflicts: string[] = [];
   let updateCount = 0;
   let deleteCount = 0;
   const now = new Date().toISOString();
 
-  for (let i = 0; i < tasksToUpdate.length; i++) {
-    const task = tasksToUpdate[i];
-    const pbRecordId = recordIdMap.get(task.id);
-
-    if (!pbRecordId) {
-      errors.push(`Task ${task.id}: not found in PocketBase`);
-      continue;
-    }
+  for (let i = 0; i < tasksToProcess.length; i++) {
+    const { task, snapshotTimestamp } = tasksToProcess[i];
 
     try {
+      // Per-item preflight: re-read the record and compare client_updated_at
+      // against the snapshot taken at the start of the batch. If the record
+      // changed underneath us, surface the id in `conflicts` and skip the
+      // write — bulk operations are continue-on-conflict, not abort-on-first.
+      const preflight = await fetchSinglePBTaskFresh(config, task.id);
+      if (!preflight) {
+        conflicts.push(task.id);
+        continue;
+      }
+      if (preflight.clientUpdatedAt !== snapshotTimestamp) {
+        conflicts.push(task.id);
+        continue;
+      }
+
       if (operation.type === 'delete') {
-        await deleteTaskInPBById(config, pbRecordId);
+        await deleteTaskInPBById(config, preflight.pbRecordId);
         deleteCount++;
       } else {
         const updated = applyOperation(task, operation, now);
-        await updateTaskInPBById(config, pbRecordId, updated, ownerId, deviceId);
+        await updateTaskInPBById(config, preflight.pbRecordId, updated, ownerId, deviceId);
         updateCount++;
       }
     } catch (error) {
@@ -167,8 +221,16 @@ export async function bulkUpdateTasks(
     }
 
     // Throttle between writes to avoid PocketBase 429s.
-    if (i < tasksToUpdate.length - 1) {
+    if (i < tasksToProcess.length - 1) {
       await sleep(PB_BULK_WRITE_DELAY_MS);
+    }
+  }
+
+  // Report tasks the caller asked for but PocketBase didn't return (deleted on
+  // another device between the request and the snapshot fetch).
+  for (const id of taskIds) {
+    if (!snapshot.has(id)) {
+      errors.push(`Task ${id}: not found in PocketBase`);
     }
   }
 
@@ -179,6 +241,7 @@ export async function bulkUpdateTasks(
     updated: updateCount,
     deleted: deleteCount,
     errors,
+    conflicts,
     dryRun: false,
   };
 }

--- a/packages/mcp-server/src/write-ops/helpers.ts
+++ b/packages/mcp-server/src/write-ops/helpers.ts
@@ -102,6 +102,74 @@ async function findPBRecordId(config: GsdConfig, taskId: string): Promise<string
 }
 
 /**
+ * Fetch a single PocketBase task record by its client task_id, bypassing any
+ * cache. Returns null if the record does not exist.
+ *
+ * Used by updateTask + bulk operations to read a fresh `client_updated_at`
+ * snapshot for LWW precondition checks. The task cache is intentionally NOT
+ * consulted here — a stale snapshot would defeat the conflict detection.
+ */
+export async function fetchSinglePBTaskFresh(
+  config: GsdConfig,
+  taskId: string
+): Promise<{ pbRecordId: string; clientUpdatedAt: string; record: PBTask } | null> {
+  const pb = getPocketBase(config);
+  try {
+    const record = await pb
+      .collection('tasks')
+      .getFirstListItem<PBTask>(`task_id = "${escapeFilterValue(taskId)}"`);
+    return {
+      pbRecordId: record.id,
+      clientUpdatedAt: record.client_updated_at,
+      record,
+    };
+  } catch (err) {
+    // PocketBase's ClientResponseError surfaces an HTTP status. Only treat a
+    // true 404 as "not found" (return null). Any other status — 401 auth, 5xx,
+    // network failure — must propagate; otherwise downstream code would
+    // misreport it as "task deleted between read and write" and the LLM may
+    // try to recreate a task that still exists.
+    const status = (err as { status?: number })?.status;
+    if (status === 404) return null;
+    throw err;
+  }
+}
+
+/**
+ * Pre-fetch fresh PocketBase records for a batch of client task ids in a
+ * single request. Returns a map keyed by client task_id.
+ *
+ * Returns the full PBTask record (not just identifiers) so the caller can both
+ * derive task content via `pbTaskToTask` AND use `client_updated_at` for LWW
+ * conflict detection. This deliberately bypasses the task cache.
+ */
+export async function fetchPBSnapshotForTasks(
+  config: GsdConfig,
+  taskIds: string[]
+): Promise<Map<string, { pbRecordId: string; clientUpdatedAt: string; record: PBTask }>> {
+  const map = new Map<
+    string,
+    { pbRecordId: string; clientUpdatedAt: string; record: PBTask }
+  >();
+  if (taskIds.length === 0) return map;
+
+  const pb = getPocketBase(config);
+  const filter = taskIds
+    .map((id) => `task_id = "${escapeFilterValue(id)}"`)
+    .join(' || ');
+
+  const records = await pb.collection('tasks').getFullList<PBTask>({ filter });
+  for (const record of records) {
+    map.set(record.task_id, {
+      pbRecordId: record.id,
+      clientUpdatedAt: record.client_updated_at,
+      record,
+    });
+  }
+  return map;
+}
+
+/**
  * Pre-fetch PocketBase record ids for a batch of client task ids in a single
  * request. Avoids the N+1 lookup pattern when bulk-updating many tasks.
  */

--- a/packages/mcp-server/src/write-ops/task-operations.ts
+++ b/packages/mcp-server/src/write-ops/task-operations.ts
@@ -4,6 +4,7 @@
  */
 
 import type { GsdConfig, Task } from '../types.js';
+import { pbTaskToTask } from '../types.js';
 import type { CreateTaskInput, UpdateTaskInput } from './types.js';
 import { listTasks } from '../tools/list-tasks.js';
 import {
@@ -11,7 +12,9 @@ import {
   deriveQuadrant,
   createTaskInPB,
   updateTaskInPB,
+  updateTaskInPBById,
   deleteTaskInPB,
+  fetchSinglePBTaskFresh,
   getAuthInfo,
 } from './helpers.js';
 import {
@@ -20,6 +23,8 @@ import {
   formatDependencyError,
 } from '../dependencies.js';
 import { extractUrlsFromTitle, buildDescription } from '../text/capture-parser.js';
+import { ConflictError } from '../errors.js';
+import { getTaskCache } from '../cache.js';
 
 /**
  * Create task result with dry-run information
@@ -129,6 +134,12 @@ export interface UpdateTaskResult {
 
 /**
  * Update an existing task
+ *
+ * LWW conflict detection (Codex finding #2): the current task snapshot is read
+ * directly from PocketBase (cache bypassed) so we never spread a stale value
+ * back over a concurrent writer's change. Immediately before the PUT we
+ * re-read the same record and compare `client_updated_at` against the value
+ * captured at first read — on mismatch we throw `ConflictError`.
  */
 export async function updateTask(
   config: GsdConfig,
@@ -137,16 +148,19 @@ export async function updateTask(
   const warnings: string[] = [];
   const changes: string[] = [];
 
-  const tasks = await listTasks(config);
-  const currentTask = tasks.find((t) => t.id === input.id);
-
-  if (!currentTask) {
+  const fresh = await fetchSinglePBTaskFresh(config, input.id);
+  if (!fresh) {
     throw new Error(`Task not found: ${input.id}\n\nThe task may have been deleted.`);
   }
+  const currentTask = pbTaskToTask(fresh.record);
+  const readClientUpdatedAt = fresh.clientUpdatedAt;
 
-  // Validate dependencies if changing
+  // Validate dependencies if changing. Cache is acceptable here: cycle-checking
+  // is a non-mutating read and the cache invalidates on writes, so a slightly
+  // stale dependency graph is safe.
   if (input.dependencies !== undefined) {
-    const validation = validateDependencies(input.id, input.dependencies, tasks);
+    const allTasks = await listTasks(config);
+    const validation = validateDependencies(input.id, input.dependencies, allTasks);
     if (!validation.valid) {
       throw new Error(formatDependencyError(validation.error!));
     }
@@ -228,8 +242,23 @@ export async function updateTask(
     };
   }
 
+  // Preflight LWW check: re-read the record and confirm `client_updated_at`
+  // hasn't moved between the initial read and now. If it has, a concurrent
+  // writer changed the task — abort with ConflictError rather than overwriting
+  // their change.
+  const preflight = await fetchSinglePBTaskFresh(config, input.id);
+  if (!preflight) {
+    throw new Error(`Task ${input.id} was deleted between read and write.`);
+  }
+  if (preflight.clientUpdatedAt !== readClientUpdatedAt) {
+    throw new ConflictError(input.id, readClientUpdatedAt, preflight.clientUpdatedAt);
+  }
+
   const { ownerId, deviceId } = await getAuthInfo(config);
-  await updateTaskInPB(config, updatedTask, ownerId, deviceId);
+  await updateTaskInPBById(config, preflight.pbRecordId, updatedTask, ownerId, deviceId);
+  // updateTaskInPBById skips the cache invalidation done in updateTaskInPB, so
+  // invalidate here explicitly (matches the contract callers expect).
+  getTaskCache().invalidate();
 
   return {
     task: updatedTask,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -206,3 +206,13 @@ None currently.
 - [x] Card consistency audit — Matrix + Archive use TaskCard
 - [x] Smart View language clarification (info tooltip)
 
+---
+
+## Follow-ups from PR5 (Codex Finding #2 review) — 2026-05-18
+
+- [ ] Decompose `updateTask` (~126 lines) and `bulkUpdateTasks` (~149 lines) in `packages/mcp-server/src/write-ops/`. Suggested extractions: `buildUpdatedTask(currentTask, input)`, `diffChanges(currentTask, input)`, `writeOneWithPreflight(...)`. Both are well over the 40-line standard.
+- [ ] Unify the conflict surface: have `bulk-operations.ts` catch `ConflictError` from a shared `writeOneWithPreflight` helper and push `err.taskId` to `conflicts`. Eliminates the duplicated `if (preflight.clientUpdatedAt !== X)` comparison and gives one definition of "conflict."
+- [ ] Verify whether PocketBase rate-limits all requests or only writes. If all requests, the bulk preflight doubles request count but the throttle only sleeps between iterations — may still trip 429s on large bulks. Either apply throttle to both preflight and write, or document the assumption.
+- [ ] Pre-existing `findPBRecordId` in `helpers.ts` has the same silent-error-swallowing flaw fixed in PR5 for `fetchSinglePBTaskFresh`. Apply the same `status === 404` discrimination there.
+- [ ] Add lessons.md entry: MCP write-path test fixtures didn't catch the original stale-spread bug because mocks never went stale between calls. Future tests should exercise the read→write timeline, not just data shapes.
+


### PR DESCRIPTION
## Summary
Closes Codex adversarial review finding #2 (high): `updateTask` read from the cached `listTasks` snapshot, then PUT the full record back without verifying `client_updated_at` hadn't changed. A concurrent edit (browser, another MCP call) could be silently reverted.

## Changes
- New `ConflictError` (`packages/mcp-server/src/errors.ts`) carrying both `readClientUpdatedAt` and `currentClientUpdatedAt` so callers can decide how to recover.
- New helpers in `write-ops/helpers.ts`:
  - `fetchSinglePBTaskFresh(config, taskId)` — direct PB read of one record by `task_id`, cache bypassed.
  - `fetchPBSnapshotForTasks(config, taskIds)` — batch fetch of full PB records (no `fields` projection so callers can derive both task content and timestamps from the fresh records).
- `updateTask` rewritten: reads current task via `fetchSinglePBTaskFresh`, captures `client_updated_at` as a precondition, re-fetches immediately before the PUT, throws `ConflictError` on mismatch.
- `bulkUpdateTasks` rewritten with the same pattern but **continue-on-conflict** semantics — conflicted task ids accumulate in a new additive `conflicts: string[]` field on `BulkUpdateResult` and the batch keeps going.
- `handleBulkUpdateTasks` surfaces `conflicts` in the response message separately from `errors` so the model can decide to refetch + retry.

## Notes for reviewer
- **Dependency validation still uses cached `listTasks`** for cycle-checking in `updateTask` — this is a non-mutating read and the cache invalidates on writes, so a slightly stale graph is acceptable.
- **PocketBase request count, bulk path**: now `1 snapshot + N preflights + N writes` (was `1 + N`). For a 50-task batch this roughly doubles PB requests — the deliberate cost of closing the stale-spread hole.
- **Narrow LWW race remains**: a concurrent writer can land between the preflight read and the write. Same window that PR4 accepts on the push side; documented in the plan's Risk Notes.
- **Additive `conflicts` field**: `BulkUpdateResult` shape is consumed only by `handleBulkUpdateTasks` (verified via grep). Existing destructuring of `{ updated, deleted, errors, dryRun }` is unaffected.
- Used the existing `pbTaskToTask` mapper (not an inline mapper).

## Versions
- Root `package.json`: `9.1.9` -> `9.1.10`
- `packages/mcp-server/package.json`: `1.1.4` -> `1.1.5`

## Test plan
- [x] `cd packages/mcp-server && npm test` — 110/110 passing (new file + existing suites updated for new mock shape)
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `cd packages/mcp-server && npm run build` — clean
- [x] Root `bun run test` — 1871 vitest passing (5 Playwright e2e files mis-picked up by vitest, same pattern on `main`)
- [ ] Manual: browser edits task description, immediately invoke `update_task` from MCP with a different field; expect a `ConflictError` describing the timestamp delta.

Plan: `docs/superpowers/plans/2026-05-18-codex-adversarial-review-fixes.md` (PR5)