### PR TITLE
fix(csp): allow Sentry ingest in CloudFront connect-src

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,11 +4,10 @@ import { ErrorBoundary } from "@/components/error-boundary";
 import { ToastProvider } from "@/components/ui/toast";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "sonner";
-import { initSentry } from "@/lib/sentry";
 import "./globals.css";
 
-initSentry();
 import { PwaRegister } from "@/components/pwa-register";
+import { SentryInit } from "@/components/sentry-init";
 import { WebMcpRegister } from "@/components/webmcp-register";
 import { InstallPwaPrompt } from "@/components/install-pwa-prompt";
 import { PwaUpdateToast } from "@/components/pwa-update-toast";
@@ -103,6 +102,7 @@ export default function RootLayout({
                   <InstallPwaPrompt />
                   <PwaUpdateToast />
                   <GlobalErrorListener />
+                  <SentryInit />
                   <Toaster richColors position="top-center" />
                 </TooltipProvider>
               </QueryProvider>

--- a/cloudfront/response-headers-policy.json
+++ b/cloudfront/response-headers-policy.json
@@ -16,7 +16,7 @@
     },
     "ContentSecurityPolicy": {
       "Override": true,
-      "ContentSecurityPolicy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://api.vinny.io https://accounts.google.com https://github.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://accounts.google.com https://github.com; object-src 'none'; manifest-src 'self'; worker-src 'self';"
+      "ContentSecurityPolicy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://api.vinny.io https://accounts.google.com https://github.com https://*.ingest.sentry.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://accounts.google.com https://github.com; object-src 'none'; manifest-src 'self'; worker-src 'self';"
     },
     "ContentTypeOptions": {
       "Override": true

--- a/components/sentry-init.tsx
+++ b/components/sentry-init.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { initSentry } from "@/lib/sentry";
+
+initSentry();
+
+export function SentryInit() {
+  return null;
+}


### PR DESCRIPTION
## Summary
- Add `https://*.ingest.sentry.io` to the `connect-src` directive in the CloudFront response-headers policy
- Without this, the browser blocks `fetch()` calls from the Sentry SDK to its ingest endpoint, silently dropping all error events

## Post-merge action
```bash
./scripts/deploy-cloudfront-response-headers-policy.sh
```
Then invalidate CloudFront cache (or wait for TTL).

## Test plan
- [x] Policy JSON is valid (`jq -e .` passes)
- [ ] After deploying, verify in browser console: `Promise.reject(new Error('test'))` → event appears in Sentry dashboard
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->