### PR TITLE
refactor(ui): retrofit Inkwell design tokens across all pages

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -217,14 +217,14 @@ export default function DashboardPage() {
                 </div>
 
                 {metrics.overdueCount > 0 && (
-                  <div className="flex items-center gap-3 rounded-xl border border-red-200 bg-red-500/5 px-5 py-3.5 dark:border-red-900/50 dark:bg-red-500/10">
-                    <AlertTriangleIcon className="h-5 w-5 shrink-0 text-red-500" />
+                  <div className="alert is-danger items-center rounded-xl px-5 py-3.5">
+                    <AlertTriangleIcon className="h-5 w-5 shrink-0 text-rust" />
                     <div className="flex-1">
-                      <p className="text-sm font-medium text-foreground">
+                      <p className="alert-title text-sm">
                         {metrics.overdueCount} overdue{" "}
                         {metrics.overdueCount === 1 ? "task" : "tasks"}
                         {metrics.dueTodayCount > 0 && (
-                          <span className="text-foreground-muted">
+                          <span className="alert-body">
                             {" "}
                             &middot; {metrics.dueTodayCount} due today
                           </span>

--- a/components/about/footer-cta.tsx
+++ b/components/about/footer-cta.tsx
@@ -13,7 +13,7 @@ export function FooterCta({ version }: FooterCtaProps) {
           <p className="mb-4 text-[11px] font-semibold uppercase tracking-[0.18em] text-foreground-muted">
             Ready When You Are
           </p>
-          <h2 className="rd-serif mb-4 text-3xl tracking-tight text-foreground sm:text-4xl">
+          <h2 className="rd-serif mb-4 text-h2 text-foreground sm:text-h1">
             Ready to get stuff done?
           </h2>
           <p className="mb-8 text-foreground-muted">

--- a/components/about/matrix-section.tsx
+++ b/components/about/matrix-section.tsx
@@ -5,25 +5,25 @@ const quadrants = [
     label: "Q1",
     name: "Do First",
     description: "Crises, deadlines. Handle now.",
-    className: "border-red-500/40 bg-red-500/5",
+    className: "border-rust/40 bg-rust-tint",
   },
   {
     label: "Q2",
     name: "Schedule",
     description: "Strategy, growth. Protect this time.",
-    className: "border-blue-500/40 bg-blue-500/5",
+    className: "border-accent/40 bg-accent-tint",
   },
   {
     label: "Q3",
     name: "Delegate",
     description: "Interruptions. Hand these off.",
-    className: "border-amber-500/40 bg-amber-500/5",
+    className: "border-olive/40 bg-olive-tint",
   },
   {
     label: "Q4",
     name: "Eliminate",
     description: "Noise. Stop doing these.",
-    className: "border-gray-500/40 bg-gray-500/5",
+    className: "border-warning/40 bg-warning-tint",
   },
 ] as const;
 

--- a/components/dashboard/streak-indicator.tsx
+++ b/components/dashboard/streak-indicator.tsx
@@ -38,11 +38,11 @@ export function StreakIndicator({ streakData }: StreakIndicatorProps) {
     >
       {/* Top: icon + streak count */}
       <div className="flex items-center gap-3">
-        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-orange-100 dark:bg-orange-900/40">
-          <FlameIcon className="h-6 w-6 text-orange-500" />
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-warning-tint">
+          <FlameIcon className="h-6 w-6 text-warning" />
         </div>
         <div className="min-w-0">
-          <p className="text-xs font-semibold uppercase tracking-wide text-foreground-muted">
+          <p className="text-eyebrow text-foreground-muted">
             Streak
           </p>
           <div className="flex items-center gap-2">
@@ -64,7 +64,7 @@ export function StreakIndicator({ streakData }: StreakIndicatorProps) {
               <div
                 className={`h-3 w-3 rounded-full transition-colors ${
                   active
-                    ? "bg-orange-500 shadow-sm shadow-orange-500/30"
+                    ? "bg-warning shadow-sm shadow-warning-tint"
                     : "bg-background-muted"
                 }`}
                 title={`${DAY_LABELS[index]}: ${active ? "Completed" : "No completions"}`}
@@ -81,7 +81,7 @@ export function StreakIndicator({ streakData }: StreakIndicatorProps) {
       <div className="mt-3 flex items-center justify-between">
         <p className="text-xs text-foreground-muted">{getStreakMessage(current)}</p>
         {milestone ? (
-          <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+          <span className="inline-flex items-center gap-1 rounded-full bg-warning-tint px-2 py-0.5 text-[10px] font-semibold text-warning-dark">
             <TrophyIcon className="h-2.5 w-2.5" />
             {milestone.label}
           </span>

--- a/components/dashboard/tag-analytics.tsx
+++ b/components/dashboard/tag-analytics.tsx
@@ -9,16 +9,16 @@ interface TagAnalyticsProps {
 }
 
 const BAR_COLORS = [
-  "bg-blue-500",
-  "bg-emerald-500",
-  "bg-amber-500",
-  "bg-purple-500",
-  "bg-rose-500",
-  "bg-cyan-500",
-  "bg-orange-500",
-  "bg-indigo-500",
-  "bg-teal-500",
-  "bg-pink-500",
+  "bg-accent",
+  "bg-olive",
+  "bg-warning",
+  "bg-rust",
+  "bg-sky",
+  "bg-accent-d",
+  "bg-info",
+  "bg-gray-500",
+  "bg-olive",
+  "bg-warning-dark",
 ];
 
 /**

--- a/components/dashboard/upcoming-deadlines.tsx
+++ b/components/dashboard/upcoming-deadlines.tsx
@@ -67,30 +67,30 @@ export function UpcomingDeadlines({ tasks, onTaskClick }: UpcomingDeadlinesProps
           {overdueTasks.length > 0 && (
             <DeadlineSection
               title="Overdue"
-              icon={<AlertCircleIcon className="h-4 w-4 text-red-500" />}
+              icon={<AlertCircleIcon className="h-4 w-4 text-status-overdue" />}
               tasks={overdueTasks}
               onTaskClick={onTaskClick}
-              color="red"
+              color="overdue"
             />
           )}
 
           {dueTodayTasks.length > 0 && (
             <DeadlineSection
               title="Due Today"
-              icon={<CalendarIcon className="h-4 w-4 text-amber-500" />}
+              icon={<CalendarIcon className="h-4 w-4 text-warning" />}
               tasks={dueTodayTasks}
               onTaskClick={onTaskClick}
-              color="amber"
+              color="warning"
             />
           )}
 
           {dueThisWeekTasks.length > 0 && (
             <DeadlineSection
               title="Due This Week"
-              icon={<ClockIcon className="h-4 w-4 text-blue-500" />}
+              icon={<ClockIcon className="h-4 w-4 text-sky" />}
               tasks={dueThisWeekTasks}
               onTaskClick={onTaskClick}
-              color="blue"
+              color="info"
             />
           )}
         </div>
@@ -104,7 +104,7 @@ interface DeadlineSectionProps {
   icon: React.ReactNode;
   tasks: TaskRecord[];
   onTaskClick?: (task: TaskRecord) => void;
-  color: "red" | "amber" | "blue";
+  color: "overdue" | "warning" | "info";
 }
 
 function DeadlineSection({
@@ -115,15 +115,15 @@ function DeadlineSection({
   color,
 }: DeadlineSectionProps) {
   const borderColor = {
-    red: "border-l-red-500",
-    amber: "border-l-amber-500",
-    blue: "border-l-blue-500",
+    overdue: "border-l-status-overdue",
+    warning: "border-l-warning",
+    info: "border-l-sky",
   }[color];
 
   const bgColor = {
-    red: "bg-red-500/5 dark:bg-red-500/10",
-    amber: "bg-amber-500/5 dark:bg-amber-500/10",
-    blue: "bg-blue-500/5 dark:bg-blue-500/10",
+    overdue: "bg-status-overdue-muted",
+    warning: "bg-warning-tint",
+    info: "bg-status-blocking-muted",
   }[color];
 
   return (

--- a/components/import-dialog.tsx
+++ b/components/import-dialog.tsx
@@ -100,18 +100,18 @@ export function ImportDialog({ open, onOpenChange, fileContents, existingTaskCou
           <button
             onClick={() => handleImport("merge")}
             disabled={isImporting}
-            className="w-full rounded-lg border-2 border-emerald-200 bg-emerald-50 p-4 text-left transition-all hover:border-emerald-300 hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-emerald-800 dark:bg-emerald-950 dark:hover:border-emerald-700 dark:hover:bg-emerald-900"
+            className="w-full rounded-lg border-2 border-olive/30 bg-olive-tint p-4 text-left transition-all hover:border-olive/50 hover:bg-status-success-muted disabled:cursor-not-allowed disabled:opacity-50"
           >
             <div className="flex items-start gap-3">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-500 text-white">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-olive text-paper">
                 <PlusCircleIcon className="h-5 w-5" />
               </div>
               <div className="flex-1">
-                <h3 className="font-semibold text-emerald-900 dark:text-emerald-100">Merge Tasks</h3>
-                <p className="mt-1 text-sm text-emerald-700 dark:text-emerald-300">
+                <h3 className="font-semibold text-foreground">Merge Tasks</h3>
+                <p className="mt-1 text-sm text-foreground-muted">
                   Keep your existing tasks and add the imported tasks. Duplicate IDs will be regenerated to avoid conflicts.
                 </p>
-                <p className="mt-2 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                <p className="mt-2 text-xs font-medium text-olive">
                   ✓ Safe - No data loss
                 </p>
               </div>
@@ -122,18 +122,18 @@ export function ImportDialog({ open, onOpenChange, fileContents, existingTaskCou
           <button
             onClick={() => handleImport("replace")}
             disabled={isImporting}
-            className="w-full rounded-lg border-2 border-red-200 bg-red-50 p-4 text-left transition-all hover:border-red-300 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-800 dark:bg-red-950 dark:hover:border-red-700 dark:hover:bg-red-900"
+            className="w-full rounded-lg border-2 border-rust-tint-border bg-rust-tint p-4 text-left transition-all hover:border-rust/50 hover:bg-status-overdue-muted disabled:cursor-not-allowed disabled:opacity-50"
           >
             <div className="flex items-start gap-3">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-red-500 text-white">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-rust text-paper">
                 <RefreshCwIcon className="h-5 w-5" />
               </div>
               <div className="flex-1">
-                <h3 className="font-semibold text-red-900 dark:text-red-100">Replace All Tasks</h3>
-                <p className="mt-1 text-sm text-red-700 dark:text-red-300">
+                <h3 className="font-semibold text-foreground">Replace All Tasks</h3>
+                <p className="mt-1 text-sm text-foreground-muted">
                   Delete all existing tasks and replace them with the imported tasks. This action cannot be undone.
                 </p>
-                <div className="mt-2 flex items-center gap-1 text-xs font-medium text-red-600 dark:text-red-400">
+                <div className="mt-2 flex items-center gap-1 text-xs font-medium text-rust">
                   <AlertTriangleIcon className="h-3 w-3" />
                   <span>Warning - Deletes {existingTaskCount} existing task{existingTaskCount !== 1 ? "s" : ""}</span>
                 </div>

--- a/components/settings-page/index.tsx
+++ b/components/settings-page/index.tsx
@@ -231,7 +231,7 @@ export function SettingsPage() {
           <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-foreground-muted">
             Preferences & Data
           </p>
-          <h1 className="rd-serif mt-2 text-4xl tracking-tight text-foreground sm:text-5xl">
+          <h1 className="rd-serif mt-2 text-h1 text-foreground sm:text-display">
             Settings
           </h1>
           <p className="mt-3 max-w-2xl text-base leading-relaxed text-foreground-muted">

--- a/components/settings-page/section-card.tsx
+++ b/components/settings-page/section-card.tsx
@@ -20,7 +20,8 @@ export function SectionCard({ eyebrow, title, description, icon: Icon, children 
   return (
     <section
       aria-labelledby={`section-${title.toLowerCase().replace(/\s+/g, "-")}`}
-      className="overflow-hidden rounded-[28px] border border-border/70 bg-card/95 shadow-[0_8px_30px_rgba(15,23,42,0.06)]"
+      className="overflow-hidden rounded-[28px] border border-border/70 bg-card/95"
+      style={{ boxShadow: "var(--shadow-md)" }}
     >
       <header className="flex items-start gap-4 border-b border-border/60 bg-gradient-to-b from-background to-background-muted/30 px-6 py-6 sm:px-8 sm:py-7">
         <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-accent/10 text-accent ring-1 ring-inset ring-accent/15">

--- a/components/settings-page/settings-sidebar.tsx
+++ b/components/settings-page/settings-sidebar.tsx
@@ -94,7 +94,7 @@ export function SettingsSidebar({ activeId, onSelect, visibleSections }: Setting
 
       {/* Desktop: vertical nav card */}
       <aside className="hidden lg:block lg:w-[260px] lg:shrink-0">
-        <div className="sticky top-24 flex flex-col gap-3 rounded-2xl border border-border bg-card p-2 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+        <div className="sticky top-24 flex flex-col gap-3 rounded-2xl border border-border bg-card p-2 shadow-sm">
           {groups.map(({ group, items }) => (
             <div key={group}>
               <p className="px-3 pb-2 pt-4 text-[10px] font-semibold uppercase tracking-[0.12em] text-foreground-muted/80">

--- a/components/settings/about-section.tsx
+++ b/components/settings/about-section.tsx
@@ -25,7 +25,7 @@ export function AboutSection() {
 			{/* Privacy Row */}
 			<div className="px-4 py-3.5 min-h-[52px]">
 				<div className="flex items-start gap-3">
-					<ShieldCheckIcon className="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" />
+					<ShieldCheckIcon className="w-5 h-5 text-olive flex-shrink-0 mt-0.5" />
 					<div>
 						<p className="text-sm font-medium text-foreground">Privacy First</p>
 						<p className="text-xs text-foreground-muted mt-1 leading-relaxed">

--- a/components/settings/data-management.tsx
+++ b/components/settings/data-management.tsx
@@ -125,14 +125,14 @@ function ActionRow({
 				w-full flex items-center gap-3 px-4 py-3.5 min-h-[52px] text-left
 				transition-colors disabled:opacity-50
 				${isDanger
-					? "hover:bg-red-50 dark:hover:bg-red-950/20"
+					? "hover:bg-rust-tint"
 					: "hover:bg-background-muted/50"
 				}
 			`}
 		>
-			<Icon className={`w-5 h-5 ${isDanger ? "text-red-500" : "text-accent"}`} />
+			<Icon className={`w-5 h-5 ${isDanger ? "text-rust" : "text-accent"}`} />
 			<div className="flex-1 min-w-0">
-				<p className={`text-sm font-medium ${isDanger ? "text-red-600 dark:text-red-400" : "text-foreground"}`}>
+				<p className={`text-sm font-medium ${isDanger ? "text-rust" : "text-foreground"}`}>
 					{label}
 				</p>
 				{description && (

--- a/components/settings/notification-settings.tsx
+++ b/components/settings/notification-settings.tsx
@@ -76,11 +76,11 @@ export function NotificationSettingsSection({
  * Permission status badge
  */
 function PermissionBadge({ permission }: { permission: NotificationPermission }) {
-	const styles = {
-		granted: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
-		denied: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
-		default: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
-	};
+	const variant = {
+		granted: "badge-success",
+		denied: "badge-danger",
+		default: "badge-warning",
+	}[permission];
 
 	const labels = {
 		granted: "Granted",
@@ -89,7 +89,7 @@ function PermissionBadge({ permission }: { permission: NotificationPermission })
 	};
 
 	return (
-		<span className={`px-2 py-0.5 rounded-full text-xs font-medium ${styles[permission]}`}>
+		<span className={`badge ${variant}`}>
 			{labels[permission]}
 		</span>
 	);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.1.10",
+	"version": "9.1.11",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

- Replace raw Tailwind palette colors (`red-*`, `green-*`, `amber-*`, `orange-*`, `blue-*`, `emerald-*`) with Inkwell semantic tokens (`rust`, `olive`, `warning`, `sky`, `accent`) and GSD status tokens (`status-overdue`, `status-success`)
- Adopt Inkwell `.alert.is-danger` and `.badge-*` primitives where hand-rolled equivalents existed
- Replace hardcoded `rgba()` shadow values with `var(--shadow-md)` / `shadow-sm` tokens
- Migrate key headings to Inkwell type scale utilities (`text-h1`, `text-h2`, `text-display`, `text-eyebrow`)

## Why

Eliminates ~20 manual `dark:` variant overrides since Inkwell's Pattern B cascade handles dark mode automatically through token reassignment. All colors now theme correctly without per-component duplication.

## Files changed (14)

| Area | Files |
|------|-------|
| Dashboard | `page.tsx`, `upcoming-deadlines.tsx`, `streak-indicator.tsx`, `tag-analytics.tsx` |
| Settings | `notification-settings.tsx`, `data-management.tsx`, `about-section.tsx` |
| Settings page shell | `section-card.tsx`, `settings-sidebar.tsx`, `index.tsx` |
| Import | `import-dialog.tsx` |
| About | `matrix-section.tsx`, `footer-cta.tsx` |

## What intentionally stayed unchanged

- Hero page `text-4xl/6xl/7xl` sizing (marketing page deliberately exceeds Inkwell's `text-display` for impact)
- Settings eyebrow `tracking-[0.16em]` (intentional GSD editorial choice; Inkwell ships `0.12em`)
- `redesign-scope` alias layer (functional, aliases correctly — collapse is a separate PR)

## Test plan

- [x] `bun typecheck` passes
- [x] `bun lint` clean
- [x] `bun run test` — 1888 tests pass
- [x] `bun run build` — production build succeeds (CSS compiles)
- [ ] Visual smoke test: dashboard, settings, about, import dialog in light + dark mode