### PR TITLE
fix(sentry): move initSentry to client component for browser execution

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,11 +4,10 @@ import { ErrorBoundary } from "@/components/error-boundary";
 import { ToastProvider } from "@/components/ui/toast";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "sonner";
-import { initSentry } from "@/lib/sentry";
 import "./globals.css";
 
-initSentry();
 import { PwaRegister } from "@/components/pwa-register";
+import { SentryInit } from "@/components/sentry-init";
 import { WebMcpRegister } from "@/components/webmcp-register";
 import { InstallPwaPrompt } from "@/components/install-pwa-prompt";
 import { PwaUpdateToast } from "@/components/pwa-update-toast";
@@ -103,6 +102,7 @@ export default function RootLayout({
                   <InstallPwaPrompt />
                   <PwaUpdateToast />
                   <GlobalErrorListener />
+                  <SentryInit />
                   <Toaster richColors position="top-center" />
                 </TooltipProvider>
               </QueryProvider>

--- a/components/sentry-init.tsx
+++ b/components/sentry-init.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { initSentry } from "@/lib/sentry";
+
+initSentry();
+
+export function SentryInit() {
+  return null;
+}


### PR DESCRIPTION
## Summary
- `initSentry()` was called at the module level of `layout.tsx` (a server component). In Next.js static export, server component code runs during `next build` in Node.js — never in the browser. Sentry was completely disabled in production.
- Created `SentryInit` client component that calls `initSentry()` when the module loads in the browser, matching the existing `PwaRegister` pattern.

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun run test` — 1910 tests pass
- [x] `bun run build` — verified DSN is baked into client bundle
- [ ] Deploy and verify `window.__SENTRY__` is defined in browser console
- [ ] Trigger test error and confirm it appears in Sentry dashboard
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->