### PR TITLE
test(e2e): expand coverage for settings, import flow, and sync UI states

### DIFF
--- a/tests/e2e/data-management.spec.ts
+++ b/tests/e2e/data-management.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from "./fixtures/test-fixtures";
+import { MatrixPage } from "./pages/matrix-page";
+import { waitForAppLoad } from "./helpers/test-helpers";
+
+/**
+ * Data & Storage flows: export, import (valid + malformed), import dialog
+ * lifecycle, and the error toasts users see when something goes wrong.
+ *
+ * Export-download is already covered by settings-navigation.spec.ts, so the
+ * focus here is the import side plus error states.
+ */
+
+async function gotoDataSection(matrixPage: MatrixPage): Promise<void> {
+  await matrixPage.openSettings();
+  await matrixPage.page
+    .locator("aside.lg\\:block")
+    .getByRole("button", { name: "Data & Storage" })
+    .click();
+  await expect(matrixPage.page.locator("main h2", { hasText: "Data & Storage" })).toBeVisible();
+}
+
+test.describe("Data Management — Import", () => {
+  let matrixPage: MatrixPage;
+
+  test.beforeEach(async ({ page, clearIndexedDB }) => {
+    matrixPage = new MatrixPage(page);
+    await matrixPage.goto();
+    await waitForAppLoad(page);
+  });
+
+  test("invalid JSON import surfaces a toast and does not open the import dialog", async ({ page }) => {
+    await gotoDataSection(matrixPage);
+
+    // Find the hidden <input type="file"> the click handler creates by listening
+    // for filechooser events. The Import button creates the input on demand.
+    const fileChooserPromise = page.waitForEvent("filechooser");
+    await page.getByRole("button", { name: /import/i }).click();
+    const fileChooser = await fileChooserPromise;
+
+    // Feed it a malformed JSON buffer
+    await fileChooser.setFiles({
+      name: "broken.json",
+      mimeType: "application/json",
+      buffer: Buffer.from("{this is not valid json"),
+    });
+
+    // Sonner toast should surface the error
+    await expect(page.getByText(/invalid json format/i)).toBeVisible({ timeout: 5000 });
+
+    // The import confirm dialog must NOT have opened
+    await expect(page.getByRole("dialog", { name: /import tasks/i })).toHaveCount(0);
+  });
+
+  test("valid JSON import opens the confirmation dialog with task count", async ({ page }) => {
+    await gotoDataSection(matrixPage);
+
+    const validPayload = JSON.stringify({
+      version: "1.0.0",
+      exportedAt: "2026-01-01T00:00:00.000Z",
+      tasks: [
+        {
+          id: "task-1",
+          title: "Imported task one",
+          description: "",
+          urgent: false,
+          important: true,
+          quadrant: "not-urgent-important",
+          completed: false,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+          recurrence: "none",
+          tags: [],
+          subtasks: [],
+          dependencies: [],
+          notificationEnabled: false,
+          notificationSent: false,
+        },
+        {
+          id: "task-2",
+          title: "Imported task two",
+          description: "",
+          urgent: true,
+          important: true,
+          quadrant: "urgent-important",
+          completed: false,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+          recurrence: "none",
+          tags: [],
+          subtasks: [],
+          dependencies: [],
+          notificationEnabled: false,
+          notificationSent: false,
+        },
+      ],
+    });
+
+    const fileChooserPromise = page.waitForEvent("filechooser");
+    await page.getByRole("button", { name: /import/i }).click();
+    const fileChooser = await fileChooserPromise;
+
+    await fileChooser.setFiles({
+      name: "valid.json",
+      mimeType: "application/json",
+      buffer: Buffer.from(validPayload),
+    });
+
+    // Import confirmation dialog should open with a task count of 2
+    const dialog = page.getByRole("dialog", { name: /import tasks/i });
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await expect(dialog).toContainText(/2 tasks/i);
+  });
+
+  test("import dialog cancel button closes the dialog without changes", async ({ page }) => {
+    await gotoDataSection(matrixPage);
+
+    const payload = JSON.stringify({
+      version: "1.0.0",
+      exportedAt: "2026-01-01T00:00:00.000Z",
+      tasks: [],
+    });
+
+    const fileChooserPromise = page.waitForEvent("filechooser");
+    await page.getByRole("button", { name: /import/i }).click();
+    const fileChooser = await fileChooserPromise;
+    await fileChooser.setFiles({
+      name: "empty.json",
+      mimeType: "application/json",
+      buffer: Buffer.from(payload),
+    });
+
+    const dialog = page.getByRole("dialog", { name: /import tasks/i });
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    await dialog.getByRole("button", { name: /cancel/i }).click();
+    await expect(dialog).toBeHidden();
+  });
+
+  test("Data section shows the current task count", async ({ page }) => {
+    await matrixPage.createTask("First task to count");
+    await matrixPage.createTask("Second task to count");
+
+    await gotoDataSection(matrixPage);
+
+    // The DataManagement section renders an active-task count.
+    // Use the inner content <main> (the settings layout nests two mains).
+    await expect(page.locator("main.min-w-0")).toContainText(/2/);
+  });
+});

