### PR TITLE
Fix iOS OAuth handoff and callback routing

### DIFF
--- a/.claude/rules/pocketbase-sync.md
+++ b/.claude/rules/pocketbase-sync.md
@@ -42,5 +42,6 @@ paths:
 
 If users hit `redirect_uri_mismatch` after a deploy:
 1. Check the `redirect_uri` registered in the provider (Google Cloud Console / GitHub OAuth App).
-2. Confirm it matches the exact origin used in production — including trailing slash and `www` vs apex.
-3. PB redirects back to `<your-app>/api/auth/oauth-callback` — verify that route exists in the static export.
+2. Confirm it matches the exact PocketBase origin used for auth — including trailing slash and `www` vs apex.
+3. The PocketBase JS SDK popup flow redirects to `<pocketbase-origin>/api/oauth2-redirect`. The static app does not own an `/api/auth/oauth-callback` route.
+4. Production CloudFront rewrites must pass `/api/*` and `/_/*` through unchanged so OAuth callback/admin paths are never turned into static `index.html` lookups.

--- a/cloudfront-function-url-rewrite.cjs
+++ b/cloudfront-function-url-rewrite.cjs
@@ -35,6 +35,18 @@ function handler(event) {
     return request;
   }
 
+  // API and PocketBase admin paths are not static-export routes. Leave them
+  // untouched so CloudFront origin behaviors can route them correctly instead
+  // of turning callback paths into `/index.html` lookups.
+  if (
+    uri === '/api' ||
+    uri.startsWith('/api/') ||
+    uri === '/_' ||
+    uri.startsWith('/_/')
+  ) {
+    return request;
+  }
+
   // 1. Resolve trailing-slash and extensionless paths to their `index.html`.
   if (uri.endsWith('/')) {
     request.uri = uri + 'index.html';

--- a/components/pwa-register.tsx
+++ b/components/pwa-register.tsx
@@ -16,6 +16,7 @@ export function PwaRegister() {
 			try {
 				const registration = await navigator.serviceWorker.register("/sw.js", {
 					scope: "/",
+					updateViaCache: "none",
 				});
 				logger.info('Service worker registered successfully');
 

--- a/components/sync/oauth-buttons.tsx
+++ b/components/sync/oauth-buttons.tsx
@@ -1,31 +1,68 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { loginWithGoogle, loginWithGithub, type AuthState } from "@/lib/sync/pb-auth";
+import {
+  cancelOAuthLogin,
+  loginWithGoogle,
+  loginWithGithub,
+  openOAuthPopup,
+  type AuthState,
+} from "@/lib/sync/pb-auth";
 
 interface OAuthButtonsProps {
-  onSuccess?: (authState: AuthState) => void;
+  onSuccess?: (authState: AuthState) => void | Promise<void>;
   onError?: (error: Error) => void;
   onStart?: (provider: "google" | "github") => void;
 }
 
 export function OAuthButtons({ onSuccess, onError, onStart }: OAuthButtonsProps) {
   const [loading, setLoading] = useState<"google" | "github" | null>(null);
+  const activeRequestKey = useRef<string | null>(null);
+  const mounted = useRef(true);
 
-  const handleOAuth = async (provider: "google" | "github") => {
+  useEffect(() => {
+    return () => {
+      mounted.current = false;
+      if (activeRequestKey.current) {
+        cancelOAuthLogin(activeRequestKey.current);
+      }
+    };
+  }, []);
+
+  const handleOAuth = (provider: "google" | "github") => {
+    const popupWindow = openOAuthPopup(provider);
+    const requestKey = createOAuthRequestKey(provider);
+    activeRequestKey.current = requestKey;
     setLoading(provider);
     onStart?.(provider);
 
+    void runOAuth(provider, requestKey, popupWindow);
+  };
+
+  const runOAuth = async (
+    provider: "google" | "github",
+    requestKey: string,
+    popupWindow: Window | null
+  ) => {
     try {
       const loginFn = provider === "google" ? loginWithGoogle : loginWithGithub;
-      const authState = await loginFn();
-      onSuccess?.(authState);
+      const authState = await loginFn({ requestKey, popupWindow });
+      if (mounted.current) {
+        await onSuccess?.(authState);
+      }
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
-      onError?.(err);
+      if (mounted.current) {
+        onError?.(err);
+      }
     } finally {
-      setLoading(null);
+      if (activeRequestKey.current === requestKey) {
+        activeRequestKey.current = null;
+      }
+      if (mounted.current) {
+        setLoading(null);
+      }
     }
   };
 
@@ -50,4 +87,13 @@ export function OAuthButtons({ onSuccess, onError, onStart }: OAuthButtonsProps)
       </Button>
     </div>
   );
+}
+
+function createOAuthRequestKey(provider: "google" | "github"): string {
+  const random =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+  return `oauth_${provider}_${random}`;
 }

--- a/components/sync/sync-auth-dialog-sections.tsx
+++ b/components/sync/sync-auth-dialog-sections.tsx
@@ -6,7 +6,7 @@ import type { AuthState } from "@/lib/sync/pb-auth";
 import type { SyncStatusInfo } from "./use-sync-auth-dialog";
 
 interface OAuthCallbacks {
-  onStart: () => void;
+  onStart: (provider: "google" | "github") => void;
   onSuccess: (authState: AuthState) => Promise<void>;
   onError: (err: Error) => void;
 }

--- a/components/sync/sync-auth-dialog.tsx
+++ b/components/sync/sync-auth-dialog.tsx
@@ -110,7 +110,7 @@ function getSubtitle(
 interface DialogBodyProps {
   state: ReturnType<typeof useSyncAuthDialog>;
   oauthCallbacks: {
-    onStart: () => void;
+    onStart: (provider: "google" | "github") => void;
     onSuccess: ReturnType<typeof useSyncAuthDialog>["handleOAuthSuccess"];
     onError: (err: Error) => void;
   };

--- a/components/sync/use-sync-auth-dialog.ts
+++ b/components/sync/use-sync-auth-dialog.ts
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { type AuthState, refreshAuth } from "@/lib/sync/pb-auth";
-import { isAuthenticated } from "@/lib/sync/pocketbase-client";
+import { getOAuthErrorMessage, type AuthState, refreshAuth } from "@/lib/sync/pb-auth";
+import { clearPocketBase, isAuthenticated } from "@/lib/sync/pocketbase-client";
 import { getSyncStatus, disableSync } from "@/lib/sync/config";
 import { getSyncQueue } from "@/lib/sync/queue";
 import { toast } from "sonner";
@@ -20,6 +20,10 @@ interface UseSyncAuthDialogProps {
   onSuccess?: () => void;
 }
 
+interface CancellationToken {
+  cancelled: boolean;
+}
+
 export function useSyncAuthDialog({ isOpen, onSuccess }: UseSyncAuthDialogProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -35,12 +39,12 @@ export function useSyncAuthDialog({ isOpen, onSuccess }: UseSyncAuthDialogProps)
   }, []);
 
   useEffect(() => {
-    let cancelled = false;
+    const cancellation: CancellationToken = { cancelled: false };
 
     if (isOpen) {
       setShowLogoutConfirm(false);
       setSessionExpired(false);
-      loadSyncStatus(cancelled, {
+      loadSyncStatus(cancellation, {
         setIsRefreshing,
         setSessionExpired,
         setSyncStatus,
@@ -48,15 +52,23 @@ export function useSyncAuthDialog({ isOpen, onSuccess }: UseSyncAuthDialogProps)
     }
 
     return () => {
-      cancelled = true;
+      cancellation.cancelled = true;
     };
   }, [isOpen]);
 
   const handleOAuthSuccess = async (authState: AuthState) => {
-    setIsLoading(false);
     setError(null);
 
-    await persistSyncConfig(authState);
+    try {
+      await persistSyncConfig(authState);
+    } catch (err) {
+      clearPocketBase();
+      setSyncStatus({ enabled: false, email: null });
+      setIsLoading(false);
+      throw new Error("Signed in, but sync setup failed. Please try again.", {
+        cause: err,
+      });
+    }
 
     setSyncStatus({
       enabled: true,
@@ -64,6 +76,7 @@ export function useSyncAuthDialog({ isOpen, onSuccess }: UseSyncAuthDialogProps)
       provider: authState.provider,
     });
 
+    setIsLoading(false);
     toast.success(`Signed in as ${authState.email}`);
     onSuccess?.();
   };
@@ -74,9 +87,10 @@ export function useSyncAuthDialog({ isOpen, onSuccess }: UseSyncAuthDialogProps)
   };
 
   const handleOAuthError = (err: Error) => {
+    const message = getOAuthErrorMessage(err);
     setIsLoading(false);
-    setError(err.message);
-    toast.error(err.message);
+    setError(message);
+    toast.error(message);
   };
 
   const handleLogout = async () => {
@@ -130,7 +144,7 @@ export function useSyncAuthDialog({ isOpen, onSuccess }: UseSyncAuthDialogProps)
 
 /** Load sync config from IndexedDB and validate token */
 async function loadSyncStatus(
-  cancelled: boolean,
+  cancellation: CancellationToken,
   setters: {
     setIsRefreshing: (v: boolean) => void;
     setSessionExpired: (v: boolean) => void;
@@ -140,7 +154,7 @@ async function loadSyncStatus(
   const db = getDb();
   const config = (await db.syncMetadata.get("sync_config")) as PBSyncConfig | undefined;
 
-  if (cancelled) return;
+  if (cancellation.cancelled) return;
 
   if (!config?.enabled) {
     setters.setSyncStatus({ enabled: false, email: null });
@@ -148,7 +162,8 @@ async function loadSyncStatus(
     return;
   }
 
-  await validateTokenAndRefresh(cancelled, setters);
+  await validateTokenAndRefresh(cancellation, setters);
+  if (cancellation.cancelled) return;
 
   setters.setSyncStatus({
     enabled: true,
@@ -159,7 +174,7 @@ async function loadSyncStatus(
 
 /** Check if token is valid; attempt silent refresh if expired */
 async function validateTokenAndRefresh(
-  cancelled: boolean,
+  cancellation: CancellationToken,
   setters: {
     setIsRefreshing: (v: boolean) => void;
     setSessionExpired: (v: boolean) => void;
@@ -175,7 +190,7 @@ async function validateTokenAndRefresh(
   // Token expired — attempt silent refresh
   setters.setIsRefreshing(true);
   const refreshed = await refreshAuth();
-  if (cancelled) return;
+  if (cancellation.cancelled) return;
   setters.setIsRefreshing(false);
 
   setters.setSessionExpired(!refreshed);

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ COPY . .
 
 # Build static export (produces out/ directory)
 RUN node scripts/generate-build-info.cjs \
+    && node scripts/update-sw-version.cjs \
     && bash -c 'source .build-env.sh && bunx --bun next build'
 
 # Download PocketBase in the Debian-based builder (avoids Alpine TLS issues)

--- a/lib/sync/pb-auth.ts
+++ b/lib/sync/pb-auth.ts
@@ -12,6 +12,7 @@ import { createLogger } from '@/lib/logger';
 const logger = createLogger('SYNC_AUTH');
 
 export type OAuthProvider = 'google' | 'github';
+const DEFAULT_OAUTH_TIMEOUT_MS = 120_000;
 
 /**
  * Runtime whitelist of OAuth providers. The `OAuthProvider` type is erased
@@ -31,6 +32,66 @@ export interface AuthState {
   provider: string | null;
 }
 
+export interface OAuthLoginOptions {
+  popupWindow?: Window | null;
+  requestKey?: string;
+  timeoutMs?: number;
+}
+
+interface OAuthDiagnosticError {
+  message?: string;
+  status?: number;
+  isAbort?: boolean;
+  response?: {
+    code?: number;
+    message?: string;
+  };
+  originalError?: {
+    message?: string;
+  };
+}
+
+export function openOAuthPopup(provider: OAuthProvider): Window | null {
+  if (typeof window === 'undefined' || typeof window.open !== 'function') {
+    return null;
+  }
+
+  const width = Math.min(1024, window.innerWidth || 1024);
+  const height = Math.min(768, window.innerHeight || 768);
+  const left = Math.max(0, Math.round((window.innerWidth - width) / 2));
+  const top = Math.max(0, Math.round((window.innerHeight - height) / 2));
+  const features = [
+    `width=${width}`,
+    `height=${height}`,
+    `top=${top}`,
+    `left=${left}`,
+    'resizable',
+    'menubar=no',
+  ].join(',');
+
+  return window.open('about:blank', `gsd_oauth_${provider}`, features);
+}
+
+export function cancelOAuthLogin(requestKey: string): void {
+  if (!requestKey) return;
+  getPocketBase().cancelRequest(requestKey);
+}
+
+export function getOAuthErrorMessage(error: unknown): string {
+  const diagnostic = error as OAuthDiagnosticError;
+
+  if (diagnostic?.isAbort) {
+    return 'OAuth sign-in was cancelled. Please try again.';
+  }
+
+  return (
+    diagnostic?.response?.message ||
+    diagnostic?.originalError?.message ||
+    diagnostic?.message ||
+    'OAuth sign-in failed. Please try again.'
+  );
+}
+
 /**
  * Initiate OAuth login via PocketBase SDK
  *
@@ -38,7 +99,10 @@ export interface AuthState {
  * OAuth2 flow (redirect, code exchange, token storage) automatically.
  * Returns the authenticated user record on success.
  */
-export async function loginWithProvider(provider: OAuthProvider): Promise<AuthState> {
+export async function loginWithProvider(
+  provider: OAuthProvider,
+  options: OAuthLoginOptions = {}
+): Promise<AuthState> {
   if (!provider || !ALLOWED_OAUTH_PROVIDERS.has(provider)) {
     throw new Error(
       `OAuth provider not allowed: ${String(provider)}. Allowed providers: ${[...ALLOWED_OAUTH_PROVIDERS].join(', ')}`
@@ -46,9 +110,43 @@ export async function loginWithProvider(provider: OAuthProvider): Promise<AuthSt
   }
 
   const pb = getPocketBase();
+  const timeoutMs = options.timeoutMs ?? DEFAULT_OAUTH_TIMEOUT_MS;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
   try {
-    const authData = await pb.collection('users').authWithOAuth2({ provider });
+    const authOptions = {
+      provider,
+      ...(options.popupWindow
+        ? {
+            urlCallback: (url: string) => {
+              if (options.popupWindow?.closed) {
+                throw new Error('OAuth sign-in window was closed before authentication started.');
+              }
+              options.popupWindow!.location.href = url;
+            },
+          }
+        : {}),
+      ...(options.requestKey ? { requestKey: options.requestKey } : {}),
+    };
+
+    const oauthPromise = pb.collection('users').authWithOAuth2(authOptions);
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      if (timeoutMs <= 0) return;
+      timeoutId = setTimeout(() => {
+        if (options.requestKey) {
+          pb.cancelRequest(options.requestKey);
+        }
+        try {
+          options.popupWindow?.close();
+        } catch {
+          // Some mobile browsers do not allow closing OAuth browser contexts.
+        }
+        reject(new Error('OAuth sign-in timed out. Please close the sign-in page and try again.'));
+      }, timeoutMs);
+    });
+
+    const authData = await Promise.race([oauthPromise, timeoutPromise]);
 
     logger.info('OAuth login successful', {
       provider,
@@ -62,21 +160,33 @@ export async function loginWithProvider(provider: OAuthProvider): Promise<AuthSt
       provider,
     };
   } catch (error) {
+    try {
+      options.popupWindow?.close();
+    } catch {
+      // Some mobile browsers do not allow closing OAuth browser contexts.
+    }
+    const diagnostic = error as OAuthDiagnosticError;
     logger.error('OAuth login failed', error instanceof Error ? error : new Error(String(error)), {
       provider,
+      status: diagnostic?.status,
+      type: diagnostic?.isAbort ? 'abort' : 'oauth',
     });
     throw error;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
   }
 }
 
 /** Convenience wrapper for Google OAuth */
-export function loginWithGoogle(): Promise<AuthState> {
-  return loginWithProvider('google');
+export function loginWithGoogle(options?: OAuthLoginOptions): Promise<AuthState> {
+  return loginWithProvider('google', options);
 }
 
 /** Convenience wrapper for GitHub OAuth */
-export function loginWithGithub(): Promise<AuthState> {
-  return loginWithProvider('github');
+export function loginWithGithub(options?: OAuthLoginOptions): Promise<AuthState> {
+  return loginWithProvider('github', options);
 }
 
 
@@ -105,4 +215,3 @@ export async function refreshAuth(): Promise<boolean> {
     return false;
   }
 }
-

--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -48,6 +48,7 @@ aws s3 sync "$BUILD_DIR/" "$S3_BUCKET/" \
   --delete \
   --exclude "*.html" \
   --exclude "sw.js" \
+  --exclude "sw-cache-logic.js" \
   --cache-control "public,max-age=31536000,immutable"
 
 echo "  → Syncing HTML files and service worker..."
@@ -55,6 +56,7 @@ aws s3 sync "$BUILD_DIR/" "$S3_BUCKET/" \
   --exclude "*" \
   --include "*.html" \
   --include "sw.js" \
+  --include "sw-cache-logic.js" \
   --cache-control "public,max-age=0,must-revalidate"
 
 echo "  → Forcing no-cache on index.html..."

--- a/tests/data/cloudfront-functions.test.ts
+++ b/tests/data/cloudfront-functions.test.ts
@@ -48,6 +48,14 @@ describe('cloudfront-function-url-rewrite (viewer-request)', () => {
 		expect(out.uri).toBe('/_next/static/chunks/main.js');
 	});
 
+	it('passes API and PocketBase admin paths through unchanged', () => {
+		for (const uri of ['/api', '/api/oauth2-redirect', '/api/auth/oauth-callback', '/_', '/_/']) {
+			const req = makeRequest(uri);
+			const out = urlRewrite({ request: req }) as CFRequest;
+			expect(out.uri).toBe(uri);
+		}
+	});
+
 	it('rewrites to .md when the client sends Accept: text/markdown', () => {
 		const req = makeRequest('/about/', { accept: 'text/markdown, text/html;q=0.9' });
 		const out = urlRewrite({ request: req }) as CFRequest;

--- a/tests/data/sync/pb-auth.test.ts
+++ b/tests/data/sync/pb-auth.test.ts
@@ -1,5 +1,6 @@
 const mockAuthWithOAuth2 = vi.fn();
 const mockAuthRefresh = vi.fn();
+const mockCancelRequest = vi.fn();
 
 const mockPb = {
   collection: vi.fn(() => ({
@@ -11,6 +12,7 @@ const mockPb = {
     isValid: true,
     record: { id: 'user-123', email: 'test@example.com' },
   },
+  cancelRequest: mockCancelRequest,
 };
 
 vi.mock('@/lib/sync/pocketbase-client', () => ({
@@ -32,6 +34,8 @@ import {
   loginWithProvider,
   loginWithGoogle,
   loginWithGithub,
+  getOAuthErrorMessage,
+  openOAuthPopup,
   refreshAuth,
 } from '@/lib/sync/pb-auth';
 
@@ -57,6 +61,53 @@ describe('PocketBase Auth', () => {
         email: 'test@example.com',
         provider: 'google',
       });
+    });
+
+    it('should pass a pre-opened popup through urlCallback', async () => {
+      mockAuthWithOAuth2.mockResolvedValue({
+        record: { id: 'user-123', email: 'test@example.com' },
+      });
+      const popupWindow = {
+        closed: false,
+        location: { href: '' },
+      } as unknown as Window;
+
+      await loginWithProvider('google', {
+        popupWindow,
+        requestKey: 'oauth_google_test',
+      });
+
+      const options = mockAuthWithOAuth2.mock.calls[0][0];
+      expect(options).toEqual(
+        expect.objectContaining({
+          provider: 'google',
+          requestKey: 'oauth_google_test',
+          urlCallback: expect.any(Function),
+        })
+      );
+
+      options.urlCallback('https://accounts.example.test/auth');
+      expect(popupWindow.location.href).toBe('https://accounts.example.test/auth');
+    });
+
+    it('should cancel the PocketBase request when OAuth times out', async () => {
+      vi.useFakeTimers();
+      try {
+        mockAuthWithOAuth2.mockReturnValue(new Promise(() => {}));
+
+        const promise = loginWithProvider('github', {
+          requestKey: 'oauth_github_timeout',
+          timeoutMs: 50,
+        });
+        const assertion = expect(promise).rejects.toThrow(/timed out/i);
+
+        await vi.advanceTimersByTimeAsync(50);
+
+        await assertion;
+        expect(mockCancelRequest).toHaveBeenCalledWith('oauth_github_timeout');
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('should rethrow errors from OAuth2', async () => {
@@ -140,6 +191,36 @@ describe('PocketBase Auth', () => {
 
       expect(mockAuthRefresh).not.toHaveBeenCalled();
       expect(result).toBe(false);
+    });
+  });
+
+  describe('openOAuthPopup', () => {
+    it('opens a named OAuth popup window', () => {
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue({} as Window);
+
+      openOAuthPopup('google');
+
+      expect(openSpy).toHaveBeenCalledWith(
+        'about:blank',
+        'gsd_oauth_google',
+        expect.stringContaining('menubar=no')
+      );
+      openSpy.mockRestore();
+    });
+  });
+
+  describe('getOAuthErrorMessage', () => {
+    it('uses PocketBase diagnostic messages when available', () => {
+      const message = getOAuthErrorMessage({
+        message: 'Outer message',
+        response: { message: 'Provider redirect failed' },
+      });
+
+      expect(message).toBe('Provider redirect failed');
+    });
+
+    it('returns a friendly cancellation message for aborts', () => {
+      expect(getOAuthErrorMessage({ isAbort: true, message: 'aborted' })).toMatch(/cancelled/i);
     });
   });
 });

--- a/tests/ui/misc-components.test.tsx
+++ b/tests/ui/misc-components.test.tsx
@@ -123,8 +123,10 @@ describe('PwaRegister', () => {
     render(<PwaRegister />);
     // Allow the async register() to run
     await vi.waitFor(() => {
-      expect(mockRegister).toHaveBeenCalledWith('/sw.js', { scope: '/' });
+      expect(mockRegister).toHaveBeenCalledWith('/sw.js', {
+        scope: '/',
+        updateViaCache: 'none',
+      });
     });
   });
 });
-

--- a/tests/ui/oauth-buttons.test.tsx
+++ b/tests/ui/oauth-buttons.test.tsx
@@ -10,15 +10,26 @@ import userEvent from '@testing-library/user-event';
 import type { AuthState } from '@/lib/sync/pb-auth';
 
 // Hoisted mocks
-const { mockLoginWithGoogle, mockLoginWithGithub } = vi.hoisted(() => ({
+const {
+  mockLoginWithGoogle,
+  mockLoginWithGithub,
+  mockOpenOAuthPopup,
+  mockCancelOAuthLogin,
+  mockPopupWindow,
+} = vi.hoisted(() => ({
   mockLoginWithGoogle: vi.fn(),
   mockLoginWithGithub: vi.fn(),
+  mockOpenOAuthPopup: vi.fn(),
+  mockCancelOAuthLogin: vi.fn(),
+  mockPopupWindow: { closed: false },
 }));
 
 // Mock PocketBase auth module
 vi.mock('@/lib/sync/pb-auth', () => ({
   loginWithGoogle: (...args: unknown[]) => mockLoginWithGoogle(...args),
   loginWithGithub: (...args: unknown[]) => mockLoginWithGithub(...args),
+  openOAuthPopup: (...args: unknown[]) => mockOpenOAuthPopup(...args),
+  cancelOAuthLogin: (...args: unknown[]) => mockCancelOAuthLogin(...args),
 }));
 
 // Import component after mocks
@@ -42,6 +53,7 @@ describe('OAuthButtons', () => {
     // Default: login functions resolve successfully
     mockLoginWithGoogle.mockResolvedValue(createAuthState({ provider: 'google' }));
     mockLoginWithGithub.mockResolvedValue(createAuthState({ provider: 'github' }));
+    mockOpenOAuthPopup.mockReturnValue(mockPopupWindow);
   });
 
   describe('Button Rendering', () => {
@@ -106,6 +118,23 @@ describe('OAuthButtons', () => {
       expect(mockLoginWithGoogle).toHaveBeenCalledOnce();
     });
 
+    it('should pre-open the OAuth popup before starting Google login', async () => {
+      const user = userEvent.setup();
+
+      render(<OAuthButtons />);
+
+      const googleButton = screen.getByRole('button', { name: /continue with google/i });
+      await user.click(googleButton);
+
+      expect(mockOpenOAuthPopup).toHaveBeenCalledWith('google');
+      expect(mockLoginWithGoogle).toHaveBeenCalledWith(
+        expect.objectContaining({
+          popupWindow: mockPopupWindow,
+          requestKey: expect.stringMatching(/^oauth_google_/),
+        })
+      );
+    });
+
     it('should call loginWithGithub when GitHub button is clicked', async () => {
       const user = userEvent.setup();
 
@@ -165,6 +194,21 @@ describe('OAuthButtons', () => {
       });
     });
 
+    it('should cancel a pending OAuth request when unmounted', async () => {
+      const user = userEvent.setup();
+      mockLoginWithGoogle.mockReturnValue(new Promise(() => {}));
+
+      const { unmount } = render(<OAuthButtons />);
+
+      const googleButton = screen.getByRole('button', { name: /continue with google/i });
+      await user.click(googleButton);
+      const requestKey = mockLoginWithGoogle.mock.calls[0][0].requestKey;
+
+      unmount();
+
+      expect(mockCancelOAuthLogin).toHaveBeenCalledWith(requestKey);
+    });
+
     it('should re-enable buttons after successful OAuth', async () => {
       const user = userEvent.setup();
       mockLoginWithGoogle.mockResolvedValue(createAuthState({ provider: 'google' }));
@@ -214,6 +258,23 @@ describe('OAuthButtons', () => {
 
       await waitFor(() => {
         expect(onSuccess).toHaveBeenCalledWith(expectedAuth);
+      });
+    });
+
+    it('should route async onSuccess failures to onError', async () => {
+      const user = userEvent.setup();
+      const onSuccess = vi.fn().mockRejectedValue(new Error('Sync setup failed'));
+      const onError = vi.fn();
+      mockLoginWithGoogle.mockResolvedValue(createAuthState({ provider: 'google' }));
+
+      render(<OAuthButtons onSuccess={onSuccess} onError={onError} />);
+
+      const googleButton = screen.getByRole('button', { name: /continue with google/i });
+      await user.click(googleButton);
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+        expect(onError.mock.calls[0][0].message).toBe('Sync setup failed');
       });
     });
 

--- a/tests/ui/sync-auth-dialog.test.tsx
+++ b/tests/ui/sync-auth-dialog.test.tsx
@@ -18,6 +18,7 @@ const {
   mockToastError,
   mockIsAuthenticated,
   mockRefreshAuth,
+  mockClearPocketBase,
 } = vi.hoisted(() => ({
   mockGetDb: vi.fn(),
   mockGetSyncQueue: vi.fn(),
@@ -27,6 +28,7 @@ const {
   mockToastError: vi.fn(),
   mockIsAuthenticated: vi.fn().mockReturnValue(true),
   mockRefreshAuth: vi.fn().mockResolvedValue(true),
+  mockClearPocketBase: vi.fn(),
 }));
 
 // Mock modules
@@ -37,10 +39,12 @@ vi.mock('@/lib/db', () => ({
 vi.mock('@/lib/sync/pb-auth', () => ({
   logout: vi.fn(),
   refreshAuth: (...args: unknown[]) => mockRefreshAuth(...args),
+  getOAuthErrorMessage: (error: Error) => error.message,
 }));
 
 vi.mock('@/lib/sync/pocketbase-client', () => ({
   isAuthenticated: () => mockIsAuthenticated(),
+  clearPocketBase: () => mockClearPocketBase(),
 }));
 
 vi.mock('@/lib/sync/config', () => ({
@@ -60,7 +64,7 @@ vi.mock('sonner', () => ({
 }));
 
 // Capture OAuthButtons callbacks so tests can invoke them directly
-let capturedOnSuccess: ((authState: AuthState) => void) | undefined;
+let capturedOnSuccess: ((authState: AuthState) => void | Promise<void>) | undefined;
 let capturedOnError: ((error: Error) => void) | undefined;
 
 vi.mock('@/components/sync/oauth-buttons', () => ({
@@ -70,7 +74,7 @@ vi.mock('@/components/sync/oauth-buttons', () => ({
     onError,
   }: {
     onStart?: (provider: 'google' | 'github') => void;
-    onSuccess?: (authState: AuthState) => void;
+    onSuccess?: (authState: AuthState) => void | Promise<void>;
     onError?: (error: Error) => void;
   }) => {
     capturedOnSuccess = onSuccess;
@@ -313,6 +317,26 @@ describe('SyncAuthDialog', () => {
       await waitFor(() => {
         expect(mockQueue.populateFromExistingTasks).toHaveBeenCalled();
       });
+    });
+
+    it('should clear PocketBase auth and report an error when sync setup fails after OAuth', async () => {
+      render(<SyncAuthDialog isOpen={true} onClose={vi.fn()} />);
+
+      await waitFor(() => {
+        expect(capturedOnSuccess).toBeDefined();
+      });
+
+      mockDb.syncMetadata.put.mockRejectedValueOnce(new Error('IndexedDB unavailable'));
+
+      const authState: AuthState = {
+        isLoggedIn: true,
+        userId: 'user123',
+        email: 'test@example.com',
+        provider: 'google',
+      };
+
+      await expect(capturedOnSuccess!(authState)).rejects.toThrow(/sync setup failed/i);
+      expect(mockClearPocketBase).toHaveBeenCalled();
     });
 
     it('should display error on OAuth failure', async () => {


### PR DESCRIPTION
## Summary
- Pre-open the OAuth window, use PocketBase `urlCallback`, and add request cancellation plus a timeout for stuck handoffs.
- Await async sync setup after OAuth success and clear auth state if IndexedDB persistence fails.
- Prevent CloudFront from rewriting `/api/*` and `/_/*`, and reduce stale PWA cache behavior with `updateViaCache: "none"` plus SW build/deploy fixes.
- Update the PocketBase sync rule and add regression coverage for the OAuth, CloudFront, and PWA paths.

## Testing
- `bun run vitest run tests/data/sync/pb-auth.test.ts tests/ui/oauth-buttons.test.tsx tests/ui/sync-auth-dialog.test.tsx tests/ui/misc-components.test.tsx tests/data/cloudfront-functions.test.ts tests/data/sw-cache-logic.test.ts`
- `bun run test`
- `bun run typecheck`
- `bun run lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->