### PR TITLE
ci: add deploy-prod workflow (v*.*.* tag-triggered + manual)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,84 @@
+name: Deploy to Production
+
+on:
+  # Tag-triggered release: v*.*.* on any branch.
+  # Matches the package.json semver (e.g. v9.1.11 → 9.1.11).
+  push:
+    tags: ['v*.*.*']
+  # Manual override — useful for re-deploying the current ref.
+  workflow_dispatch:
+
+# Locked decision §7.7: queue overlapping deploys, never cancel.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to production
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    # The `production` environment carries the required-reviewer gate
+    # (locked decision §7.5). The job pauses for human approval before
+    # any of these steps run — no compute wasted on rejected deploys.
+    environment:
+      name: production
+      url: ${{ vars.SITE_URL }}
+    permissions:
+      id-token: write   # OIDC token for AWS role assumption
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # Mirrors publish-mcp-server.yml's tag-vs-package.json check.
+      # Stops a v9.1.11 tag from accidentally deploying a 9.1.10 build.
+      - name: Verify tag matches package.json version
+        if: github.event_name == 'push'
+        env:
+          TAG_REF: ${{ github.ref_name }}
+        run: |
+          TAG_VERSION="${TAG_REF#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Deploying version $PKG_VERSION"
+          echo "## Deploying v$PKG_VERSION to production" >> "$GITHUB_STEP_SUMMARY"
+
+      # Always rebuild for prod — the tag can point at any commit, and the
+      # 14-day artifact retention from CI can't be relied on for older tags.
+      # The build is deterministic from the tree, so this produces the same
+      # bytes CI built when the tagged commit was on main.
+      - name: Build static export
+        uses: ./.github/actions/build-static-export
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Deploy to S3 + create CloudFront invalidation
+        id: deploy
+        env:
+          S3_BUCKET: ${{ vars.S3_BUCKET }}
+          CLOUDFRONT_ID: ${{ vars.CLOUDFRONT_ID }}
+          ENV_LABEL: ${{ vars.ENV_LABEL }}
+          SITE_URL: ${{ vars.SITE_URL }}
+        run: bash scripts/deploy-app.sh
+
+      - name: Wait for CloudFront invalidation
+        run: |
+          aws cloudfront wait invalidation-completed \
+            --distribution-id "${{ vars.CLOUDFRONT_ID }}" \
+            --id "${{ steps.deploy.outputs.invalidation_id }}"
+
+      - name: Smoke test
+        env:
+          SITE_URL: ${{ vars.SITE_URL }}
+        run: bash scripts/smoke-test.sh

