### PR TITLE
[codex] Harden service worker and Docker defaults

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -134,24 +134,24 @@ img-src 'self' data: blob:;
 font-src 'self' data:;
 connect-src 'self' https://api.vinny.io https://accounts.google.com https://github.com;
 frame-ancestors 'none';
-base-uri 'self';
+base-uri 'none';
 form-action 'self' https://accounts.google.com https://github.com;
 ```
 
-**Production (Recommended):**
+**Production (Current):**
 ```
 default-src 'self';
-script-src 'self';
-style-src 'self';
+script-src 'self' 'unsafe-inline';
+style-src 'self' 'unsafe-inline';
 img-src 'self' data: blob:;
-font-src 'self';
+font-src 'self' data:;
 connect-src 'self' https://api.vinny.io https://accounts.google.com https://github.com https://*.ingest.us.sentry.io;
 frame-ancestors 'none';
-base-uri 'self';
+base-uri 'none';
 form-action 'self' https://accounts.google.com https://github.com;
 ```
 
-> **Note:** The production CSP removes `unsafe-inline` and `unsafe-eval`. The `connect-src` includes the PocketBase server, OAuth provider domains, and the Sentry US-region ingest endpoint for error reporting.
+> **Note:** The current static Next.js export emits inline hydration/RSC scripts, so production still allows `unsafe-inline` for scripts and styles. Production must not allow `unsafe-eval`, and `connect-src` should stay limited to the app origin, PocketBase, OAuth provider domains, and the Sentry US-region ingest endpoint. The next hardening step is a deploy-time CSP hash pipeline that removes script `unsafe-inline`.
 
 #### 2. X-Frame-Options
 ```

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,20 +16,42 @@ import { ClientLayout } from "@/components/client-layout";
 import { QueryProvider } from "@/components/query-provider";
 import { FirstTimeRedirect } from "@/components/first-time-redirect";
 
+// The current static Next export emits inline hydration/RSC scripts. Keep
+// production inline script allowance until a deploy-time hash pipeline exists.
 const scriptSrc = process.env.NODE_ENV === "development"
   ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
   : "script-src 'self' 'unsafe-inline'";
 
+const connectSrc = process.env.NODE_ENV === "development"
+  ? [
+      "connect-src 'self'",
+      "http://127.0.0.1:8090",
+      "http://localhost:8090",
+      "ws://127.0.0.1:8090",
+      "ws://localhost:8090",
+      "https://api.vinny.io",
+      "https://accounts.google.com",
+      "https://github.com",
+      "https://*.ingest.us.sentry.io",
+    ].join(" ")
+  : [
+      "connect-src 'self'",
+      "https://api.vinny.io",
+      "https://accounts.google.com",
+      "https://github.com",
+      "https://*.ingest.us.sentry.io",
+    ].join(" ");
+
 const contentSecurityPolicy = [
   "default-src 'self'",
-  "base-uri 'self'",
+  "base-uri 'none'",
   "object-src 'none'",
   "form-action 'self'",
   "img-src 'self' data: blob:",
   "font-src 'self' data:",
   scriptSrc,
   "style-src 'self' 'unsafe-inline'",
-  "connect-src 'self' https: wss:",
+  connectSrc,
   "worker-src 'self' blob:",
   "manifest-src 'self'",
 ].join("; ");

--- a/cloudfront/response-headers-policy.json
+++ b/cloudfront/response-headers-policy.json
@@ -16,7 +16,7 @@
     },
     "ContentSecurityPolicy": {
       "Override": true,
-      "ContentSecurityPolicy": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.vinny.io https://accounts.google.com https://github.com https://*.ingest.us.sentry.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://accounts.google.com https://github.com; object-src 'none'; manifest-src 'self'; worker-src 'self' blob:;"
+      "ContentSecurityPolicy": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.vinny.io https://accounts.google.com https://github.com https://*.ingest.us.sentry.io; frame-ancestors 'none'; base-uri 'none'; form-action 'self' https://accounts.google.com https://github.com; object-src 'none'; manifest-src 'self'; worker-src 'self' blob:;"
     },
     "ContentTypeOptions": {
       "Override": true

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -39,7 +39,7 @@
 		# allowlist did not cover.
 		Permissions-Policy           "accelerometer=(), autoplay=(), bluetooth=(), browsing-topics=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), hid=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), serial=(), usb=()"
 
-		Content-Security-Policy      "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://accounts.google.com https://github.com; object-src 'none'; manifest-src 'self'; worker-src 'self';"
+		Content-Security-Policy      "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self' https://accounts.google.com https://github.com; object-src 'none'; manifest-src 'self'; worker-src 'self';"
 
 		# Hide server / upstream framework banners.
 		-Server
@@ -52,9 +52,11 @@
 		reverse_proxy localhost:8090
 	}
 
