### PR TITLE
feat(logger): forward logger.error to Sentry with privacy-preserving masking

### DIFF
--- a/components/error-boundary.tsx
+++ b/components/error-boundary.tsx
@@ -3,7 +3,6 @@
 import { Component, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { createLogger } from "@/lib/logger";
-import { captureException } from "@/lib/sentry";
 
 const logger = createLogger("ERROR_BOUNDARY");
 
@@ -28,10 +27,8 @@ class ErrorBoundaryClass extends Component<ErrorBoundaryProps, ErrorBoundaryStat
 
   componentDidCatch(error: Error, errorInfo: unknown) {
     const info = errorInfo as { componentStack?: string } | undefined;
+    // logger.error forwards to Sentry; no separate captureException needed.
     logger.error("Error caught by boundary", error, {
-      componentStack: info?.componentStack ?? undefined,
-    });
-    captureException(error, {
       componentStack: info?.componentStack ?? undefined,
     });
   }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -21,6 +21,8 @@
  * ```
  */
 
+import { captureException, captureMessage } from '@/lib/sentry';
+
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 export type LogContext =
@@ -190,6 +192,71 @@ function formatLog(
 }
 
 /**
+ * Create a copy of an error with secrets masked from its message and stack.
+ * Sentry reads `message`/`stack` directly off the Error object, so masking the
+ * copy itself (not just metadata) is required to keep secrets off the wire.
+ * The caller's error is never mutated; the type name is preserved for grouping.
+ */
+function maskError(error: Error): Error {
+  const masked = new Error(maskSensitiveString(error.message));
+  masked.name = error.name;
+  masked.stack = error.stack ? maskSensitiveString(error.stack) : undefined;
+  return masked;
+}
+
+/**
+ * Diagnostic metadata keys that are safe to send to Sentry (an external SaaS).
+ * Allowlist, not denylist: anything not listed — task `input`, PocketBase
+ * `record`, etc. — is dropped so free-text user content never leaves the device.
+ */
+const SENTRY_SAFE_METADATA_KEYS: ReadonlySet<string> = new Set([
+  'correlationId', 'userId', 'taskId', 'deviceId', 'phase', 'operation',
+  'trigger', 'triggeredBy', 'validationErrors', 'componentStack', 'count',
+  'attempt', 'status', 'statusCode', 'type', 'url', 'timestamp',
+]);
+
+/**
+ * Build the Sentry context: the logger context name plus only the allowlisted,
+ * secret-masked diagnostic metadata. Content-bearing keys are stripped.
+ */
+function buildSentryContext(
+  context: LogContext,
+  metadata?: LogMetadata
+): Record<string, unknown> {
+  const allowed: LogMetadata = {};
+  for (const key of Object.keys(metadata ?? {})) {
+    if (SENTRY_SAFE_METADATA_KEYS.has(key)) {
+      allowed[key] = metadata![key];
+    }
+  }
+  return { context, ...(sanitizeMetadata(allowed) ?? {}) };
+}
+
+/**
+ * Forward an error log to Sentry. Errors with an Error object are captured as
+ * exceptions (using a masked copy); message-only errors as messages. Wrapped so
+ * a misconfigured Sentry can never turn an error-log into a thrown exception.
+ */
+function reportToSentry(
+  context: LogContext,
+  message: string,
+  error?: Error,
+  metadata?: LogMetadata
+): void {
+  try {
+    const sentryContext = buildSentryContext(context, metadata);
+
+    if (error) {
+      captureException(maskError(error), sentryContext);
+    } else {
+      captureMessage(maskSensitiveString(message), sentryContext);
+    }
+  } catch {
+    // Telemetry must never break the application's error path.
+  }
+}
+
+/**
  * Logger class with context-aware logging
  */
 export class Logger {
@@ -229,8 +296,9 @@ export class Logger {
   }
 
   /**
-   * Log error message with optional Error object
-   * Integrates with existing error-logger.ts for structured error tracking
+   * Log error message with optional Error object.
+   * Logs to the console (structured, masked) and forwards to Sentry so every
+   * `logger.error` call is captured for monitoring.
    */
   error(message: string, error?: Error, metadata?: LogMetadata): void {
     if (shouldLog('error', this.minLevel)) {
@@ -243,8 +311,7 @@ export class Logger {
 
       formatLog('error', this.context, message, errorMetadata);
 
-      // If this is a critical error that needs tracking, you can call error-logger.ts here
-      // For now, we'll just use console.error with structured format
+      reportToSentry(this.context, message, error, metadata);
     }
   }
 

--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -28,6 +28,22 @@ export function captureException(
   );
 }
 
+/**
+ * Capture a string message as an error-level Sentry event.
+ * Used for logged errors that carry no Error object (e.g. validation failures).
+ */
+export function captureMessage(
+  message: string,
+  context?: Record<string, unknown>
+): void {
+  if (!Sentry.getClient()) return;
+
+  Sentry.captureMessage(message, {
+    level: "error",
+    ...(context ? { contexts: { gsd: context } } : {}),
+  });
+}
+
 export function isInitialized(): boolean {
   return !!Sentry.getClient();
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.3.6",
+	"version": "9.4.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/data/logger.test.ts
+++ b/tests/data/logger.test.ts
@@ -6,6 +6,14 @@ import {
 	type LogMetadata,
 } from "@/lib/logger";
 
+const mockCaptureException = vi.hoisted(() => vi.fn());
+const mockCaptureMessage = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/sentry", () => ({
+	captureException: mockCaptureException,
+	captureMessage: mockCaptureMessage,
+}));
+
 describe("Logger module", () => {
 	let consoleDebugSpy: ReturnType<typeof vi.spyOn>;
 	let consoleLogSpy: ReturnType<typeof vi.spyOn>;
@@ -17,6 +25,8 @@ describe("Logger module", () => {
 		consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 		consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		mockCaptureException.mockClear();
+		mockCaptureMessage.mockClear();
 	});
 
 	afterEach(() => {
@@ -653,6 +663,138 @@ describe("Logger module", () => {
 					}),
 				}),
 			);
+		});
+	});
+
+	describe("Sentry forwarding", () => {
+		it("should forward logged errors to Sentry via captureException", () => {
+			const logger = createLogger("SYNC_ENGINE", "debug");
+			const error = new Error("Connection failed");
+
+			logger.error("sync failed", error, { phase: "push" });
+
+			expect(mockCaptureException).toHaveBeenCalledTimes(1);
+			expect(mockCaptureMessage).not.toHaveBeenCalled();
+			const [forwardedError, context] = mockCaptureException.mock.calls[0];
+			expect(forwardedError).toBeInstanceOf(Error);
+			expect((forwardedError as Error).message).toBe("Connection failed");
+			expect(context).toMatchObject({
+				context: "SYNC_ENGINE",
+				phase: "push",
+			});
+		});
+
+		it("should preserve the original error type name when forwarding to Sentry", () => {
+			class SyncError extends Error {
+				constructor(message: string) {
+					super(message);
+					this.name = "SyncError";
+				}
+			}
+
+			const logger = createLogger("SYNC_ENGINE", "debug");
+			logger.error("sync issue", new SyncError("timeout"));
+
+			const [forwardedError] = mockCaptureException.mock.calls[0];
+			expect((forwardedError as Error).name).toBe("SyncError");
+		});
+
+		it("should mask secrets in the error and context before forwarding to Sentry", () => {
+			const logger = createLogger("SYNC_ENGINE", "debug");
+			const error = new Error(
+				"auth failed token=abc123 with Bearer xyz789",
+			);
+
+			logger.error("login failed", error, {
+				url: "https://api.example.com?token=secret123",
+			});
+
+			const [forwardedError, context] = mockCaptureException.mock.calls[0];
+			const masked = forwardedError as Error;
+			expect(masked.message).not.toContain("abc123");
+			expect(masked.message).toContain("token=***");
+			expect(masked.message).toContain("Bearer ***");
+			expect(masked.stack ?? "").not.toContain("abc123");
+			expect((context as Record<string, unknown>).url).toBe(
+				"https://api.example.com?token=***",
+			);
+		});
+
+		it("should forward message-only errors to Sentry via captureMessage", () => {
+			const logger = createLogger("SYNC_RETRY", "debug");
+
+			logger.error("Cannot record failure: sync config not found");
+
+			expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
+			expect(mockCaptureException).not.toHaveBeenCalled();
+			const [message, context] = mockCaptureMessage.mock.calls[0];
+			expect(message).toBe("Cannot record failure: sync config not found");
+			expect(context).toMatchObject({ context: "SYNC_RETRY" });
+		});
+
+		it("should mask secrets in message-only forwards to Sentry", () => {
+			const logger = createLogger("SYNC_ENGINE", "debug");
+
+			logger.error("request failed with token=abc123");
+
+			const [message] = mockCaptureMessage.mock.calls[0];
+			expect(message).toBe("request failed with token=***");
+		});
+
+		it("should drop content-bearing metadata keys before forwarding to Sentry", () => {
+			const logger = createLogger("TASK_CRUD", "debug");
+
+			logger.error("Task validation failed", undefined, {
+				input: { title: "Call oncologist about results" },
+				validationErrors: "title required",
+			});
+
+			const [, context] = mockCaptureMessage.mock.calls[0];
+			const ctx = context as Record<string, unknown>;
+			expect(ctx).not.toHaveProperty("input");
+			expect(ctx.validationErrors).toBe("title required");
+			expect(ctx.context).toBe("TASK_CRUD");
+		});
+
+		it("should keep allowlisted diagnostic keys when forwarding to Sentry", () => {
+			const logger = createLogger("SYNC_PUSH", "debug");
+
+			logger.error("Push failed", new Error("boom"), {
+				taskId: "task-1",
+				phase: "push",
+				correlationId: "corr-9",
+				record: { title: "private note" },
+			});
+
+			const [, context] = mockCaptureException.mock.calls[0];
+			const ctx = context as Record<string, unknown>;
+			expect(ctx.taskId).toBe("task-1");
+			expect(ctx.phase).toBe("push");
+			expect(ctx.correlationId).toBe("corr-9");
+			expect(ctx).not.toHaveProperty("record");
+		});
+
+		it("should not forward debug, info, or warn logs to Sentry", () => {
+			const logger = createLogger("SYNC_ENGINE", "debug");
+
+			logger.debug("d");
+			logger.info("i");
+			logger.warn("w");
+
+			expect(mockCaptureException).not.toHaveBeenCalled();
+			expect(mockCaptureMessage).not.toHaveBeenCalled();
+		});
+
+		it("should not throw when Sentry forwarding fails", () => {
+			mockCaptureException.mockImplementationOnce(() => {
+				throw new Error("Sentry down");
+			});
+			const logger = createLogger("SYNC_ENGINE", "debug");
+
+			expect(() =>
+				logger.error("boom", new Error("real error")),
+			).not.toThrow();
+			expect(consoleErrorSpy).toHaveBeenCalled();
 		});
 	});
 

--- a/tests/data/sentry.test.ts
+++ b/tests/data/sentry.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockInit = vi.hoisted(() => vi.fn());
 const mockCaptureException = vi.hoisted(() => vi.fn());
+const mockCaptureMessage = vi.hoisted(() => vi.fn());
 const mockGetClient = vi.hoisted(() => vi.fn());
 
 vi.mock("@sentry/browser", () => ({
@@ -10,6 +11,7 @@ vi.mock("@sentry/browser", () => ({
     mockGetClient.mockReturnValue({});
   },
   captureException: mockCaptureException,
+  captureMessage: mockCaptureMessage,
   getClient: mockGetClient,
 }));
 
@@ -77,6 +79,31 @@ describe("Sentry wrapper", () => {
     captureException(new Error("test"), { action: "test" });
 
     expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it("should call Sentry.captureMessage with error level when initialized", async () => {
+    process.env.NEXT_PUBLIC_SENTRY_DSN = "https://key@sentry.io/123";
+
+    const { initSentry, captureMessage } = await import("@/lib/sentry");
+    initSentry();
+
+    captureMessage("something went wrong", { action: "test" });
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith("something went wrong", {
+      level: "error",
+      contexts: { gsd: { action: "test" } },
+    });
+  });
+
+  it("should not call Sentry.captureMessage when not initialized", async () => {
+    delete process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+    const { initSentry, captureMessage } = await import("@/lib/sentry");
+    initSentry();
+
+    captureMessage("noop", { action: "test" });
+
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
   });
 
   it("should report initialization state via isInitialized()", async () => {

--- a/tests/ui/error-boundary.test.tsx
+++ b/tests/ui/error-boundary.test.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary } from "@/components/error-boundary";
 
 vi.mock("@/lib/sentry", () => ({
   captureException: vi.fn(),
+  captureMessage: vi.fn(),
 }));
 
 const ThrowError = ({ shouldThrow }: { shouldThrow: boolean }) => {
@@ -88,7 +89,7 @@ describe("ErrorBoundary", () => {
     consoleError.mockRestore();
   });
 
-  it("should call captureException when error is caught", async () => {
+  it("should report the caught error to Sentry exactly once", async () => {
     const { captureException } = await import("@/lib/sentry");
     const mockCapture = vi.mocked(captureException);
     mockCapture.mockClear();
@@ -105,6 +106,8 @@ describe("ErrorBoundary", () => {
       </ErrorBoundary>
     );
 
+    // logger.error forwards to Sentry; the boundary must not double-report.
+    expect(mockCapture).toHaveBeenCalledTimes(1);
     expect(mockCapture).toHaveBeenCalledWith(
       expect.any(Error),
       expect.objectContaining({ componentStack: expect.anything() })


### PR DESCRIPTION
## What & why

`logger.error()` (the structured logger in `lib/logger.ts`) only wrote to `console.error` — its `error()` method literally carried the comment *"For now, we'll just use console.error."* So the bulk of the app's errors (all sync failures, task CRUD, notifications, and the unhandled-promise-rejection handler in `global-error-listener.tsx`) **never reached Sentry**. Only the separate `logError()` path did.

This wires Sentry into `Logger.error()` **once**, so all ~45 `logger.error` call sites are covered without touching each site.

## How it works

- **`lib/sentry.ts`** — new guarded `captureMessage()` (error-level; no-ops without a DSN) for message-only error logs.
- **`lib/logger.ts`** — `Logger.error()` forwards to Sentry:
  - With an `Error` → `captureException` using a **masked synthetic copy** (Sentry reads `.message`/`.stack` off the object, so the copy itself is scrubbed; `.name` preserved for grouping).
  - Message-only → `captureMessage` (masked).
  - **Privacy:** context is gated by an **allowlist** (`SENTRY_SAFE_METADATA_KEYS`) — diagnostic keys only (correlationId, taskId, phase, validationErrors, …). Content-bearing keys (`input`, `record`) are dropped so task titles/notes never leave the device. Consistent with the privacy-first posture.
  - Wrapped in try/catch so a misconfigured Sentry can never turn an error-log into a thrown exception.
- **`components/error-boundary.tsx`** — removed the now-redundant explicit `captureException` (would have double-reported).

## Scope / boundaries

- **MCP server intentionally excluded** — `packages/mcp-server/` uses its own `createMcpLogger` (stderr, Node runtime); `@sentry/browser` can't run there. Covering it would need `@sentry/node` + separate init (happy to do as a follow-up).
- **Judgment call:** `userId`/`deviceId` are in the allowlist for per-user/device error attribution — identifiers, not content.
- **Pre-existing, untouched:** the parallel `logError` path (`lib/error-logger.ts`) still sends raw error + context unmasked; the two Sentry paths now differ. Worth a future cleanup.

## How to test locally

- `bun run test` — full suite (1860 passing); new coverage in `tests/data/logger.test.ts`, `tests/data/sentry.test.ts`, `tests/ui/error-boundary.test.tsx`.
- `bun typecheck` and `bun lint` — clean.
- `bun run build` — succeeds (verifies the new `logger → sentry` import edge bundles).

## Notes

- TDD throughout (red → green per behavior).
- No new dependencies. No UI/markup changes (a11y-reviewed: 0 regressions).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->