### PR TITLE
chore: package repeated workflow assets

### DIFF
--- a/.claude/agents/pb-sync-reviewer.md
+++ b/.claude/agents/pb-sync-reviewer.md
@@ -1,28 +1,41 @@
 ---
 name: pb-sync-reviewer
-description: Reviews changes under lib/sync/ against the documented PocketBase v0.23+ gotchas in CLAUDE.md. Read-only. Use after editing pb-sync-engine, pb-realtime, pb-auth, task-mapper, or sync-coordinator.
+description: Reviews changes under lib/sync/, import/export, and MCP task write paths against the documented PocketBase v0.23+ gotchas plus prior Codex adversarial data-loss findings. Read-only. Use after editing pb-sync-engine, pb-realtime, pb-auth, task-mapper, sync-coordinator, import/export, or MCP task write handlers.
 model: sonnet
 tools: Read, Grep, Glob, Bash
 ---
 
 You are a strict reviewer for the PocketBase sync layer. The authoritative gotcha list lives in `CLAUDE.md` under "PocketBase v0.23+ Gotchas" and "Cloud Sync". Treat those as the spec.
 
+Also treat prior Codex adversarial review fixes as regression guards. Several bugs looked correct at the happy-path level but could silently lose data, poison cursors, or hide partial failures.
+
 ## Scope
 
-Review every changed file under `lib/sync/**` (and any caller in `lib/tasks/**` that touches sync). Read the gotcha list before reviewing.
+Review every changed file under `lib/sync/**`, import/export paths that enqueue sync work, and any MCP task write path under `packages/mcp-server/src/**`. Include callers in `lib/tasks/**` when they touch sync state or queued writes.
+
+Read the gotcha list before reviewing. Then apply the adversarial data-loss checks below.
 
 ## Required checks
 
-1. **System fields in sort/filter** — `created` and `updated` cannot appear in `sort:` or `filter:` strings. The replacement is `client_updated_at`. Flag any string-literal that mentions `-created`, `created`, `-updated`, `updated` inside a PB SDK call.
+1. **System fields in sort/filter** — `created` and `updated` cannot appear in `sort:` or `filter:` strings. The replacement is `client_updated_at`. Flag any string literal that mentions `-created`, `created`, `-updated`, or `updated` inside a PB SDK call.
 2. **Admin auth endpoint** — Admin login must use `/api/collections/_superusers/auth-with-password`. Flag any reference to `/api/admins/auth-with-password`.
 3. **Relation field types** — The `_pb_users_auth_` placeholder does not work as `collectionId`. The `owner` field on `tasks` must be `text`, not `relation` to that placeholder.
-4. **Custom indexes** — Any new index must reference custom fields only, never `created` / `updated`.
+4. **Custom indexes** — Any new index must reference custom fields only, never `created` or `updated`.
 5. **Rate limiting** — Push paths must throttle (current convention: 100ms). Pull paths should batch via `fetchRemoteTaskIndex()` rather than N individual `getOne()` calls. Flag any new N+1 pattern.
 6. **LWW conflict resolution** — Conflict resolution compares `client_updated_at`. Flag any path that uses local `updatedAt`, server `updated`, or wall-clock `Date.now()` for conflict decisions.
 7. **Echo filtering** — Realtime SSE handlers must skip events where `device_id` matches the local device. Flag any subscriber that processes its own writes.
 8. **Auth state** — PocketBase SDK persists auth in localStorage automatically. Flag any code that hand-rolls token storage.
 9. **Field mapping** — All camelCase ↔ snake_case must go through `task-mapper.ts`. Flag inline `snake_case` field access outside the mapper.