--- a/docs/ops/github-actions-iam.md
+++ b/docs/ops/github-actions-iam.md
@@ -150,9 +150,63 @@ Add these **Environment variables** (not secrets — none of these are confident
 
 ---
 
+## Step 5 — Create the production deploy role and environment
+
+Same shape as Steps 2-3, with these substitutions:
+
+| Setting | Dev (already done) | Prod (this step) |
+|---|---|---|
+| IAM role name | `gsd-deploy-development` | `gsd-deploy-prod` |
+| Trust `sub` claim | `repo:vscarpenter/gsd-task-manager:environment:development` | `repo:vscarpenter/gsd-task-manager:environment:production` |
+| S3 bucket ARN | `arn:aws:s3:::gsd-dev.vinny.dev` | `arn:aws:s3:::gsd.vinny.dev` |
+| CloudFront distribution ARN | `arn:aws:cloudfront::ACCT:distribution/E1HY1IKF5GT513` | `arn:aws:cloudfront::ACCT:distribution/E1T6GDX0TQEP94` |
+| GitHub Environment name | `development` | `production` |
+| Required reviewers | none | **vscarpenter** (locked decision §7.5) |
+| `S3_BUCKET` var | `s3://gsd-dev.vinny.dev` | `s3://gsd.vinny.dev` |
+| `CLOUDFRONT_ID` var | `E1HY1IKF5GT513` | `E1T6GDX0TQEP94` |
+| `ENV_LABEL` var | `Development` | `Production` |
+| `SITE_URL` var | `https://gsd-dev.vinny.dev` | `https://gsd.vinny.dev` |
+
+Concretely:
+
+```bash
+# Reuse trust-policy-development.json, swap the sub claim, save as trust-policy-prod.json
+sed 's|environment:development|environment:production|' \
+  trust-policy-development.json > trust-policy-prod.json
+
+# Reuse policy-development.json, swap the bucket name and distribution ID, save as policy-prod.json
+sed -e 's|gsd-dev\.vinny\.dev|gsd.vinny.dev|g' \
+    -e 's|E1HY1IKF5GT513|E1T6GDX0TQEP94|g' \
+  policy-development.json > policy-prod.json
+
+aws iam create-role \
+  --role-name gsd-deploy-prod \
+  --assume-role-policy-document file://trust-policy-prod.json
+
+aws iam put-role-policy \
+  --role-name gsd-deploy-prod \
+  --policy-name gsd-deploy-prod-inline \
+  --policy-document file://policy-prod.json
+```
+
+Then in GitHub: Settings → Environments → New environment → `production` →
+- **Required reviewers:** add `vscarpenter`.
+- **Variables:** the 5 from the table above, including `AWS_DEPLOY_ROLE_ARN` = `arn:aws:iam::ACCT:role/gsd-deploy-prod`.
+
+### First-run prod test
+
+1. Bump `package.json` version (e.g. 9.1.10 → 9.1.11), commit to main, merge via PR.
+2. Tag the merge commit: `git tag v9.1.11 && git push origin v9.1.11`.
+3. Watch the **Deploy to Production** workflow appear in Actions.
+4. It pauses at "Waiting for approval" — go to **Environments → production** and approve.
+5. The deploy runs, smoke-tests, completes. Verify `https://gsd.vinny.dev/` serves the new build.
+
+A `workflow_dispatch` from the Actions tab also works — useful for re-deploying the current main without bumping the version.
+
+---
+
 ## Future phases (heads-up)
 
-- **Phase 4 — production deploy.** Same shape, separate role `gsd-deploy-prod` scoped to `environment:production`, separate GitHub Environment with a **required reviewer**.
 - **Phase 5 — CloudFront infra.** Separate role `gsd-deploy-cloudfront-infra` with the additional `cloudfront:CreateFunction / UpdateFunction / PublishFunction / GetDistributionConfig / UpdateDistribution / *ResponseHeadersPolicy` permissions. Also gated by a required reviewer.
 
 Each subsequent role reuses the OIDC provider from Step 1 — that step is one-time per AWS account.


### PR DESCRIPTION
## Summary

Phase 4 of `docs/superpowers/plans/2026-05-18-github-ci-deploy-pipeline.md` — production deploy workflow. Tag-triggered, gated by a required reviewer on the `production` GitHub Environment.

Code only. Workflow stays dormant until the prod-side setup in `docs/ops/github-actions-iam.md` Step 5 is done.

## Changes

| File | Change |
|---|---|
| `.github/workflows/deploy-prod.yml` | **New.** `v*.*.*` tag push + manual `workflow_dispatch`. OIDC, tag-vs-package.json verification, build, deploy, invalidation wait, smoke test. |
| `docs/ops/github-actions-iam.md` | **New Step 5.** Production role + environment setup as a diff against the dev setup; sed shortcut for generating prod trust/permission JSON. |

## Design notes

**Why rebuild inline instead of downloading the CI artifact.** Tags can point at any commit, and CI artifacts have 14-day retention. If we tagged a 3-week-old commit and tried to download its artifact, we'd find nothing. Always rebuilding from the tagged tree is more robust, and the build is deterministic enough that the bytes match what CI built for that same commit.

**Why tag-vs-package.json verification.** Same trap `publish-mcp-server.yml` already guards against: tagging `v9.1.11` while `package.json` is still at `9.1.10` would deploy the wrong version under a misleading tag. Hard fail before any AWS calls happen.

**Why the required reviewer.** The `production` GitHub Environment gate pauses the job at "Waiting for approval" before any compute runs. No wasted minutes on rejected deploys; no race between an erroneous tag and an actual production push. Locked decision §7.5: `vscarpenter` solo.

**Why no `version` input on workflow_dispatch.** The dispatched ref (branch or tag) already conveys what to deploy. Adding a version input would just be a redundant second source of truth that could drift from `package.json`.

## Required manual setup (yours, before this workflow can actually deploy)

Full runbook: `docs/ops/github-actions-iam.md` Step 5. Short version:

1. **AWS** — Create `gsd-deploy-prod` IAM role using the dev role's JSON with the substitutions in the table. The sed shortcut in the runbook generates the JSON for you.
2. **GitHub** — Settings → Environments → New environment "`production`":
   - **Required reviewers:** `vscarpenter`
   - **Variables:** `AWS_DEPLOY_ROLE_ARN`, `S3_BUCKET=s3://gsd.vinny.dev`, `CLOUDFRONT_ID=E1T6GDX0TQEP94`, `ENV_LABEL=Production`, `SITE_URL=https://gsd.vinny.dev`
3. **First-run test** — Bump `package.json` version, tag the commit `v9.1.11`, push the tag, approve the deploy in GitHub UI.

## What's next (after this merges + your setup is done)

- **Acceptance:** Push a `v*.*.*` tag → reviewer prompted → on approval, prod deploys, smoke test passes.
- **Phase 5:** `deploy-cloudfront-infra.yml` — path-filtered workflow for CloudFront Function + response headers policy changes. Also gated by a required reviewer.

## Test plan

- [ ] Merge this PR (code-only, no live effect until manual setup)
- [ ] Complete the prod role + environment setup per `docs/ops/github-actions-iam.md` Step 5
- [ ] Bump `package.json` version + tag → verify workflow appears in Actions
- [ ] Verify the job pauses at "Waiting for approval" before any AWS calls
- [ ] Approve → verify deploy + smoke test green
- [ ] `curl -I https://gsd.vinny.dev/` shows the expected no-cache + new ETag
- [ ] Negative test: tag `v9.9.9` on a commit where `package.json` is 9.1.10 → workflow should fail at "Verify tag matches package.json version" before doing anything

https://claude.ai/code/session_01UjcDMhtr77Ss4qZGVxZsNN

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjcDMhtr77Ss4qZGVxZsNN)_