### PR TITLE
ci: add deploy-dev workflow with OIDC + smoke test

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,88 @@
+name: Deploy to Development
+
+on:
+  # Auto-deploy after CI succeeds on a push to main.
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+  # Manual override — re-builds inline and deploys.
+  workflow_dispatch:
+
+# Per locked decision §7.7 of the plan: queue overlapping deploys rather
+# than cancel. A half-applied S3 sync is worse than a slightly delayed deploy.
+concurrency:
+  group: deploy-development
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to development
+    # Gate workflow_run on success + push (a failed CI or a PR-targeted CI
+    # run should never reach this point). workflow_dispatch is trusted.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: development
+      url: ${{ vars.SITE_URL }}
+    permissions:
+      id-token: write   # OIDC token for AWS role assumption
+      contents: read
+      actions: read     # cross-workflow artifact download
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          # workflow_run runs against the default branch context; for a
+          # push to main the head_sha is also on main, so a default checkout
+          # gives us the right tree. workflow_dispatch checks out the
+          # branch the user dispatched against.
+
+      # workflow_run path: the CI workflow already built and uploaded
+      # static-export-<sha> for us. Download it — do NOT rebuild.
+      - name: Download CI build artifact
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: static-export-${{ github.event.workflow_run.head_sha }}
+          path: out/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      # workflow_dispatch path: no upstream artifact, so build inline.
+      - name: Build (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        uses: ./.github/actions/build-static-export
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Deploy to S3 + create CloudFront invalidation
+        id: deploy
+        env:
+          S3_BUCKET: ${{ vars.S3_BUCKET }}
+          CLOUDFRONT_ID: ${{ vars.CLOUDFRONT_ID }}
+          ENV_LABEL: ${{ vars.ENV_LABEL }}
+          SITE_URL: ${{ vars.SITE_URL }}
+        run: bash scripts/deploy-app.sh
+
+      # Block until every edge has the invalidation; otherwise the smoke
+      # test below races stale cache and produces false negatives.
+      - name: Wait for CloudFront invalidation
+        run: |
+          aws cloudfront wait invalidation-completed \
+            --distribution-id "${{ vars.CLOUDFRONT_ID }}" \
+            --id "${{ steps.deploy.outputs.invalidation_id }}"
+
+      - name: Smoke test
+        env:
+          SITE_URL: ${{ vars.SITE_URL }}
+        run: bash scripts/smoke-test.sh

--- a/docs/ops/github-actions-iam.md
+++ b/docs/ops/github-actions-iam.md
@@ -1,0 +1,158 @@
+# GitHub Actions → AWS Setup Runbook
+
+This is the one-time manual configuration required before `.github/workflows/deploy-dev.yml` (and later `deploy-prod.yml`, `deploy-cloudfront-infra.yml`) can deploy. Everything below happens in **your AWS account** and **your GitHub repo settings** — none of it is in code.
+
+Trust model: GitHub-issued OIDC tokens authenticate to AWS roles scoped to specific GitHub Environments. No long-lived AWS access keys are stored anywhere.
+
+---
+
+## Step 1 — Add GitHub as an OIDC identity provider in AWS (once per account)
+
+If your AWS account does not already have `token.actions.githubusercontent.com` as an IAM OIDC provider, add it:
+
+```bash
+aws iam create-open-id-connect-provider \
+  --url https://token.actions.githubusercontent.com \
+  --client-id-list sts.amazonaws.com \
+  --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1
+```
+
+(Thumbprint is GitHub's well-known cert thumbprint; AWS now also accepts this provider without a thumbprint check, but supplying it is harmless and documented.)
+
+Verify it exists:
+
+```bash
+aws iam list-open-id-connect-providers
+```
+
+---
+
+## Step 2 — Create the development deploy role
+
+### 2a. Trust policy
+
+Save as `trust-policy-development.json`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<YOUR_ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:vscarpenter/gsd-task-manager:environment:development"
+        }
+      }
+    }
+  ]
+}
+```
+
+The `sub` condition scopes this role to GitHub Actions runs **inside the `development` environment** of this specific repo. A different env or a different repo cannot assume it.
+
+### 2b. Permission policy
+
+Save as `policy-development.json`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "S3DeployBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation"
+      ],
+      "Resource": "arn:aws:s3:::gsd-dev.vinny.dev"
+    },
+    {
+      "Sid": "S3DeployObjects",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": "arn:aws:s3:::gsd-dev.vinny.dev/*"
+    },
+    {
+      "Sid": "CloudFrontInvalidate",
+      "Effect": "Allow",
+      "Action": [
+        "cloudfront:CreateInvalidation",
+        "cloudfront:GetInvalidation"
+      ],
+      "Resource": "arn:aws:cloudfront::<YOUR_ACCOUNT_ID>:distribution/E1HY1IKF5GT513"
+    }
+  ]
+}
+```
+
+`cloudfront:GetInvalidation` is required by `aws cloudfront wait invalidation-completed` in the workflow.
+
+### 2c. Create the role
+
+```bash
+aws iam create-role \
+  --role-name gsd-deploy-development \
+  --assume-role-policy-document file://trust-policy-development.json
+
+aws iam put-role-policy \
+  --role-name gsd-deploy-development \
+  --policy-name gsd-deploy-development-inline \
+  --policy-document file://policy-development.json
+```
+
+Note the role ARN — you'll paste it into the GitHub Environment in Step 3.
+
+```
+arn:aws:iam::<YOUR_ACCOUNT_ID>:role/gsd-deploy-development
+```
+
+---
+
+## Step 3 — Create the `development` GitHub Environment
+
+GitHub → `vscarpenter/gsd-task-manager` → **Settings → Environments → New environment** → name: `development`.
+
+Required reviewers: **none** (dev auto-deploys on push to main, per locked decision §7.3).
+
+Add these **Environment variables** (not secrets — none of these are confidential):
+
+| Name | Value |
+|---|---|
+| `AWS_DEPLOY_ROLE_ARN` | `arn:aws:iam::<YOUR_ACCOUNT_ID>:role/gsd-deploy-development` |
+| `S3_BUCKET` | `s3://gsd-dev.vinny.dev` |
+| `CLOUDFRONT_ID` | `E1HY1IKF5GT513` |
+| `ENV_LABEL` | `Development` |
+| `SITE_URL` | `https://gsd-dev.vinny.dev` |
+
+---
+
+## Step 4 — First-run sanity check
+
+1. Merge any commit to `main` (or trigger the workflow manually: Actions → Deploy to Development → Run workflow).
+2. Watch the run — `deploy` job should:
+   - Download the `static-export-<sha>` artifact from the CI run.
+   - Assume the IAM role via OIDC (no secrets used).
+   - Sync to S3, create + wait on the CloudFront invalidation.
+   - Pass the four smoke-test assertions.
+3. Verify the dev URL serves the new build: `curl -I https://gsd-dev.vinny.dev/`.
+
+---
+
+## Future phases (heads-up)
+
+- **Phase 4 — production deploy.** Same shape, separate role `gsd-deploy-prod` scoped to `environment:production`, separate GitHub Environment with a **required reviewer**.
+- **Phase 5 — CloudFront infra.** Separate role `gsd-deploy-cloudfront-infra` with the additional `cloudfront:CreateFunction / UpdateFunction / PublishFunction / GetDistributionConfig / UpdateDistribution / *ResponseHeadersPolicy` permissions. Also gated by a required reviewer.
+
+Each subsequent role reuses the OIDC provider from Step 1 — that step is one-time per AWS account.