-10. **Logger usage** — Sync code must use `lib/logger.ts` (not `console.log`). Logger sanitizes secrets — flag any token/PII passed to `console.*`.
+10. **Logger usage** — Sync code must use `lib/logger.ts` (not `console.log`). Logger sanitizes secrets. Flag any token/PII passed to `console.*`.
+
+## Adversarial data-loss regression checks
+
+11. **Partial failures are not success** — Any path that completes only part of a push/pull/bulk sync must record `status: 'partial'` or return a distinct partial/conflict result. Flag any partial failure path that writes `success`, suppresses the failure, or only logs it.
+12. **Replace imports propagate deletes** — Replace-mode import must compute local tasks removed by the import and enqueue remote `delete` operations when sync is enabled. The local task mutation and sync queue writes must be in the same Dexie transaction. Flag any replace path that clears local tasks but only enqueues creates/updates.
+13. **Pull cursors cannot be poisoned** — Pull cursor advancement must be based only on records actually applied after validation and LWW checks. Future `client_updated_at` values must be clamped (current convention: now + 5 minutes), and the persisted cursor should keep the overlap window (current convention: subtract 30 seconds and use `>=` on the next pull). Flag cursor updates derived from all fetched records, invalid records, skipped records, or unbounded client timestamps.
+14. **Stale queued writes cannot overwrite newer remote data** — Push update/delete paths must compare the remote `client_updated_at` with the queued payload or queue item timestamp before writing. Stale operations should be skipped and dequeued, and skipped counts should not inflate pushed counts. Flag push paths that write solely because `task_id` exists remotely.
+15. **MCP writes cannot stale-spread cached records** — `updateTask` and bulk task writes must fresh-read the PocketBase record, capture `client_updated_at` as a precondition, re-fetch or otherwise verify before PUT, and surface conflicts distinctly from validation/errors. Bulk paths should continue on conflict and report conflict IDs. Flag full-record PUTs derived from cached `listTasks()` snapshots.
+16. **Remote snapshots preserve both content and timestamps** — Any batch helper used for write preconditions must fetch full remote records or otherwise carry the timestamp required for conflict detection. Flag helpers that project away `client_updated_at` but later perform writes that depend on it.
 
 ## Output format
 
