### PR TITLE
fix(sync): downgrade transient sync failures from ERROR to WARN

### DIFF
--- a/docs/superpowers/plans/2026-05-18-github-ci-deploy-pipeline.md
+++ b/docs/superpowers/plans/2026-05-18-github-ci-deploy-pipeline.md
@@ -1,0 +1,228 @@
+# Plan: GitHub Actions CI/CD Deploy Pipeline
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-18 |
+| Status | **Proposed — awaiting review** |
+| Owner | vscarpenter |
+| Branch | `claude/github-ci-deploy-plan-Sbd9P` |
+
+---
+
+## 1. Context: What "deploy" looks like today
+
+There is **no `deploy.sh` at the repo root**. The current deployment surface is fragmented across four scripts and one `package.json` chain. Any CI design has to account for all of them:
+
+| Surface | Where | Targets | Trigger today |
+|---|---|---|---|
+| **Prod app deploy** | `package.json` → `deploy` (chains `deploy:s3` + `deploy:cf`) | `s3://gsd.vinny.dev`, CF `E1T6GDX0TQEP94`, `https://gsd.vinny.dev` | Manual `bun run deploy` from a dev's laptop |
+| **Dev app deploy** | `scripts/deploy-dev.sh` | `s3://gsd-dev.vinny.dev`, CF `E1HY1IKF5GT513`, `https://gsd-dev.vinny.dev` | Manual `bun run deploy:dev` |
+| **CloudFront Function** (URL rewrite + agent-discovery response headers) | `scripts/deploy-cloudfront-function.sh` | Two CF Functions attached to the prod distribution | Manual, only when `cloudfront-function-*.cjs` changes |
+| **Response Headers Policy** (CSP/HSTS/COOP/Permissions-Policy) | `scripts/deploy-cloudfront-response-headers-policy.sh` | `gsd-security-headers` policy referenced by the distribution | Manual, only when `cloudfront/response-headers-policy.json` changes |
+| **Discovery file content-types** | `scripts/fix-discovery-content-types.sh` | Called by both app deploys; rewrites S3 metadata on `.well-known/*` and markdown renditions | (Sub-step of app deploys) |
+
+**Shared shape of the two app deploys.** Both do the same five things in the same order:
+
+1. Clean (`rimraf .next out`) and build (`next build` → static export in `out/`).
+2. Sync non-HTML / non-`sw.js` assets with `Cache-Control: public,max-age=31536000,immutable`.
+3. Sync HTML and `sw.js` with `max-age=0,must-revalidate`.
+4. Force `no-cache,no-store,must-revalidate` on `index.html` (with explicit `Content-Type: text/html`).
+5. Run `fix-discovery-content-types.sh` to fix `.well-known/*` and markdown renditions, then create a `/*` CloudFront invalidation.
+
+**Important asymmetry.** The prod deploy is an inline bash one-liner inside `package.json` (`deploy:s3`). The dev deploy is a proper script (`scripts/deploy-dev.sh`). This is the first refactor any CI plan has to do, because CI needs to call the *same* logic for both environments.
+
+**Existing CI today.** No build/test/deploy CI. Five workflows exist:
+
+- `security-audit.yml` — `bun audit` on push/PR + nightly cron
+- `sonarcloud.yml` — coverage upload on push/PR to main
+- `claude-code-review.yml` / `claude.yml` — Claude automation
+- `publish-mcp-server.yml` — npm publish triggered by `mcp-v*.*.*` tags (uses OIDC `id-token: write` — useful reference pattern)
+
+**`.github/REPOSITORY_SETTINGS.md`** already declares the *intent* to require `typecheck`, `lint`, `test`, `build` as PR status checks, but no workflow currently produces them. That gap is in scope for this plan.
+
+---
+
+## 2. Goals & non-goals
+
+### Goals
+- Move prod and dev deploys off developer laptops into GitHub Actions.
+- Wire the four PR status checks declared in `REPOSITORY_SETTINGS.md` (`typecheck`, `lint`, `test`, `build`).
+- Use OIDC (no long-lived AWS keys in GitHub secrets) — same pattern as `publish-mcp-server.yml`.
+- Build the static export **exactly once** per deploy and promote that artifact, so dev and prod can deploy bit-identical bytes.
+- Add a smoke-test gate after deploy (curl the canonical URL, check `Content-Type` on a `.well-known/*` file) so a broken deploy fails loudly instead of silently.
+- Keep the CloudFront Function + Response Headers Policy deploys *separate* from app deploys (path-filtered, manual approval) — these can take the site down if misconfigured.
+
+### Non-goals (explicit)
+- **No rollback automation.** Out of scope for v1. S3 versioning + manual revert is acceptable for now; if we want automated rollback, that's a follow-up plan.
+- **No blue/green or canary deploys.** Static export to S3; not justified at this traffic level.
+- **No multi-region.** Single CloudFront distribution per environment.
+- **No replacing the existing manual `bun run deploy` escape hatch.** Devs keep the ability to deploy from a laptop if CI is down.
+- **No Docker self-hosted deploy automation.** `docker/docker-compose.yml` is for user self-hosting, not our infra.
+- **No changes to the MCP server publish workflow.** That's already CI'd and working.
+- **No PocketBase deployment.** Backend lives on AWS EC2 and is managed separately.
+
+---
+
+## 3. Options considered
+
+### Option A — Tag-based prod, push-to-main → dev (recommended)
+- Push to `main` → run CI (typecheck/lint/test/build) → on green, auto-deploy to dev.
+- Git tag matching `v*.*.*` → require approval → deploy to prod.
+- Mirrors `publish-mcp-server.yml`'s `mcp-v*.*.*` pattern; tag = explicit release intent.
+
+**Pros:** Every merge gets a real dev URL test surface for free. Prod requires deliberate action (tag + approval). One reviewer-controlled gate.
+**Cons:** Devs have to remember to tag. Hotfix flow is "tag, push tag, approve" — three steps.
+
+### Option B — Branch-based (`main` → dev, `release` → prod)
+- Push to `main` → dev. Merge `main` → `release` → prod.
+
+**Pros:** No tags to remember. Visible branch state.
+**Cons:** Extra branch to maintain. `release` becomes a long-lived branch with merge conflicts. Doesn't mesh with the existing tag-based MCP release flow.
+
+### Option C — Fully manual `workflow_dispatch`
+- Both dev and prod deploys triggered by manual button-press with environment input.
+
+**Pros:** Zero surprise deploys. Maximum control.
+**Cons:** Loses most of the value of CI deploy — devs still have to "do the deploy", just via a different button. PRs don't get auto-dev URLs.
+
+**Recommendation: Option A.** Matches existing conventions, gives the most leverage, keeps prod safe behind tags + GitHub Environment approval.
+
+---
+
+## 4. Proposed file & infra layout
+
+### 4.1 Refactor existing scripts (prerequisite — small PR)
+
+Hoist the inline `deploy:s3` one-liner out of `package.json` into a proper script, so dev and prod call identical code paths:
+
+- **New:** `scripts/deploy-app.sh` — parameterized version of `deploy-dev.sh` that takes env vars (`S3_BUCKET`, `CLOUDFRONT_ID`, `ENV_LABEL`, `SITE_URL`). Replaces the body of both `deploy-dev.sh` and the inline `deploy:s3`.
+- **Update:** `scripts/deploy-dev.sh` → thin wrapper that exports dev env vars and calls `scripts/deploy-app.sh`.
+- **Update:** `package.json` — `deploy:dev` and `deploy` both call the new script with their respective env vars. The 600-character `deploy:s3` one-liner goes away.
+
+This is a no-behavior-change refactor. It exists purely to give CI a single entry point and to make the bash testable.
+
+### 4.2 New `.github/workflows/` files
+
+| File | Trigger | Purpose |
+|---|---|---|
+| `ci.yml` | PR to `main`, push to `main` | Required status checks: `typecheck`, `lint`, `test`, `build`. Uploads the built `out/` as an artifact for downstream deploy jobs to consume. |
+| `deploy-dev.yml` | Push to `main` (after `ci.yml` succeeds via `workflow_run`), or manual `workflow_dispatch` | Downloads the `out/` artifact, syncs to dev S3, invalidates dev CF, runs smoke test. |
+| `deploy-prod.yml` | Tag push `v*.*.*` or manual `workflow_dispatch` with version input | Same as dev but for prod, gated by `environment: production` (GitHub-side approval). |
+| `deploy-cloudfront-infra.yml` | Push to `main` with path filter on `cloudfront-function-*.cjs`, `cloudfront/response-headers-policy.json`, or the relevant scripts. Always manual approval. | Runs `deploy-cloudfront-function.sh` and/or `deploy-cloudfront-response-headers-policy.sh` depending on which paths changed. |
+
+**Shared logic** lives in `.github/actions/build-static-export/action.yml` (composite action): checkout → setup Bun → `bun install --frozen-lockfile` → cache `.next/cache` → `bun run build` → upload `out/` artifact. Both `ci.yml` and the deploy workflows reuse it.
+
+### 4.3 GitHub Environments
+
+| Environment | Purpose | Protections |
+|---|---|---|
+| `development` | Holds `AWS_DEPLOY_ROLE_ARN`, `S3_BUCKET=gsd-dev.vinny.dev`, `CLOUDFRONT_ID=E1HY1IKF5GT513`, `SITE_URL=https://gsd-dev.vinny.dev` | None (auto-deploy on main) |
+| `production` | Holds prod equivalents (`E1T6GDX0TQEP94`, `gsd.vinny.dev`) | **Required reviewer = vscarpenter.** Wait timer optional. |
+| `cloudfront-infra` | Same prod role | **Required reviewer.** Separate from `production` so an app deploy doesn't accidentally re-publish a CF Function. |
+
+Putting the bucket/distribution IDs in environment-scoped variables (not workflow YAML) is what lets one workflow file serve both envs without `if: github.ref == ...` branching.
+
+### 4.4 AWS IAM (you have to create these — not in repo)
+
+Two IAM roles (one per environment), each with:
+
+- **Trust policy:** GitHub OIDC provider, conditioned on `repo:vscarpenter/gsd-task-manager:environment:development` (or `:production`, `:cloudfront-infra`).
+- **Permissions for app deploy roles:**
+  - `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket`, `s3:GetObject` on the specific bucket ARN
+  - `cloudfront:CreateInvalidation` on the specific distribution ARN
+- **Additional permissions for `cloudfront-infra` role:**
+  - `cloudfront:CreateFunction`, `UpdateFunction`, `DescribeFunction`, `PublishFunction`, `ListFunctions`
+  - `cloudfront:GetDistributionConfig`, `UpdateDistribution`
+  - `cloudfront:CreateResponseHeadersPolicy`, `UpdateResponseHeadersPolicy`, `GetResponseHeadersPolicy`, `ListResponseHeadersPolicies`
+
+I'll document these as a `docs/ops/github-actions-iam.md` runbook when we implement.
+
+---
+
+## 5. Smoke test (the gate that catches "deploy succeeded but site is broken")
+
+After the S3 sync + CF invalidation, before declaring the job green, the deploy workflow runs a small bash check:
+
+1. `curl -fsS -o /dev/null ${SITE_URL}/` (200)
+2. `curl -fsS ${SITE_URL}/sw.js | head -c 100 | grep -q "GSD"` (service worker served, not the SPA fallback)
+3. `curl -fsSI ${SITE_URL}/.well-known/api-catalog | grep -i "^content-type: application/linkset+json"` (proves `fix-discovery-content-types.sh` ran)
+4. `curl -fsSI ${SITE_URL}/ | grep -i "^cache-control:.*no-cache"` (proves the index.html no-cache step worked)
+
+These are the four things that have historically silently broken. Cheap to check, expensive to miss.
+
+---
+
+## 6. Implementation phases
+
+Each phase is one PR, small enough to review.
+
+### Phase 1 — Script refactor (no CI yet)
+- Extract `scripts/deploy-app.sh` parameterized by env vars.
+- Update `scripts/deploy-dev.sh` to be a thin wrapper.
+- Update `package.json` — remove `deploy:s3` one-liner, route `deploy` through the new script.
+- Run `bun run deploy:dev` manually once to verify byte-identical behavior.
+- **Acceptance:** `bun run deploy:dev` produces the same S3 state as before. Diff `aws s3 ls --recursive` output before/after.
+
+### Phase 2 — `ci.yml` (PR gates only, no deploy)
+- Add `.github/actions/build-static-export/action.yml` composite action.
+- Add `ci.yml` running typecheck, lint, test, build as parallel jobs.
+- Update `.github/REPOSITORY_SETTINGS.md` with exact required-check job names.
+- Manually enable required checks in repo settings.
+- **Acceptance:** A new PR shows four green checks. A PR that breaks `bun typecheck` is blocked.
+
+### Phase 3 — `deploy-dev.yml`
+- Create `development` GitHub Environment with vars + OIDC role ARN.
+- Add workflow triggered by `workflow_run` after `ci.yml` succeeds on `main`, plus `workflow_dispatch`.
+- Implement smoke test (Section 5).
+- **Acceptance:** Merge a no-op PR to main → dev URL serves the new build within ~5 minutes. Smoke test passes.
+
+### Phase 4 — `deploy-prod.yml`
+- Create `production` GitHub Environment with required reviewer.
+- Add workflow triggered by `v*.*.*` tag push + manual dispatch.
+- Same smoke test, pointed at prod URL.
+- **Acceptance:** Tag a release → reviewer gets prompted → on approval, prod deploys + smoke-tests green.
+
+### Phase 5 — `deploy-cloudfront-infra.yml`
+- Create `cloudfront-infra` environment with required reviewer.
+- Path-filtered workflow that conditionally runs each of the two infra scripts based on which file changed.
+- **Acceptance:** Edit `cloudfront/response-headers-policy.json` on a branch → merge to main → CI shows the infra workflow waiting for approval → on approval, policy updates.
+
+### Phase 6 — Remove the manual deploy fallback? (optional, post-bake)
+- After 2-4 weeks of green CI deploys, decide whether to remove `bun run deploy` / `bun run deploy:dev` from `package.json` or keep them as escape hatches. Recommend **keep**, but document in README that CI is the supported path.
+
+---
+
+## 7. Open decisions (need your input before Phase 1)
+
+1. **Did you mean a specific deploy script?** This plan covers all four deploy surfaces. If you wanted just one (e.g. only `deploy-dev.sh`), I can narrow Phases 3-5.
+2. **Trigger model.** Option A (tag-based prod, auto-dev) recommended. Confirm, or switch to B/C.
+3. **Prod approval reviewer.** GitHub Environment "required reviewers" needs at least one GitHub user/team. Assume `vscarpenter` solo?
+4. **Tag naming for app releases.** `v*.*.*` (matches package.json `version: 9.1.10`) — but the MCP server uses `mcp-v*.*.*`. Confirm `v*.*.*` won't collide with anything else.
+5. **CloudFront infra workflow — split or combined?** One workflow that runs both infra scripts on a path-matched change, or two separate workflows? Plan above assumes one; happy to split.
+6. **Smoke test failure handling.** If smoke test fails after a successful deploy, do we (a) just fail the job and alert (current plan), or (b) attempt to roll back by re-syncing the previous artifact? (b) is more work — recommend (a) for v1.
+7. **Concurrency.** Plan adds `concurrency: group: deploy-${{ env }}, cancel-in-progress: false` so back-to-back merges queue rather than race. Confirm `cancel-in-progress: false` (safer) vs `true` (faster).
+
+---
+
+## 8. What I will NOT do without explicit go-ahead
+
+- Create the IAM roles in AWS (you own that account; I'd give you the trust + permission JSON to paste).
+- Enable required status checks in GitHub repo settings (one-click step you should do manually after Phase 2).
+- Delete `bun run deploy` from `package.json` (Phase 6 is opt-in).
+- Touch the MCP server publish workflow.
+- Modify the docker-compose self-host deploy.
+
+---
+
+## 9. Estimated effort
+
+| Phase | LOC | Review time |
+|---|---|---|
+| 1. Script refactor | ~80 lines bash + package.json edit | 15 min |
+| 2. `ci.yml` + composite action | ~120 lines YAML | 20 min |
+| 3. `deploy-dev.yml` | ~80 lines YAML | 15 min |
+| 4. `deploy-prod.yml` | ~80 lines YAML (mostly copy of dev) | 10 min |
+| 5. `deploy-cloudfront-infra.yml` | ~100 lines YAML | 20 min |
+| **Total** | ~460 lines | ~80 min review across 5 PRs |
+
+Each PR is under the 400-LOC ceiling from `coding-standards.md` Part 5.

--- a/lib/sync/error-categorizer.ts
+++ b/lib/sync/error-categorizer.ts
@@ -58,6 +58,31 @@ export function isAuthError(error: Error): boolean {
 }
 
 /**
+ * Should this failure be treated as transient operational noise?
+ *
+ * Returns true for errors the retry/backoff machinery already handles
+ * (network blips, 5xx, 429, PocketBase SDK `status === 0`). Callers use
+ * this to choose WARN over ERROR log severity so error-monitoring tools
+ * are not flooded with handled events from offline-leg syncs and brief
+ * backend hiccups.
+ *
+ * Returns false for unknown errors so genuinely new failure modes still
+ * surface as ERROR for investigation.
+ */
+export function isTransientSyncFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+
+  // PocketBase ClientResponseError exposes a numeric `status` field; a 0
+  // means the fetch never produced an HTTP response (network fault or
+  // aborted request). This is the canonical "ClientResponseError 0:
+  // Something went wrong." signature and is purely operational noise.
+  const status = (error as { status?: unknown }).status;
+  if (typeof status === 'number' && status === 0) return true;
+
+  return isTransientError(error);
+}
+
+/**
  * Check if error is permanent (400/404/validation)
  */
 export function isPermanentError(error: Error): boolean {

--- a/lib/sync/error-categorizer.ts
+++ b/lib/sync/error-categorizer.ts
@@ -130,6 +130,14 @@ export function sanitizeSyncError(error: unknown): SyncErrorCode {
     return 'unknown_error';
   }
 
+  // PocketBase ClientResponseError surfaces network faults as `status === 0`
+  // with a generic "Something went wrong." message. Detect via the structured
+  // status field rather than the (unreliable) message text.
+  const status = (error as { status?: unknown }).status;
+  if (typeof status === 'number' && status === 0) {
+    return 'network_error';
+  }
+
   const message = error.message.toLowerCase();
 
   // Rate limit must be checked first — 429 contains '4' and the validation

--- a/lib/sync/pb-push.ts
+++ b/lib/sync/pb-push.ts
@@ -10,7 +10,7 @@ import { getSyncQueue } from './queue';
 import { taskRecordToPocketBase } from './task-mapper';
 import { createLogger } from '@/lib/logger';
 import { THROTTLE_MS, delay, getDeviceId, getCurrentUserId, fetchRemoteTaskIndex } from './pb-sync-helpers';
-import { sanitizeSyncError } from './error-categorizer';
+import { sanitizeSyncError, isTransientSyncFailure } from './error-categorizer';
 import type { SyncQueueItem, RemoteTaskIndexEntry } from './types';
 
 const logger = createLogger('SYNC_ENGINE');
@@ -211,11 +211,20 @@ export async function pushLocalChanges(): Promise<PushResult> {
       // which (for 4xx responses) can echo task content back from PocketBase.
       const errorCode = sanitizeSyncError(error);
       lastError = errorCode;
-      logger.error('Push failed for item', error instanceof Error ? error : new Error(String(error)), {
-        taskId: item.taskId,
-        operation: item.operation,
-        errorCode,
-      });
+      const errorObj = error instanceof Error ? error : new Error(String(error));
+      if (isTransientSyncFailure(errorObj)) {
+        logger.warn('Push failed for item (transient)', {
+          taskId: item.taskId,
+          operation: item.operation,
+          errorCode,
+        });
+      } else {
+        logger.error('Push failed for item', errorObj, {
+          taskId: item.taskId,
+          operation: item.operation,
+          errorCode,
+        });
+      }
       await queue.recordAttemptFailure(item.id, errorCode);
 
       // 429 means the server is under load. Abort the push loop early so

--- a/lib/sync/pb-sync-engine.ts
+++ b/lib/sync/pb-sync-engine.ts
@@ -11,6 +11,7 @@ import { createLogger } from '@/lib/logger';
 import { getRetryManager } from './retry-manager';
 import { recordSyncSuccess, recordSyncError, recordSyncPartial } from '@/lib/sync-history';
 import { notifySyncSuccess, notifySyncError } from './notifications';
+import { isTransientSyncFailure } from './error-categorizer';
 import { getDeviceId } from './pb-sync-helpers';
 import { pushLocalChanges } from './pb-push';
 import { pullRemoteChanges } from './pb-pull';
@@ -174,6 +175,10 @@ async function reportSyncError(
   await retryManager.recordFailure(errorObj);
   await recordSyncError(errorObj.message, deviceId, triggeredBy, Date.now() - startTime);
   notifySyncError(errorObj.message, false);
-  logger.error('Full sync failed', errorObj, { triggeredBy });
+  if (isTransientSyncFailure(errorObj)) {
+    logger.warn('Full sync failed (transient)', { triggeredBy, errorMessage: errorObj.message });
+  } else {
+    logger.error('Full sync failed', errorObj, { triggeredBy });
+  }
   return { status: 'error', error: errorObj.message };
 }

--- a/lib/sync/sync-coordinator.ts
+++ b/lib/sync/sync-coordinator.ts
@@ -8,6 +8,7 @@
 
 import { fullSync } from './pb-sync-engine';
 import { getRetryManager } from './retry-manager';
+import { isTransientSyncFailure } from './error-categorizer';
 import type { PBSyncResult, PBSyncConfig } from './types';
 import { getDb } from '@/lib/db';
 import { createLogger } from '@/lib/logger';
@@ -130,10 +131,15 @@ export class SyncCoordinator {
       this.lastResult = result;
       logger.info('Sync completed', { status: result.status });
     } catch (error) {
-      logger.error('Sync failed', error instanceof Error ? error : new Error(String(error)));
+      const errorObj = error instanceof Error ? error : new Error(String(error));
+      if (isTransientSyncFailure(errorObj)) {
+        logger.warn('Sync failed (transient)', { errorMessage: errorObj.message });
+      } else {
+        logger.error('Sync failed', errorObj);
+      }
       this.lastResult = {
         status: 'error',
-        error: error instanceof Error ? error.message : 'Sync failed',
+        error: errorObj.message,
       };
     } finally {
       this.isRunning = false;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,6 +2,16 @@
 
 ---
 
+## Pending plan — 2026-05-18: GitHub Actions CI/CD deploy pipeline
+
+Move dev + prod app deploys off laptops into GitHub Actions (OIDC, no long-lived keys), wire the `typecheck`/`lint`/`test`/`build` PR status checks already declared in `REPOSITORY_SETTINGS.md`, and gate CloudFront infra changes behind manual approval. 5-phase rollout, one PR per phase.
+
+Full plan: `docs/superpowers/plans/2026-05-18-github-ci-deploy-pipeline.md`
+
+Status: **Proposed — awaiting review.** Open decisions in §7 of the plan.
+
+---
+
 ## Pending plan — 2026-05-18: Codex adversarial review fixes
 
 5-PR plan addressing silent data-loss paths in sync/MCP/import.

--- a/tests/data/sync/error-categorizer.test.ts
+++ b/tests/data/sync/error-categorizer.test.ts
@@ -136,6 +136,15 @@ describe('error-categorizer', () => {
       expect(sanitizeSyncError(new Error('Request timeout'))).toBe('network_error');
     });
 
+    it('returns network_error for PocketBase ClientResponseError status 0', () => {
+      // PB SDK reports network faults with `status === 0` and a generic
+      // "Something went wrong." message. Detect via the structured field.
+      const pbError = Object.assign(new Error('Something went wrong.'), {
+        status: 0,
+      });
+      expect(sanitizeSyncError(pbError)).toBe('network_error');
+    });
+
     it('returns unknown_error for unrecognized errors', () => {
       expect(sanitizeSyncError(new Error('something broke'))).toBe('unknown_error');
     });

--- a/tests/data/sync/error-categorizer.test.ts
+++ b/tests/data/sync/error-categorizer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   categorizeError,
   isTransientError,
+  isTransientSyncFailure,
   isAuthError,
   isPermanentError,
   sanitizeSyncError,
@@ -155,6 +156,71 @@ describe('error-categorizer', () => {
       expect(sanitizeSyncError(null)).toBe('unknown_error');
       expect(sanitizeSyncError(undefined)).toBe('unknown_error');
       expect(sanitizeSyncError({ message: 'an object' })).toBe('unknown_error');
+    });
+  });
+
+  describe('isTransientSyncFailure', () => {
+    it('returns true for PocketBase ClientResponseError with status 0 (network fault)', () => {
+      // Mirrors the PB SDK shape: Error subclass with a numeric `status` field.
+      // status === 0 means the fetch produced no HTTP response.
+      const pbError = Object.assign(new Error('Something went wrong.'), {
+        status: 0,
+        isAbort: false,
+      });
+      expect(isTransientSyncFailure(pbError)).toBe(true);
+    });
+
+    it('returns true for aborted PB SDK requests (status 0, isAbort true)', () => {
+      const pbAbort = Object.assign(new Error('The request was aborted.'), {
+        status: 0,
+        isAbort: true,
+      });
+      expect(isTransientSyncFailure(pbAbort)).toBe(true);
+    });
+
+    it('returns true for known transient text patterns', () => {
+      expect(isTransientSyncFailure(new Error('Network error'))).toBe(true);
+      expect(isTransientSyncFailure(new Error('Request timeout'))).toBe(true);
+      expect(isTransientSyncFailure(new Error('500 Internal Server Error'))).toBe(true);
+      expect(isTransientSyncFailure(new Error('502 Bad Gateway'))).toBe(true);
+      expect(isTransientSyncFailure(new Error('429 Too Many Requests'))).toBe(true);
+    });
+
+    it('returns false for auth errors (still need ERROR-level visibility)', () => {
+      expect(isTransientSyncFailure(new Error('401 Unauthorized'))).toBe(false);
+      expect(isTransientSyncFailure(new Error('403 Forbidden'))).toBe(false);
+      expect(isTransientSyncFailure(new Error('Token expired'))).toBe(false);
+    });
+
+    it('returns false for permanent errors (validation, 4xx)', () => {
+      expect(isTransientSyncFailure(new Error('400 Bad Request'))).toBe(false);
+      expect(isTransientSyncFailure(new Error('404 Not Found'))).toBe(false);
+      expect(isTransientSyncFailure(new Error('422 Unprocessable'))).toBe(false);
+      expect(isTransientSyncFailure(new Error('Validation failed'))).toBe(false);
+    });
+
+    it('returns false for unknown errors without status (preserve ERROR visibility)', () => {
+      // An unrecognized error should NOT be silently downgraded. The whole
+      // point of this helper is to suppress *known* transient noise; unknown
+      // failures must still surface as ERROR so they can be investigated.
+      expect(isTransientSyncFailure(new Error('Something exploded'))).toBe(false);
+    });
+
+    it('returns false for "Something went wrong" string without status field', () => {
+      // Match by `status === 0` only — text alone is too ambiguous to trust.
+      expect(isTransientSyncFailure(new Error('Something went wrong.'))).toBe(false);
+    });
+
+    it('returns false for non-Error inputs', () => {
+      expect(isTransientSyncFailure('string error')).toBe(false);
+      expect(isTransientSyncFailure(null)).toBe(false);
+      expect(isTransientSyncFailure(undefined)).toBe(false);
+      expect(isTransientSyncFailure({ status: 0 })).toBe(false);
+    });
+
+    it('ignores non-numeric status values', () => {
+      const weird = Object.assign(new Error('weird'), { status: '0' });
+      expect(isTransientSyncFailure(weird)).toBe(false);
     });
   });
 

--- a/tests/data/sync/pb-push.test.ts
+++ b/tests/data/sync/pb-push.test.ts
@@ -231,6 +231,78 @@ describe('pushLocalChanges LWW guard', () => {
     expect(await getSyncQueue().getPendingCount()).toBe(0);
   });
 
+  it('records a transient PB ClientResponseError as network_error without crashing the loop', async () => {
+    // Per-item catch: when the SDK's update() rejects with a status-0
+    // ClientResponseError, the loop logs WARN, records the failure with a
+    // sanitized error code, and continues. This exercises the WARN branch
+    // of the catch handler.
+    const payload = makeTask('t1', '2026-05-18T12:00:00.000Z');
+    await getSyncQueue().enqueue('update', 't1', payload);
+
+    fetchRemoteTaskIndexMock.mockResolvedValue({
+      index: new Map([
+        ['t1', { pbRecordId: 'rec-1', clientUpdatedAt: '2026-05-18T11:00:00.000Z' }],
+      ]),
+      fetchSucceeded: true,
+    });
+
+    const pbNetworkError = Object.assign(new Error('Something went wrong.'), {
+      status: 0,
+      isAbort: false,
+    });
+    const updateSpy = vi.fn(async () => {
+      throw pbNetworkError;
+    });
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({ create: vi.fn(), update: updateSpy, delete: vi.fn() }),
+    });
+
+    const result = await pushLocalChanges();
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(result.pushedCount).toBe(0);
+    expect(result.failedCount).toBe(1);
+    expect(result.lastError).toBe('network_error');
+    // Item should remain queued for a future retry.
+    expect(await getSyncQueue().getPendingCount()).toBe(1);
+  });
+
+  it('records a permanent validation error via the ERROR log branch', async () => {
+    // Per-item catch: a 422 validation error is non-transient and goes
+    // through the ERROR log branch. The error code is still sanitized so
+    // task content never leaks into the persisted lastError field.
+    const payload = makeTask('t1', '2026-05-18T12:00:00.000Z');
+    await getSyncQueue().enqueue('update', 't1', payload);
+
+    fetchRemoteTaskIndexMock.mockResolvedValue({
+      index: new Map([
+        ['t1', { pbRecordId: 'rec-1', clientUpdatedAt: '2026-05-18T11:00:00.000Z' }],
+      ]),
+      fetchSucceeded: true,
+    });
+
+    const validationError = Object.assign(
+      new Error("422 failed to validate field 'title'"),
+      { status: 422 },
+    );
+    const updateSpy = vi.fn(async () => {
+      throw validationError;
+    });
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({ create: vi.fn(), update: updateSpy, delete: vi.fn() }),
+    });
+
+    const result = await pushLocalChanges();
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(result.pushedCount).toBe(0);
+    expect(result.failedCount).toBe(1);
+    expect(result.lastError).toBe('validation_failed');
+    // Crucially, the persisted lastError must NEVER echo task field names
+    // or values that the 4xx response body might have included.
+    expect(result.lastError).not.toContain('title');
+  });
+
   it('fails open and proceeds with the write when remote clientUpdatedAt is unparseable', async () => {
     // NaN contract: isRemoteNewer returns false on parse failure, so the
     // write must proceed rather than silently dropping the user's edit.

--- a/tests/data/sync/pb-sync-engine.test.ts
+++ b/tests/data/sync/pb-sync-engine.test.ts
@@ -237,5 +237,38 @@ describe('pb-sync-engine', () => {
       expect(result.error).toContain('Connection refused');
       expect(mockRetryManager.recordFailure).toHaveBeenCalled();
     });
+
+    it('reports non-transient errors via the ERROR log branch', async () => {
+      // A permanent (validation) error should NOT be treated as transient
+      // noise — it takes the ERROR-level branch in reportSyncError. All
+      // side-effects (recordFailure, recordSyncError) still fire identically.
+      const { pushLocalChanges } = await import('@/lib/sync/pb-push');
+      vi.mocked(pushLocalChanges).mockRejectedValueOnce(
+        new Error('422 Unprocessable Entity'),
+      );
+
+      const result = await fullSync();
+
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('422 Unprocessable Entity');
+      expect(mockRetryManager.recordFailure).toHaveBeenCalled();
+    });
+
+    it('reports PB ClientResponseError status 0 via the WARN log branch', async () => {
+      // PB SDK network fault — Error with `status: 0`. The reportSyncError
+      // function downgrades the log level to WARN but the returned result
+      // shape and side-effects remain unchanged.
+      const { pushLocalChanges } = await import('@/lib/sync/pb-push');
+      const pbNetworkError = Object.assign(new Error('Something went wrong.'), {
+        status: 0,
+      });
+      vi.mocked(pushLocalChanges).mockRejectedValueOnce(pbNetworkError);
+
+      const result = await fullSync();
+
+      expect(result.status).toBe('error');
+      expect(result.error).toBe('Something went wrong.');
+      expect(mockRetryManager.recordFailure).toHaveBeenCalled();
+    });
   });
 });

