### PR TITLE
ci: add deploy-cloudfront-infra workflow (path-filtered + manual)

### DIFF
--- a/.github/workflows/deploy-cloudfront-infra.yml
+++ b/.github/workflows/deploy-cloudfront-infra.yml
@@ -1,0 +1,129 @@
+name: Deploy CloudFront Infrastructure
+
+on:
+  push:
+    branches: [main]
+    # Only fire when the relevant sources change. The workflow itself is
+    # NOT in this list — editing the workflow file should not trigger a
+    # spurious approval prompt with nothing to deploy.
+    paths:
+      - 'cloudfront-function-url-rewrite.cjs'
+      - 'cloudfront-function-response-headers.cjs'
+      - 'cloudfront/response-headers-policy.json'
+      - 'scripts/deploy-cloudfront-function.sh'
+      - 'scripts/deploy-cloudfront-response-headers-policy.sh'
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: Which infra component to deploy
+        type: choice
+        required: true
+        default: both
+        options:
+          - both
+          - functions
+          - policy
+
+# Locked decision §7.7: queue overlapping deploys, never cancel.
+concurrency:
+  group: deploy-cloudfront-infra
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy CloudFront infrastructure
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # The cloudfront-infra environment gates this on a required reviewer.
+    # A broken viewer-request function or a malformed policy can take the
+    # whole distribution offline at the edge — slower to recover than an
+    # S3 sync mistake. Treated as a tier-1 change.
+    environment:
+      name: cloudfront-infra
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so `git diff github.event.before HEAD` always
+          # resolves, even when a push contains multiple commits.
+          fetch-depth: 0
+
+      - name: Detect what changed
+        id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DEPLOY_INPUT: ${{ inputs.deploy }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
+        run: |
+          set -euo pipefail
+
+          deploy_functions=false
+          deploy_policy=false
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            case "$DEPLOY_INPUT" in
+              both)      deploy_functions=true; deploy_policy=true ;;
+              functions) deploy_functions=true ;;
+              policy)    deploy_policy=true ;;
+              *)
+                echo "::error::Unknown deploy input: $DEPLOY_INPUT"
+                exit 1
+                ;;
+            esac
+          else
+            # Push event: compute the diff against the previous main tip.
+            # First push to a new branch sets before to all-zeros; treat
+            # that as "everything is new".
+            if [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
+              changed=$(git ls-files \
+                'cloudfront-function-*.cjs' \
+                'cloudfront/response-headers-policy.json' \
+                'scripts/deploy-cloudfront-*.sh')
+            else
+              changed=$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" || true)
+            fi
+
+            echo "Changed files in this push:"
+            echo "$changed" | sed 's/^/  /'
+
+            if echo "$changed" | grep -qE '^(cloudfront-function-.+\.cjs|scripts/deploy-cloudfront-function\.sh)$'; then
+              deploy_functions=true
+            fi
+            if echo "$changed" | grep -qE '^(cloudfront/response-headers-policy\.json|scripts/deploy-cloudfront-response-headers-policy\.sh)$'; then
+              deploy_policy=true
+            fi
+          fi
+
+          echo "deploy_functions=$deploy_functions" >> "$GITHUB_OUTPUT"
+          echo "deploy_policy=$deploy_policy" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## CloudFront infra deploy plan"
+            echo "- Trigger: $EVENT_NAME"
+            echo "- Deploy CloudFront Functions: $deploy_functions"
+            echo "- Deploy Response Headers Policy: $deploy_policy"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Configure AWS credentials (OIDC)
+        if: |
+          steps.changes.outputs.deploy_functions == 'true' ||
+          steps.changes.outputs.deploy_policy == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Deploy CloudFront Functions
+        if: steps.changes.outputs.deploy_functions == 'true'
+        env:
+          CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
+        run: bash scripts/deploy-cloudfront-function.sh
+
+      - name: Deploy Response Headers Policy
+        if: steps.changes.outputs.deploy_policy == 'true'
+        run: bash scripts/deploy-cloudfront-response-headers-policy.sh

--- a/docs/ops/github-actions-iam.md
+++ b/docs/ops/github-actions-iam.md
@@ -205,8 +205,140 @@ A `workflow_dispatch` from the Actions tab also works — useful for re-deployin
 
 ---
 
-## Future phases (heads-up)
+## Step 6 — Create the CloudFront infrastructure role and environment
 
-- **Phase 5 — CloudFront infra.** Separate role `gsd-deploy-cloudfront-infra` with the additional `cloudfront:CreateFunction / UpdateFunction / PublishFunction / GetDistributionConfig / UpdateDistribution / *ResponseHeadersPolicy` permissions. Also gated by a required reviewer.
+This role is separate from the app deploy roles because it has materially
+broader privileges: it can publish new edge functions and modify the
+distribution config. A misconfigured viewer-request function can take the
+whole distribution offline, so the blast radius warrants a dedicated role
+and a dedicated approval gate.
 
-Each subsequent role reuses the OIDC provider from Step 1 — that step is one-time per AWS account.
+### 6a. Trust policy
+
+Same shape as Step 2a, but the `sub` claim scopes to the new environment.
+Save as `trust-policy-cloudfront-infra.json`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<YOUR_ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:vscarpenter/gsd-task-manager:environment:cloudfront-infra"
+        }
+      }
+    }
+  ]
+}
+```
+
+### 6b. Permission policy
+
+Save as `policy-cloudfront-infra.json`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ManageFunctions",
+      "Effect": "Allow",
+      "Action": [
+        "cloudfront:ListFunctions",
+        "cloudfront:DescribeFunction",
+        "cloudfront:CreateFunction",
+        "cloudfront:UpdateFunction",
+        "cloudfront:PublishFunction"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "AttachFunctionsToDistribution",
+      "Effect": "Allow",
+      "Action": [
+        "cloudfront:GetDistributionConfig",
+        "cloudfront:UpdateDistribution",
+        "cloudfront:CreateInvalidation"
+      ],
+      "Resource": "arn:aws:cloudfront::<YOUR_ACCOUNT_ID>:distribution/E1T6GDX0TQEP94"
+    },
+    {
+      "Sid": "ManageResponseHeadersPolicy",
+      "Effect": "Allow",
+      "Action": [
+        "cloudfront:ListResponseHeadersPolicies",
+        "cloudfront:GetResponseHeadersPolicy",
+        "cloudfront:CreateResponseHeadersPolicy",
+        "cloudfront:UpdateResponseHeadersPolicy"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+Notes on resource scoping:
+
+- `ManageFunctions` is `Resource: "*"` because CloudFront Function ARNs are
+  not allowed in IAM resource scoping for these actions — they have to be
+  account-wide. The trust-policy scoping to the `cloudfront-infra`
+  environment is the actual access boundary.
+- `AttachFunctionsToDistribution` is scoped to the prod distribution ID
+  (the same one the prod app deploy role uses). Update if you add staging.
+- `ManageResponseHeadersPolicy` is `Resource: "*"` for the same reason —
+  IAM doesn't accept policy ARNs as scopes for these actions.
+
+### 6c. Create the role
+
+```bash
+aws iam create-role \
+  --role-name gsd-deploy-cloudfront-infra \
+  --assume-role-policy-document file://trust-policy-cloudfront-infra.json
+
+aws iam put-role-policy \
+  --role-name gsd-deploy-cloudfront-infra \
+  --policy-name gsd-deploy-cloudfront-infra-inline \
+  --policy-document file://policy-cloudfront-infra.json
+```
+
+### 6d. Create the `cloudfront-infra` GitHub Environment
+
+Settings → Environments → New environment → `cloudfront-infra`:
+
+- **Required reviewers:** `vscarpenter` (same gate as production)
+- **Variables:**
+
+| Name | Value |
+|---|---|
+| `AWS_DEPLOY_ROLE_ARN` | `arn:aws:iam::<YOUR_ACCOUNT_ID>:role/gsd-deploy-cloudfront-infra` |
+| `CLOUDFRONT_DISTRIBUTION_ID` | `E1T6GDX0TQEP94` |
+
+(No `S3_BUCKET` / `SITE_URL` / `ENV_LABEL` — this environment doesn't touch
+S3 or run the app deploy.)
+
+### First-run cloudfront-infra test
+
+Pick the safer of the two scripts as the first test — the response headers
+policy update is reversible and doesn't take the site down on failure:
+
+1. Make a trivial whitespace edit to `cloudfront/response-headers-policy.json` on a branch.
+2. Open + merge a PR.
+3. Watch the **Deploy CloudFront Infrastructure** workflow appear in Actions.
+4. Verify the "Detect what changed" step output shows `deploy_policy=true`, `deploy_functions=false`.
+5. Approve in **Environments → cloudfront-infra**.
+6. Verify the policy ID stays the same and the in-place update succeeded
+   (`aws cloudfront get-response-headers-policy --id <ID>`).
+
+For testing the function-deploy path, modify a comment in
+`cloudfront-function-url-rewrite.cjs` (no behavior change), open + merge a PR,
+approve, then `aws cloudfront describe-function --name gsd-url-rewrite --stage LIVE`
+to confirm the new ETag.
+
+---


### PR DESCRIPTION
## Summary

Phase 5 (the final phase) of `docs/superpowers/plans/2026-05-18-github-ci-deploy-pipeline.md` — CloudFront infrastructure deploy workflow. Path-filtered, single workflow file, gated by required reviewer on a new `cloudfront-infra` environment.

Code only. Workflow stays dormant until the prod-side setup in `docs/ops/github-actions-iam.md` Step 6 is done.

## Changes

| File | Change |
|---|---|
| `.github/workflows/deploy-cloudfront-infra.yml` | **New.** push-with-paths + workflow_dispatch (with choice input). Detect-changes step decides which of the two deploy scripts to run. |
| `docs/ops/github-actions-iam.md` | **New Step 6.** Trust + permission JSON for `gsd-deploy-cloudfront-infra`, environment setup, first-run test walkthrough. |

## Design notes

**Why a single workflow with path filters.** Locked decision §7.3. Two scripts (functions vs. policy) but they share the same OIDC role, environment, and approval gate. Splitting into two workflows would duplicate that wiring. The detect-changes step runs only what actually changed.

**Why a separate environment + role from production.** Privileges differ materially. The cloudfront-infra role can publish new edge functions and modify the distribution config — a misconfigured viewer-request function can take the whole site offline at the edge, and recovery means rolling back via the AWS console. The app-deploy roles can only sync S3 and create invalidations. Separate roles + separate approval gates keep the blast radius scoped.

**Why the workflow file itself is NOT in the paths filter.** Editing the workflow YAML triggers the workflow, but no source files actually changed → the detect step would set both flags to false → the job runs, prompts the approver, does nothing. Annoying. Easier to require `workflow_dispatch` for testing workflow changes.

**Why `Resource: "*"` on `ManageFunctions` and `ManageResponseHeadersPolicy`.** IAM doesn't accept CloudFront Function ARNs or Response Headers Policy ARNs as resource scopes for these actions (only `cloudfront:CreateInvalidation` accepts a distribution ARN). The trust policy's `sub` condition on the GitHub Environment is the actual access boundary. Documented in the runbook.

**`fetch-depth: 0`.** The detect step runs `git diff $before $after`. If multiple commits land in a single push (rare with PR-only main), shallow checkout fails. Full history is cheap for this repo.

## Required manual setup (yours, before this workflow can actually deploy)

Full runbook: `docs/ops/github-actions-iam.md` Step 6. Short version:

1. **AWS** — Create `gsd-deploy-cloudfront-infra` IAM role with the trust + permission JSON in Step 6a/6b.
2. **GitHub** — Settings → Environments → `cloudfront-infra`:
   - **Required reviewers:** `vscarpenter`
   - **Variables:** `AWS_DEPLOY_ROLE_ARN`, `CLOUDFRONT_DISTRIBUTION_ID=E1T6GDX0TQEP94`
3. **First-run test** — Whitespace edit to `cloudfront/response-headers-policy.json` on a branch → merge → approve → verify policy update.

## What's next

Plan complete after this merges + your setup is done. Five phases, five PRs, ~610 LOC total. Optional Phase 6 in the plan (Section 6) is removing the manual `bun run deploy` escape hatch — recommended to **keep** as fallback.

## Test plan

- [ ] Merge this PR (code-only, no live effect until manual setup)
- [ ] Complete the cloudfront-infra role + environment setup per `docs/ops/github-actions-iam.md` Step 6
- [ ] Whitespace edit to `cloudfront/response-headers-policy.json` on a branch → merge → verify only the policy step runs
- [ ] Edit a comment in `cloudfront-function-url-rewrite.cjs` → merge → verify only the functions step runs
- [ ] Both changes in one PR → merge → verify both steps run
- [ ] `workflow_dispatch` with each of the three input options (both/functions/policy) → verify the right steps fire

https://claude.ai/code/session_01UjcDMhtr77Ss4qZGVxZsNN

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjcDMhtr77Ss4qZGVxZsNN)_