@@ -33,6 +46,6 @@ File: lib/sync/<file>.ts
 Summary: X blocking, Y suggestions
 ```
 
-Prefix non-blocking items with `nit:`. If a sync file is clean, list it under "Clean".
+Prefix non-blocking items with `nit:`. If a reviewed file is clean, list it under "Clean".
 
 Do not modify files. Do not run tests. If you need to verify SDK behavior, grep `node_modules/pocketbase/dist/` rather than guessing.

--- a/.claude/skills/inkwell-retrofit/SKILL.md
+++ b/.claude/skills/inkwell-retrofit/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: inkwell-retrofit
+description: Apply the Inkwell design system to an existing page or component without creating a competing styling system. Use for styling retrofits, standalone HTML explainers, docs pages, or Tailwind v4 token alignment.
+disable-model-invocation: false
+---
+
+# inkwell-retrofit
+
+Use this skill when an existing page, component, or standalone document needs to adopt Inkwell while preserving its content and behavior.
+
+## Good fits
+
+- Re-skin an existing page with Inkwell tokens and primitives.
+- Convert a standalone HTML explainer or report to the Inkwell visual system.
+- Remove duplicate token declarations or competing CSS shims.
+- Align a Tailwind v4 project with Inkwell's token and theme model.
+
+Do not use this skill to redesign the product information architecture or rewrite content. The default move is visual alignment, not content invention.
+
+## First read
+
+Before editing, read:
+
+1. `CLAUDE.md` for project-specific styling rules.
+2. Existing Inkwell files under `app/css/` and `public/css/`.
+3. Any sibling page already using Inkwell, such as a report or explainer.
+4. The target page/component end to end so content stays intact.
+
+## Core rules
+
+- Reuse existing Inkwell tokens before adding project-specific tokens.
+- Do not hardcode hex colors outside token definitions.
+- Prefer semantic tokens such as `--ivory`, `--paper`, `--slate`, `--accent`, `--border`, and `--backdrop`.
+- Keep one saturated accent unless the page truly needs data-viz hues.
+- Use Inkwell primitives where available: `.card`, `.alert`, `.tbl`, `.tldr`, `.toc`, `.sec-head`, `.eyebrow`, `.badge`, `.chip-dot`.
+- Preserve the 1.5px hairline convention unless the project explicitly documents a different value.
+- Keep typography roles consistent: serif for major headings and editorial callouts, mono for labels/file refs/code, sans for normal body UI.
+- Preserve dark-mode behavior through `data-theme` and tokens, not per-component ad hoc overrides.
+- SVG fills and strokes should reference tokens so diagrams theme correctly.
+
+## Retrofit steps
+
+1. Identify the current styling source: global CSS, inline styles, Tailwind utilities, standalone `<style>`, or linked CSS.
+2. Remove competing token systems only when Inkwell fully replaces them.
+3. Map existing colors, borders, typography, spacing, and callouts to Inkwell tokens and primitives.
+4. Keep app-specific extensions small, named, and layered after Inkwell imports.
+5. Replace hardcoded rgba/hex values with semantic tokens.
+6. Preserve content and IDs unless the task explicitly asks for content edits.
+7. Verify light and dark modes.
+8. Verify the page renders standalone if it was standalone before.
+
+## Tailwind v4 integration checklist
+
+- [ ] Inkwell imports are reachable through the app CSS pipeline.
+- [ ] `@import` statements appear before other rules.
+- [ ] `@theme` aliases are defined once.
+- [ ] `[data-theme]` dark-mode cascade works.
+- [ ] Old v3 config token duplication is removed only after equivalent v4 tokens exist.
+- [ ] External consumers still have any needed files under `public/css/`.
+
+## Verification
+
+Run the smallest meaningful set:
+
+- `bun typecheck`
+- `bun lint`
+- `bun run build`
+- targeted tests for touched components, if any
+- browser smoke test for light, dark, and responsive behavior
+
+## PR notes
+
+In the PR body, include:
+
+- What visual system changed.
+- What content intentionally stayed unchanged.
+- Any intentional deviation from default Inkwell guidance.
+- Light/dark verification notes.
+- A short list of hardcoded style values removed.

--- a/.claude/skills/reviewable-pr-slicing/SKILL.md
+++ b/.claude/skills/reviewable-pr-slicing/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: reviewable-pr-slicing
+description: Convert an approved technical plan into a sequence of small, reviewable PRs with clear phase boundaries, validation gates, and PR descriptions. Use for multi-step refactors, workflow changes, security-remediation tranches, documentation-plus-code rollouts, or any change that is too risky or noisy for one PR.
+disable-model-invocation: false
+---
+
+# reviewable-pr-slicing
+
+Use this skill when a plan is ready to implement, but the work should be split into small PRs instead of one broad change.
+
+This skill only changes repository artifacts. It may document manual prerequisites, but it must not perform external account setup, store secrets, or change settings outside the repo.
+
+## Good fits
+
+- A plan that already has goals, non-goals, and a target state.
+- Work that affects multiple layers, such as scripts, workflows, docs, tests, and runtime code.
+- Security findings that should land as narrow remediation tranches.
+- Refactors that need behavior-preserving setup before behavior-changing work.
+- Documentation plus implementation rollouts where reviewers need a clean breadcrumb trail.
+
+Do not use this for tiny fixes, speculative ideas, or work without a clear stopping condition.
+
+## Required inputs
+
+Before editing code, collect:
+
+1. Approved plan or issue path.
+2. Current behavior and affected surfaces.
+3. Goals and non-goals.
+4. Locked decisions and open decisions.
+5. Manual prerequisites the human must complete outside the repo.
+6. Validation commands.
+7. Manual acceptance tests.
+8. Rollback or fallback posture.
+
+If these are missing, add them to the plan first and stop before implementation.
+
+## Phase design rules
+
+- Keep each PR independently understandable.
+- Prefer one concern per PR.
+- Put plan-only documentation before implementation.
+- Put shared foundations before files that consume them.
+- Put read-only validation before write-path changes.
+- Put lower-risk environments or paths before higher-risk ones.
+- Keep manual prerequisites explicit and separate from code behavior.
+- Stop after the current phase. Do not sneak in the next phase.
+
+## Default phase pattern
+
+Adapt the names to the work, but start here:
+
+1. **Plan PR** — canonical plan, options, decisions, phase list. No behavior change.
+2. **Foundation PR** — shared helpers, scripts, types, or docs scaffolding. Preserve behavior.
+3. **Validation PR** — checks, tests, assertions, or reports that make later change safer.
+4. **First behavior PR** — narrow live behavior change with the smallest blast radius.
+5. **Second behavior PR** — next scoped behavior change after the first proves clean.
+6. **Cleanup PR** — remove old paths only after the replacement has been validated.
+
+## PR body template
+
+```md
+## Summary
+
+Phase N of `<plan path>` — <one-sentence scope>. State whether this is plan-only, behavior-preserving, dormant until manual prerequisites, or live on merge.
+
+## Changes
+
+| File | Change |
+|---|---|
+| `<path>` | <specific change> |
+
+## Design notes
+
+**Why <decision>.** <rationale and tradeoff>
+
+**Why not <tempting alternative>.** <reason it was skipped>
+
+## Manual prerequisites
+
+List only work the human must complete outside this PR. If none, say none.
+
+## What is next
+
+Name the next phase and this phase's acceptance condition.
+
+## Test plan
+
+- [ ] Automated validation.
+- [ ] Manual first-run or review check.
+- [ ] Negative or failure-mode check for the riskiest path.
+```
+
+## Implementation checklist
+
+- [ ] Read the plan end to end.
+- [ ] Confirm the phase and stopping condition.
+- [ ] Keep unrelated cleanup out.
+- [ ] Update the runbook or docs next to the changed surface.
+- [ ] Include manual prerequisites in both docs and PR body.
+- [ ] Run static validation for changed file types.
+- [ ] Add a negative test or failure-mode check when practical.
+- [ ] Stop at the phase boundary.
+
+## Review checklist
+
+Before marking ready:
+
+- [ ] A reviewer can understand the PR without reading chat history.
+- [ ] The blast radius is stated honestly.
+- [ ] Manual prerequisites are clear.
+- [ ] Validation is specific and reproducible.
+- [ ] Next step is explicit.
+- [ ] No secrets, account identifiers, or local-only paths are committed unless intentionally documented as examples.


### PR DESCRIPTION
## Summary

Packages three high-confidence repeated workflows from recent work into narrow Claude Code assets:

| Asset | Change |
|---|---|
| `.claude/agents/pb-sync-reviewer.md` | Extends the existing PocketBase sync reviewer with adversarial data-loss regression checks from the May 18 Codex findings. |
| `.claude/skills/reviewable-pr-slicing/SKILL.md` | Adds a safe, repo-only workflow for turning approved plans into small reviewable PR series. |
| `.claude/skills/inkwell-retrofit/SKILL.md` | Adds a focused workflow for applying Inkwell to existing pages without creating a competing styling system. |

## Why these

Recent work showed three repeated patterns worth packaging:

- Phased plan-to-PR rollouts across CI/CD, security remediation, and cross-cutting refactors.
- Repeated Codex adversarial findings around sync data loss, stale writes, partial failures, and cursor poisoning.
- Repeated Inkwell retrofits across app CSS, Tailwind v4 integration, and standalone documentation pages.

## Deliberate scope

- No broad "do everything" agent.
- No external account setup automation.
- No writing/blog workflow added here because that appears better handled outside this application repo.

## Test plan

- [ ] Read each asset for clarity and overlap with existing `.claude/README.md` guidance.
- [ ] Confirm `pb-sync-reviewer` still covers the original PocketBase v0.23+ gotchas.
- [ ] Invoke `Skill(reviewable-pr-slicing)` against an approved plan and confirm the output stops at phase boundaries.
- [ ] Invoke `Skill(inkwell-retrofit)` against a docs page and confirm it preserves content while replacing ad hoc styling.
