### PR TITLE
fix(sentry): stop preventDefault from blocking unhandled rejection capture

### DIFF
--- a/components/global-error-listener.tsx
+++ b/components/global-error-listener.tsx
@@ -3,7 +3,6 @@
 import { useEffect } from "react";
 import { toast } from "sonner";
 import { createLogger } from "@/lib/logger";
-import { captureException } from "@/lib/sentry";
 
 const logger = createLogger("GLOBAL_ERROR");
 
@@ -14,18 +13,12 @@ export function GlobalErrorListener() {
     let lastToastTime = 0;
 
     function handleRejection(event: PromiseRejectionEvent) {
-      event.preventDefault();
-
       const error =
         event.reason instanceof Error
           ? event.reason
           : new Error(String(event.reason ?? "Unknown rejection"));
 
       logger.error("Unhandled promise rejection", error, {
-        type: event.reason instanceof Error ? event.reason.name : typeof event.reason,
-      });
-
-      captureException(error, {
         type: event.reason instanceof Error ? event.reason.name : typeof event.reason,
       });
 

--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -1,8 +1,6 @@
 import * as Sentry from "@sentry/browser";
 import { ENV_CONFIG } from "@/lib/env-config";
 
-let initialized = false;
-
 export function initSentry(): void {
   const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
@@ -16,15 +14,13 @@ export function initSentry(): void {
     tracesSampleRate: 0.1,
     enabled: true,
   });
-
-  initialized = true;
 }
 
 export function captureException(
   error: unknown,
   context?: Record<string, unknown>
 ): void {
-  if (!initialized) return;
+  if (!Sentry.getClient()) return;
 
   Sentry.captureException(
     error,
@@ -33,5 +29,5 @@ export function captureException(
 }
 
 export function isInitialized(): boolean {
-  return initialized;
+  return !!Sentry.getClient();
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.3.2",
+	"version": "9.3.3",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/data/sentry.test.ts
+++ b/tests/data/sentry.test.ts
@@ -2,10 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockInit = vi.hoisted(() => vi.fn());
 const mockCaptureException = vi.hoisted(() => vi.fn());
+const mockGetClient = vi.hoisted(() => vi.fn());
 
 vi.mock("@sentry/browser", () => ({
-  init: mockInit,
+  init: (...args: unknown[]) => {
+    mockInit(...args);
+    mockGetClient.mockReturnValue({});
+  },
   captureException: mockCaptureException,
+  getClient: mockGetClient,
 }));
 
 describe("Sentry wrapper", () => {
@@ -14,6 +19,7 @@ describe("Sentry wrapper", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockGetClient.mockReturnValue(undefined);
     delete process.env.NEXT_PUBLIC_SENTRY_DSN;
   });
 


### PR DESCRIPTION
## Summary
- `event.preventDefault()` on `unhandledrejection` events was causing Sentry's `GlobalHandlers` integration to skip the event — Sentry checks `defaultPrevented` and silently drops the rejection
- Since `GlobalErrorListener` registers via `addEventListener` (fires first) and Sentry uses `window.onunhandledrejection` (fires after), `defaultPrevented` was always `true` by the time Sentry saw the event
- Removed `preventDefault()` and the redundant manual `captureException()` call — Sentry's automatic handler now captures rejections
- Replaced the module-scoped `initialized` flag with `Sentry.getClient()` check, which is resilient to bundler code-splitting across client component boundaries

## Test plan
- [ ] Merge, rebuild, and redeploy
- [ ] Open browser console on `gsd.vinny.dev`, open the Network tab
- [ ] Run `Promise.reject(new Error('Test error - ignore'))` 
- [ ] Confirm a POST request to `o83690.ingest.us.sentry.io` appears with 200 status
- [ ] Confirm the error appears in the Sentry dashboard
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->