### PR TITLE
perf(sw): split single cache into immutable/pages/runtime strategy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,15 @@ Logic in `lib/quadrants.ts` with `resolveQuadrantId()` and `quadrantOrder`.
 
 ### PWA Configuration
 - `public/manifest.json` - App metadata
-- `public/sw.js` - Service worker for offline caching
+- `public/sw.js` - Service worker with multi-cache strategy (see ADR 0012)
+- `public/sw-cache-logic.js` - Pure cache routing functions loaded via `importScripts()`
+- `lib/sw-cache-logic.ts` - Canonical TypeScript source for the cache logic (keep in sync with the JS copy)
 - `components/pwa-register.tsx` - SW registration
+
+**Cache architecture** (three purpose-specific caches):
+- `gsd-immutable-v1` — content-hashed `/_next/static/*` assets (cache-first, FIFO-pruned at 60 entries, survives deploys)
+- `gsd-pages-v{version}` — HTML + RSC flight data (network-first, rotated on deploy)
+- `gsd-runtime-v{version}` — icons, manifest, other static (cache-first, rotated on deploy)
 
 ### Cloud Sync Architecture
 - **Backend**: Self-hosted PocketBase at `https://api.vinny.io` (AWS EC2)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -86,6 +86,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <head>
         <meta httpEquiv="Content-Security-Policy" content={contentSecurityPolicy} />
+        <link rel="preconnect" href="https://api.vinny.io" />
       </head>
       <body className="font-sans bg-background text-foreground antialiased">
         <ErrorBoundary>

--- a/docs/adr/0012-sw-multi-cache-strategy.md
+++ b/docs/adr/0012-sw-multi-cache-strategy.md
@@ -1,0 +1,50 @@
+# ADR 0012: Service Worker Multi-Cache Strategy
+
+- **Date:** 2026-05-25
+- **Status:** Accepted
+- **Deciders:** Vinny Carpenter
+
+## Context
+
+The PWA service worker used a single cache (`gsd-cache-v{version}`) for all assets. Every deploy bumped the version, which deleted the entire cache during activation — including content-hashed JS chunks under `/_next/static/` that are immutable by definition (their URL changes when content changes). This forced users to re-download ~2.6MB of chunks on every deploy, even when only 1-2 files changed.
+
+## Decision
+
+Split the single cache into three purpose-specific caches:
+
+| Cache | Strategy | Invalidation |
+|---|---|---|
+| `gsd-immutable-v1` | Cache-first | Never version-invalidated; FIFO-pruned at 60 entries |
+| `gsd-pages-v{version}` | Network-first | Rotated on every deploy |
+| `gsd-runtime-v{version}` | Cache-first | Rotated on every deploy |
+
+Cache routing logic is extracted into `public/sw-cache-logic.js` (pure functions) with a canonical TypeScript source at `lib/sw-cache-logic.ts` for testing.
+
+Classification rules:
+- `/_next/static/*` → immutable (content-hashed chunks, build manifests)
+- HTML (`text/html` accept header, trailing `/`, `.html`) and RSC flight data (`/__next.*`) → pages
+- Same-origin GET for everything else (icons, manifest) → runtime
+- Cross-origin or non-GET → passthrough (no SW interception)
+
+## Consequences
+
+**Easier:**
+- Repeat visits after deploys only download changed chunks (~95% bandwidth reduction for typical patches)
+- Cache inspection in DevTools is clearer with three labeled caches
+- Cache logic is independently testable (27 unit tests)
+
+**Harder:**
+- Two files must stay in sync (`lib/sw-cache-logic.ts` and `public/sw-cache-logic.js`)
+- First deploy after this change causes a one-time full re-download (old single cache is deleted)
+
+**Out of scope:**
+- Workbox integration (avoided to keep the SW dependency-free and debuggable)
+- True LRU eviction (Cache Storage API has no access timestamps; FIFO is equivalent for content-hashed assets)
+
+## Alternatives
+
+| Alternative | Why rejected |
+|---|---|
+| Workbox with precache manifest | Adds build dependency and abstraction for a 230-line file |
+| Single cache with selective cleanup | Cache API has no per-entry metadata to identify stale entries by build version |
+| LRU eviction via IndexedDB tracking | Complexity not justified — FIFO is correct for immutable hashed assets |