-	# Admin dashboard
+	# PocketBase admin is intentionally not exposed on the public app origin.
+	# For setup, either use scripts/setup-pocketbase-collections.sh through
+	# /api/* or publish 127.0.0.1:8090 from docker-compose temporarily.
 	handle /_/* {
-		reverse_proxy localhost:8090
+		respond "PocketBase admin is not exposed through this origin." 404
 	}
 
 	# ---- Static site (SPA fallback) ----

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,15 +15,26 @@ Open **https://localhost** (accept the self-signed certificate warning on first 
 
 PocketBase starts with no collections or admin account. Complete these steps once:
 
-1. Visit **https://localhost/_/** to open the PocketBase admin dashboard.
-2. Create a superuser account (email + password).
-3. Create the **tasks** collection. You can either:
-   - Use the admin UI to create it manually (see the schema below), or
-   - Run the setup script from outside the container:
-     ```bash
-     PB_URL=https://localhost ./scripts/setup-pocketbase-collections.sh
-     ```
-4. Go to **Settings → Auth providers** to configure OAuth (Google, GitHub) if desired.
+1. Create or update a PocketBase superuser inside the container:
+   ```bash
+   docker compose exec gsd pocketbase superuser upsert admin@example.com 'change-this-password' --dir=/pb_data
+   ```
+2. Create the **tasks** collection from outside the container:
+   ```bash
+   PB_URL=https://localhost \
+   PB_ADMIN_EMAIL=admin@example.com \
+   PB_ADMIN_PASSWORD='change-this-password' \
+   ../scripts/setup-pocketbase-collections.sh
+   ```
+3. If you need the PocketBase admin dashboard, temporarily publish it on localhost only:
+   ```yaml
+   ports:
+     - "443:443"
+     - "80:80"
+     - "127.0.0.1:8090:8090"
+   ```
+   Then open **http://127.0.0.1:8090/_/** and remove the port mapping when setup is complete.
+4. Go to **Settings → Auth providers** in the local admin dashboard to configure OAuth (Google, GitHub) if desired.
 
 ## Architecture
 
@@ -36,12 +47,12 @@ Browser (https://localhost)
 │  :443                        │
 │                              │
 │  /api/*  ──► PocketBase:8090 │
-│  /_/*    ──► PocketBase:8090 │
 │  /*      ──► Static files    │
 └──────────────────────────────┘
 ```
 
 Everything runs behind a single HTTPS origin, so there are no CORS or mixed-content issues.
+The PocketBase admin dashboard is not exposed through the public app origin by default.
 For custom domains, the app now defaults sync to the same origin unless
 `NEXT_PUBLIC_POCKETBASE_URL` is explicitly set.
 
@@ -159,7 +170,7 @@ ports:
 Then access `https://localhost:8443`.
 
 ### PocketBase admin not loading
-Wait a few seconds after container start — PocketBase needs time to initialize on first run. Check logs with `docker compose logs -f`.
+The admin dashboard is not exposed through `https://localhost/_/` by default. Temporarily add `127.0.0.1:8090:8090` to `ports`, restart, and open `http://127.0.0.1:8090/_/`. Remove that port mapping when setup is complete. If the local port still does not respond, wait a few seconds after container start and check logs with `docker compose logs -f`.
 
 ### OAuth not working
 OAuth providers must be configured in PocketBase admin (**Settings → Auth providers**). The redirect URL should be `https://localhost/api/oauth2-redirect` (or your custom `SITE_ADDRESS`).

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     ports:
       - "443:443"    # HTTPS — app + PocketBase API
       - "80:80"      # HTTP  — redirects to HTTPS
+      # Optional local-only PocketBase admin/API access for initial setup:
+      # - "127.0.0.1:8090:8090"
     volumes:
       - pb_data:/pb_data          # PocketBase database persistence
       # Uncomment to use your own SSL certificates (see README.md):

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -45,7 +45,7 @@ echo ""
 echo "==========================================="
 echo "  GSD Task Manager is running!"
 echo "  App:   https://${SITE_ADDRESS:-localhost}"
-echo "  Admin: https://${SITE_ADDRESS:-localhost}/_/"
+echo "  Admin: not exposed on the public app origin"
 echo "==========================================="
 echo ""
 

--- a/docker/docker-setup-and-run.md
+++ b/docker/docker-setup-and-run.md
@@ -36,7 +36,7 @@ Once ready you'll see:
 ===========================================
   GSD Task Manager is running!
   App:   https://localhost
-  Admin: https://localhost/_/
+  Admin: not exposed on the public app origin
 ===========================================
 ```
 
@@ -44,15 +44,26 @@ Once ready you'll see:
 
 PocketBase starts with no collections or admin account. Complete these steps once:
 
-1. Open **https://localhost/_/** in your browser (accept the self-signed cert warning).
-2. Create a superuser account (email + password).
-3. Set up the **tasks** collection — either:
-   - Manually via the admin UI (see the schema in `docker/README.md`), or
-   - Via the setup script from **another terminal**:
-     ```bash
-     PB_URL=https://localhost ./scripts/setup-pocketbase-collections.sh
-     ```
-4. Optionally configure OAuth providers under **Settings → Auth providers**.
+1. Create or update a PocketBase superuser inside the container:
+   ```bash
+   docker compose exec gsd pocketbase superuser upsert admin@example.com 'change-this-password' --dir=/pb_data
+   ```
+2. Set up the **tasks** collection via the setup script from the repo root:
+   ```bash
+   PB_URL=https://localhost \
+   PB_ADMIN_EMAIL=admin@example.com \
+   PB_ADMIN_PASSWORD='change-this-password' \
+   ./scripts/setup-pocketbase-collections.sh
+   ```
+3. To use the admin UI, temporarily publish PocketBase on localhost only:
+   ```yaml
+   ports:
+     - "443:443"
+     - "80:80"
+     - "127.0.0.1:8090:8090"
+   ```
+   Restart, open **http://127.0.0.1:8090/_/**, then remove the port mapping when setup is complete.
+4. Optionally configure OAuth providers under **Settings → Auth providers** in the local admin dashboard.
 
 ## Test the App
 
@@ -69,11 +80,11 @@ curl -ks https://localhost/ | head -5
 # PocketBase API responds on same origin
 curl -ks https://localhost/api/health
 
-# PocketBase admin is accessible
+# PocketBase admin is not exposed on the app origin
 curl -ks -o /dev/null -w "%{http_code}" https://localhost/_/
 ```
 
-All three should return `200` from the same `https://localhost` origin.
+The static site and API should return `200` from the same `https://localhost` origin. The admin check should return `404` unless you temporarily publish `127.0.0.1:8090:8090`.
 
 ## Useful Commands
 
@@ -174,7 +185,7 @@ Then access the app at `https://localhost:8443`.
 
 ### PocketBase admin not loading
 
-Wait a few seconds after container start — PocketBase needs time to initialize on first run. Check logs:
+The admin dashboard is not exposed through `https://localhost/_/` by default. Temporarily add `127.0.0.1:8090:8090` to `ports`, restart, and open `http://127.0.0.1:8090/_/`. If the local port still does not respond, wait a few seconds after container start and check logs:
 
 ```bash
 docker compose logs -f

--- a/lib/browser-cache.ts
+++ b/lib/browser-cache.ts
@@ -1,0 +1,25 @@
+const APP_CACHE_PREFIX = "gsd-";
+
+/**
+ * Delete Cache Storage entries created by this app's service worker.
+ */
+export async function clearAppCaches(): Promise<string[]> {
+	if (typeof globalThis === "undefined" || !("caches" in globalThis)) {
+		return [];
+	}
+
+	const cacheStorage = globalThis.caches;
+	const cacheNames = await cacheStorage.keys();
+	const appCacheNames = cacheNames.filter((name) =>
+		name.startsWith(APP_CACHE_PREFIX),
+	);
+
+	const deleted = await Promise.all(
+		appCacheNames.map(async (name) => {
+			const wasDeleted = await cacheStorage.delete(name);
+			return wasDeleted ? name : null;
+		}),
+	);
+
+	return deleted.filter((name): name is string => name !== null);
+}

