### PR TITLE
fix(cloudfront): match path traversal by segment, not substring

### DIFF
--- a/cloudfront-function-url-rewrite.cjs
+++ b/cloudfront-function-url-rewrite.cjs
@@ -25,11 +25,17 @@ function handler(event) {
   //    characters, null bytes, or path-traversal sequences. CloudFront and
   //    S3 reject most of these downstream, but a cheap defense-in-depth check
   //    here prevents any chance of CRLF injection into the rewritten URI.
+  //
+  //    Traversal is a `..` *path segment* (`/../`), so we match `..` only as a
+  //    whole segment — NOT as a substring. Turbopack content hashes legitimately
+  //    contain `..` inside a filename (e.g. `chunks/09g3a9~1ks65..js`); a naive
+  //    `indexOf('..')` would rewrite those real assets to `/index.html`, serving
+  //    HTML where the browser expects JavaScript.
   if (
     uri.indexOf('\r') !== -1 ||
     uri.indexOf('\n') !== -1 ||
     uri.indexOf('\0') !== -1 ||
-    uri.indexOf('..') !== -1
+    uri.split('/').indexOf('..') !== -1
   ) {
     request.uri = '/index.html';
     return request;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.4.0",
+	"version": "9.4.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/data/cloudfront-functions.test.ts
+++ b/tests/data/cloudfront-functions.test.ts
@@ -48,6 +48,15 @@ describe('cloudfront-function-url-rewrite (viewer-request)', () => {
 		expect(out.uri).toBe('/_next/static/chunks/main.js');
 	});
 
+	it('passes through chunk filenames whose content hash contains a double-dot', () => {
+		// Turbopack content hashes can contain `..` (e.g. `09g3a9~1ks65..js`).
+		// These are real files, not path traversal — the guard must not rewrite
+		// them to /index.html, which serves HTML where the browser expects JS.
+		const req = makeRequest('/_next/static/chunks/09g3a9~1ks65..js');
+		const out = urlRewrite({ request: req }) as CFRequest;
+		expect(out.uri).toBe('/_next/static/chunks/09g3a9~1ks65..js');
+	});
+
 	it('passes API and PocketBase admin paths through unchanged', () => {
 		for (const uri of ['/api', '/api/oauth2-redirect', '/api/auth/oauth-callback', '/_', '/_/']) {
 			const req = makeRequest(uri);


### PR DESCRIPTION
## What & why

The CloudFront viewer-request guard rewrote any URI containing the **substring** `..` to `/index.html`. Turbopack content hashes legitimately contain `..` inside a filename (e.g. `/_next/static/chunks/09g3a9~1ks65..js`), so those real chunks were served as `text/html` and refused by the browser's strict MIME check:

> Refused to execute script from '…09g3a9~1ks65..js' because its MIME type ('text/html') is not executable

With the app's chunk failing to load, the OAuth callback page couldn't run — so OAuth *appeared* broken. The guard predates #338; the colliding filenames are what's new (#339 reshuffled the chunk graph into `..`-containing hashes). 2 of 36 chunks in the current build are affected, and since hashes are effectively random this would keep breaking random deploys.

## The fix

Narrow the check to a `..` **path segment** (real traversal is always `/../`):

```js
- uri.indexOf('..') !== -1
+ uri.split('/').indexOf('..') !== -1
```

Filenames containing `..` now pass through; `/foo/../bar`, `/..`, and `/about/../../etc/passwd` stay blocked.

## Verification

Confirmed against production before the fix:

| Chunk | Has `..`? | Live `content-type` |
|---|---|---|
| `turbopack-0x1h2c8sz836n.js` | no | `text/javascript` ✅ |
| `09g3a9~1ks65..js` | yes | `text/html` ❌ |

- Added regression test using the literal failing filename (red confirmed before green)
- Full suite: **1899 passed, 1 skipped, 0 failed**
- `bun typecheck` clean; `bun lint` clean (changed files)
- `node --check` passes — valid for the CloudFront V8 runtime
- Handler smoke-tested: the two real `..` chunks pass through, all traversal cases still rewrite to `/index.html`

## ⚠️ Deploy required

This is inert in production until the edge function is republished:

\`\`\`bash
CLOUDFRONT_DISTRIBUTION_ID=<dist-id> ./scripts/deploy-cloudfront-function.sh
\`\`\`

Post-deploy check (should flip to `text/javascript`):

\`\`\`bash
curl -sI 'https://gsd.vinny.dev/_next/static/chunks/09g3a9~1ks65..js' | grep -i content-type
\`\`\`

Note: clients that already cached the bad `text/html` response in the service worker's immutable cache may need a hard refresh until the chunk's content/hash next changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->