--- a/lib/sw-cache-logic.ts
+++ b/lib/sw-cache-logic.ts
@@ -1,0 +1,66 @@
+// Canonical source for SW cache routing logic.
+// public/sw-cache-logic.js is a plain-JS copy of these functions for
+// use with importScripts() in the service worker. Keep them in sync.
+
+export type CacheClassification = "immutable" | "pages" | "runtime" | "passthrough";
+
+export interface CacheNameSet {
+	immutable: string;
+	pages: string;
+	runtime: string;
+}
+
+export function classifyRequest(
+	pathname: string,
+	acceptHeader: string | null,
+	isSameOrigin: boolean,
+	method: string,
+): CacheClassification {
+	if (method !== "GET" || !isSameOrigin) {
+		return "passthrough";
+	}
+
+	if (pathname.startsWith("/_next/static/")) {
+		return "immutable";
+	}
+
+	if (
+		(acceptHeader && acceptHeader.includes("text/html")) ||
+		pathname.endsWith("/") ||
+		pathname.endsWith(".html") ||
+		pathname.includes("/__next.")
+	) {
+		return "pages";
+	}
+
+	return "runtime";
+}
+
+export function getCacheNames(
+	cacheVersion: string,
+	immutableVersion: number,
+): CacheNameSet {
+	return {
+		immutable: `gsd-immutable-v${immutableVersion}`,
+		pages: `gsd-pages-v${cacheVersion}`,
+		runtime: `gsd-runtime-v${cacheVersion}`,
+	};
+}
+
+export function shouldDeleteCache(
+	cacheName: string,
+	currentCacheNames: CacheNameSet,
+): boolean {
+	const currentValues = Object.values(currentCacheNames);
+	if (currentValues.includes(cacheName)) {
+		return false;
+	}
+	return cacheName.startsWith("gsd-");
+}
+
+export function getEvictionCandidates<T>(keys: T[], maxEntries: number): T[] {
+	if (keys.length <= maxEntries) {
+		return [];
+	}
+	return keys.slice(0, keys.length - maxEntries);
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.3.4",
+	"version": "9.3.5",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/public/sw-cache-logic.js
+++ b/public/sw-cache-logic.js
@@ -1,0 +1,56 @@
+// Service worker cache routing logic — pure functions for testability.
+// Loaded via importScripts() in sw.js (functions land on global scope).
+// Imported in tests via: require("../../public/sw-cache-logic")
+
+function classifyRequest(pathname, acceptHeader, isSameOrigin, method) {
+	if (method !== "GET" || !isSameOrigin) {
+		return "passthrough";
+	}
+
+	if (pathname.startsWith("/_next/static/")) {
+		return "immutable";
+	}
+
+	if (
+		(acceptHeader && acceptHeader.includes("text/html")) ||
+		pathname.endsWith("/") ||
+		pathname.endsWith(".html") ||
+		pathname.includes("/__next.")
+	) {
+		return "pages";
+	}
+
+	return "runtime";
+}
+
+function getCacheNames(cacheVersion, immutableVersion) {
+	return {
+		immutable: `gsd-immutable-v${immutableVersion}`,
+		pages: `gsd-pages-v${cacheVersion}`,
+		runtime: `gsd-runtime-v${cacheVersion}`,
+	};
+}
+
+function shouldDeleteCache(cacheName, currentCacheNames) {
+	const currentValues = Object.values(currentCacheNames);
+	if (currentValues.includes(cacheName)) {
+		return false;
+	}
+	return cacheName.startsWith("gsd-");
+}
+
+function getEvictionCandidates(keys, maxEntries) {
+	if (keys.length <= maxEntries) {
+		return [];
+	}
+	return keys.slice(0, keys.length - maxEntries);
+}
+
+if (typeof module !== "undefined" && module.exports) {
+	module.exports = {
+		classifyRequest,
+		getCacheNames,
+		shouldDeleteCache,
+		getEvictionCandidates,
+	};
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,8 +1,14 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '9.3.1';
-const CACHE_NAME = `gsd-cache-v${CACHE_VERSION}`;
-const OFFLINE_ASSETS = [
+const CACHE_VERSION = '9.3.4';
+const IMMUTABLE_CACHE_VERSION = 1;
+const IMMUTABLE_MAX_ENTRIES = 60;
+
+importScripts('./sw-cache-logic.js');
+
+const CACHE_NAMES = getCacheNames(CACHE_VERSION, IMMUTABLE_CACHE_VERSION);
+
+const PRECACHE_PAGES = [
 	"/",
 	"/about/",
 	"/archive/",
@@ -10,6 +16,9 @@ const OFFLINE_ASSETS = [
 	"/install/",
 	"/settings/",
 	"/sync-history/",
+];
+
+const PRECACHE_RUNTIME = [
 	"/manifest.json",
 	"/icons/icon-192.png",
 	"/icons/icon-512.png",
@@ -18,10 +27,14 @@ const OFFLINE_ASSETS = [
 
 self.addEventListener("install", (event) => {
 	event.waitUntil(
-		caches
-			.open(CACHE_NAME)
-			.then((cache) => cache.addAll(OFFLINE_ASSETS))
-			.then(() => self.skipWaiting()),
+		Promise.all([
+			caches
+				.open(CACHE_NAMES.pages)
+				.then((cache) => cache.addAll(PRECACHE_PAGES)),
+			caches
+				.open(CACHE_NAMES.runtime)
+				.then((cache) => cache.addAll(PRECACHE_RUNTIME)),
+		]).then(() => self.skipWaiting()),
 	);
 });
 
@@ -32,7 +45,7 @@ self.addEventListener("activate", (event) => {
 			.then((keys) =>
 				Promise.all(
 					keys.map((key) => {
-						if (key !== CACHE_NAME) {
+						if (shouldDeleteCache(key, CACHE_NAMES)) {
 							return caches.delete(key);
 						}
 						return undefined;
@@ -58,45 +71,39 @@ self.addEventListener("fetch", (event) => {
 		return;
 	}
 
-	// Don't intercept cross-origin requests (PocketBase API, OAuth, etc.)
 	const requestUrl = new URL(request.url);
-	if (requestUrl.hostname !== self.location.hostname) {
+	const isSameOrigin = requestUrl.hostname === self.location.hostname;
+	const classification = classifyRequest(
+		requestUrl.pathname,
+		request.headers.get("accept"),
+		isSameOrigin,
+		request.method,
+	);
+
+	if (classification === "passthrough") {
 		return;
 	}
 
-	if (request.method !== "GET") {
-		return;
-	}
-
-	// Network-first for HTML pages and Next.js RSC flight data.
-	// RSC data (__next.*.txt) contains build-specific module IDs that
-	// must stay in sync with the JS chunks. Serving stale RSC data from
-	// a previous build causes React error #130 (undefined component).
-	const isNetworkFirst =
-		request.headers.get("accept")?.includes("text/html") ||
-		request.url.endsWith("/") ||
-		request.url.endsWith(".html") ||
-		request.url.includes("/__next.");
-
-	if (isNetworkFirst) {
+	if (classification === "pages") {
+		// Network-first for HTML pages and Next.js RSC flight data.
+		// RSC data (__next.*.txt) contains build-specific module IDs that
+		// must stay in sync with the JS chunks. Serving stale RSC data from
+		// a previous build causes React error #130 (undefined component).
 		event.respondWith(
 			fetch(request)
 				.then((response) => {
-					// Cache the fresh HTML response
 					if (response && response.status === 200) {
 						const clone = response.clone();
-						caches.open(CACHE_NAME).then((cache) => {
+						caches.open(CACHE_NAMES.pages).then((cache) => {
 							cache.put(request, clone).catch(() => {});
 						});
 					}
 					return response;
 				})
 				.catch(() => {
-					// Try to match the request with or without trailing slash
 					return caches.match(request).then((cached) => {
 						if (cached) return cached;
 
-						// If request ends with /, try without it, and vice versa
 						const url = new URL(request.url);
 						const altPath = url.pathname.endsWith("/")
 							? url.pathname.slice(0, -1)
@@ -108,39 +115,54 @@ self.addEventListener("fetch", (event) => {
 					});
 				}),
 		);
-	} else {
-		// Cache-first for static assets (JS chunks, CSS, fonts, images)
-		event.respondWith(
-			caches.match(request).then((cachedResponse) => {
-				if (cachedResponse) {
-					return cachedResponse;
-				}
-
-				return fetch(request)
-					.then((response) => {
-						// Only cache successful responses
-						if (
-							response &&
-							response.status === 200 &&
-							response.type === "basic"
-						) {
-							const clone = response.clone();
-							caches.open(CACHE_NAME).then((cache) => {
-								cache.put(request, clone).catch(() => {
-									// Silently fail if caching fails
-								});
-							});
-						}
-						return response;
-					})
-					.catch(() => {
-						// Only fall back to cached root for navigation-like requests.
-						// Returning HTML for a JS/CSS/font request would cause errors.
-						return caches.match(request);
-					});
-			}),
-		);
+		return;
 	}
+
+	// Cache-first for immutable and runtime assets
+	const cacheName =
+		classification === "immutable"
+			? CACHE_NAMES.immutable
+			: CACHE_NAMES.runtime;
+
+	event.respondWith(
+		caches.match(request).then((cachedResponse) => {
+			if (cachedResponse) {
+				return cachedResponse;
+			}
+
+			return fetch(request)
+				.then((response) => {
+					if (
+						response &&
+						response.status === 200 &&
+						response.type === "basic"
+					) {
+						const clone = response.clone();
+						caches.open(cacheName).then((cache) => {
+							cache
+								.put(request, clone)
+								.then(() => {
+									if (classification !== "immutable") return;
+									return cache.keys().then((keys) => {
+										const toDelete = getEvictionCandidates(
+											keys,
+											IMMUTABLE_MAX_ENTRIES,
+										);
+										return Promise.all(
+											toDelete.map((key) => cache.delete(key)),
+										);
+									});
+								})
+								.catch(() => {});
+						});
+					}
+					return response;
+				})
+				.catch(() => {
+					return caches.match(request);
+				});
+		}),
+	);
 });
 
 // Handle notification clicks
@@ -151,7 +173,6 @@ self.addEventListener("notificationclick", (event) => {
 		clients
 			.matchAll({ type: "window", includeUncontrolled: true })
 			.then((clientList) => {
-				// If app is already open, focus it
 				for (const client of clientList) {
 					if (
 						client.url.includes(self.registration.scope) &&
@@ -160,7 +181,6 @@ self.addEventListener("notificationclick", (event) => {
 						return client.focus();
 					}
 				}
-				// Otherwise open a new window
 				if (clients.openWindow) {
 					return clients.openWindow("/");
 				}
@@ -186,11 +206,9 @@ self.addEventListener("push", (event) => {
 	try {
 		data = event.data.json();
 	} catch {
-		// Invalid JSON payload — ignore
 		return;
 	}
 
-	// Validate payload shape
 	if (typeof data !== "object" || data === null) {
 		return;
 	}
@@ -208,21 +226,9 @@ self.addEventListener("push", (event) => {
 	event.waitUntil(self.registration.showNotification(title, options));
 });
 
-/**
- * Check tasks and send notifications (background sync version)
- * This is a simplified version that works in service worker context
- */
 async function checkAndNotifyTasks() {
 	try {
-		// Open IndexedDB and check for due tasks
-		// Note: This would require importing Dexie or using native IndexedDB API
-		// For now, we'll rely on the active polling when app is open
-		// This is a placeholder for future enhancement if needed
-
-		// Update badge count
 		if ("setAppBadge" in self.navigator) {
-			// In a real implementation, query IndexedDB for task count
-			// For now, this is a placeholder
 			await self.navigator.setAppBadge(0);
 		}
 	} catch (error) {

--- a/tests/data/sw-cache-logic.test.ts
+++ b/tests/data/sw-cache-logic.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+	classifyRequest,
+	getCacheNames,
+	shouldDeleteCache,
+	getEvictionCandidates,
+} from "@/lib/sw-cache-logic";
+
+describe("classifyRequest", () => {
+	it("should return immutable for /_next/static/chunks/*.js", () => {
+		expect(
+			classifyRequest("/_next/static/chunks/0-a349cgetoh4.js", null, true, "GET"),
+		).toBe("immutable");
+	});
+
+	it("should return immutable for /_next/static/chunks/*.css", () => {
+		expect(
+			classifyRequest("/_next/static/chunks/styles-abc123.css", null, true, "GET"),
+		).toBe("immutable");
+	});
+
+	it("should return immutable for /_next/static/{buildId}/_buildManifest.js", () => {
+		expect(
+			classifyRequest(
+				"/_next/static/_zrEi3OuxXcRwG__wU8cr/_buildManifest.js",
+				null,
+				true,
+				"GET",
+			),
+		).toBe("immutable");
+	});
+
+	it("should return pages for HTML requests (accept: text/html)", () => {
+		expect(
+			classifyRequest("/dashboard/", "text/html,application/xhtml+xml", true, "GET"),
+		).toBe("pages");
+	});
+
+	it("should return pages for URLs ending in /", () => {
+		expect(classifyRequest("/settings/", null, true, "GET")).toBe("pages");
+	});
+
+	it("should return pages for URLs ending in .html", () => {
+		expect(classifyRequest("/404.html", null, true, "GET")).toBe("pages");
+	});
+
+	it("should return pages for RSC flight data (/__next. URLs)", () => {
+		expect(
+			classifyRequest("/__next._tree.txt", null, true, "GET"),
+		).toBe("pages");
+	});
+
+	it("should return runtime for /manifest.json", () => {
+		expect(classifyRequest("/manifest.json", null, true, "GET")).toBe(
+			"runtime",
+		);
+	});
+
+	it("should return runtime for /icons/*.png", () => {
+		expect(classifyRequest("/icons/icon-192.png", null, true, "GET")).toBe(
+			"runtime",
+		);
+	});
+
+	it("should return passthrough for cross-origin requests", () => {
+		expect(
+			classifyRequest("/api/collections/tasks", null, false, "GET"),
+		).toBe("passthrough");
+	});
+
+	it("should return passthrough for non-GET requests", () => {
+		expect(classifyRequest("/api/tasks", null, true, "POST")).toBe(
+			"passthrough",
+		);
+	});
+
+	it("should return passthrough for cross-origin non-GET requests", () => {
+		expect(classifyRequest("/api/tasks", null, false, "POST")).toBe(
+			"passthrough",
+		);
+	});
+});
+
+describe("getCacheNames", () => {
+	it("should return three cache names with version embedded", () => {
+		const names = getCacheNames("9.3.4", 1);
+		expect(names).toEqual({
+			immutable: "gsd-immutable-v1",
+			pages: "gsd-pages-v9.3.4",
+			runtime: "gsd-runtime-v9.3.4",
+		});
+	});
+
+	it("should keep immutable version separate from deploy version", () => {
+		const names = getCacheNames("10.0.0", 1);
+		expect(names.immutable).toBe("gsd-immutable-v1");
+		expect(names.pages).toBe("gsd-pages-v10.0.0");
+		expect(names.runtime).toBe("gsd-runtime-v10.0.0");
+	});
+});
+
+describe("shouldDeleteCache", () => {
+	const currentNames = getCacheNames("9.3.4", 1);
+
+	it("should return true for old gsd-cache-v* single-cache format (migration)", () => {
+		expect(shouldDeleteCache("gsd-cache-v9.3.3", currentNames)).toBe(true);
+	});
+
+	it("should return true for outdated gsd-pages-v* caches", () => {
+		expect(shouldDeleteCache("gsd-pages-v9.3.3", currentNames)).toBe(true);
+	});
+
+	it("should return true for outdated gsd-runtime-v* caches", () => {
+		expect(shouldDeleteCache("gsd-runtime-v9.3.3", currentNames)).toBe(true);
+	});
+
+	it("should return false for current pages cache", () => {
+		expect(shouldDeleteCache("gsd-pages-v9.3.4", currentNames)).toBe(false);
+	});
+
+	it("should return false for current runtime cache", () => {
+		expect(shouldDeleteCache("gsd-runtime-v9.3.4", currentNames)).toBe(false);
+	});
+
+	it("should return false for current immutable cache", () => {
+		expect(shouldDeleteCache("gsd-immutable-v1", currentNames)).toBe(false);
+	});
+
+	it("should return false for unrecognized cache names (not ours)", () => {
+		expect(shouldDeleteCache("workbox-precache-v2", currentNames)).toBe(
+			false,
+		);
+	});
+
+	it("should return true for old immutable cache version", () => {
+		const names = getCacheNames("9.3.4", 2);
+		expect(shouldDeleteCache("gsd-immutable-v1", names)).toBe(true);
+	});
+});
+
+describe("getEvictionCandidates", () => {
+	it("should return empty array when under limit", () => {
+		expect(getEvictionCandidates(["a", "b"], 5)).toEqual([]);
+	});
+
+	it("should return empty array when at exact limit", () => {
+		expect(getEvictionCandidates(["a", "b", "c"], 3)).toEqual([]);
+	});
+
+	it("should return oldest keys when over limit (FIFO order)", () => {
+		expect(getEvictionCandidates(["a", "b", "c", "d", "e"], 3)).toEqual([
+			"a",
+			"b",
+		]);
+	});
+
+	it("should return correct count to bring entries within limit", () => {
+		const keys = Array.from({ length: 65 }, (_, i) => `chunk-${i}.js`);
+		const candidates = getEvictionCandidates(keys, 60);
+		expect(candidates).toHaveLength(5);
+		expect(candidates[0]).toBe("chunk-0.js");
+		expect(candidates[4]).toBe("chunk-4.js");
+	});
+
+	it("should handle empty keys array", () => {
+		expect(getEvictionCandidates([], 60)).toEqual([]);
+	});
+});
+
+describe("source sync check", () => {
+	it("should have matching function signatures in public/sw-cache-logic.js and lib/sw-cache-logic.ts", () => {
+		const jsPath = resolve(__dirname, "../../public/sw-cache-logic.js");
+		const tsPath = resolve(__dirname, "../../lib/sw-cache-logic.ts");
+		const jsSource = readFileSync(jsPath, "utf-8");
+		const tsSource = readFileSync(tsPath, "utf-8");
+
+		const extractFunctionNames = (source: string): string[] =>
+			[...source.matchAll(/(?:export )?function (\w+)[<(]/g)].map((m) => m[1]).sort();
+
+		const jsFunctions = extractFunctionNames(jsSource);
+		const tsFunctions = extractFunctionNames(tsSource);
+
+		expect(jsFunctions).toEqual(tsFunctions);
+	});
+
+	it("should produce identical results from both sources", () => {
+		// Verify the JS file is loadable and its functions produce the same
+		// results as the TS source — catches logic drift between the two files.
+		const jsPath = resolve(__dirname, "../../public/sw-cache-logic.js");
+		const jsSource = readFileSync(jsPath, "utf-8");
+
+		// Extract and execute JS functions in a clean scope
+		const jsModule: Record<string, unknown> = {};
+		const wrappedCode = `(function(module, exports) { ${jsSource} })`;
+		 
+		const factory = (0, eval)(wrappedCode) as (m: { exports: Record<string, unknown> }, e: Record<string, unknown>) => void;
+		const mod = { exports: jsModule };
+		factory(mod, jsModule);
+		const js = mod.exports as typeof import("@/lib/sw-cache-logic");
+
+		// Compare outputs for representative inputs
+		expect(js.classifyRequest("/_next/static/chunks/a.js", null, true, "GET")).toBe(
+			classifyRequest("/_next/static/chunks/a.js", null, true, "GET"),
+		);
+		expect(js.classifyRequest("/about/", "text/html", true, "GET")).toBe(
+			classifyRequest("/about/", "text/html", true, "GET"),
+		);
+		expect(js.classifyRequest("/manifest.json", null, true, "GET")).toBe(
+			classifyRequest("/manifest.json", null, true, "GET"),
+		);
+		expect(js.classifyRequest("/api/x", null, false, "GET")).toBe(
+			classifyRequest("/api/x", null, false, "GET"),
+		);
+		expect(js.getCacheNames("1.0.0", 1)).toEqual(getCacheNames("1.0.0", 1));
+		expect(js.shouldDeleteCache("gsd-cache-v1", js.getCacheNames("2.0.0", 1))).toBe(
+			shouldDeleteCache("gsd-cache-v1", getCacheNames("2.0.0", 1)),
+		);
+		expect(js.getEvictionCandidates(["a", "b", "c"], 2)).toEqual(
+			getEvictionCandidates(["a", "b", "c"], 2),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- **Split single SW cache into three purpose-specific caches** to prevent full cache invalidation on every deploy:
  - `gsd-immutable-v1` — content-hashed `/_next/static/*` assets (survives deploys, FIFO-pruned at 60 entries)
  - `gsd-pages-v{version}` — HTML + RSC flight data (network-first, rotated on deploy)
  - `gsd-runtime-v{version}` — icons, manifest, other static (cache-first, rotated on deploy)
- **Extracted cache routing logic** into testable pure functions (`lib/sw-cache-logic.ts` + `public/sw-cache-logic.js`)
- **Added preconnect hint** for PocketBase API (`<link rel="preconnect" href="https://api.vinny.io" />`)
- **29 unit tests** covering classification, eviction, cleanup, and TS↔JS drift detection

### Why

Every version bump forced users to re-download all 37 content-hashed JS chunks (~2.6MB) because the single `gsd-cache-v{version}` cache was entirely deleted on activate. Content-hashed assets are immutable by definition — their URL changes when content changes — so they should persist across deploys. After this change, a typical patch deploy only downloads the 1-2 chunks that actually changed (~95% bandwidth reduction on repeat loads).

### Migration

First deploy after merge deletes the old `gsd-cache-v*` cache (one-time full re-download). Starting from the next deploy, only pages + runtime caches rotate; the immutable cache persists.

See `docs/adr/0012-sw-multi-cache-strategy.md` for full architecture decision.

## Test plan

- [x] `bun run test` — 1939 tests pass (29 new)
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun run build` — static export succeeds
- [x] `update-sw-version.cjs` — correctly targets only `CACHE_VERSION` (not `IMMUTABLE_CACHE_VERSION`)
- [x] Local browser testing — three caches visible in DevTools Application → Cache Storage
- [ ] Verify offline fallback works (disable network, navigate cached routes)
- [ ] Verify update toast flow (install → new version → SKIP_WAITING → reload)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->