--- a/lib/sw-cache-logic.ts
+++ b/lib/sw-cache-logic.ts
@@ -15,8 +15,21 @@ export function classifyRequest(
 	acceptHeader: string | null,
 	isSameOrigin: boolean,
 	method: string,
+	hasAuthorizationHeader = false,
+	cacheMode: string | null = null,
 ): CacheClassification {
 	if (method !== "GET" || !isSameOrigin) {
+		return "passthrough";
+	}
+
+	if (
+		hasAuthorizationHeader ||
+		cacheMode === "no-store" ||
+		pathname === "/api" ||
+		pathname.startsWith("/api/") ||
+		pathname === "/_" ||
+		pathname.startsWith("/_/")
+	) {
 		return "passthrough";
 	}
 
@@ -33,7 +46,19 @@ export function classifyRequest(
 		return "pages";
 	}
 
-	return "runtime";
+	if (isRuntimeAsset(pathname)) {
+		return "runtime";
+	}
+
+	return "passthrough";
+}
+
+function isRuntimeAsset(pathname: string): boolean {
+	return (
+		pathname === "/manifest.json" ||
+		pathname === "/favicon.svg" ||
+		pathname.startsWith("/icons/")
+	);
 }
 
 export function getCacheNames(

--- a/lib/sync/config/disable.ts
+++ b/lib/sync/config/disable.ts
@@ -9,6 +9,7 @@ import { clearPocketBase } from "../pocketbase-client";
 import type { PBSyncConfig } from "../types";
 import { getSyncConfig } from "./get-set";
 import { createLogger } from "@/lib/logger";
+import { clearAppCaches } from "@/lib/browser-cache";
 
 const logger = createLogger('SYNC_CONFIG');
 
@@ -58,6 +59,21 @@ async function resetSyncConfigState(current: PBSyncConfig): Promise<void> {
   await db.syncHistory.clear();
 }
 
+async function clearBrowserCaches(): Promise<void> {
+  try {
+    const clearedCaches = await clearAppCaches();
+    if (clearedCaches.length > 0) {
+      logger.info('Cleared app caches during sync disable', {
+        clearedCacheCount: clearedCaches.length,
+      });
+    }
+  } catch (err) {
+    logger.warn('Failed to clear app caches during sync disable', {
+      errorMessage: err instanceof Error ? err.message : 'Unknown error',
+    });
+  }
+}
+
 /**
  * Disable sync (logout)
  */
@@ -65,6 +81,8 @@ export async function disableSync(): Promise<void> {
   const current = await getSyncConfig();
 
   if (!current) {
+    clearPocketBase();
+    await clearBrowserCaches();
     return;
   }
 
@@ -73,6 +91,7 @@ export async function disableSync(): Promise<void> {
 
   // Clear PocketBase auth state (token + localStorage)
   clearPocketBase();
+  await clearBrowserCaches();
 
   // Reset config in IndexedDB
   await resetSyncConfigState(current);

--- a/public/sw-cache-logic.js
+++ b/public/sw-cache-logic.js
@@ -2,8 +2,26 @@
 // Loaded via importScripts() in sw.js (functions land on global scope).
 // Imported in tests via: require("../../public/sw-cache-logic")
 
-function classifyRequest(pathname, acceptHeader, isSameOrigin, method) {
+function classifyRequest(
+	pathname,
+	acceptHeader,
+	isSameOrigin,
+	method,
+	hasAuthorizationHeader,
+	cacheMode,
+) {
 	if (method !== "GET" || !isSameOrigin) {
+		return "passthrough";
+	}
+
+	if (
+		hasAuthorizationHeader ||
+		cacheMode === "no-store" ||
+		pathname === "/api" ||
+		pathname.startsWith("/api/") ||
+		pathname === "/_" ||
+		pathname.startsWith("/_/")
+	) {
 		return "passthrough";
 	}
 
@@ -20,7 +38,19 @@ function classifyRequest(pathname, acceptHeader, isSameOrigin, method) {
 		return "pages";
 	}
 
-	return "runtime";
+	if (isRuntimeAsset(pathname)) {
+		return "runtime";
+	}
+
+	return "passthrough";
+}
+
+function isRuntimeAsset(pathname) {
+	return (
+		pathname === "/manifest.json" ||
+		pathname === "/favicon.svg" ||
+		pathname.startsWith("/icons/")
+	);
 }
 
 function getCacheNames(cacheVersion, immutableVersion) {

--- a/public/sw.js
+++ b/public/sw.js
@@ -72,12 +72,14 @@ self.addEventListener("fetch", (event) => {
 	}
 
 	const requestUrl = new URL(request.url);
-	const isSameOrigin = requestUrl.hostname === self.location.hostname;
+	const isSameOrigin = requestUrl.origin === self.location.origin;
 	const classification = classifyRequest(
 		requestUrl.pathname,
 		request.headers.get("accept"),
 		isSameOrigin,
 		request.method,
+		request.headers.has("authorization"),
+		request.cache,
 	);
 
 	if (classification === "passthrough") {

--- a/tests/data/browser-cache.test.ts
+++ b/tests/data/browser-cache.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearAppCaches } from "@/lib/browser-cache";
+
+describe("clearAppCaches", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		Reflect.deleteProperty(globalThis, "caches");
+	});
+
+	it("deletes only app-owned Cache Storage entries", async () => {
+		const deleteCache = vi.fn().mockResolvedValue(true);
+		Object.defineProperty(globalThis, "caches", {
+			configurable: true,
+			value: {
+				keys: vi
+					.fn()
+					.mockResolvedValue([
+						"gsd-runtime-v9.3.7",
+						"gsd-pages-v9.3.7",
+						"workbox-precache-v2",
+					]),
+				delete: deleteCache,
+			},
+		});
+
+		await expect(clearAppCaches()).resolves.toEqual([
+			"gsd-runtime-v9.3.7",
+			"gsd-pages-v9.3.7",
+		]);
+		expect(deleteCache).toHaveBeenCalledTimes(2);
+		expect(deleteCache).not.toHaveBeenCalledWith("workbox-precache-v2");
+	});
+
+	it("returns empty when Cache Storage is unavailable", async () => {
+		await expect(clearAppCaches()).resolves.toEqual([]);
+	});
+});

--- a/tests/data/security-headers-policy.test.ts
+++ b/tests/data/security-headers-policy.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("CloudFront response headers policy", () => {
+	it("keeps CSP base and connection directives tight", () => {
+		const policyPath = resolve(
+			__dirname,
+			"../../cloudfront/response-headers-policy.json",
+		);
+		const policy = JSON.parse(readFileSync(policyPath, "utf-8"));
+		const csp =
+			policy.SecurityHeadersConfig.ContentSecurityPolicy.ContentSecurityPolicy;
+
+		expect(csp).toContain("base-uri 'none'");
+		expect(csp).toContain(
+			"connect-src 'self' https://api.vinny.io https://accounts.google.com https://github.com https://*.ingest.us.sentry.io",
+		);
+		expect(csp).not.toContain("connect-src 'self' https: wss:");
+		expect(csp).not.toContain("'unsafe-eval'");
+	});
+});

--- a/tests/data/sw-cache-logic.test.ts
+++ b/tests/data/sw-cache-logic.test.ts
@@ -64,6 +64,36 @@ describe("classifyRequest", () => {
 		);
 	});
 
+	it("should return passthrough for same-origin API requests", () => {
+		expect(
+			classifyRequest("/api/collections/tasks/records", null, true, "GET"),
+		).toBe("passthrough");
+	});
+
+	it("should return passthrough for PocketBase admin requests", () => {
+		expect(classifyRequest("/_/", "text/html", true, "GET")).toBe(
+			"passthrough",
+		);
+	});
+
+	it("should return passthrough for auth-bearing requests", () => {
+		expect(
+			classifyRequest("/manifest.json", null, true, "GET", true),
+		).toBe("passthrough");
+	});
+
+	it("should return passthrough for no-store requests", () => {
+		expect(
+			classifyRequest("/manifest.json", null, true, "GET", false, "no-store"),
+		).toBe("passthrough");
+	});
+
+	it("should return passthrough for unknown same-origin runtime requests", () => {
+		expect(classifyRequest("/robots.txt", null, true, "GET")).toBe(
+			"passthrough",
+		);
+	});
+
 	it("should return passthrough for cross-origin requests", () => {
 		expect(
 			classifyRequest("/api/collections/tasks", null, false, "GET"),
@@ -212,6 +242,12 @@ describe("source sync check", () => {
 		);
 		expect(js.classifyRequest("/api/x", null, false, "GET")).toBe(
 			classifyRequest("/api/x", null, false, "GET"),
+		);
+		expect(js.classifyRequest("/api/x", null, true, "GET")).toBe(
+			classifyRequest("/api/x", null, true, "GET"),
+		);
+		expect(js.classifyRequest("/robots.txt", null, true, "GET")).toBe(
+			classifyRequest("/robots.txt", null, true, "GET"),
 		);
 		expect(js.getCacheNames("1.0.0", 1)).toEqual(getCacheNames("1.0.0", 1));
 		expect(js.shouldDeleteCache("gsd-cache-v1", js.getCacheNames("2.0.0", 1))).toBe(

--- a/tests/data/sync/config.test.ts
+++ b/tests/data/sync/config.test.ts
@@ -35,6 +35,12 @@ vi.mock('@/lib/sync/pocketbase-client', () => ({
   clearPocketBase: vi.fn(),
 }));
 
+const mockClearAppCaches = vi.hoisted(() => vi.fn().mockResolvedValue([]));
+
+vi.mock('@/lib/browser-cache', () => ({
+  clearAppCaches: (...args: unknown[]) => mockClearAppCaches(...args),
+}));
+
 describe('Sync Config', () => {
   let db: ReturnType<typeof getDb>;
   const mockSyncConfig: PBSyncConfig = {
@@ -265,11 +271,20 @@ describe('Sync Config', () => {
       expect(clearPocketBase).toHaveBeenCalled();
     });
 
+    it('should clear app service worker caches', async () => {
+      mockClearAppCaches.mockResolvedValueOnce(['gsd-runtime-v9.3.7']);
+
+      await disableSync();
+
+      expect(mockClearAppCaches).toHaveBeenCalledTimes(1);
+    });
+
     it('should handle disabling when config does not exist', async () => {
       await db.syncMetadata.clear();
 
-      // Should not throw — disableSync returns early when config is null
+      // Should not throw — auth and browser caches are still cleared for privacy.
       await expect(disableSync()).resolves.not.toThrow();
+      expect(mockClearAppCaches).toHaveBeenCalledTimes(1);
     });
 
     it('should clear sync history (privacy on shared device)', async () => {

--- a/tests/ui/app-pages.test.tsx
+++ b/tests/ui/app-pages.test.tsx
@@ -156,7 +156,10 @@ describe('RootLayout', () => {
     const csp = document.querySelector('meta[http-equiv="Content-Security-Policy"]');
     expect(csp).toHaveAttribute('content', expect.stringContaining("form-action 'self'"));
     expect(csp).toHaveAttribute('content', expect.stringContaining("object-src 'none'"));
-    expect(csp).toHaveAttribute('content', expect.stringContaining("base-uri 'self'"));
+    expect(csp).toHaveAttribute('content', expect.stringContaining("base-uri 'none'"));
+    const cspContent = csp?.getAttribute('content') ?? '';
+    expect(cspContent).not.toContain("connect-src 'self' https: wss:");
+    expect(cspContent).toContain('https://api.vinny.io');
   });
 });
 


### PR DESCRIPTION
## Summary

- tighten service worker request classification so API, PocketBase admin, auth-bearing, no-store, and unknown same-origin requests bypass Cache Storage
- clear app-owned service worker caches when sync is disabled or logout cleanup runs
- narrow CSP/base-uri/connect-src policy across the app meta fallback, CloudFront policy, and security docs
- stop exposing the PocketBase admin UI through the public Docker app origin by default and update setup docs for localhost-only admin access

## Why

The security review identified privacy and exposure risks around broad service-worker runtime caching, stale browser-held data after logout/reset, permissive CSP connection/base directives, and Docker defaults that exposed PocketBase admin through the same public origin as the app.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test tests/data/sw-cache-logic.test.ts tests/data/browser-cache.test.ts tests/data/security-headers-policy.test.ts tests/data/sync/config.test.ts tests/ui/app-pages.test.tsx`
- `git diff --cached --check`