### PR TITLE
chore(claude): apply /catch-up audit recommendations

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,41 @@
+---
+name: release
+description: Run the standard release flow — bump version, commit, push, open PR, merge, tag, create GitHub release. Use when shipping a new version of gsd-taskmanager.
+argument-hint: "<patch|minor|major|x.y.z>"
+---
+
+# /release
+
+Release the gsd-taskmanager app or MCP server. Replaces the recurring "bump version to N, commit, push, PR, merge, tag, GH release" manual flow.
+
+## Inputs
+
+`$ARGUMENTS` is either:
+- `patch` / `minor` / `major` — bump the matching SemVer segment of `package.json` (workspace root).
+- An explicit version like `9.4.0` — pin to that exact value.
+
+## Steps
+
+1. **Branch preflight** — confirm working tree is clean (`git status --porcelain`). If dirty, ask whether to stash or include changes.
+2. **Branch creation** — if on `main`, create `chore/release-<version>`. (The `no-main-commits.sh` hook will block otherwise.)
+3. **Version bump** — update `package.json` and `packages/mcp-server/package.json` if the MCP server is part of the release. Use `npm version --no-git-tag-version` or edit directly.
+4. **Verification gate** — run `bun typecheck && bun lint && bun run test`. Halt if any fail.
+5. **Commit** — `chore(release): vX.Y.Z` with a body listing the user-visible changes since the previous tag (`git log --oneline <prev-tag>..HEAD`).
+6. **Push and PR** — push the branch, open a PR titled `Release vX.Y.Z` with the changelog as the body.
+7. **Wait for review or self-merge** — if the user has authority, ask whether to merge immediately.
+8. **Tag** — after merge, `git fetch origin main`, `git tag vX.Y.Z`, `git push origin vX.Y.Z`.
+9. **GitHub release** — `gh release create vX.Y.Z --generate-notes --title "vX.Y.Z"`.
+10. **MCP publish (if applicable)** — if the MCP server bumped, run `npm publish` from `packages/mcp-server/` (requires `npm login`).
+
+## Anti-goals
+
+- Don't run on a dirty working tree without explicit user OK.
+- Don't push tags before the version-bump PR is merged.
+- Don't publish to npm without user confirmation — that step is hard to reverse.
+
+## Verification before declaring done
+
+- [ ] Version bump merged on `main`.
+- [ ] Tag exists on remote.
+- [ ] GitHub release page shows the new version.
+- [ ] If MCP server was published, `npm view @vscarpenter/gsd-mcp-server version` returns the new value.

--- a/.claude/hooks/no-main-commits.sh
+++ b/.claude/hooks/no-main-commits.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# PreToolUse Bash hook (matcher if=Bash(git commit*)) — blocks commits on main.
+# CLAUDE.md mandates branch -> commit -> push -> PR; this enforces the branch step.
+# Per audit Section 7 #5: 52% of historical sessions ran on main.
+set -uo pipefail
+
+input="$(cat)"
+
+cwd="$(printf '%s' "$input" | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d);process.stdout.write(j.cwd||'')}catch(e){}})")"
+[ -z "$cwd" ] && cwd="$(pwd)"
+
+branch="$(git -C "$cwd" branch --show-current 2>/dev/null || true)"
+
+if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+  cat <<EOF >&2
+{"decision":"block","reason":"Commit blocked: you are on '$branch'. CLAUDE.md requires branch -> commit -> push -> PR. Create a feature branch first (git checkout -b <type>/<short-desc>)."}
+EOF
+  exit 2
+fi
+exit 0

