### PR TITLE
fix(csp,logging): remove frame-ancestors from meta tag and demote sync logs

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,6 @@ const contentSecurityPolicy = [
   "base-uri 'self'",
   "object-src 'none'",
   "form-action 'self'",
-  "frame-ancestors 'none'",
   "img-src 'self' data: blob:",
   "font-src 'self' data:",
   scriptSrc,

--- a/lib/sync-history.ts
+++ b/lib/sync-history.ts
@@ -40,7 +40,7 @@ export async function recordSyncSuccess(
 
   await db.syncHistory.add(record);
 
-  logger.info('Sync success recorded', {
+  logger.debug('Sync success recorded', {
     id: record.id,
     pushedCount,
     pulledCount,

--- a/lib/sync/background-sync.ts
+++ b/lib/sync/background-sync.ts
@@ -38,7 +38,7 @@ export class BackgroundSyncManager {
         this.config = config;
         this.isActive = true;
 
-        logger.info('Starting background sync', {
+        logger.debug('Starting background sync', {
             enabled: config.enabled,
             intervalMinutes: config.intervalMinutes,
         });
@@ -194,7 +194,7 @@ export class BackgroundSyncManager {
             const queue = getSyncQueue();
             const pendingCount = await queue.getPendingCount();
 
-            logger.info('Triggering background sync', { trigger, pendingCount });
+            logger.debug('Triggering background sync', { trigger, pendingCount });
             this.lastSyncTimestamp = now;
 
             const coordinator = getSyncCoordinator();

--- a/lib/sync/pb-auth.ts
+++ b/lib/sync/pb-auth.ts
@@ -96,7 +96,7 @@ export async function refreshAuth(): Promise<boolean> {
 
   try {
     await pb.collection('users').authRefresh();
-    logger.info('Auth token refreshed successfully');
+    logger.debug('Auth token refreshed successfully');
     return true;
   } catch (error) {
     logger.warn('Auth token refresh failed', {

--- a/lib/sync/pb-pull.ts
+++ b/lib/sync/pb-pull.ts
@@ -146,7 +146,7 @@ export async function pullRemoteChanges(lastSyncAt: string | null): Promise<{ pu
 
   await reconcileDeletedTasks(ownerId);
 
-  logger.info('Pull completed', { pulledCount, fetched: records.length });
+  logger.debug('Pull completed', { pulledCount, fetched: records.length });
   return { pulledCount, authenticated: true, maxObservedTimestamp };
 }
 

--- a/lib/sync/pb-push.ts
+++ b/lib/sync/pb-push.ts
@@ -233,6 +233,6 @@ export async function pushLocalChanges(): Promise<PushResult> {
     }
   }
 
-  logger.info('Push completed', { pushedCount, failedCount, skippedCount, total: pending.length });
+  logger.debug('Push completed', { pushedCount, failedCount, skippedCount, total: pending.length });
   return { pushedCount, failedCount, lastError, authenticated: true };
 }

--- a/lib/sync/pb-realtime.ts
+++ b/lib/sync/pb-realtime.ts
@@ -51,11 +51,11 @@ export async function subscribe(deviceId: string): Promise<void> {
     return;
   }
 
-  logger.info('Subscribing to realtime task changes');
+  logger.debug('Subscribing to realtime task changes');
 
   unsubscribeFn = await pb.collection('tasks').subscribe('*', handleRealtimeEvent);
 
-  logger.info('Realtime subscription active');
+  logger.debug('Realtime subscription active');
 }
 
 /**
@@ -66,7 +66,7 @@ export function unsubscribe(): void {
     unsubscribeFn();
     unsubscribeFn = null;
     currentDeviceId = null;
-    logger.info('Unsubscribed from realtime');
+    logger.debug('Unsubscribed from realtime');
   }
 }
 

--- a/lib/sync/sync-coordinator.ts
+++ b/lib/sync/sync-coordinator.ts
@@ -128,7 +128,7 @@ export class SyncCoordinator {
       logger.debug('Starting sync execution', { priority });
       const result = await fullSync(priority);
       this.lastResult = result;
-      logger.info('Sync completed', { status: result.status });
+      logger.debug('Sync completed', { status: result.status });
     } catch (error) {
       logger.error('Sync failed', error instanceof Error ? error : new Error(String(error)));
       this.lastResult = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.3.0",
+	"version": "9.3.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/data/sync/pb-auth.test.ts
+++ b/tests/data/sync/pb-auth.test.ts
@@ -21,6 +21,7 @@ vi.mock('@/lib/sync/pocketbase-client', () => ({
 
 vi.mock('@/lib/logger', () => ({
   createLogger: () => ({
+    debug: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),


### PR DESCRIPTION
## Summary
- Remove `frame-ancestors 'none'` from CSP `<meta>` tag in `layout.tsx` — the W3C CSP spec disallows this directive in meta elements (it's only valid as an HTTP header). CloudFront already delivers it via response-headers policy.
- Demote routine sync operational logs (push/pull completed, sync history recorded, background sync triggers, realtime subscribe/unsubscribe, auth token refresh) from `info` to `debug` level. In production, min log level is `info`, so these were flooding the browser console on every sync cycle.
- Add missing `debug` mock to `pb-auth.test.ts` logger mock.

## What's NOT fixed (and why)
- **COOP `window.close` warning**: The `Cross-Origin-Opener-Policy: same-origin-allow-popups` header is correct for OAuth popup flows. The warning occurs because the popup navigates cross-origin (Google/GitHub) during OAuth, which severs the opener relationship. This is a known browser behavior — OAuth still completes successfully. Downgrading to `unsafe-none` would remove the warning but weaken security.

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun run test` — 1910 tests pass
- [x] `bun run build` — static export succeeds
- [ ] Deploy and verify browser console no longer shows CSP or sync log noise
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->