### PR TITLE
fix: show task card actions on iPad and touch devices

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -880,3 +880,10 @@ main {
 .overdue-task {
   border-left-color: var(--rust);
 }
+
+/* Touch-primary devices (iPad, iPhone): show always-visible mobile actions instead of
+   hover-only desktop actions. Unlayered rules override Tailwind's @layer utilities. */
+@media (hover: none) {
+  .task-card-mobile-actions { display: flex; }
+  .task-card-desktop-actions { display: none; }
+}

--- a/components/task-card/task-card-actions.tsx
+++ b/components/task-card/task-card-actions.tsx
@@ -88,7 +88,7 @@ interface DesktopActionsProps {
 
 function DesktopActions({ task, onEdit, onDelete, onShare, onDuplicate, onSnooze }: DesktopActionsProps) {
   return (
-    <div className="hidden sm:flex items-center gap-0.5 opacity-0 transition group-hover:opacity-100">
+    <div className="task-card-desktop-actions hidden sm:flex items-center gap-0.5 opacity-0 transition group-hover:opacity-100">
       {onShare && (
         <Tooltip>
           <TooltipTrigger asChild>
@@ -164,7 +164,7 @@ interface MobileActionsProps {
 
 function MobileActions({ task, onEdit, onDelete, onShare, onDuplicate }: MobileActionsProps) {
   return (
-    <div className="flex sm:hidden items-center gap-0.5">
+    <div className="task-card-mobile-actions flex sm:hidden items-center gap-0.5">
       <button
         data-testid="edit-task-mobile"
         type="button"


### PR DESCRIPTION
Fixes #294

Task card edit/delete actions were hidden on iPad because the mobile action bar used sm:hidden (640px), but iPads are wider than 640px so they fell into the desktop path — which uses opacity-0 and only reveals on hover. Touch devices have no hover, so actions were permanently invisible.

Adds a `@media (hover: none)` CSS rule in globals.css to show the mobile action bar (edit + overflow menu) on any touch-primary device, regardless of screen width.

Generated with [Claude Code](https://claude.ai/code)