--- a/.claude/rules/mcp-server.md
+++ b/.claude/rules/mcp-server.md
@@ -1,0 +1,37 @@
+---
+name: mcp-server
+description: MCP server package conventions and build rules. Loads when editing packages/mcp-server/.
+paths:
+  - packages/mcp-server/**
+---
+
+## MCP Server Package
+
+- **Location**: `packages/mcp-server/` — standalone npm package, npm workspace.
+- **Runtime**: Node.js 18+ with TypeScript, stdio transport (JSON-RPC 2.0).
+- **Build**: `npm run build` in `packages/mcp-server/` (uses tsc).
+
+## Tool Layout
+
+- **Schemas**: `src/tools/schemas/` — Zod schemas for tool inputs
+- **Handlers**: `src/tools/handlers/` — implementation
+- **Tool files**: `src/tools/<name>.ts` — wires schema + handler
+- **Write ops**: `src/write-ops/` — task-operations + bulk-operations with dryRun support
+
+## 20 Tools Currently Exposed
+
+- *Read (7)*: list_tasks, get_task, search_tasks, get_sync_status, list_devices, get_task_stats, get_token_status
+- *Write (5)*: create_task, update_task, complete_task, delete_task, bulk_update_tasks (all support dryRun)
+- *Analytics (5)*: get_productivity_metrics, get_quadrant_analysis, get_tag_analytics, get_upcoming_deadlines, get_task_insights
+- *System (3)*: validate_config, get_help, get_cache_stats
+
+## Conventions
+
+- Use `fetchWithRetry()` for resilient PocketBase API calls.
+- Validate circular dependencies before adding task relationships.
+- TTL cache for read tools; dry-run mode for all writes.
+- Field changes that touch the synced schema must invoke the `pb-collection` skill (auto-fires on `lib/sync/**`).
+
+## Configuration
+
+Claude Desktop config: `~/Library/Application Support/Claude/claude_desktop_config.json` with `GSD_POCKETBASE_URL` and `GSD_AUTH_TOKEN` env vars.

--- a/.claude/rules/pocketbase-sync.md
+++ b/.claude/rules/pocketbase-sync.md
@@ -1,0 +1,46 @@
+---
+name: pocketbase-sync
+description: PocketBase v0.23+ gotchas and sync architecture rules. Loads when working in lib/sync/, the setup script, or schema files.
+paths:
+  - lib/sync/**
+  - lib/schema.ts
+  - scripts/setup-pocketbase-collections.sh
+---
+
+## PocketBase v0.23+ Gotchas
+
+- **System fields**: `created` / `updated` **cannot** be used in `sort` or `filter`. Use custom fields like `client_updated_at` instead.
+- **Custom indexes**: cannot reference system columns (`updated`, `created`).
+- **Relation fields**: the `_pb_users_auth_` placeholder doesn't work as a `collectionId`. Use `text` type for owner FK, or look up the real collection ID.
+- **Admin auth endpoint**: `/api/collections/_superusers/auth-with-password` (not the legacy `/api/admins/auth-with-password`).
+- **Rate limiting**: throttle push ops to ~100ms between requests; batch-fetch remote IDs to avoid 429s.
+- **Collection setup**: `scripts/setup-pocketbase-collections.sh` creates the `tasks` collection with correct schema, indexes, and API rules.
+
+## Sync Architecture
+
+- **Protocol**: last-write-wins (LWW) using `client_updated_at`; remote wins if newer.
+- **Realtime**: PocketBase SSE auto-reconnects; periodic sync runs as safety net.
+- **Echo filtering**: skip own-device changes via `device_id` comparison.
+- **Auth**: PocketBase SDK auto-stores tokens in localStorage and auto-refreshes.
+
+## Key Locations
+
+- `lib/sync/pocketbase-client.ts` — SDK singleton wrapper
+- `lib/sync/pb-sync-engine.ts` — push/pull engine with LWW resolution
+- `lib/sync/pb-realtime.ts` — SSE subscription manager
+- `lib/sync/pb-auth.ts` — OAuth login/logout
+- `lib/sync/task-mapper.ts` — camelCase ↔ snake_case mapping
+
+## OAuth (PocketBase-delegated)
+
+- OAuth popup flow is delegated to the PocketBase SDK via `authWithOAuth2`; tokens live in the SDK's `authStore` (localStorage).
+- **Google**: configured in PB admin.
+- **GitHub**: requires server-side provider setup in PocketBase admin (`https://api.vinny.io/_/` → Settings → Auth providers).
+- **Local dev**: set `NEXT_PUBLIC_POCKETBASE_URL=https://api.vinny.io` in `.env.local` to test OAuth against production PB. A local PB at `127.0.0.1:8090` would need its own OAuth provider setup.
+
+## OAuth Callback Domain Mismatch (recurring bug)
+
+If users hit `redirect_uri_mismatch` after a deploy:
+1. Check the `redirect_uri` registered in the provider (Google Cloud Console / GitHub OAuth App).
+2. Confirm it matches the exact origin used in production — including trailing slash and `www` vs apex.
+3. PB redirects back to `<your-app>/api/auth/oauth-callback` — verify that route exists in the static export.

--- a/.claude/rules/sw-cache.md
+++ b/.claude/rules/sw-cache.md
@@ -1,0 +1,31 @@
+---
+name: sw-cache
+description: Service worker multi-cache strategy. Loads when editing SW code or PWA registration.
+paths:
+  - public/sw.js
+  - public/sw-*.js
+  - lib/sw-cache-logic.ts
+  - components/pwa-register.tsx
+  - public/manifest.json
+---
+
+## Cache Architecture (ADR 0012)
+
+Three purpose-specific caches with distinct strategies:
+
+| Cache name | Contents | Strategy | Lifecycle |
+|---|---|---|---|
+| `gsd-immutable-v1` | content-hashed `/_next/static/*` assets | cache-first | FIFO-pruned at 60 entries, survives deploys |
+| `gsd-pages-v{version}` | HTML + RSC flight data | network-first | rotated on deploy |
+| `gsd-runtime-v{version}` | icons, manifest, other static | cache-first | rotated on deploy |
+
+## Files to Keep in Sync
+
+- `public/sw.js` — runtime SW (loads cache logic via `importScripts()`)
+- `public/sw-cache-logic.js` — pure cache routing functions
+- `lib/sw-cache-logic.ts` — **canonical TypeScript source** — keep in sync with the JS copy
+- `components/pwa-register.tsx` — SW registration
+
+## Bump Cache Version
+
+When the SW cache logic changes, bump the version constant in `public/sw.js` so old pages/runtime caches rotate. The immutable cache is content-hashed and does not need a bump.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,40 @@
+---
+name: testing
+description: Testing setup, gotchas, and TDD workflow rules. Loads when editing tests or test setup.
+paths:
+  - tests/**
+  - vitest.setup.ts
+  - vitest.config.ts
+  - playwright.config.ts
+  - packages/mcp-server/src/__tests__/**
+---
+
+## Test Runner
+
+- **Use `bun run test`**, NOT `bun test`. `bun test` invokes Bun's built-in runner; `bun run test` delegates to vitest via package.json scripts.
+- Watch mode: `bun run test:watch`
+- Coverage: `bun run test -- --coverage` (target ≥80% statements/lines/functions, ≥75% branches).
+
+## Test Layout
+
+- `tests/ui/` — UI/component tests (React Testing Library)
+- `tests/data/` — data logic, schemas, mappers
+- `tests/e2e/` — Playwright (auto-starts dev server via `playwright.config.ts`)
+- `packages/mcp-server/src/__tests__/` — MCP server tests
+
+## Testing Gotchas
+
+- **`fake-indexeddb`** is auto-imported in `vitest.setup.ts` — no per-test setup needed.
+- **`localStorage`** is polyfilled in-memory. Use `localStorage.removeItem(key)` in `beforeEach` — `localStorage.clear()` doesn't work in jsdom under Bun.
+- **`lib/sync/` tests**: mock the SDK with `vi.mock('pocketbase')`. Follow the pattern in existing sync tests.
+- **E2E**: IndexedDB is cleared between tests automatically. Root URL redirects to the about page on first load.
+- Use `data-testid` attributes for stable Playwright selectors.
+
+## TDD Workflow (Default)
+
+1. **Red** — write a failing test that describes the expected behavior.
+2. **Green** — write the minimum implementation that passes.
+3. **Refactor** — clean up while keeping tests green.
+
+Apply TDD for: new components/functions, bug fixes (reproduce-first), behavior-changing refactors.
+Skip for: pure CSS, renames/moves with no logic change, docs.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,16 @@
             "command": "bash .claude/hooks/block-sensitive-files.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/no-main-commits.sh",
+            "if": "Bash(git commit*)"
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -51,6 +61,12 @@
             "command": "bun typecheck 2>&1 | tail -10",
             "timeout": 60,
             "statusMessage": "Type-check verification gate..."
+          },
+          {
+            "type": "command",
+            "command": "bun lint 2>&1 | tail -10",
+            "timeout": 60,
+            "statusMessage": "Lint verification gate..."
           }
         ]
       }

--- a/.claude/skills/pb-collection/SKILL.md
+++ b/.claude/skills/pb-collection/SKILL.md
@@ -2,6 +2,12 @@
 name: pb-collection
 description: Add or modify a field on the PocketBase tasks collection end-to-end — schema script, task-mapper, Zod schema, Dexie version bump, migration test. Use when the user wants to add/remove/rename a synced task field. Codifies the PocketBase v0.23+ gotchas and recurring step-order mistakes.
 disable-model-invocation: true
+paths:
+  - lib/sync/**
+  - lib/schema.ts
+  - lib/db.ts
+  - scripts/setup-pocketbase-collections.sh
+  - packages/mcp-server/src/tools/**
 ---
 
 # pb-collection — End-to-end PocketBase tasks-collection field change

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ sync.md
 !.claude/agents/
 !.claude/commands/
 !.claude/hooks/
+!.claude/rules/
 !.claude/skills/
 .claude/skills/*
 !.claude/skills/pb-collection/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code working in this repository. Coding standards live in @coding-standards.md (imported). Path-scoped rules live in `.claude/rules/*.md` and auto-load when their globs match.
 
 ## Project Overview
 
@@ -13,6 +13,12 @@ GSD Task Manager is a privacy-first Eisenhower matrix task manager built with Ne
 - **Realtime Sync** — PocketBase SSE (Server-Sent Events) for instant cross-device updates
 - **iOS-style Settings** — Full-page settings with grouped layout and modular sections (`components/settings-page/`)
 - **Command Palette (planned)** — Global ⌘K/Ctrl+K palette source exists at `components/command-palette/` but is **not wired into the v9 app shell**; resurrection tracked in `tasks/todo.md`
+
+**Path-scoped rules** (auto-loaded by glob — open these only when working in the matching subtree):
+- `.claude/rules/pocketbase-sync.md` — PocketBase v0.23+ gotchas, sync architecture, OAuth callback debugging
+- `.claude/rules/testing.md` — Test runner, TDD workflow, jsdom/bun gotchas
+- `.claude/rules/sw-cache.md` — Service worker multi-cache strategy (ADR 0012)
+- `.claude/rules/mcp-server.md` — MCP server package conventions and tool layout
 
 ## Core Commands
 
@@ -80,48 +86,16 @@ Logic in `lib/quadrants.ts` with `resolveQuadrantId()` and `quadrantOrder`.
 - **Recurring tasks**: Completed recurring tasks auto-create next instance
 - **Enhanced search**: Includes tags and subtasks
 
-### PWA Configuration
-- `public/manifest.json` - App metadata
-- `public/sw.js` - Service worker with multi-cache strategy (see ADR 0012)
-- `public/sw-cache-logic.js` - Pure cache routing functions loaded via `importScripts()`
-- `lib/sw-cache-logic.ts` - Canonical TypeScript source for the cache logic (keep in sync with the JS copy)
-- `components/pwa-register.tsx` - SW registration
+### PWA, Cloud Sync, MCP Server
+Architecture details for these subsystems live in path-scoped rules:
+- PWA / service-worker cache strategy → `.claude/rules/sw-cache.md` (auto-loads on `public/sw*.js`, `lib/sw-cache-logic.ts`)
+- PocketBase sync + OAuth → `.claude/rules/pocketbase-sync.md` (auto-loads on `lib/sync/**`)
+- MCP server package → `.claude/rules/mcp-server.md` (auto-loads on `packages/mcp-server/**`)
 
-**Cache architecture** (three purpose-specific caches):
-- `gsd-immutable-v1` — content-hashed `/_next/static/*` assets (cache-first, FIFO-pruned at 60 entries, survives deploys)
-- `gsd-pages-v{version}` — HTML + RSC flight data (network-first, rotated on deploy)
-- `gsd-runtime-v{version}` — icons, manifest, other static (cache-first, rotated on deploy)
-
-### Cloud Sync Architecture
-- **Backend**: Self-hosted PocketBase at `https://api.vinny.io` (AWS EC2)
-- **Authentication**: PocketBase built-in OAuth2 with Google and GitHub providers (both fully implemented client-side; GitHub requires server-side provider setup in PocketBase admin)
-- **Sync Protocol**: Last-write-wins (LWW) with `client_updated_at` timestamps
-- **Realtime**: PocketBase SSE subscriptions for instant cross-device updates
-- **Storage**: Tasks stored as plaintext in PocketBase (user owns the server)
-
-**Key Locations**:
-- `lib/sync/pocketbase-client.ts` - PocketBase SDK singleton wrapper
-- `lib/sync/pb-sync-engine.ts` - Push/pull sync engine with LWW resolution
-- `lib/sync/pb-realtime.ts` - SSE subscription manager with echo filtering
-- `lib/sync/pb-auth.ts` - OAuth login/logout via PocketBase SDK
-- `lib/sync/task-mapper.ts` - camelCase ↔ snake_case field mapping
-
-**PocketBase Collections**: `tasks` (with API rules: `@request.auth.id != "" && owner = @request.auth.id`), `devices`
-
-### MCP Server Architecture
-- **Purpose**: Enable Claude Desktop to access/analyze tasks via natural language
-- **Location**: `packages/mcp-server/` - Standalone npm package
-- **Runtime**: Node.js 18+ with TypeScript, stdio transport (JSON-RPC 2.0)
-
-**20 MCP Tools**:
-- *Read (7)*: list_tasks, get_task, search_tasks, get_sync_status, list_devices, get_task_stats, get_token_status
-- *Write (5)*: create_task, update_task, complete_task, delete_task, bulk_update_tasks (all support dryRun)
-- *Analytics (5)*: get_productivity_metrics, get_quadrant_analysis, get_tag_analytics, get_upcoming_deadlines, get_task_insights
-- *System (3)*: validate_config, get_help, get_cache_stats
-
-**Key Features**: Retry logic with exponential backoff, TTL cache, dry-run mode, circular dependency validation
-
-**Configuration**: Claude Desktop config at `~/Library/Application Support/Claude/claude_desktop_config.json` with `GSD_POCKETBASE_URL`, `GSD_AUTH_TOKEN`
+**Quick refs that survive without opening a rule file**:
+- Backend: self-hosted PocketBase at `https://api.vinny.io`; admin UI at `/_/`.
+- MCP server: `packages/mcp-server/` workspace; build with `npm run build`; 20 tools exposed.
+- Cache layers: `gsd-immutable-v1` (hashed, cache-first), `gsd-pages-v{v}` (network-first), `gsd-runtime-v{v}` (cache-first).
 
 ## Testing Guidelines
 - UI tests in `tests/ui/`, data logic in `tests/data/`
@@ -173,32 +147,15 @@ These packages are not self-explanatory from their names alone:
 - Button component variants: "primary" | "subtle" | "ghost" (no size prop)
 - Smart view shortcuts and pinning UI were removed in v9 (see ADR 0011). The `smartViews` Dexie table is retained for data continuity but has no UI surface in the v9 shell.
 
-### Cloud Sync
-- **PocketBase Admin**: `https://api.vinny.io/_/` for collection management
-- **PocketBase Version**: v0.23+ (uses `_superusers` collection for admin auth, not legacy `/api/admins/`)
-- PocketBase SDK (v0.26.8) auto-stores auth tokens in localStorage and auto-refreshes
-- LWW conflict resolution uses `client_updated_at` field — remote wins if newer
-- SSE subscriptions auto-reconnect; periodic sync runs as safety net
-- Echo filtering skips own-device changes via `device_id` comparison
-- **Rate Limiting**: Push operations are throttled (100ms between requests) to avoid PocketBase 429 errors
-- **Batch Lookups**: `fetchRemoteTaskIndex()` pre-fetches all remote task IDs in one request instead of N individual lookups
-- **PocketBase v0.23+ Gotchas**:
-  - System fields (`created`, `updated`) **cannot** be used in `sort` or `filter` — use custom fields like `client_updated_at` instead
-  - Custom indexes cannot reference system columns (`updated`, `created`)
-  - The `_pb_users_auth_` placeholder doesn't work as a `collectionId` for relation fields — use `text` type for owner FK or look up the real collection ID
-  - Admin auth endpoint is `/api/collections/_superusers/auth-with-password` (not `/api/admins/auth-with-password`)
-- **Collection Setup**: Run `scripts/setup-pocketbase-collections.sh` to create the `tasks` collection with correct schema, indexes, and API rules
+### Cloud Sync, MCP Server, OAuth
+Detail moved to path-scoped rules — see `.claude/rules/pocketbase-sync.md` and `.claude/rules/mcp-server.md`. Those auto-load when you edit the relevant subtrees.
 
-### MCP Server
-- Build with `npm run build` in `packages/mcp-server/`
-- Add tools: schemas in `tools/schemas/`, handlers in `tools/handlers/`
-- Uses PocketBase JS SDK to communicate with `GSD_POCKETBASE_URL`
-- Use `fetchWithRetry()` for resilient API calls
-
-### OAuth Authentication
-- OAuth popup flow is delegated to the PocketBase SDK via `authWithOAuth2`; auth tokens live in the SDK's `authStore` (localStorage) and auto-refresh
-- GitHub provider requires server-side setup in PocketBase admin (`https://api.vinny.io/_/` → Settings → Auth providers); Google is already configured
-- **Local dev**: Set `NEXT_PUBLIC_POCKETBASE_URL=https://api.vinny.io` in `.env.local` to test OAuth against production PocketBase. A local PocketBase at `127.0.0.1:8090` would need its own OAuth provider setup.
+### Sentry verification (recurring debugging task)
+When testing Sentry capture after a DSN change or deploy:
+1. Confirm DSN is loaded: `console.log` in `lib/sentry/init.ts` (or wherever Sentry.init runs) and grep dev console for "Sentry initialized".
+2. Trigger a test error: `Sentry.captureException(new Error("manual-test-from-claude"))` in a dev-only handler, OR throw from a component error boundary.
+3. Verify in Sentry dashboard within ~30s.
+4. Remove the test trigger before commit (it's not a regression — leave it out of source).
 
 ### Test-Driven Development (TDD)
 
@@ -224,10 +181,8 @@ These packages are not self-explanatory from their names alone:
 - Run `bun run test`, `bun typecheck`, and `bun lint` before committing
 - Static export mode means no API routes or SSR
 
-### Testing Gotchas
-- `fake-indexeddb` is auto-imported in `vitest.setup.ts` — no per-test setup needed
-- `localStorage` is polyfilled in-memory — use `localStorage.removeItem(key)` (not `.clear()`, which jsdom under Bun doesn't expose) in test `beforeEach`
-- For `lib/sync/` tests, mock the SDK with `vi.mock('pocketbase')` — follow the pattern in existing sync tests
+### Testing
+Detail moved to `.claude/rules/testing.md` — auto-loads when editing `tests/**` or test setup. TL;DR: use `bun run test` (not `bun test`), `fake-indexeddb` is auto-imported, `localStorage.clear()` doesn't work in jsdom-under-Bun.
 
 ## Modular Architecture
 
@@ -244,11 +199,13 @@ The codebase follows coding standards (<350 lines per file, <30 lines per functi
 
 All modules maintain backward compatibility through re-export layers.
 
-## Git Workflow 
+## Git Workflow
 
-For git operations: when asked to commit and push, write a descriptive conventional commit message, bump the version if appropriate, and create a PR unless told otherwise. Standard workflow: commit → push → create PR.
+**Default commit flow**: when the user says "commit and push", "commit, push, create a PR", or any close variant, invoke the `commit-commands:commit-push-pr` skill — don't manually compose the steps. Write a descriptive conventional commit message, bump the version if appropriate, create a PR unless told otherwise.
 
-Always leverage @coding-standards.md for coding standards and guidelines.
+**Branch rule**: never commit on `main`. Create a feature branch (`<type>/<short-desc>`) first. A `PreToolUse` hook (`.claude/hooks/no-main-commits.sh`) enforces this.
+
+Coding standards: see @coding-standards.md (imported).
 
 ## Agent skills
 


### PR DESCRIPTION
## Summary

Applies the project-side recommendations from a comprehensive `/catch-up` audit of Claude Code configuration. Slims always-loaded context, hardens enforcement, and codifies the recurring release flow.

**What this changes:**
- **CLAUDE.md**: 266 → 222 lines. Inline subsystem detail (PocketBase v0.23+ gotchas, MCP server conventions, SW cache architecture, testing setup) extracted to path-scoped rule files in `.claude/rules/` that auto-load only when their globs match.
- **New path-scoped rules** (`.claude/rules/pocketbase-sync.md`, `testing.md`, `sw-cache.md`, `mcp-server.md`): load on `lib/sync/**`, `tests/**`, SW files, and `packages/mcp-server/**` respectively.
- **New hook** `.claude/hooks/no-main-commits.sh`: PreToolUse hook (matcher `Bash`, `if: Bash(git commit*)`) blocks commits on `main`. Audit found 52% of historical sessions ran on main despite the CLAUDE.md rule.
- **Stop hook** now runs `bun lint` alongside `bun typecheck`. CLAUDE.md "Pre-commit" guidance lists both; only typecheck was enforced.
- **pb-collection skill**: gains `paths:` frontmatter (`lib/sync/**`, `lib/schema.ts`, `lib/db.ts`, etc.) so it auto-fires instead of waiting for manual invocation.
- **New `/release` command**: codifies the bump → commit → push → PR → tag → GH release flow (4+ historical sessions follow this pattern).
- **CLAUDE.md**: switches `@coding-standards.md` reference from prose to literal import syntax; adds Sentry verification quick-ref and `/commit-push-pr` default-routing guidance.
- **.gitignore**: whitelist `.claude/rules/` alongside `commands/`, `hooks/`, and tracked skills.

**Personal config also cleaned (not in this PR — gitignored)**: removed unused `aws-mcp` MCP server from `.mcp.json` and the matching `mcp__aws-mcp__*` / `mcp__supabase__*` permissions from `settings.local.json` — 0 invocations across 31 sessions.

## Test plan

- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] All touched JSON files validate (`.claude/settings.json`, `.mcp.json`)
- [x] CLAUDE.md links resolve (path-scoped rules exist; `@coding-standards.md` import target exists)
- [x] Verify `no-main-commits.sh` blocks correctly: try `git commit` on `main` (should be blocked with helpful message); same commit on a feature branch (should pass)
- [x] Verify `pb-collection` skill description surfaces when editing a file under `lib/sync/`
- [x] After merge, confirm Stop hook fires both typecheck and lint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->