### PR TITLE
fix(mcp): make the fatal error handler resilient to telemetry failure

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-mcp-server",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "MCP server for GSD Task Manager — 20 tools for task CRUD, analytics, and diagnostics over PocketBase. Validated inputs, dry-run support, JWT-aware token health, and dependency-safe deletes.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/src/__tests__/utils/sentry.test.ts
+++ b/packages/mcp-server/src/__tests__/utils/sentry.test.ts
@@ -126,6 +126,38 @@ describe('MCP Sentry wrapper', () => {
     expect(mockCaptureMessage).not.toHaveBeenCalled();
   });
 
+  it('should capture with fatal context and flush in reportFatal', async () => {
+    mockGetClient.mockReturnValue({});
+    const { reportFatal } = await import('../../utils/sentry.js');
+
+    await reportFatal(new Error('fatal boom'));
+
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    const [, opts] = mockCaptureException.mock.calls[0];
+    expect(opts).toEqual({
+      contexts: { gsd: { module: 'SERVER', phase: 'fatal' } },
+    });
+    expect(mockFlush).toHaveBeenCalled();
+  });
+
+  it('should not throw from reportFatal when captureException throws', async () => {
+    mockGetClient.mockReturnValue({});
+    mockCaptureException.mockImplementationOnce(() => {
+      throw new Error('sentry down');
+    });
+    const { reportFatal } = await import('../../utils/sentry.js');
+
+    await expect(reportFatal(new Error('fatal'))).resolves.toBeUndefined();
+  });
+
+  it('should not throw from reportFatal when flush rejects', async () => {
+    mockGetClient.mockReturnValue({});
+    mockFlush.mockImplementationOnce(() => Promise.reject(new Error('flush down')));
+    const { reportFatal } = await import('../../utils/sentry.js');
+
+    await expect(reportFatal(new Error('fatal'))).resolves.toBeUndefined();
+  });
+
   it('should mask Bearer tokens and token/apikey params in maskSecrets', async () => {
     const { maskSecrets } = await import('../../utils/sentry.js');
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -5,7 +5,7 @@ import { parseCLIArgs, showHelp, runSetupWizard, runValidation } from './cli.js'
 import { loadConfig } from './server/config.js';
 import { createServer, registerHandlers } from './server/setup.js';
 import { createMcpLogger } from './utils/logger.js';
-import { initSentry, captureException, flush } from './utils/sentry.js';
+import { initSentry, reportFatal } from './utils/sentry.js';
 
 const logger = createMcpLogger('SERVER');
 
@@ -60,9 +60,9 @@ async function main() {
 }
 
 main().catch(async (error) => {
-  captureException(error, { module: 'SERVER', phase: 'fatal' });
+  // Diagnostic first so it is never lost to a telemetry failure.
   console.error('Fatal error:', error);
-  // Flush queued events before exit (no-op unless Sentry is initialized).
-  await flush();
+  // Best-effort capture + flush; reportFatal is guaranteed not to throw.
+  await reportFatal(error);
   process.exit(1);
 });

--- a/packages/mcp-server/src/utils/sentry.ts
+++ b/packages/mcp-server/src/utils/sentry.ts
@@ -86,3 +86,17 @@ export function flush(timeoutMs = 2000): Promise<boolean> {
   if (!Sentry.getClient()) return Promise.resolve(true);
   return Sentry.flush(timeoutMs);
 }
+
+/**
+ * Best-effort fatal-error report: capture + flush, guaranteed not to throw.
+ * Used by the entry point so a telemetry failure can never swallow the final
+ * diagnostic or block the process exit.
+ */
+export async function reportFatal(error: unknown): Promise<void> {
+  try {
+    captureException(error, { module: 'SERVER', phase: 'fatal' });
+    await flush();
+  } catch {
+    // Telemetry must never break the fatal error path.
+  }
+}


### PR DESCRIPTION
## What & why

Follow-up to #327. A [Devin review on #327](https://github.com/vscarpenter/gsd-task-manager/pull/327) flagged a real bug in the MCP server's fatal error handler — but #327 merged at a stale commit (a GitHub PR-head sync glitch) **before this fix was included**, so the bug is currently on `main`.

**The bug:** `index.ts`'s `main().catch()` called `captureException` + `await flush()` **un-wrapped**. If either throws — a pathological error object with a throwing `.message`/`.stack` getter (hits `maskError`), or a `Sentry.flush()` rejection — the `console.error('Fatal error:', …)` diagnostic and `process.exit(1)` never run. The user loses the final diagnostic on the one path where it matters most, and the process can hang on an unhandled rejection. This violates the spec's own constraint: *"the forward must never throw on the error path."*

## Fix

- **`sentry.ts`** — add `reportFatal(error)`: best-effort `captureException` + `flush`, wrapped in try/catch so it's **guaranteed not to throw**.
- **`index.ts`** — log the `Fatal error:` diagnostic **first** (never lost), then `await reportFatal(error)`, then `process.exit(1)`.
- Moves the logic out of the coverage-excluded entry file into a unit-tested function.

## Tests

3 new tests (`sentry.test.ts`): `reportFatal` captures with fatal context + flushes; does not throw when `captureException` throws; does not throw when `flush` rejects. Full MCP suite: **130 passing**. `tsc` build: clean.

Version: `1.2.0 → 1.2.1` (patch).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->