--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -78,6 +78,12 @@ INVALIDATION_ID=$(aws cloudfront create-invalidation \
 echo -e "${GREEN}✓${NC} Invalidation created: ${INVALIDATION_ID}"
 echo ""
 
+# Expose the invalidation ID to GitHub Actions so the calling workflow can
+# wait on it before running the smoke test. No-op outside CI.
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "invalidation_id=${INVALIDATION_ID}" >> "$GITHUB_OUTPUT"
+fi
+
 echo -e "${BLUE}[3/3]${NC} Deployment Summary"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo -e "Environment:   ${GREEN}${ENV_LABEL}${NC}"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Post-deploy smoke test. Validates that a freshly-deployed environment
+# is actually serving the new build. Designed to be cheap (4 HTTP requests)
+# and to catch the four classes of silent breakage observed historically:
+#
+#   1. Site doesn't return 200 (DNS/cert/origin broken)
+#   2. sw.js missing or replaced by an SPA fallback
+#   3. .well-known/api-catalog wrong Content-Type
+#      (fix-discovery-content-types.sh did not run)
+#   4. index.html missing no-cache headers
+#      (the metadata-REPLACE step did not run)
+#
+# Required env var: SITE_URL (e.g. https://gsd-dev.vinny.dev)
+#
+# Exit code: 0 on success, 1 on any failed assertion.
+
+set -euo pipefail
+
+: "${SITE_URL:?Required env var SITE_URL}"
+
+# Strip trailing slash so we can concat paths consistently.
+SITE_URL="${SITE_URL%/}"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+fail() {
+  echo -e "${RED}✗ Smoke test FAILED: $1${NC}" >&2
+  exit 1
+}
+
+pass() {
+  echo -e "${GREEN}✓${NC} $1"
+}
+
+echo "Smoke testing ${SITE_URL} ..."
+
+# 1. Root URL returns 200.
+echo "  [1/4] GET ${SITE_URL}/"
+curl -fsS -o /dev/null "${SITE_URL}/" \
+  || fail "root URL did not return 200"
+pass "root URL returns 200"
+
+# 2. sw.js contains the cache marker. If S3 routing fell back to the SPA
+#    shell, /sw.js would return index.html instead and this would fail.
+echo "  [2/4] GET ${SITE_URL}/sw.js"
+sw_body=$(curl -fsS "${SITE_URL}/sw.js" | head -c 500)
+echo "$sw_body" | grep -q "gsd-cache" \
+  || fail "sw.js did not contain 'gsd-cache' marker (SPA fallback?)"
+pass "sw.js served correctly"
+
+# 3. .well-known/api-catalog must be application/linkset+json (RFC 9727).
+#    S3 cannot infer this from the (extensionless) filename, so this header
+#    can only be correct if fix-discovery-content-types.sh ran.
+echo "  [3/4] HEAD ${SITE_URL}/.well-known/api-catalog"
+catalog_headers=$(curl -fsSI "${SITE_URL}/.well-known/api-catalog" | tr -d '\r')
+echo "$catalog_headers" | grep -iq "^content-type: application/linkset+json" \
+  || fail ".well-known/api-catalog wrong Content-Type (discovery fix skipped)"
+pass ".well-known/api-catalog Content-Type correct"
+
+# 4. index.html must serve with no-cache. If the cp --metadata-directive
+#    REPLACE step was skipped, the previous immutable cache-control sticks.
+echo "  [4/4] HEAD ${SITE_URL}/"
+index_headers=$(curl -fsSI "${SITE_URL}/" | tr -d '\r')
+echo "$index_headers" | grep -iq "^cache-control:.*no-cache" \
+  || fail "index.html missing no-cache header"
+pass "index.html no-cache header present"
+
+echo ""
+echo -e "${GREEN}✓ All smoke tests passed for ${SITE_URL}${NC}"


### PR DESCRIPTION
## Summary

Phase 3 of `docs/superpowers/plans/2026-05-18-github-ci-deploy-pipeline.md` — adds the development deploy workflow that consumes Phase 2's `static-export-<sha>` artifact.

This PR is **code only**. The workflow stays dormant until the AWS-side setup in `docs/ops/github-actions-iam.md` is done by you (OIDC provider, IAM role, GitHub Environment vars). Nothing in this PR can break the live site.

## Changes

| File | Change |
|---|---|
| `.github/workflows/deploy-dev.yml` | **New.** `workflow_run` (after CI on main) + `workflow_dispatch`. OIDC auth, artifact download, deploy, invalidation wait, smoke test. |
| `scripts/smoke-test.sh` | **New.** Four-curl post-deploy gate per §5 of the plan. |
| `scripts/deploy-app.sh` | Append `invalidation_id` to `$GITHUB_OUTPUT` when set. No-op outside CI. |
| `docs/ops/github-actions-iam.md` | **New.** Runbook for the manual AWS + GitHub Environment setup. |

## Design notes

**Build once, deploy many.** The `workflow_run` path downloads the exact artifact CI built — it does NOT rebuild. Same bytes ship to dev as will eventually ship to prod, even if `main` advances between CI and deploy.

**Why wait on invalidation before smoke test.** A `/*` invalidation takes 1-2 minutes to propagate. Without the wait, the smoke test races stale edge cache and produces false positives (still-stale headers on `index.html`) or false negatives (404s on freshly-deployed files). `aws cloudfront wait invalidation-completed` blocks until every edge has the invalidation; the smoke test that follows hits guaranteed-fresh content.

**Why `workflow_dispatch` rebuilds inline instead of consuming an artifact.** Manual deploys don't have a triggering CI run to download from. Re-building via the composite action takes ~90s — acceptable for a manual deploy. The alternative (look up the most recent artifact on main) is more brittle.

**Smoke test failure mode.** Per locked decision §7.6: workflow fails loudly, no auto-rollback. Site is already deployed at that point — the smoke test failure tells you the deploy succeeded but something is wrong (e.g. a `.well-known/api-catalog` content-type that should have been fixed). Manual investigation; S3 versioning is the rollback escape hatch.

## Required manual setup (yours, before this workflow can actually deploy)

Full runbook: `docs/ops/github-actions-iam.md`. Short version:

1. **AWS** — Create OIDC provider (if not already present) + `gsd-deploy-development` IAM role with the trust + permission JSON in the runbook.
2. **GitHub** — Settings → Environments → New environment "`development`" with five variables:
   - `AWS_DEPLOY_ROLE_ARN` → the role ARN from step 1
   - `S3_BUCKET` → `s3://gsd-dev.vinny.dev`
   - `CLOUDFRONT_ID` → `E1HY1IKF5GT513`
   - `ENV_LABEL` → `Development`
   - `SITE_URL` → `https://gsd-dev.vinny.dev`
3. **First-run test** — Trigger Deploy to Development manually (Actions → Run workflow). Watch all five steps pass.

## What's next (after this merges + your setup is done)

- **Acceptance:** Next merge to main auto-deploys to dev within ~5 minutes. Smoke test passes.
- **Phase 4:** `deploy-prod.yml` — same shape, `v*.*.*` tag-triggered, required reviewer on `production` environment.

## Test plan

- [ ] Merge this PR (code-only, safe)
- [ ] Complete the AWS + GitHub Environment setup per `docs/ops/github-actions-iam.md`
- [ ] Manually trigger Deploy to Development → verify all steps pass
- [ ] Verify `https://gsd-dev.vinny.dev/` serves the latest commit's build
- [ ] Verify `curl -I https://gsd-dev.vinny.dev/.well-known/api-catalog` → `Content-Type: application/linkset+json`
- [ ] Verify `curl -I https://gsd-dev.vinny.dev/` → `Cache-Control: no-cache,...`
- [ ] Push a follow-up commit to main → confirm auto-deploy runs and passes

https://claude.ai/code/session_01UjcDMhtr77Ss4qZGVxZsNN

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjcDMhtr77Ss4qZGVxZsNN)_