--- a/tests/e2e/settings-sections.spec.ts
+++ b/tests/e2e/settings-sections.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from "./fixtures/test-fixtures";
+import { MatrixPage } from "./pages/matrix-page";
+import { waitForAppLoad } from "./helpers/test-helpers";
+
+/**
+ * Settings sections that are NOT covered by settings-navigation.spec.ts:
+ *  - Notifications section content
+ *  - Archive section content + View archive link
+ *  - About section content
+ *  - Sync section visibility (hidden when sync disabled)
+ *  - Hashchange-driven section selection (e.g. /settings#data)
+ */
+test.describe("Settings Sections", () => {
+  let matrixPage: MatrixPage;
+
+  test.beforeEach(async ({ page, clearIndexedDB }) => {
+    matrixPage = new MatrixPage(page);
+    await matrixPage.goto();
+    await waitForAppLoad(page);
+  });
+
+  test("notifications section renders its controls", async ({ page }) => {
+    await matrixPage.openSettings();
+    await page.locator("aside.lg\\:block").getByRole("button", { name: "Notifications" }).click();
+    await expect(page.locator("main h2", { hasText: "Notifications" })).toBeVisible();
+
+    // The notification settings section renders at least one switch
+    // (browser notification toggle or default reminder toggle).
+    const switches = page.locator("main").getByRole("switch");
+    expect(await switches.count()).toBeGreaterThan(0);
+  });
+
+  test("archive section renders the auto-archive controls", async ({ page }) => {
+    await matrixPage.openSettings();
+    await page.locator("aside.lg\\:block").getByRole("button", { name: "Archive" }).click();
+    await expect(page.locator("main h2", { hasText: "Archive" })).toBeVisible();
+
+    // Auto-archive toggle is always present (the "View archive" link is
+    // conditionally rendered only when archivedCount > 0, so it isn't a
+    // reliable signal that the section rendered).
+    await expect(page.getByText("Auto-archive", { exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^run$/i })).toBeVisible();
+  });
+
+  test("about section renders app metadata", async ({ page }) => {
+    await matrixPage.openSettings();
+    await page.locator("aside.lg\\:block").getByRole("button", { name: "About" }).click();
+    await expect(page.locator("main h2", { hasText: "About" })).toBeVisible();
+  });
+
+  test("sync section is hidden when cloud sync is disabled", async ({ page }) => {
+    await matrixPage.openSettings();
+
+    // The sidebar should NOT include a "Sync" entry when syncEnabled=false.
+    const sidebar = page.locator("aside.lg\\:block");
+    const syncButton = sidebar.getByRole("button", { name: "Cloud Sync" });
+    await expect(syncButton).toHaveCount(0);
+  });
+
+  test("deep-linking to /settings#data activates Data & Storage section", async ({ page }) => {
+    await page.goto("/settings#data");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.locator("main h2", { hasText: "Data & Storage" })).toBeVisible();
+  });
+
+  test("deep-linking to /settings#archive activates Archive section", async ({ page }) => {
+    await page.goto("/settings#archive");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.locator("main h2", { hasText: "Archive" })).toBeVisible();
+  });
+
+  test("hashchange after initial load swaps the active section", async ({ page }) => {
+    await matrixPage.openSettings();
+    await expect(page.locator("main h2", { hasText: "Appearance" })).toBeVisible();
+
+    // Programmatic hash change should trigger the listener in the page
+    await page.evaluate(() => {
+      window.location.hash = "#data";
+    });
+
+    await expect(page.locator("main h2", { hasText: "Data & Storage" })).toBeVisible();
+  });
+});

