### PR TITLE
fix(sync,hydration): eliminate phantom sync toast and hydration mismatch

### DIFF
--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -66,10 +66,13 @@ export function MatrixSimplified() {
   const [editingTask, setEditingTask] = useState<TaskRecord | null>(null);
   const [createDrawerOpen, setCreateDrawerOpen] = useState(false);
   const [createInitial, setCreateInitial] = useState<Partial<EditDraft> | undefined>(undefined);
-  const [showCompleted, setShowCompleted] = useState<boolean>(readShowCompleted);
+  const [showCompleted, setShowCompleted] = useState(false);
   const [sharingTask, setSharingTask] = useState<TaskRecord | null>(null);
 
-  useEffect(() => { setMounted(true); }, []);
+  useEffect(() => {
+    setMounted(true);
+    setShowCompleted(readShowCompleted());
+  }, []);
 
   useEffect(() => {
     const handler = (e: Event) => {

--- a/lib/sync/pb-pull.ts
+++ b/lib/sync/pb-pull.ts
@@ -91,7 +91,7 @@ async function applyRemoteRecords(records: RecordModel[]): Promise<{
     } else {
       const remoteTime = new Date(remoteTask.updatedAt).getTime();
       const localTime = new Date(localTask.updatedAt).getTime();
-      if (remoteTime >= localTime) {
+      if (remoteTime > localTime) {
         await db.tasks.put(remoteTask);
         appliedRecords.push(record);
         pulledCount++;
@@ -105,7 +105,7 @@ async function applyRemoteRecords(records: RecordModel[]): Promise<{
 /**
  * Pull remote changes from PocketBase into local IndexedDB.
  * Fetches tasks updated after the last sync timestamp.
- * LWW: remote wins if remote client_updated_at >= local updatedAt.
+ * LWW: remote wins if remote client_updated_at > local updatedAt.
  */
 export async function pullRemoteChanges(lastSyncAt: string | null): Promise<{ pulledCount: number; authenticated: boolean; maxObservedTimestamp: string | null }> {
   const pb = getPocketBase();

--- a/lib/sync/pb-sync-engine.ts
+++ b/lib/sync/pb-sync-engine.ts
@@ -57,7 +57,7 @@ export async function applyRemoteChange(
 
   // update — LWW
   const localTask = await db.tasks.get(remoteTask.id);
-  if (!localTask || new Date(remoteTask.updatedAt).getTime() >= new Date(localTask.updatedAt).getTime()) {
+  if (!localTask || new Date(remoteTask.updatedAt).getTime() > new Date(localTask.updatedAt).getTime()) {
     // Re-map with existing local task to preserve device-local fields
     const mergedTask = localTask ? pocketBaseToTaskRecord(record, localTask) : remoteTask;
     if (mergedTask) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.3.5",
+	"version": "9.3.6",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/data/sync/pb-pull.test.ts
+++ b/tests/data/sync/pb-pull.test.ts
@@ -72,4 +72,38 @@ describe('pullRemoteChanges cursor clamping', () => {
     // can re-catch boundary records reliably across clock drift.
     expect(maxObservedTimestamp).toBe('2026-05-17T23:59:30.000Z');
   });
+
+  it('skips records where remote timestamp equals local (no phantom pull count)', async () => {
+    const timestamp = '2026-05-18T12:00:00.000Z';
+
+    const { getDb } = await import('@/lib/db');
+    const db = getDb();
+    await db.tasks.add({
+      id: 't-equal',
+      title: 'Existing',
+      description: '',
+      urgent: false,
+      important: false,
+      quadrant: 'not-urgent-not-important',
+      completed: false,
+      createdAt: '2026-05-18T00:00:00.000Z',
+      updatedAt: timestamp,
+      tags: [],
+      subtasks: [],
+      dependencies: [],
+      notificationEnabled: false,
+      notificationSent: false,
+      timeSpent: 0,
+      timeEntries: [],
+    });
+
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({
+        getFullList: vi.fn(async () => [pbRecord('t-equal', timestamp)]),
+      }),
+    });
+
+    const { pulledCount } = await pullRemoteChanges(null);
+    expect(pulledCount).toBe(0);
+  });
 });

--- a/tests/data/sync/pb-sync-engine.test.ts
+++ b/tests/data/sync/pb-sync-engine.test.ts
@@ -148,6 +148,16 @@ describe('pb-sync-engine', () => {
       expect(mockDb.tasks.put).not.toHaveBeenCalled();
     });
 
+    it('should skip realtime update when timestamps are equal (consistent LWW with pull/push)', async () => {
+      const equalTimestamp = '2026-04-08T00:00:00.000Z';
+      mockTasks.set('task-1', { id: 'task-1', title: 'Local', updatedAt: equalTimestamp });
+
+      const record = { task_id: 'task-1', title: 'Remote Same Time', client_updated_at: equalTimestamp };
+      await applyRemoteChange('update', record as never);
+
+      expect(mockDb.tasks.put).not.toHaveBeenCalled();
+    });
+
     it('should apply a remote delete', async () => {
       mockTasks.set('task-1', { id: 'task-1', title: 'To Delete' });
 


### PR DESCRIPTION
## Summary

- **Phantom sync toast**: Changed LWW timestamp comparison in `pb-pull.ts` from `>=` to `>`. The 30s cursor overlap re-fetches boundary records as a safety net, but `>=` treated equal timestamps as "remote wins," causing a spurious "Sync Completed — 1 change downloaded" toast on every page refresh. The push engine already used strict `>`.
- **Hydration mismatch**: `showCompleted` was initialized via `readShowCompleted` as a lazy `useState` initializer, which reads `localStorage` during render. On the static export build (no `window`), it returns `false`; on the client it reads the real stored value. Moved the read into `useEffect` so server and client always start with `false`.
- **Inconsistent realtime LWW** (Devin Review fix): The realtime SSE handler at `pb-sync-engine.ts:60` still used `>=` while pull and push paths used strict `>`. Changed to `>` so all three sync paths have consistent LWW semantics. Added a test confirming equal-timestamp records are skipped in the realtime update path.
- Version bump to 9.3.6.

## Review & Testing Checklist for Human

- [ ] Deploy and verify no "Sync Completed" toast on refresh at gsd.vinny.dev
- [ ] Verify React error #418 no longer appears in browser console
- [ ] Toggle "show completed" on, refresh — confirm no hydration error
- [ ] Verify realtime SSE updates still apply correctly when remote is genuinely newer

### Notes

The `claude-review` CI failure is a bot-access config issue (rejects non-human initiators), and the SonarCloud failure is a pre-existing coverage threshold issue on the original commit (28.6% vs required 80%). All functional checks (test, lint, typecheck, build, audit) pass.

Link to Devin session: https://app.devin.ai/sessions/dcdba7b8549c4a0b9fed11822241c386
Requested by: @vscarpenter
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->