### PR TITLE
[codex] Expose command palette and smart views

### DIFF
--- a/components/command-palette/index.tsx
+++ b/components/command-palette/index.tsx
@@ -3,6 +3,7 @@
 import { Command } from "cmdk";
 import { useCommandPalette } from "@/lib/use-command-palette";
 import { buildCommandActions, type CommandActionHandlers } from "@/lib/command-actions";
+import { DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { getSmartViews } from "@/lib/smart-views";
 import { useTasks } from "@/lib/use-tasks";
 import { useState, useEffect, useMemo } from "react";
@@ -17,10 +18,10 @@ interface CommandPaletteProps {
     selectionMode: boolean;
     hasSelection: boolean;
   };
+  onSelectTask?: (taskId: string) => void;
   /**
    * When false, the palette will not load or render built-in smart-view
-   * actions. v9 (ADR 0011) removed the smart-view UI; the shell passes
-   * `showSmartViews={false}` to keep the palette consistent with that surface.
+   * actions. The shell wires this to the user's feature preference.
    */
   showSmartViews?: boolean;
 }
@@ -31,7 +32,12 @@ interface CommandPaletteProps {
  * Opens with ⌘K / Ctrl+K
  * Provides quick access to actions, navigation, and task search
  */
-export function CommandPalette({ handlers, conditions, showSmartViews = true }: CommandPaletteProps) {
+export function CommandPalette({
+  handlers,
+  conditions,
+  onSelectTask,
+  showSmartViews = true,
+}: CommandPaletteProps) {
   const { all: tasks } = useTasks();
   const [smartViews, setSmartViews] = useState<SmartView[]>([]);
 
@@ -59,7 +65,7 @@ export function CommandPalette({ handlers, conditions, showSmartViews = true }: 
     matchingTasks,
     executeAction,
     selectTask,
-  } = useCommandPalette({ actions, tasks });
+  } = useCommandPalette({ actions, tasks, onSelectTask });
 
   // Group actions by section
   const actionsBySection = useMemo(
@@ -79,23 +85,17 @@ export function CommandPalette({ handlers, conditions, showSmartViews = true }: 
 
   return (
     <>
-      {/* Visually hidden but accessible title and description */}
-      <div className="sr-only">
-        <h2 id="command-palette-title">Command Palette</h2>
-        <p id="command-palette-description">
-          Search for tasks, actions, and settings. Use arrow keys to navigate and Enter to select.
-        </p>
-      </div>
-
       <Command.Dialog
         open={open}
         onOpenChange={setOpen}
         label="Command Palette"
         className="fixed left-[50%] top-[20%] z-50 w-full max-w-[640px] translate-x-[-50%] overflow-hidden rounded-xl border border-border bg-card shadow-2xl sm:top-[20%] md:w-[640px]"
         contentClassName="max-h-[60vh] overflow-y-auto"
-        aria-labelledby="command-palette-title"
-        aria-describedby="command-palette-description"
       >
+        <DialogTitle className="sr-only">Command Palette</DialogTitle>
+        <DialogDescription className="sr-only">
+          Search for tasks, actions, and settings. Use arrow keys to navigate and Enter to select.
+        </DialogDescription>
         <SearchInput search={search} onSearchChange={setSearch} />
 
         <Command.List className="max-h-[400px] overflow-y-auto p-2">

--- a/components/matrix-simplified/app-shell.tsx
+++ b/components/matrix-simplified/app-shell.tsx
@@ -1,11 +1,20 @@
 "use client";
 
 import { useEffect, useState, type ReactNode, type RefObject } from "react";
+import { CommandIcon } from "lucide-react";
 import { IconRail } from "./icon-rail";
 import { SimplifiedTopbar } from "./topbar";
 import { HelpDrawer } from "@/components/matrix-simplified/help-drawer";
 import { AppFooter } from "@/components/app-footer";
 import { CommandPalette } from "@/components/command-palette";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  APP_PREFERENCES_EVENT,
+  getAppPreferences,
+  type AppPreferencesEventDetail,
+} from "@/lib/smart-views";
+import { OPEN_COMMAND_PALETTE_EVENT } from "@/lib/use-command-palette";
 import { useShellCommandHandlers } from "@/lib/use-shell-command-handlers";
 
 interface AppShellProps {
@@ -28,13 +37,47 @@ export function AppShell({
   children,
 }: AppShellProps) {
   const [helpOpen, setHelpOpen] = useState(false);
-  const { handlers, conditions } = useShellCommandHandlers();
+  const [smartViewsEnabled, setSmartViewsEnabled] = useState(false);
+  const { handlers, onSelectTask, conditions } = useShellCommandHandlers();
 
   useEffect(() => {
     const open = () => setHelpOpen(true);
     window.addEventListener("gsd:open-help", open);
     return () => window.removeEventListener("gsd:open-help", open);
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getAppPreferences()
+      .then((preferences) => {
+        if (!cancelled) {
+          setSmartViewsEnabled(preferences.smartViewsEnabled);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSmartViewsEnabled(false);
+        }
+      });
+
+    const onPreferencesChange = (event: Event) => {
+      const preferences = (event as CustomEvent<AppPreferencesEventDetail>).detail?.preferences;
+      if (preferences) {
+        setSmartViewsEnabled(preferences.smartViewsEnabled);
+      }
+    };
+
+    window.addEventListener(APP_PREFERENCES_EVENT, onPreferencesChange);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(APP_PREFERENCES_EVENT, onPreferencesChange);
+    };
+  }, []);
+
+  const openCommandPalette = () => {
+    window.dispatchEvent(new CustomEvent(OPEN_COMMAND_PALETTE_EVENT));
+  };
 
   return (
     <div className="flex min-h-screen bg-background">
@@ -46,7 +89,27 @@ export function AppShell({
           searchQuery={searchQuery}
           onSearchChange={onSearchChange}
           searchInputRef={searchInputRef}
-          rightSlot={topbarRightSlot}
+          rightSlot={
+            <div className="flex items-center gap-2">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="subtle"
+                    className="h-10 w-10 p-0"
+                    aria-label="Open command palette"
+                    onClick={openCommandPalette}
+                  >
+                    <CommandIcon className="h-4 w-4" aria-hidden />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Command Palette</p>
+                </TooltipContent>
+              </Tooltip>
+              {topbarRightSlot}
+            </div>
+          }
         />
         <main className="mx-auto w-full max-w-[1320px] flex-1 px-4 py-5 pb-20 sm:px-9 sm:py-6 md:pb-6">
           {children}
@@ -54,7 +117,12 @@ export function AppShell({
         <AppFooter />
       </div>
       <HelpDrawer open={helpOpen} onClose={() => setHelpOpen(false)} />
-      <CommandPalette handlers={handlers} conditions={conditions} showSmartViews={false} />
+      <CommandPalette
+        handlers={handlers}
+        conditions={conditions}
+        onSelectTask={onSelectTask}
+        showSmartViews={smartViewsEnabled}
+      />
     </div>
   );
 }

--- a/components/matrix-simplified/help-drawer.tsx
+++ b/components/matrix-simplified/help-drawer.tsx
@@ -98,6 +98,7 @@ export function HelpDrawer({ open, onClose }: HelpDrawerProps) {
 
           <Section label="Keyboard shortcuts">
             <ShortcutRow keys={["n"]} action="Jump to the capture bar" />
+            <ShortcutRow keys={["⌘", "K"]} action="Open the command palette" />
             <ShortcutRow keys={["Shift", "N"]} action="Open the full composer" />
             <ShortcutRow keys={["/"]} action="Focus the search field" />
             <ShortcutRow keys={["Tab"]} action="Cycle quadrant override (in the capture bar)" />

--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -13,11 +13,25 @@ import { useDragAndDrop } from "@/lib/use-drag-and-drop";
 import { useAutoArchive } from "@/lib/use-auto-archive";
 import { useNotificationChecker } from "@/lib/use-notification-checker";
 import { TOAST_DURATION } from "@/lib/constants";
+import { applyFilters, type SmartView } from "@/lib/filters";
 import {
   SHOW_COMPLETED_EVENT,
   type ShowCompletedEventDetail,
   readShowCompleted,
 } from "@/lib/preferences/show-completed";
+import {
+  APPLY_SMART_VIEW_EVENT,
+  HIGHLIGHT_TASK_EVENT,
+  NEW_TASK_EVENT,
+  type ApplySmartViewEventDetail,
+} from "@/lib/use-shell-command-handlers";
+import {
+  APP_PREFERENCES_EVENT,
+  getAppPreferences,
+  getSmartView,
+  getSmartViews,
+  type AppPreferencesEventDetail,
+} from "@/lib/smart-views";
 import type { TaskRecord } from "@/lib/types";
 import { quadrantByRdKey, type RedesignQuadrantKey } from "@/lib/quadrants";
 import { TaskCard } from "@/components/task-card";
@@ -26,6 +40,7 @@ import { AppShell } from "./app-shell";
 import { CaptureBar, type CapturePayload } from "./capture-bar";
 import { MatrixGrid } from "./matrix-grid";
 import { EditDrawer, type EditDraft } from "./edit-drawer";
+import { SmartViewStrip } from "./smart-view-strip";
 
 function isEditable(el: Element | null): boolean {
   if (!(el instanceof HTMLElement)) return false;
@@ -66,12 +81,71 @@ export function MatrixSimplified() {
   const [createInitial, setCreateInitial] = useState<Partial<EditDraft> | undefined>(undefined);
   const [mounted, setMounted] = useState(false);
   const [showCompleted, setShowCompleted] = useState(false);
+  const [smartViewsEnabled, setSmartViewsEnabled] = useState(false);
+  const [smartViews, setSmartViews] = useState<SmartView[]>([]);
+  const [activeSmartView, setActiveSmartView] = useState<SmartView | null>(null);
   const [sharingTask, setSharingTask] = useState<TaskRecord | null>(null);
+  const [highlightedTaskId, setHighlightedTaskId] = useState<string | null>(null);
+  const taskRefs = useRef(new Map<string, HTMLElement>());
+  const clearHighlightTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
     setMounted(true); // eslint-disable-line react-hooks/set-state-in-effect -- canonical SSR-safe pattern for static export
     setShowCompleted(readShowCompleted());
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadSmartViewPreference = async () => {
+      const preferences = await getAppPreferences();
+      if (!cancelled) {
+        setSmartViewsEnabled(preferences.smartViewsEnabled);
+      }
+    };
+
+    loadSmartViewPreference().catch(() => {
+      if (!cancelled) {
+        setSmartViewsEnabled(false);
+      }
+    });
+
+    const onPreferencesChange = (event: Event) => {
+      const preferences = (event as CustomEvent<AppPreferencesEventDetail>).detail?.preferences;
+      if (!preferences) return;
+      setSmartViewsEnabled(preferences.smartViewsEnabled);
+      if (!preferences.smartViewsEnabled) {
+        setActiveSmartView(null);
+      }
+    };
+
+    window.addEventListener(APP_PREFERENCES_EVENT, onPreferencesChange);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(APP_PREFERENCES_EVENT, onPreferencesChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!smartViewsEnabled) return;
+
+    let cancelled = false;
+    getSmartViews()
+      .then((views) => {
+        if (!cancelled) {
+          setSmartViews(views);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSmartViews([]);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [smartViewsEnabled]);
 
   useEffect(() => {
     const handler = (e: Event) => {
@@ -124,6 +198,63 @@ export function MatrixSimplified() {
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
+  const handleTaskRef = useCallback((taskId: string, element: HTMLElement | null) => {
+    if (element) {
+      taskRefs.current.set(taskId, element);
+    } else {
+      taskRefs.current.delete(taskId);
+    }
+  }, []);
+
+  const scrollTaskIntoView = useCallback((taskId: string) => {
+    const node = taskRefs.current.get(taskId);
+    if (!node) return;
+
+    const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    node.scrollIntoView({
+      block: "center",
+      behavior: reduceMotion ? "auto" : "smooth",
+    });
+    node.focus({ preventScroll: true });
+  }, []);
+
+  const highlightTaskById = useCallback((taskId: string) => {
+    if (!taskId) return;
+
+    setSearchQuery("");
+    setHighlightedTaskId(taskId);
+
+    if (clearHighlightTimerRef.current) {
+      window.clearTimeout(clearHighlightTimerRef.current);
+    }
+    clearHighlightTimerRef.current = window.setTimeout(() => {
+      setHighlightedTaskId((current) => (current === taskId ? null : current));
+      clearHighlightTimerRef.current = null;
+    }, 3500);
+  }, []);
+
+  const applySmartViewById = useCallback(async (viewId: string) => {
+    const view = await getSmartView(viewId);
+    if (!view) {
+      toast.error("Smart view not found", { duration: TOAST_DURATION.SHORT });
+      return;
+    }
+    setSearchQuery("");
+    setActiveSmartView(view);
+  }, []);
+
+  const handleClearSmartView = useCallback(() => {
+    setActiveSmartView(null);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (clearHighlightTimerRef.current) {
+        window.clearTimeout(clearHighlightTimerRef.current);
+      }
+    };
+  }, []);
+
   const trimmedSearchQuery = searchQuery.trim();
   const { visibleTasks, total, completed, overdue } = useMemo(() => {
     const todayIso = new Date().toISOString().slice(0, 10);
@@ -142,14 +273,27 @@ export function MatrixSimplified() {
       }
     }
 
-    const base = showCompleted ? all : activeTasks;
+    const effectiveSmartView = smartViewsEnabled ? activeSmartView : null;
+    const base = effectiveSmartView ? all : showCompleted ? all : activeTasks;
+    const smartViewTasks = effectiveSmartView
+      ? applyFilters(base, effectiveSmartView.criteria, all)
+      : base;
     return {
-      visibleTasks: filterTasks(base, trimmedSearchQuery),
+      visibleTasks: filterTasks(smartViewTasks, trimmedSearchQuery),
       total: all.length,
       completed: completedCount,
       overdue: overdueCount,
     };
-  }, [all, showCompleted, trimmedSearchQuery]);
+  }, [activeSmartView, all, showCompleted, smartViewsEnabled, trimmedSearchQuery]);
+
+  useEffect(() => {
+    if (!highlightedTaskId) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      scrollTaskIntoView(highlightedTaskId);
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [highlightedTaskId, scrollTaskIntoView, visibleTasks]);
 
   const handleCapture = useCallback(
     async ({ title, urgent, important, tags }: CapturePayload) => {
@@ -227,6 +371,54 @@ export function MatrixSimplified() {
     setCreateDrawerOpen(true);
   }, []);
 
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const taskId = params.get("highlight");
+    const smartViewId = params.get("smartView");
+    if (!taskId && !smartViewId) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      if (taskId) {
+        highlightTaskById(taskId);
+      }
+      if (smartViewId) {
+        void applySmartViewById(smartViewId);
+      }
+    });
+    params.delete("highlight");
+    params.delete("smartView");
+    const next = params.toString();
+    window.history.replaceState({}, "", `${window.location.pathname}${next ? `?${next}` : ""}`);
+    return () => window.cancelAnimationFrame(frame);
+  }, [applySmartViewById, highlightTaskById]);
+
+  useEffect(() => {
+    const openNewTask = () => handleOpenCreateDrawer();
+    const highlightTask = (event: Event) => {
+      const taskId = (event as CustomEvent<{ taskId?: string }>).detail?.taskId;
+      if (taskId) {
+        highlightTaskById(taskId);
+      }
+    };
+    const applySmartView = (event: Event) => {
+      const viewId = (event as CustomEvent<ApplySmartViewEventDetail>).detail?.viewId;
+      if (viewId) {
+        void applySmartViewById(viewId);
+      }
+    };
+
+    window.addEventListener(NEW_TASK_EVENT, openNewTask);
+    window.addEventListener(HIGHLIGHT_TASK_EVENT, highlightTask);
+    window.addEventListener(APPLY_SMART_VIEW_EVENT, applySmartView);
+    window.addEventListener("highlightTask", highlightTask);
+    return () => {
+      window.removeEventListener(NEW_TASK_EVENT, openNewTask);
+      window.removeEventListener(HIGHLIGHT_TASK_EVENT, highlightTask);
+      window.removeEventListener(APPLY_SMART_VIEW_EVENT, applySmartView);
+      window.removeEventListener("highlightTask", highlightTask);
+    };
+  }, [applySmartViewById, handleOpenCreateDrawer, highlightTaskById]);
+
   const handleCreateClose = useCallback(() => {
     setCreateDrawerOpen(false);
     setCreateInitial(undefined);
@@ -298,6 +490,16 @@ export function MatrixSimplified() {
       >
         <div className="sticky top-[60px] z-10 -mx-4 mb-10 bg-background/85 px-4 py-3 backdrop-blur-xl backdrop-saturate-150 sm:-mx-9 sm:mb-12 sm:px-9 sm:py-4">
           <CaptureBar onSubmit={handleCapture} onMoreOptions={handleOpenCreateDrawer} inputRef={captureInputRef} />
+          {smartViewsEnabled ? (
+            <div className="mt-3">
+              <SmartViewStrip
+                views={smartViews}
+                activeViewId={activeSmartView?.id}
+                onSelectView={applySmartViewById}
+                onClearView={handleClearSmartView}
+              />
+            </div>
+          ) : null}
         </div>
         <MatrixGrid
           tasks={visibleTasks}
@@ -307,6 +509,8 @@ export function MatrixSimplified() {
           onDelete={handleDelete}
           onShare={handleShareOpen}
           onAddInQuadrant={handleAddInQuadrant}
+          highlightedTaskId={highlightedTaskId}
+          onTaskRef={handleTaskRef}
         />
       </AppShell>
 

--- a/components/matrix-simplified/matrix-grid.tsx
+++ b/components/matrix-simplified/matrix-grid.tsx
@@ -13,6 +13,8 @@ interface MatrixGridProps {
   onDelete: (task: TaskRecord) => void | Promise<void>;
   onShare: (task: TaskRecord) => void;
   onAddInQuadrant: (key: RedesignQuadrantKey) => void;
+  highlightedTaskId?: string | null;
+  onTaskRef?: (taskId: string, element: HTMLElement | null) => void;
 }
 
 export function MatrixGrid({
@@ -23,6 +25,8 @@ export function MatrixGrid({
   onDelete,
   onShare,
   onAddInQuadrant,
+  highlightedTaskId,
+  onTaskRef,
 }: MatrixGridProps) {
   const grouped = useMemo(() => {
     const out: Record<RedesignQuadrantKey, TaskRecord[]> = { q1: [], q2: [], q3: [], q4: [] };
@@ -58,6 +62,8 @@ export function MatrixGrid({
           onDelete={onDelete}
           onShare={onShare}
           onAddInQuadrant={onAddInQuadrant}
+          highlightedTaskId={highlightedTaskId}
+          onTaskRef={onTaskRef}
         />
       ))}
     </div>

--- a/components/matrix-simplified/quadrant-pane.tsx
+++ b/components/matrix-simplified/quadrant-pane.tsx
@@ -46,6 +46,8 @@ interface QuadrantPaneProps {
   onDelete: (task: TaskRecord) => void | Promise<void>;
   onShare: (task: TaskRecord) => void;
   onAddInQuadrant: (key: RedesignQuadrantKey) => void;
+  highlightedTaskId?: string | null;
+  onTaskRef?: (taskId: string, element: HTMLElement | null) => void;
 }
 
 export function QuadrantPane({
@@ -58,6 +60,8 @@ export function QuadrantPane({
   onDelete,
   onShare,
   onAddInQuadrant,
+  highlightedTaskId,
+  onTaskRef,
 }: QuadrantPaneProps) {
   const { setNodeRef, isOver } = useDroppable({ id: meta.id });
   const accent = QUADRANT_ACCENT[meta.rdKey];
@@ -139,6 +143,8 @@ export function QuadrantPane({
                 onDelete={onDelete}
                 onShare={onShare}
                 onToggleComplete={onToggleComplete}
+                isHighlighted={task.id === highlightedTaskId}
+                taskRef={(element) => onTaskRef?.(task.id, element)}
               />
             ))
           )}

--- a/components/matrix-simplified/smart-view-strip.tsx
+++ b/components/matrix-simplified/smart-view-strip.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { SmartView } from "@/lib/filters";
+import { cn } from "@/lib/utils";
+
+interface SmartViewStripProps {
+  views: SmartView[];
+  activeViewId?: string | null;
+  onSelectView: (viewId: string) => void;
+  onClearView: () => void;
+}
+
+export function SmartViewStrip({
+  views,
+  activeViewId,
+  onSelectView,
+  onClearView,
+}: SmartViewStripProps) {
+  if (views.length === 0) return null;
+
+  return (
+    <div
+      className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      aria-label="Smart views"
+    >
+      <SmartViewButton active={!activeViewId} label="All tasks" onClick={onClearView} />
+      {views.map((view) => (
+        <SmartViewButton
+          key={view.id}
+          active={view.id === activeViewId}
+          label={view.name}
+          icon={view.icon}
+          onClick={() => onSelectView(view.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SmartViewButton({
+  active,
+  label,
+  icon,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  icon?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        "inline-flex h-9 shrink-0 items-center gap-1.5 rounded-full border px-3 text-xs font-medium transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
+        active
+          ? "border-accent/40 bg-accent/10 text-foreground"
+          : "border-border bg-card text-foreground-muted hover:bg-background-muted hover:text-foreground",
+      )}
+    >
+      {icon ? <span aria-hidden>{icon}</span> : null}
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/components/settings-page/index.tsx
+++ b/components/settings-page/index.tsx
@@ -12,10 +12,16 @@ import {
   getNotificationSettings,
   updateNotificationSettings,
 } from "@/lib/notifications";
-import type { NotificationSettings } from "@/lib/types";
+import type { AppPreferences, NotificationSettings } from "@/lib/types";
 import { getSyncStatus } from "@/lib/sync/config";
 import { exportToJson } from "@/lib/tasks";
 import { createLogger } from "@/lib/logger";
+import {
+  APP_PREFERENCES_EVENT,
+  getAppPreferences,
+  updateAppPreferences,
+  type AppPreferencesEventDetail,
+} from "@/lib/smart-views";
 import {
   SHOW_COMPLETED_EVENT,
   SHOW_COMPLETED_KEY,
@@ -23,6 +29,7 @@ import {
 } from "@/lib/preferences/show-completed";
 
 import { AppearanceSettings } from "@/components/settings/appearance-settings";
+import { FeatureSettings } from "@/components/settings/feature-settings";
 import { NotificationSettingsSection } from "@/components/settings/notification-settings";
 import { SyncSettings } from "@/components/settings/sync-settings";
 import { ArchiveSettings } from "@/components/settings/archive-settings";
@@ -50,6 +57,7 @@ export function SettingsPage() {
 
   const [activeSection, setActiveSection] = useState<SettingsSectionId>(DEFAULT_SECTION);
   const [showCompleted, setShowCompleted] = useState(false);
+  const [appPreferences, setAppPreferences] = useState<AppPreferences | null>(null);
   const [notificationSettings, setNotificationSettings] = useState<NotificationSettings | null>(null);
   const [syncEnabled, setSyncEnabled] = useState(false);
   const [pendingSync, setPendingSync] = useState(0);
@@ -76,12 +84,14 @@ export function SettingsPage() {
     let cancelled = false;
     (async () => {
       try {
-        const [notif, sync] = await Promise.all([
+        const [notif, sync, prefs] = await Promise.all([
           getNotificationSettings(),
           getSyncStatus(),
+          getAppPreferences(),
         ]);
         if (cancelled) return;
         setNotificationSettings(notif);
+        setAppPreferences(prefs);
         setSyncEnabled(sync.enabled);
         setPendingSync(sync.pendingCount);
         setShowCompleted(readShowCompleted());
@@ -117,6 +127,19 @@ export function SettingsPage() {
       return next;
     });
   }, []);
+
+  const handleToggleSmartViews = useCallback(async () => {
+    if (!appPreferences) return;
+    const updated = await updateAppPreferences({
+      smartViewsEnabled: !appPreferences.smartViewsEnabled,
+    });
+    setAppPreferences(updated);
+    window.dispatchEvent(
+      new CustomEvent<AppPreferencesEventDetail>(APP_PREFERENCES_EVENT, {
+        detail: { preferences: updated },
+      }),
+    );
+  }, [appPreferences]);
 
   const reloadNotificationSettings = useCallback(async () => {
     const next = await getNotificationSettings();
@@ -261,6 +284,12 @@ export function SettingsPage() {
                   <AppearanceSettings
                     showCompleted={showCompleted}
                     onToggleCompleted={handleToggleCompleted}
+                  />
+                )}
+                {activeSection === "features" && appPreferences && (
+                  <FeatureSettings
+                    smartViewsEnabled={appPreferences.smartViewsEnabled}
+                    onToggleSmartViews={handleToggleSmartViews}
                   />
                 )}
                 {activeSection === "notifications" && (

--- a/components/settings-page/settings-sidebar.tsx
+++ b/components/settings-page/settings-sidebar.tsx
@@ -8,12 +8,14 @@ import {
   ArchiveIcon,
   DatabaseIcon,
   InfoIcon,
+  SlidersHorizontalIcon,
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export type SettingsSectionId =
   | "appearance"
+  | "features"
   | "notifications"
   | "sync"
   | "archive"
@@ -32,6 +34,7 @@ export interface SectionMeta {
 
 export const SETTINGS_SECTIONS: SectionMeta[] = [
   { id: "appearance", label: "Appearance", icon: PaletteIcon, description: "Theme and display preferences", group: "Preferences" },
+  { id: "features", label: "Features", icon: SlidersHorizontalIcon, description: "Optional workspace capabilities", group: "Preferences" },
   { id: "notifications", label: "Notifications", icon: BellIcon, description: "Reminders and alerts", group: "Preferences" },
   { id: "sync", label: "Cloud Sync", icon: CloudIcon, description: "Multi-device synchronization", group: "Preferences" },
   { id: "archive", label: "Archive", icon: ArchiveIcon, description: "Auto-archive completed tasks", group: "Data" },

--- a/components/settings/feature-settings.tsx
+++ b/components/settings/feature-settings.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Switch } from "@/components/ui/switch";
+import { SettingsRow } from "./shared-components";
+
+interface FeatureSettingsProps {
+  smartViewsEnabled: boolean;
+  onToggleSmartViews: () => void;
+}
+
+export function FeatureSettings({
+  smartViewsEnabled,
+  onToggleSmartViews,
+}: FeatureSettingsProps) {
+  return (
+    <div className="divide-y divide-border">
+      <SettingsRow
+        label="Smart views"
+        description="Show reusable task filters in the matrix and command palette"
+        state={smartViewsEnabled}
+      >
+        <Switch
+          id="smart-views-enabled"
+          checked={smartViewsEnabled}
+          onCheckedChange={onToggleSmartViews}
+          aria-label="Enable smart views"
+        />
+      </SettingsRow>
+    </div>
+  );
+}

--- a/components/task-card/index.tsx
+++ b/components/task-card/index.tsx
@@ -56,10 +56,11 @@ function TaskCardComponent({
       data-task-title={task.title}
       ref={(node) => {
         setNodeRef(node);
-        if (taskRef && node) {
+        if (taskRef) {
           taskRef(node);
         }
       }}
+      tabIndex={-1}
       style={style}
       className={cn(
         "group relative flex flex-col gap-2 rounded-xl border bg-card p-3 transition-all duration-200 animate-slide-in-card",

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -226,7 +226,8 @@ class GsdDatabase extends Dexie {
         return trans.table("appPreferences").add({
           id: "preferences",
           pinnedSmartViewIds: [],
-          maxPinnedViews: 5
+          maxPinnedViews: 5,
+          smartViewsEnabled: false
         });
       });
 

--- a/lib/smart-views.ts
+++ b/lib/smart-views.ts
@@ -5,6 +5,19 @@ import type { AppPreferences } from "@/lib/types";
 import { isoNow } from "@/lib/utils";
 import { SMART_VIEWS_CONFIG } from "@/lib/constants";
 
+export const APP_PREFERENCES_EVENT = "gsd:app-preferences";
+
+export interface AppPreferencesEventDetail {
+  preferences: AppPreferences;
+}
+
+const DEFAULT_APP_PREFERENCES: AppPreferences = {
+  id: "preferences",
+  pinnedSmartViewIds: [],
+  maxPinnedViews: SMART_VIEWS_CONFIG.MAX_PINNED,
+  smartViewsEnabled: false,
+};
+
 /**
  * Get all Smart Views (built-in + custom)
  */
@@ -119,14 +132,14 @@ export async function getAppPreferences(): Promise<AppPreferences> {
 
   // Return defaults if not found (for initial load before migration runs)
   if (!prefs) {
-    return {
-      id: "preferences" as const,
-      pinnedSmartViewIds: [],
-      maxPinnedViews: SMART_VIEWS_CONFIG.MAX_PINNED
-    };
+    return DEFAULT_APP_PREFERENCES;
   }
 
-  return prefs;
+  return {
+    ...DEFAULT_APP_PREFERENCES,
+    ...prefs,
+    id: "preferences",
+  };
 }
 
 /**
@@ -191,4 +204,3 @@ export async function unpinSmartView(viewId: string): Promise<void> {
     pinnedSmartViewIds: prefs.pinnedSmartViewIds.filter(id => id !== viewId)
   });
 }
-

--- a/lib/sync/pb-auth.ts
+++ b/lib/sync/pb-auth.ts
@@ -72,6 +72,14 @@ export function openOAuthPopup(provider: OAuthProvider): Window | null {
   return window.open('about:blank', `gsd_oauth_${provider}`, features);
 }
 
+function closeOAuthPopup(popupWindow?: Window | null): void {
+  try {
+    popupWindow?.close?.();
+  } catch {
+    // Some mobile browsers do not allow closing OAuth browser contexts.
+  }
+}
+
 export function cancelOAuthLogin(requestKey: string): void {
   if (!requestKey) return;
   getPocketBase().cancelRequest(requestKey);
@@ -137,11 +145,6 @@ export async function loginWithProvider(
         if (options.requestKey) {
           pb.cancelRequest(options.requestKey);
         }
-        try {
-          options.popupWindow?.close();
-        } catch {
-          // Some mobile browsers do not allow closing OAuth browser contexts.
-        }
         reject(new Error('OAuth sign-in timed out. Please close the sign-in page and try again.'));
       }, timeoutMs);
     });
@@ -160,11 +163,6 @@ export async function loginWithProvider(
       provider,
     };
   } catch (error) {
-    try {
-      options.popupWindow?.close();
-    } catch {
-      // Some mobile browsers do not allow closing OAuth browser contexts.
-    }
     const diagnostic = error as OAuthDiagnosticError;
     logger.error('OAuth login failed', error instanceof Error ? error : new Error(String(error)), {
       provider,
@@ -176,6 +174,7 @@ export async function loginWithProvider(
     if (timeoutId) {
       clearTimeout(timeoutId);
     }
+    closeOAuthPopup(options.popupWindow);
   }
 }
 

--- a/lib/task-card-memo.ts
+++ b/lib/task-card-memo.ts
@@ -111,6 +111,7 @@ function hasUIStateChanged(prevProps: TaskCardProps, nextProps: TaskCardProps): 
   return (
     prevProps.selectionMode !== nextProps.selectionMode ||
     prevProps.isSelected !== nextProps.isSelected ||
+    prevProps.isHighlighted !== nextProps.isHighlighted ||
     prevProps.allTasks.length !== nextProps.allTasks.length
   );
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -104,6 +104,7 @@ export interface AppPreferences {
   id: "preferences";
   pinnedSmartViewIds: string[]; // IDs of smart views pinned to header
   maxPinnedViews: number; // Maximum number of views that can be pinned (default: 5)
+  smartViewsEnabled: boolean; // Exposes Smart Views in the matrix and command palette
 }
 
 /**

--- a/lib/use-command-palette.ts
+++ b/lib/use-command-palette.ts
@@ -4,15 +4,18 @@ import type { TaskRecord } from "@/lib/types";
 import { applyFilters } from "@/lib/filters";
 import { SEARCH_CONFIG } from "@/lib/constants/ui";
 
+export const OPEN_COMMAND_PALETTE_EVENT = "gsd:open-command-palette";
+
 interface UseCommandPaletteOptions {
   actions: CommandAction[];
   tasks: TaskRecord[];
+  onSelectTask?: (taskId: string) => void;
 }
 
 /**
  * Hook to manage command palette state and filtering
  */
-export function useCommandPalette({ actions, tasks }: UseCommandPaletteOptions) {
+export function useCommandPalette({ actions, tasks, onSelectTask }: UseCommandPaletteOptions) {
   const [open, setOpenState] = useState(false);
   const [search, setSearch] = useState('');
   const [selectedActionId, setSelectedActionId] = useState<string | null>(null);
@@ -45,6 +48,12 @@ export function useCommandPalette({ actions, tasks }: UseCommandPaletteOptions) 
     document.addEventListener('keydown', down);
     return () => document.removeEventListener('keydown', down);
   }, [open, setOpen]);
+
+  useEffect(() => {
+    const openPalette = () => setOpen(true);
+    window.addEventListener(OPEN_COMMAND_PALETTE_EVENT, openPalette);
+    return () => window.removeEventListener(OPEN_COMMAND_PALETTE_EVENT, openPalette);
+  }, [setOpen]);
 
   // Filter actions by search query
   const filteredActions = useMemo(() => {
@@ -89,13 +98,19 @@ export function useCommandPalette({ actions, tasks }: UseCommandPaletteOptions) 
 
   // Handle task selection (navigate to matrix and highlight)
   const selectTask = useCallback((taskId: string) => {
+    if (onSelectTask) {
+      onSelectTask(taskId);
+      setOpen(false);
+      return;
+    }
+
     // Dispatch event for matrix to handle highlighting
     window.dispatchEvent(new CustomEvent('highlightTask', {
       detail: { taskId }
     }));
 
     setOpen(false);
-  }, [setOpen]);
+  }, [onSelectTask, setOpen]);
 
   return {
     open,

--- a/lib/use-shell-command-handlers.ts
+++ b/lib/use-shell-command-handlers.ts
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useTheme } from "next-themes";
 import type { CommandActionHandlers } from "@/lib/command-actions";
+import type { FilterCriteria } from "@/lib/filters";
 
 /**
  * Window event dispatched by the command palette when the user picks
@@ -11,6 +12,8 @@ import type { CommandActionHandlers } from "@/lib/command-actions";
  * Other routes fall back to a URL-driven flow (`/?action=new-task`).
  */
 export const NEW_TASK_EVENT = "gsd:new-task";
+export const HIGHLIGHT_TASK_EVENT = "gsd:highlight-task";
+export const APPLY_SMART_VIEW_EVENT = "gsd:apply-smart-view";
 
 /**
  * Window event dispatched by the command palette when the user picks
@@ -18,8 +21,14 @@ export const NEW_TASK_EVENT = "gsd:new-task";
  */
 export const OPEN_HELP_EVENT = "gsd:open-help";
 
+export interface ApplySmartViewEventDetail {
+  viewId: string;
+  criteria?: FilterCriteria;
+}
+
 interface ShellCommandResult {
   handlers: CommandActionHandlers;
+  onSelectTask: (taskId: string) => void;
   conditions: {
     isSyncEnabled: boolean;
     selectionMode: boolean;
@@ -40,6 +49,17 @@ export function useShellCommandHandlers(): ShellCommandResult {
   const { theme, resolvedTheme, setTheme } = useTheme();
 
   return useMemo(() => {
+    const onSelectTask = (taskId: string) => {
+      if (typeof window === "undefined") return;
+      if (window.location.pathname === "/") {
+        window.dispatchEvent(
+          new CustomEvent(HIGHLIGHT_TASK_EVENT, { detail: { taskId } })
+        );
+      } else {
+        router.push(`/?highlight=${encodeURIComponent(taskId)}`);
+      }
+    };
+
     const handlers: CommandActionHandlers = {
       onNewTask: () => {
         if (typeof window === "undefined") return;
@@ -67,14 +87,23 @@ export function useShellCommandHandlers(): ShellCommandResult {
       onViewDashboard: () => router.push("/dashboard"),
       onViewMatrix: () => router.push("/"),
       onViewArchive: () => router.push("/archive"),
-      onApplySmartView: () => {
-        // Smart-view actions are not surfaced in v9 (see ADR 0011); this
-        // handler exists only to satisfy the CommandActionHandlers contract.
+      onApplySmartView: (criteria, viewId) => {
+        if (typeof window === "undefined") return;
+        if (window.location.pathname === "/") {
+          window.dispatchEvent(
+            new CustomEvent<ApplySmartViewEventDetail>(APPLY_SMART_VIEW_EVENT, {
+              detail: { viewId, criteria },
+            })
+          );
+        } else {
+          router.push(`/?smartView=${encodeURIComponent(viewId)}`);
+        }
       },
     };
 
     return {
       handlers,
+      onSelectTask,
       conditions: {
         isSyncEnabled: false,
         selectionMode: false,

--- a/tests/data/db-upgrade-paths.test.ts
+++ b/tests/data/db-upgrade-paths.test.ts
@@ -248,6 +248,7 @@ describe('db upgrade callbacks', () => {
     expect(prefs).toBeDefined();
     expect(prefs!.pinnedSmartViewIds).toEqual([]);
     expect(prefs!.maxPinnedViews).toBe(5);
+    expect(prefs!.smartViewsEnabled).toBe(false);
   });
 
   it('v12 upgrade: should initialise time-tracking fields and reset corrupt data', async () => {

--- a/tests/data/smart-views.test.ts
+++ b/tests/data/smart-views.test.ts
@@ -352,13 +352,18 @@ describe('Smart Views', () => {
       expect(prefs.id).toBe('preferences');
       expect(prefs.pinnedSmartViewIds).toEqual([]);
       expect(prefs.maxPinnedViews).toBe(5);
+      expect(prefs.smartViewsEnabled).toBe(false);
     });
 
     it('should persist updated preferences', async () => {
-      await updateAppPreferences({ pinnedSmartViewIds: ['view-1', 'view-2'] });
+      await updateAppPreferences({
+        pinnedSmartViewIds: ['view-1', 'view-2'],
+        smartViewsEnabled: true,
+      });
 
       const prefs = await getAppPreferences();
       expect(prefs.pinnedSmartViewIds).toEqual(['view-1', 'view-2']);
+      expect(prefs.smartViewsEnabled).toBe(true);
     });
   });
 

--- a/tests/data/sync/pb-auth.test.ts
+++ b/tests/data/sync/pb-auth.test.ts
@@ -90,6 +90,22 @@ describe('PocketBase Auth', () => {
       expect(popupWindow.location.href).toBe('https://accounts.example.test/auth');
     });
 
+    it('should close a pre-opened popup after successful OAuth handoff', async () => {
+      mockAuthWithOAuth2.mockResolvedValue({
+        record: { id: 'user-123', email: 'test@example.com' },
+      });
+      const close = vi.fn();
+      const popupWindow = {
+        closed: false,
+        location: { href: '' },
+        close,
+      } as unknown as Window;
+
+      await loginWithProvider('google', { popupWindow });
+
+      expect(close).toHaveBeenCalledOnce();
+    });
+
     it('should cancel the PocketBase request when OAuth times out', async () => {
       vi.useFakeTimers();
       try {

--- a/tests/data/task-card-memo.test.ts
+++ b/tests/data/task-card-memo.test.ts
@@ -99,6 +99,12 @@ describe('areTaskCardPropsEqual', () => {
     expect(areTaskCardPropsEqual(prev, next)).toBe(false);
   });
 
+  it('returns false when highlight state changes', () => {
+    const prev = createProps({ isHighlighted: false });
+    const next = createProps({ isHighlighted: true });
+    expect(areTaskCardPropsEqual(prev, next)).toBe(false);
+  });
+
   it('returns false when allTasks length changes', () => {
     const prev = createProps({ allTasks: [] });
     const next = createProps({ allTasks: [createTask()] });

--- a/tests/data/use-command-palette.test.ts
+++ b/tests/data/use-command-palette.test.ts
@@ -22,7 +22,7 @@ vi.mock('@/lib/constants/ui', () => ({
   },
 }));
 
-import { useCommandPalette } from '@/lib/use-command-palette';
+import { OPEN_COMMAND_PALETTE_EVENT, useCommandPalette } from '@/lib/use-command-palette';
 import type { CommandAction } from '@/lib/command-actions';
 import type { TaskRecord } from '@/lib/types';
 
@@ -245,6 +245,31 @@ describe('useCommandPalette', () => {
     dispatchSpy.mockRestore();
   });
 
+  it('should use onSelectTask when provided', () => {
+    const onSelectTask = vi.fn();
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+    const { result } = renderHook(() =>
+      useCommandPalette({ actions, tasks, onSelectTask })
+    );
+
+    act(() => {
+      result.current.setOpen(true);
+    });
+
+    act(() => {
+      result.current.selectTask('task-42');
+    });
+
+    expect(onSelectTask).toHaveBeenCalledWith('task-42');
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'highlightTask' })
+    );
+    expect(result.current.open).toBe(false);
+
+    dispatchSpy.mockRestore();
+  });
+
   it('should open palette directly with setOpen(true)', () => {
     const { result } = renderHook(() =>
       useCommandPalette({ actions, tasks })
@@ -254,6 +279,18 @@ describe('useCommandPalette', () => {
 
     act(() => {
       result.current.setOpen(true);
+    });
+
+    expect(result.current.open).toBe(true);
+  });
+
+  it('should open palette when the shell open event is dispatched', () => {
+    const { result } = renderHook(() =>
+      useCommandPalette({ actions, tasks })
+    );
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(OPEN_COMMAND_PALETTE_EVENT));
     });
 
     expect(result.current.open).toBe(true);

--- a/tests/ui/app-shell.test.tsx
+++ b/tests/ui/app-shell.test.tsx
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AppShell } from "@/components/matrix-simplified/app-shell";
 
 const pushMock = vi.fn();
+const mockGetAppPreferences = vi.fn();
+const mockGetSmartViews = vi.fn();
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: pushMock }),
@@ -30,7 +32,9 @@ vi.mock("@/lib/use-tasks", () => ({
 }));
 
 vi.mock("@/lib/smart-views", () => ({
-  getSmartViews: vi.fn().mockResolvedValue([]),
+  APP_PREFERENCES_EVENT: "gsd:app-preferences",
+  getAppPreferences: (...args: unknown[]) => mockGetAppPreferences(...args),
+  getSmartViews: (...args: unknown[]) => mockGetSmartViews(...args),
 }));
 
 const setThemeMock = vi.fn();
@@ -50,6 +54,16 @@ if (!Element.prototype.scrollIntoView) {
 }
 
 describe("AppShell command palette wiring", () => {
+  beforeEach(() => {
+    mockGetAppPreferences.mockResolvedValue({
+      id: "preferences",
+      pinnedSmartViewIds: [],
+      maxPinnedViews: 5,
+      smartViewsEnabled: false,
+    });
+    mockGetSmartViews.mockResolvedValue([]);
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
   });
@@ -86,6 +100,23 @@ describe("AppShell command palette wiring", () => {
     });
   });
 
+  it("opens the command palette from the visible topbar button", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppShell title="Test">
+        <div>content</div>
+      </AppShell>
+    );
+
+    await user.click(screen.getByRole("button", { name: /open command palette/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText("Search tasks, actions, settings...")
+      ).toBeInTheDocument();
+    });
+  });
+
   it("does not surface smart-view actions in the palette", async () => {
     render(
       <AppShell title="Test">
@@ -101,6 +132,37 @@ describe("AppShell command palette wiring", () => {
     );
 
     expect(screen.queryByText("Smart Views")).not.toBeInTheDocument();
+  });
+
+  it("surfaces smart-view actions when the feature preference is enabled", async () => {
+    mockGetAppPreferences.mockResolvedValue({
+      id: "preferences",
+      pinnedSmartViewIds: [],
+      maxPinnedViews: 5,
+      smartViewsEnabled: true,
+    });
+    mockGetSmartViews.mockResolvedValue([
+      {
+        id: "built-in-focus",
+        name: "Today's Focus",
+        icon: "🎯",
+        criteria: { status: "active" },
+        isBuiltIn: true,
+        createdAt: "2025-01-01T00:00:00.000Z",
+        updatedAt: "2025-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    render(
+      <AppShell title="Test">
+        <div>content</div>
+      </AppShell>
+    );
+
+    fireEvent.keyDown(document, { key: "k", metaKey: true });
+
+    await waitFor(() => expect(screen.getByText("Smart Views")).toBeInTheDocument());
+    expect(screen.getByText("🎯 Today's Focus")).toBeInTheDocument();
   });
 
   it("navigates to /settings when Open settings is executed", async () => {

--- a/tests/ui/matrix-simplified.test.tsx
+++ b/tests/ui/matrix-simplified.test.tsx
@@ -2,8 +2,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { TaskRecord } from "@/lib/types";
+import type { SmartView } from "@/lib/filters";
 
 const tasksFixture = vi.hoisted(() => ({ current: [] as TaskRecord[] }));
+const smartViewsFixture = vi.hoisted(() => ({
+  enabled: false,
+  current: [] as SmartView[],
+}));
 
 vi.mock("@/lib/use-tasks", () => ({
   useTasks: () => ({
@@ -44,6 +49,22 @@ vi.mock("@/lib/tasks", () => ({
   toggleCompleted: vi.fn().mockResolvedValue(undefined),
   updateTask: vi.fn().mockResolvedValue(undefined),
   deleteTask: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/smart-views", () => ({
+  APP_PREFERENCES_EVENT: "gsd:app-preferences",
+  getAppPreferences: vi.fn().mockImplementation(() =>
+    Promise.resolve({
+      id: "preferences",
+      pinnedSmartViewIds: [],
+      maxPinnedViews: 5,
+      smartViewsEnabled: smartViewsFixture.enabled,
+    })
+  ),
+  getSmartViews: vi.fn().mockImplementation(() => Promise.resolve(smartViewsFixture.current)),
+  getSmartView: vi.fn().mockImplementation((id: string) =>
+    Promise.resolve(smartViewsFixture.current.find((view) => view.id === id))
+  ),
 }));
 
 vi.mock("@/lib/confetti", () => ({
@@ -105,7 +126,13 @@ import { celebrateCompletion } from "@/lib/confetti";
 describe("<MatrixSimplified>", () => {
   beforeEach(() => {
     tasksFixture.current = [];
+    smartViewsFixture.enabled = false;
+    smartViewsFixture.current = [];
     localStorage.removeItem("gsd:show-completed");
+    window.history.replaceState({}, "", "/");
+    if (!Element.prototype.scrollIntoView) {
+      Element.prototype.scrollIntoView = vi.fn();
+    }
     vi.mocked(celebrateCompletion).mockClear();
     vi.mocked(toggleCompleted).mockClear();
   });
@@ -164,6 +191,63 @@ describe("<MatrixSimplified>", () => {
     expect(screen.getByRole("region", { name: /schedule quadrant/i })).toBeInTheDocument();
     expect(screen.getByRole("region", { name: /delegate quadrant/i })).toBeInTheDocument();
     expect(screen.getByRole("region", { name: /eliminate quadrant/i })).toBeInTheDocument();
+  });
+
+  it("opens the create drawer when the shell new-task event fires", async () => {
+    render(<MatrixSimplified />);
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("gsd:new-task"));
+    });
+
+    expect(await screen.findByRole("heading", { name: /new task/i })).toBeInTheDocument();
+  });
+
+  it("highlights a task when the shell highlight event fires", async () => {
+    tasksFixture.current = [makeTask({ id: "target", title: "Target task" })];
+    render(<MatrixSimplified />);
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("gsd:highlight-task", { detail: { taskId: "target" } })
+      );
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("task-card")).toHaveClass("ring-4")
+    );
+  });
+
+  it("shows and applies smart views when the feature preference is enabled", async () => {
+    const user = userEvent.setup();
+    smartViewsFixture.enabled = true;
+    smartViewsFixture.current = [
+      {
+        id: "built-in-completed",
+        name: "All Completed",
+        icon: "✅",
+        criteria: { status: "completed" },
+        isBuiltIn: true,
+        createdAt: "2025-01-01T00:00:00.000Z",
+        updatedAt: "2025-01-01T00:00:00.000Z",
+      },
+    ];
+    tasksFixture.current = [
+      makeTask({ id: "active", title: "Active alpha", completed: false }),
+      makeTask({ id: "done", title: "Done bravo", completed: true }),
+    ];
+
+    render(<MatrixSimplified />);
+
+    expect(screen.getByText("Active alpha")).toBeInTheDocument();
+    expect(screen.queryByText("Done bravo")).not.toBeInTheDocument();
+
+    await user.click(await screen.findByRole("button", { name: /all completed/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Active alpha")).not.toBeInTheDocument();
+      expect(screen.getByText("Done bravo")).toBeInTheDocument();
+    });
   });
 
   describe("show-completed preference", () => {

--- a/tests/ui/settings-components.test.tsx
+++ b/tests/ui/settings-components.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import { SettingsRow, SettingsSelectRow } from '@/components/settings/shared-components';
 import { AboutSection } from '@/components/settings/about-section';
 import { AppearanceSettings } from '@/components/settings/appearance-settings';
+import { FeatureSettings } from '@/components/settings/feature-settings';
 import { NotificationSettingsSection } from '@/components/settings/notification-settings';
 import { ArchiveSettings } from '@/components/settings/archive-settings';
 import { DataManagement } from '@/components/settings/data-management';
@@ -202,6 +203,21 @@ describe('Settings Components', () => {
     it('switch reflects showCompleted=true state', () => {
       render(<AppearanceSettings showCompleted={true} onToggleCompleted={vi.fn()} />);
       expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+    });
+  });
+
+  describe('FeatureSettings', () => {
+    it('renders the smart views feature toggle', () => {
+      render(<FeatureSettings smartViewsEnabled={false} onToggleSmartViews={vi.fn()} />);
+      expect(screen.getByText('Smart views')).toBeInTheDocument();
+      expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('calls onToggleSmartViews when the switch is clicked', () => {
+      const onToggle = vi.fn();
+      render(<FeatureSettings smartViewsEnabled={false} onToggleSmartViews={onToggle} />);
+      fireEvent.click(screen.getByRole('switch'));
+      expect(onToggle).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Summary

- Close the custom PocketBase OAuth popup after successful handoff so users are not left on the forbidden PocketBase admin redirect page.
- Expose the command palette through a visible top-bar button while keeping Cmd/Ctrl+K support.
- Add a Settings > Features toggle for Smart Views, then surface smart-view pills on the matrix and smart-view actions in the command palette when enabled.
- Wire task selection, smart-view application, and matrix task highlighting across routes.

## Validation

- `bun run test` passed: 1881 passed, 1 skipped.
- `bun run typecheck` passed.
- `bun run lint` passed with only the existing generated coverage warnings under `packages/mcp-server/coverage`.
- `git diff --check` passed.
- Browser sanity check passed for opening the command palette and enabling/applying Smart Views.

## Notes

`public/sw.js` has unrelated local cache-version churn and was intentionally left out of this PR.