--- a/tests/e2e/sync-states.spec.ts
+++ b/tests/e2e/sync-states.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "./fixtures/test-fixtures";
+import { MatrixPage } from "./pages/matrix-page";
+import { waitForAppLoad } from "./helpers/test-helpers";
+
+/**
+ * Sync UI states verifiable without a real PocketBase backend.
+ *
+ * The local-first design means most of the sync surface is opt-in and only
+ * appears once a user signs in. These tests guard the "sync disabled" path:
+ * the sidebar entry stays hidden, the topbar shows a connect affordance,
+ * and /sync-history still renders an empty state.
+ */
+test.describe("Sync UI States (sync disabled)", () => {
+  let matrixPage: MatrixPage;
+
+  test.beforeEach(async ({ page, clearIndexedDB }) => {
+    matrixPage = new MatrixPage(page);
+    await matrixPage.goto();
+    await waitForAppLoad(page);
+  });
+
+  test("sync-history page renders without errors when nothing has synced", async ({ page }) => {
+    await page.goto("/sync-history");
+    await page.waitForLoadState("networkidle");
+
+    // Page heading should be present even with no sync history
+    await expect(page.locator("main h1, main h2", { hasText: /sync history/i })).toBeVisible();
+  });
+
+  test("settings sidebar omits Cloud Sync until the user enables it", async ({ page }) => {
+    await matrixPage.openSettings();
+
+    const sidebar = page.locator("aside.lg\\:block");
+    const syncEntry = sidebar.getByRole("button", { name: /cloud sync/i });
+    await expect(syncEntry).toHaveCount(0);
+  });
+
+  test("direct navigation to /settings#sync falls back to the default section when sync is off", async ({ page }) => {
+    await page.goto("/settings#sync");
+    await page.waitForLoadState("networkidle");
+
+    // SettingsPage clamps invalid/hidden sections back to Appearance
+    await expect(page.locator("main h2", { hasText: "Appearance" })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

External code review flagged settings flows, sync scenarios, and error states as E2E gaps. The existing [tests/e2e/settings-navigation.spec.ts](tests/e2e/settings-navigation.spec.ts) covers theme toggle, show-completed, section navigation, and export download — this PR fills the rest.

Three new specs adding 14 tests (E2E count 34 → 48):

| Spec | What it guards |
|---|---|
| [tests/e2e/settings-sections.spec.ts](tests/e2e/settings-sections.spec.ts) | Notifications/Archive/About section rendering; sync sidebar hidden when disabled; deep-link via \`#data\`/\`#archive\`; hashchange listener |
| [tests/e2e/data-management.spec.ts](tests/e2e/data-management.spec.ts) | Invalid JSON → error toast; valid JSON → confirm dialog; cancel closes dialog; active task count surfaces |
| [tests/e2e/sync-states.spec.ts](tests/e2e/sync-states.spec.ts) | Sync-history page renders empty; Cloud Sync sidebar hidden; \`/settings#sync\` falls back to Appearance when sync off |

## Why

External review's recommendation to expand E2E coverage, scoped to settings/sync/errors. I skipped the reviewer's "smart views / subtask editor / archive navigation" suggestions because [tasks/todo.md #6](tasks/todo.md) documents those as intentional v9 omissions per [ADR 0011](docs/adr/0011-v9-single-matrix-refactor.md), not coverage gaps.

## Test plan

- [x] All 14 new tests pass on Chromium.
- [x] Full E2E suite: 48 passing on Chromium (was 34); 0 regressions.
- [x] \`bun typecheck\` clean.
- [x] \`bun lint\` clean.
- [ ] CI will exercise Firefox + WebKit; verify they pass before merge.

## Out of scope

- Sync push/pull/conflict E2E (requires a running PocketBase backend; unit tests cover the sync engine).
- Topbar sync button visibility test (button has no \`data-testid\` and aria-label is state-dependent; unit tests cover the button).
- Smart-view E2E (feature was deliberately removed in v9).
- Subtask editor E2E (no subtask editor surface in v9).