--- a/tests/sync/sync-coordinator.test.ts
+++ b/tests/sync/sync-coordinator.test.ts
@@ -272,5 +272,49 @@ describe('SyncCoordinator', () => {
       expect(status.lastResult?.status).toBe('error');
       expect(status.lastError).toBe('Network failure');
     });
+
+    it('records non-transient errors with full status / error message', async () => {
+      // A permanent error (validation) should NOT be downgraded to WARN — it
+      // takes the ERROR branch in executeSync's catch. Both branches still
+      // surface identical PBSyncResult shape.
+      mockFullSync.mockRejectedValueOnce(new Error('400 Bad Request: invalid'));
+
+      await coordinator.requestSync('user');
+
+      const status = await coordinator.getStatus();
+
+      expect(status.lastResult?.status).toBe('error');
+      expect(status.lastError).toBe('400 Bad Request: invalid');
+    });
+
+    it('records transient PB ClientResponseError status 0 (network fault)', async () => {
+      // PocketBase SDK signature: Error with `status: 0` and "Something went
+      // wrong." message. This is the case the Sentry noise fix targets.
+      const pbNetworkError = Object.assign(new Error('Something went wrong.'), {
+        status: 0,
+        isAbort: false,
+      });
+      mockFullSync.mockRejectedValueOnce(pbNetworkError);
+
+      await coordinator.requestSync('auto');
+
+      const status = await coordinator.getStatus();
+
+      expect(status.lastResult?.status).toBe('error');
+      expect(status.lastError).toBe('Something went wrong.');
+    });
+
+    it('handles non-Error thrown values from fullSync', async () => {
+      // Defensive path: the `error instanceof Error ? error : new Error(...)`
+      // guard converts non-Error throws into Error instances.
+      mockFullSync.mockRejectedValueOnce('plain string failure');
+
+      await coordinator.requestSync('auto');
+
+      const status = await coordinator.getStatus();
+
+      expect(status.lastResult?.status).toBe('error');
+      expect(status.lastError).toBe('plain string failure');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Resolves Sentry noise from `ClientResponseError 0: Something went wrong.` — PocketBase SDK's signature for a `fetch()` that produced no HTTP response (transient network drop, brief backend hiccup, aborted request).

- Add `isTransientSyncFailure()` in `lib/sync/error-categorizer.ts` that detects PB SDK `status === 0` plus known transient text patterns (5xx, 429, timeouts, ECONNREFUSED)
- Wire it into the three sync log sites — `sync-coordinator.executeSync` catch, `pb-sync-engine.reportSyncError`, and `pb-push` per-item catch — to choose `logger.warn` over `logger.error` for transient failures
- All side effects unchanged: retry counter, sync history, toast notifications, queue dequeue, and `PBSyncResult.status === 'error'` still happen identically

Unknown errors deliberately still log at ERROR so genuinely new failure modes stay visible.

## Root cause (from Sentry trace)

The error originates inside the PocketBase SDK fetch wrapper (`status = 0`), bubbles up through `pushLocalChanges`/`pullRemoteChanges` → `fullSync` → `SyncCoordinator.executeSync`. The coordinator's `try/catch` correctly handles it, but the `logger.error(...)` call inside the catch invokes `console.error` with the original `Error` object — which Sentry's `consoleIntegration` captures with the original throw stack intact. Result: every transient network blip becomes a Sentry event labeled `handled = yes / mechanism = generic`. There is no actual escape of an unhandled exception.

## Test plan

- [x] `bun run test tests/data/sync/` — 351/351 sync tests pass (added 9 new tests for `isTransientSyncFailure`)
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] Full suite: 1897/1897 unit tests pass (5 pre-existing Playwright/vitest e2e discovery failures unrelated to this change, present on baseline)
- [ ] Manual: throttle network in DevTools to "offline", trigger a sync, confirm console shows WARN instead of ERROR and that Sentry no longer reports the event
- [ ] Manual: trigger a real auth/validation failure and confirm those still log at ERROR


---
_Generated by [Claude Code](https://claude.ai/code/session_01UjcDMhtr77Ss4qZGVxZsNN)_