### PR TITLE
chore(claude): expand permission allowlist with read-only tool patterns

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,8 +5,18 @@
       "Bash(bun lint:*)",
       "Bash(bun audit:*)",
       "Bash(bun outdated:*)",
+      "Bash(bun run test)",
+      "Bash(bun run test *)",
+      "Bash(bun run test:e2e)",
+      "Bash(bun run test:e2e *)",
+      "Bash(bun run build)",
+      "Bash(bun run build *)",
       "mcp__claude-in-chrome__tabs_context_mcp",
-      "mcp__claude-in-chrome__read_page"
+      "mcp__claude-in-chrome__read_page",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__take_screenshot",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__navigate_page",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__resize_page",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__list_pages"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary
- Scanned 50 recent session transcripts across all projects to identify frequently-prompted read-only commands
- Added 10 new permission allowlist entries to `.claude/settings.json`:
  - `bun run test` / `bun run test:e2e` / `bun run build` (with wildcard variants for args/redirects)
  - 4 Chrome DevTools MCP tools: `take_screenshot`, `navigate_page`, `resize_page`, `list_pages`
- Reduces permission prompts during TDD cycles and browser testing workflows

## Test plan
- [ ] Verify `bun run test` no longer prompts for permission
- [ ] Verify `bun run test:e2e` no longer prompts for permission
- [ ] Verify `bun run build` no longer prompts for permission
- [ ] Verify DevTools MCP tools no longer prompt for permission
- [ ] Confirm existing allowlist entries still work (typecheck, lint, audit, outdated)