### PR TITLE
[codex] fix security scan findings

### DIFF
--- a/.github/REPOSITORY_SETTINGS.md
+++ b/.github/REPOSITORY_SETTINGS.md
@@ -82,7 +82,34 @@ Navigate to: **Settings → Code security and analysis**
 - [x] **Secret scanning**: Enable (if available)
 - [x] **Push protection**: Enable (if available)
 
-## Step 4: Moderation Settings
+## Step 4: Release Environments and Tag Rules
+
+Navigate to: **Settings → Environments**
+
+Create or verify these environments:
+
+- [x] `production`
+  - [x] Required reviewers: `vscarpenter`
+  - [x] Deployment branches and tags: protected branches and protected tags only
+
+- [x] `mcp-release`
+  - [x] Required reviewers: `vscarpenter`
+  - [x] Deployment branches and tags: protected branches and protected tags only
+
+Navigate to: **Settings → Rules → Rulesets**
+
+Create release tag rulesets:
+
+- [x] `v*.*.*` app release tags
+- [x] `mcp-v*.*.*` MCP package release tags
+- [x] Require creation/update through reviewed `main` release flow
+- [x] Block force-pushes and deletions
+
+The workflows also verify that release commits are reachable from `origin/main`.
+The environment rules provide the human approval boundary before production
+deploys or package publishes can use protected credentials.
+
+## Step 5: Moderation Settings
 
 Navigate to: **Settings → Moderation options**
 
@@ -93,7 +120,7 @@ Navigate to: **Settings → Moderation options**
 ### Code review limits
 - Leave at default (allow anyone)
 
-## Step 5: Make Repository Public
+## Step 6: Make Repository Public
 
 Navigate to: **Settings → General → Danger Zone**
 
@@ -103,7 +130,7 @@ Navigate to: **Settings → General → Danger Zone**
 4. Type repository name to confirm: `gsd-task-manager`
 5. Click **I understand, change repository visibility**
 
-## Step 6: Add Repository Topics (Optional)
+## Step 7: Add Repository Topics (Optional)
 
 At the top of your repository page:
 
@@ -119,7 +146,7 @@ Add topics:
 - `indexeddb`
 - `productivity`
 
-## Step 7: Update Repository Description
+## Step 8: Update Repository Description
 
 In the same About section:
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,11 +1,11 @@
 name: Deploy to Production
 
 on:
-  # Tag-triggered release: v*.*.* on any branch.
+  # Tag-triggered release: v*.*.*. The job verifies the tagged commit is on main.
   # Matches the package.json semver (e.g. v9.1.11 → 9.1.11).
   push:
     tags: ['v*.*.*']
-  # Manual override — useful for re-deploying the current ref.
+  # Manual override — useful for re-deploying a reviewed main ref.
   workflow_dispatch:
 
 # Locked decision §7.7: queue overlapping deploys, never cancel.
@@ -32,7 +32,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+
+      - name: Verify deployment ref is on main
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          DEPLOY_COMMIT=$(git rev-parse "${GITHUB_SHA}^{commit}")
+          if ! git merge-base --is-ancestor "$DEPLOY_COMMIT" origin/main; then
+            echo "::error::Deployment commit $DEPLOY_COMMIT is not reachable from origin/main"
+            exit 1
+          fi
 
       # Mirrors publish-mcp-server.yml's tag-vs-package.json check.
       # Stops a v9.1.11 tag from accidentally deploying a 9.1.10 build.
@@ -50,7 +59,7 @@ jobs:
           echo "Deploying version $PKG_VERSION"
           echo "## Deploying v$PKG_VERSION to production" >> "$GITHUB_STEP_SUMMARY"
 
-      # Always rebuild for prod — the tag can point at any commit, and the
+      # Always rebuild for prod — older release tags might not have retained
       # 14-day artifact retention from CI can't be relied on for older tags.
       # The build is deterministic from the tree, so this produces the same
       # bytes CI built when the tagged commit was on main.

--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -19,6 +19,9 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment:
+      name: mcp-release
+      url: https://www.npmjs.com/package/gsd-mcp-server
     defaults:
       run:
         working-directory: packages/mcp-server
@@ -26,6 +29,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify publish ref is reviewed
+        if: github.event_name == 'push' || inputs.dry_run == false
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::error::Manual publish must run from the main branch."
+            exit 1
+          fi
+
+          RELEASE_COMMIT=$(git rev-parse "${GITHUB_SHA}^{commit}")
+          if ! git merge-base --is-ancestor "$RELEASE_COMMIT" origin/main; then
+            echo "::error::Publish commit $RELEASE_COMMIT is not reachable from origin/main"
+            exit 1
+          fi
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/lib/sync/pb-push.ts
+++ b/lib/sync/pb-push.ts
@@ -30,6 +30,12 @@ function isRateLimitError(error: unknown): boolean {
   return false;
 }
 
+function makeSafePushError(errorCode: string): Error {
+  const error = new Error(errorCode);
+  error.name = 'SyncPushError';
+  return error;
+}
+
 export interface PushResult {
   pushedCount: number;
   failedCount: number;
@@ -219,7 +225,7 @@ export async function pushLocalChanges(): Promise<PushResult> {
           errorCode,
         });
       } else {
-        logger.error('Push failed for item', errorObj, {
+        logger.error('Push failed for item', makeSafePushError(errorCode), {
           taskId: item.taskId,
           operation: item.operation,
           errorCode,

--- a/packages/mcp-server/src/__tests__/tools/input-schemas.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/input-schemas.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { SCHEMA_LIMITS } from '../../constants.js';
 import { validateToolArgs } from '../../tools/handlers/input-schemas.js';
 
 describe('validateToolArgs', () => {
@@ -73,6 +74,74 @@ describe('validateToolArgs', () => {
       ).toThrow(/estimatedMinutes/);
     });
 
+    it('rejects oversized write payload fields', () => {
+      const basePayload = {
+        title: 'x',
+        urgent: true,
+        important: true,
+      };
+
+      expect(() =>
+        validateToolArgs('create_task', {
+          ...basePayload,
+          title: 'x'.repeat(SCHEMA_LIMITS.TASK_TITLE_MAX_LENGTH + 1),
+        })
+      ).toThrow(/title/);
+
+      expect(() =>
+        validateToolArgs('create_task', {
+          ...basePayload,
+          description: 'x'.repeat(SCHEMA_LIMITS.TASK_DESCRIPTION_MAX_LENGTH + 1),
+        })
+      ).toThrow(/description/);
+
+      expect(() =>
+        validateToolArgs('create_task', {
+          ...basePayload,
+          tags: Array.from({ length: SCHEMA_LIMITS.MAX_TAGS + 1 }, (_, i) => `tag-${i}`),
+        })
+      ).toThrow(/tags/);
+
+      expect(() =>
+        validateToolArgs('create_task', {
+          ...basePayload,
+          tags: ['x'.repeat(SCHEMA_LIMITS.TAG_MAX_LENGTH + 1)],
+        })
+      ).toThrow(/tags/);
+
+      expect(() =>
+        validateToolArgs('create_task', {
+          ...basePayload,
+          subtasks: Array.from({ length: SCHEMA_LIMITS.MAX_SUBTASKS + 1 }, () => ({
+            title: 'subtask',
+            completed: false,
+          })),
+        })
+      ).toThrow(/subtasks/);
+
+      expect(() =>
+        validateToolArgs('create_task', {
+          ...basePayload,
+          subtasks: [
+            {
+              title: 'x'.repeat(SCHEMA_LIMITS.SUBTASK_TITLE_MAX_LENGTH + 1),
+              completed: false,
+            },
+          ],
+        })
+      ).toThrow(/subtasks/);
+
+      expect(() =>
+        validateToolArgs('create_task', {
+          ...basePayload,
+          dependencies: Array.from(
+            { length: SCHEMA_LIMITS.MAX_DEPENDENCIES + 1 },
+            (_, i) => `dep-${i}`
+          ),
+        })
+      ).toThrow(/dependencies/);
+    });
+
     it('rejects unknown fields (strict mode)', () => {
       expect(() =>
         validateToolArgs('create_task', {
@@ -97,6 +166,42 @@ describe('validateToolArgs', () => {
     it('requires id', () => {
       expect(() => validateToolArgs('update_task', { title: 'x' })).toThrow(/id/);
     });
+
+    it('rejects oversized mutable fields', () => {
+      expect(() =>
+        validateToolArgs('update_task', {
+          id: 'abc',
+          title: 'x'.repeat(SCHEMA_LIMITS.TASK_TITLE_MAX_LENGTH + 1),
+        })
+      ).toThrow(/title/);
+
+      expect(() =>
+        validateToolArgs('update_task', {
+          id: 'abc',
+          tags: ['x'.repeat(SCHEMA_LIMITS.TAG_MAX_LENGTH + 1)],
+        })
+      ).toThrow(/tags/);
+
+      expect(() =>
+        validateToolArgs('update_task', {
+          id: 'abc',
+          subtasks: [
+            {
+              id: 'sub-1',
+              title: 'x'.repeat(SCHEMA_LIMITS.SUBTASK_TITLE_MAX_LENGTH + 1),
+              completed: false,
+            },
+          ],
+        })
+      ).toThrow(/subtasks/);
+
+      expect(() =>
+        validateToolArgs('update_task', {
+          id: 'abc',
+          dependencies: ['x'.repeat(SCHEMA_LIMITS.ID_MAX_LENGTH + 1)],
+        })
+      ).toThrow(/dependencies/);
+    });
   });
 
   describe('bulk_update_tasks', () => {
@@ -118,13 +223,42 @@ describe('validateToolArgs', () => {
     });
 
     it('rejects more than 50 task ids', () => {
-      const ids = Array.from({ length: 51 }, (_, i) => `id${i}`);
+      const ids = Array.from({ length: SCHEMA_LIMITS.MAX_BULK_TASKS + 1 }, (_, i) => `id${i}`);
       expect(() =>
         validateToolArgs('bulk_update_tasks', {
           taskIds: ids,
           operation: { type: 'delete' },
         })
       ).toThrow(/taskIds/);
+    });
+
+    it('rejects oversized task ids and operation tags', () => {
+      expect(() =>
+        validateToolArgs('bulk_update_tasks', {
+          taskIds: ['x'.repeat(SCHEMA_LIMITS.ID_MAX_LENGTH + 1)],
+          operation: { type: 'delete' },
+        })
+      ).toThrow(/taskIds/);
+
+      expect(() =>
+        validateToolArgs('bulk_update_tasks', {
+          taskIds: ['id1'],
+          operation: {
+            type: 'add_tags',
+            tags: Array.from({ length: SCHEMA_LIMITS.MAX_TAGS + 1 }, (_, i) => `tag-${i}`),
+          },
+        })
+      ).toThrow(/tags/);
+
+      expect(() =>
+        validateToolArgs('bulk_update_tasks', {
+          taskIds: ['id1'],
+          operation: {
+            type: 'remove_tags',
+            tags: ['x'.repeat(SCHEMA_LIMITS.TAG_MAX_LENGTH + 1)],
+          },
+        })
+      ).toThrow(/tags/);
     });
 
     it('rejects caller-supplied maxTasks (policy lives server-side, not in input)', () => {

--- a/packages/mcp-server/src/__tests__/tools/schemas.test.ts
+++ b/packages/mcp-server/src/__tests__/tools/schemas.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { SCHEMA_LIMITS } from '../../constants.js';
 import {
   allTools,
   readTools,
@@ -171,6 +172,47 @@ describe('Tool Schemas', () => {
       expect(properties).toHaveProperty('notifyBefore');
       expect(properties).toHaveProperty('notificationEnabled');
       expect(properties).toHaveProperty('estimatedMinutes');
+    });
+
+    it('write tool schemas should advertise bounded payload sizes', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const createProperties = createTaskTool.inputSchema.properties as any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const updateProperties = updateTaskTool.inputSchema.properties as any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const completeProperties = completeTaskTool.inputSchema.properties as any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const deleteProperties = deleteTaskTool.inputSchema.properties as any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const bulkProperties = bulkUpdateTasksTool.inputSchema.properties as any;
+
+      expect(createProperties.title.maxLength).toBe(SCHEMA_LIMITS.TASK_TITLE_MAX_LENGTH);
+      expect(createProperties.description.maxLength).toBe(
+        SCHEMA_LIMITS.TASK_DESCRIPTION_MAX_LENGTH
+      );
+      expect(createProperties.tags.maxItems).toBe(SCHEMA_LIMITS.MAX_TAGS);
+      expect(createProperties.tags.items.maxLength).toBe(SCHEMA_LIMITS.TAG_MAX_LENGTH);
+      expect(createProperties.subtasks.maxItems).toBe(SCHEMA_LIMITS.MAX_SUBTASKS);
+      expect(createProperties.subtasks.items.properties.title.maxLength).toBe(
+        SCHEMA_LIMITS.SUBTASK_TITLE_MAX_LENGTH
+      );
+      expect(createProperties.dependencies.maxItems).toBe(SCHEMA_LIMITS.MAX_DEPENDENCIES);
+      expect(createProperties.dependencies.items.maxLength).toBe(SCHEMA_LIMITS.ID_MAX_LENGTH);
+
+      expect(updateProperties.id.maxLength).toBe(SCHEMA_LIMITS.ID_MAX_LENGTH);
+      expect(updateProperties.title.maxLength).toBe(SCHEMA_LIMITS.TASK_TITLE_MAX_LENGTH);
+      expect(updateProperties.tags.maxItems).toBe(SCHEMA_LIMITS.MAX_TAGS);
+      expect(updateProperties.subtasks.maxItems).toBe(SCHEMA_LIMITS.MAX_SUBTASKS);
+      expect(updateProperties.dependencies.maxItems).toBe(SCHEMA_LIMITS.MAX_DEPENDENCIES);
+      expect(completeProperties.id.maxLength).toBe(SCHEMA_LIMITS.ID_MAX_LENGTH);
+      expect(deleteProperties.id.maxLength).toBe(SCHEMA_LIMITS.ID_MAX_LENGTH);
+
+      expect(bulkProperties.taskIds.maxItems).toBe(SCHEMA_LIMITS.MAX_BULK_TASKS);
+      expect(bulkProperties.taskIds.items.maxLength).toBe(SCHEMA_LIMITS.ID_MAX_LENGTH);
+      expect(bulkProperties.operation.properties.tags.maxItems).toBe(SCHEMA_LIMITS.MAX_TAGS);
+      expect(bulkProperties.operation.properties.tags.items.maxLength).toBe(
+        SCHEMA_LIMITS.TAG_MAX_LENGTH
+      );
     });
 
     it('update_task should expose notification and time fields', () => {

--- a/packages/mcp-server/src/constants.ts
+++ b/packages/mcp-server/src/constants.ts
@@ -3,3 +3,20 @@
  * Must match Worker schema validation limit
  */
 export const MAX_TASKS_PER_PULL = 100;
+
+/**
+ * Payload bounds shared by MCP Zod validation and advertised JSON schemas.
+ * These mirror the web app task schema so remote tool clients cannot submit
+ * larger write payloads than the first-party UI accepts.
+ */
+export const SCHEMA_LIMITS = {
+  ID_MAX_LENGTH: 255,
+  TASK_TITLE_MAX_LENGTH: 80,
+  TASK_DESCRIPTION_MAX_LENGTH: 600,
+  TAG_MAX_LENGTH: 30,
+  SUBTASK_TITLE_MAX_LENGTH: 100,
+  MAX_TAGS: 20,
+  MAX_SUBTASKS: 50,
+  MAX_DEPENDENCIES: 50,
+  MAX_BULK_TASKS: 50,
+} as const;

--- a/packages/mcp-server/src/tools/handlers/input-schemas.ts
+++ b/packages/mcp-server/src/tools/handlers/input-schemas.ts
@@ -10,6 +10,7 @@
  */
 
 import { z } from 'zod';
+import { SCHEMA_LIMITS } from '../../constants.js';
 
 export const quadrantSchema = z.enum([
   'urgent-important',
@@ -21,18 +22,25 @@ export const quadrantSchema = z.enum([
 export const recurrenceSchema = z.enum(['none', 'daily', 'weekly', 'monthly']);
 
 const optionalIsoDatetime = z.string().datetime({ offset: true }).optional();
+const idSchema = z.string().min(1).max(SCHEMA_LIMITS.ID_MAX_LENGTH);
+const taskTitleSchema = z.string().min(1).max(SCHEMA_LIMITS.TASK_TITLE_MAX_LENGTH);
+const taskDescriptionSchema = z.string().max(SCHEMA_LIMITS.TASK_DESCRIPTION_MAX_LENGTH);
+const tagSchema = z.string().min(1).max(SCHEMA_LIMITS.TAG_MAX_LENGTH);
+const subtaskTitleSchema = z.string().min(1).max(SCHEMA_LIMITS.SUBTASK_TITLE_MAX_LENGTH);
+const tagsSchema = z.array(tagSchema).max(SCHEMA_LIMITS.MAX_TAGS);
+const dependenciesSchema = z.array(idSchema).max(SCHEMA_LIMITS.MAX_DEPENDENCIES);
 
 export const listTasksArgsSchema = z
   .object({
     quadrant: quadrantSchema.optional(),
     completed: z.boolean().optional(),
-    tags: z.array(z.string()).optional(),
+    tags: tagsSchema.optional(),
   })
   .strict();
 
 export const getTaskArgsSchema = z
   .object({
-    taskId: z.string().min(1),
+    taskId: idSchema,
   })
   .strict();
 
@@ -65,17 +73,18 @@ const estimatedMinutesSchema = z.number().int().min(1).max(10080).optional();
 
 export const createTaskArgsSchema = z
   .object({
-    title: z.string().min(1),
-    description: z.string().optional(),
+    title: taskTitleSchema,
+    description: taskDescriptionSchema.optional(),
     urgent: z.boolean(),
     important: z.boolean(),
     dueDate: optionalIsoDatetime,
-    tags: z.array(z.string()).optional(),
+    tags: tagsSchema.optional(),
     subtasks: z
-      .array(z.object({ title: z.string().min(1), completed: z.boolean() }))
+      .array(z.object({ title: subtaskTitleSchema, completed: z.boolean() }))
+      .max(SCHEMA_LIMITS.MAX_SUBTASKS)
       .optional(),
     recurrence: recurrenceSchema.optional(),
-    dependencies: z.array(z.string().min(1)).optional(),
+    dependencies: dependenciesSchema.optional(),
     notifyBefore: notifyBeforeSchema,
     notificationEnabled: z.boolean().optional(),
     estimatedMinutes: estimatedMinutesSchema,
@@ -85,27 +94,28 @@ export const createTaskArgsSchema = z
 
 export const updateTaskArgsSchema = z
   .object({
-    id: z.string().min(1),
-    title: z.string().min(1).optional(),
-    description: z.string().optional(),
+    id: idSchema,
+    title: taskTitleSchema.optional(),
+    description: taskDescriptionSchema.optional(),
     urgent: z.boolean().optional(),
     important: z.boolean().optional(),
     // Empty string clears the due date; non-empty must be an ISO 8601 datetime.
     dueDate: z
       .union([z.literal(''), z.string().datetime({ offset: true })])
       .optional(),
-    tags: z.array(z.string()).optional(),
+    tags: tagsSchema.optional(),
     subtasks: z
       .array(
         z.object({
-          id: z.string().min(1),
-          title: z.string().min(1),
+          id: idSchema,
+          title: subtaskTitleSchema,
           completed: z.boolean(),
         })
       )
+      .max(SCHEMA_LIMITS.MAX_SUBTASKS)
       .optional(),
     recurrence: recurrenceSchema.optional(),
-    dependencies: z.array(z.string().min(1)).optional(),
+    dependencies: dependenciesSchema.optional(),
     completed: z.boolean().optional(),
     notifyBefore: notifyBeforeSchema,
     notificationEnabled: z.boolean().optional(),
@@ -116,7 +126,7 @@ export const updateTaskArgsSchema = z
 
 export const completeTaskArgsSchema = z
   .object({
-    id: z.string().min(1),
+    id: idSchema,
     completed: z.boolean(),
     dryRun: z.boolean().optional(),
   })
@@ -124,7 +134,7 @@ export const completeTaskArgsSchema = z
 
 export const deleteTaskArgsSchema = z
   .object({
-    id: z.string().min(1),
+    id: idSchema,
     dryRun: z.boolean().optional(),
   })
   .strict();
@@ -136,8 +146,8 @@ const bulkOperationSchema = z.discriminatedUnion('type', [
     urgent: z.boolean(),
     important: z.boolean(),
   }),
-  z.object({ type: z.literal('add_tags'), tags: z.array(z.string().min(1)).min(1) }),
-  z.object({ type: z.literal('remove_tags'), tags: z.array(z.string().min(1)).min(1) }),
+  z.object({ type: z.literal('add_tags'), tags: tagsSchema.min(1) }),
+  z.object({ type: z.literal('remove_tags'), tags: tagsSchema.min(1) }),
   z.object({
     type: z.literal('set_due_date'),
     dueDate: z.union([z.literal(''), z.string().datetime({ offset: true })]).optional(),
@@ -147,7 +157,7 @@ const bulkOperationSchema = z.discriminatedUnion('type', [
 
 export const bulkUpdateTasksArgsSchema = z
   .object({
-    taskIds: z.array(z.string().min(1)).min(1).max(50),
+    taskIds: z.array(idSchema).min(1).max(SCHEMA_LIMITS.MAX_BULK_TASKS),
     operation: bulkOperationSchema,
     dryRun: z.boolean().optional(),
   })

--- a/packages/mcp-server/src/tools/schemas/write-tools.ts
+++ b/packages/mcp-server/src/tools/schemas/write-tools.ts
@@ -1,4 +1,5 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { SCHEMA_LIMITS } from '../../constants.js';
 
 /**
  * Write operation tool schemas for modifying task data
@@ -13,10 +14,13 @@ export const createTaskTool: Tool = {
     properties: {
       title: {
         type: 'string',
+        minLength: 1,
+        maxLength: SCHEMA_LIMITS.TASK_TITLE_MAX_LENGTH,
         description: 'Task title (required)',
       },
       description: {
         type: 'string',
+        maxLength: SCHEMA_LIMITS.TASK_DESCRIPTION_MAX_LENGTH,
         description: 'Task description',
       },
       urgent: {
@@ -33,15 +37,21 @@ export const createTaskTool: Tool = {
       },
       tags: {
         type: 'array',
-        items: { type: 'string' },
+        maxItems: SCHEMA_LIMITS.MAX_TAGS,
+        items: { type: 'string', minLength: 1, maxLength: SCHEMA_LIMITS.TAG_MAX_LENGTH },
         description: 'Tags for categorization (e.g., ["#work", "#project-alpha"])',
       },
       subtasks: {
         type: 'array',
+        maxItems: SCHEMA_LIMITS.MAX_SUBTASKS,
         items: {
           type: 'object',
           properties: {
-            title: { type: 'string' },
+            title: {
+              type: 'string',
+              minLength: 1,
+              maxLength: SCHEMA_LIMITS.SUBTASK_TITLE_MAX_LENGTH,
+            },
             completed: { type: 'boolean' },
           },
           required: ['title', 'completed'],
@@ -55,7 +65,8 @@ export const createTaskTool: Tool = {
       },
       dependencies: {
         type: 'array',
-        items: { type: 'string' },
+        maxItems: SCHEMA_LIMITS.MAX_DEPENDENCIES,
+        items: { type: 'string', minLength: 1, maxLength: SCHEMA_LIMITS.ID_MAX_LENGTH },
         description: 'Task IDs that must be completed before this task',
       },
       notifyBefore: {
@@ -92,14 +103,19 @@ export const updateTaskTool: Tool = {
     properties: {
       id: {
         type: 'string',
+        minLength: 1,
+        maxLength: SCHEMA_LIMITS.ID_MAX_LENGTH,
         description: 'Task ID (required)',
       },
       title: {
         type: 'string',
+        minLength: 1,
+        maxLength: SCHEMA_LIMITS.TASK_TITLE_MAX_LENGTH,
         description: 'New task title',
       },
       description: {
         type: 'string',
+        maxLength: SCHEMA_LIMITS.TASK_DESCRIPTION_MAX_LENGTH,
         description: 'New task description',
       },
       urgent: {
@@ -116,16 +132,22 @@ export const updateTaskTool: Tool = {
       },
       tags: {
         type: 'array',
-        items: { type: 'string' },
+        maxItems: SCHEMA_LIMITS.MAX_TAGS,
+        items: { type: 'string', minLength: 1, maxLength: SCHEMA_LIMITS.TAG_MAX_LENGTH },
         description: 'Replace tags entirely',
       },
       subtasks: {
         type: 'array',
+        maxItems: SCHEMA_LIMITS.MAX_SUBTASKS,
         items: {
           type: 'object',
           properties: {
-            id: { type: 'string' },
-            title: { type: 'string' },
+            id: { type: 'string', minLength: 1, maxLength: SCHEMA_LIMITS.ID_MAX_LENGTH },
+            title: {
+              type: 'string',
+              minLength: 1,
+              maxLength: SCHEMA_LIMITS.SUBTASK_TITLE_MAX_LENGTH,
+            },
             completed: { type: 'boolean' },
           },
           required: ['id', 'title', 'completed'],
@@ -139,7 +161,8 @@ export const updateTaskTool: Tool = {
       },
       dependencies: {
         type: 'array',
-        items: { type: 'string' },
+        maxItems: SCHEMA_LIMITS.MAX_DEPENDENCIES,
+        items: { type: 'string', minLength: 1, maxLength: SCHEMA_LIMITS.ID_MAX_LENGTH },
         description: 'Replace dependencies entirely',
       },
       completed: {
@@ -179,6 +202,8 @@ export const completeTaskTool: Tool = {
     properties: {
       id: {
         type: 'string',
+        minLength: 1,
+        maxLength: SCHEMA_LIMITS.ID_MAX_LENGTH,
         description: 'Task ID',
       },
       completed: {
@@ -203,6 +228,8 @@ export const deleteTaskTool: Tool = {
     properties: {
       id: {
         type: 'string',
+        minLength: 1,
+        maxLength: SCHEMA_LIMITS.ID_MAX_LENGTH,
         description: 'Task ID to delete',
       },
       dryRun: {
@@ -223,7 +250,9 @@ export const bulkUpdateTasksTool: Tool = {
     properties: {
       taskIds: {
         type: 'array',
-        items: { type: 'string' },
+        minItems: 1,
+        maxItems: SCHEMA_LIMITS.MAX_BULK_TASKS,
+        items: { type: 'string', minLength: 1, maxLength: SCHEMA_LIMITS.ID_MAX_LENGTH },
         description: 'Array of task IDs to update (max 50)',
       },
       operation: {
@@ -250,7 +279,9 @@ export const bulkUpdateTasksTool: Tool = {
           },
           tags: {
             type: 'array',
-            items: { type: 'string' },
+            minItems: 1,
+            maxItems: SCHEMA_LIMITS.MAX_TAGS,
+            items: { type: 'string', minLength: 1, maxLength: SCHEMA_LIMITS.TAG_MAX_LENGTH },
             description: 'For type=add_tags or remove_tags: array of tags',
           },
           dueDate: {

--- a/scripts/setup-pocketbase-collections.sh
+++ b/scripts/setup-pocketbase-collections.sh
@@ -23,12 +23,40 @@ if [[ -z "${PB_ADMIN_EMAIL:-}" || -z "${PB_ADMIN_PASSWORD:-}" ]]; then
   exit 1
 fi
 
+for cmd in curl mktemp python3; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: Required command not found: $cmd"
+    exit 1
+  fi
+done
+
+AUTH_PAYLOAD_FILE=$(mktemp)
+COLLECTION_PAYLOAD_FILE=$(mktemp)
+COLLECTION_CURL_CONFIG=$(mktemp)
+chmod 600 "$AUTH_PAYLOAD_FILE" "$COLLECTION_PAYLOAD_FILE" "$COLLECTION_CURL_CONFIG"
+trap 'rm -f "$AUTH_PAYLOAD_FILE" "$COLLECTION_PAYLOAD_FILE" "$COLLECTION_CURL_CONFIG"' EXIT
+
 echo "==> Authenticating with PocketBase at $PB_URL..."
+
+python3 - "$AUTH_PAYLOAD_FILE" <<'PY'
+import json
+import os
+import sys
+
+with open(sys.argv[1], "w", encoding="utf-8") as handle:
+    json.dump(
+        {
+            "identity": os.environ["PB_ADMIN_EMAIL"],
+            "password": os.environ["PB_ADMIN_PASSWORD"],
+        },
+        handle,
+    )
+PY
 
 # PocketBase v0.23+ uses _superusers collection for admin auth
 AUTH_RESPONSE=$(curl -s -X POST "$PB_URL/api/collections/_superusers/auth-with-password" \
   -H "Content-Type: application/json" \
-  -d "{\"identity\":\"$PB_ADMIN_EMAIL\",\"password\":\"$PB_ADMIN_PASSWORD\"}")
+  --data-binary @"$AUTH_PAYLOAD_FILE")
 
 TOKEN=$(echo "$AUTH_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('token',''))" 2>/dev/null)
 
@@ -40,8 +68,13 @@ fi
 
 echo "==> Authenticated. Creating 'tasks' collection..."
 
+cat > "$COLLECTION_CURL_CONFIG" <<EOF
+header = "Content-Type: application/json"
+header = "Authorization: $TOKEN"
+EOF
+
 # Create the tasks collection with all fields matching PBTaskRecord
-COLLECTION_PAYLOAD=$(cat <<'ENDJSON'
+cat > "$COLLECTION_PAYLOAD_FILE" <<'ENDJSON'
 {
   "name": "tasks",
   "type": "base",
@@ -49,7 +82,7 @@ COLLECTION_PAYLOAD=$(cat <<'ENDJSON'
   "listRule": "@request.auth.id != \"\" && owner = @request.auth.id",
   "viewRule": "@request.auth.id != \"\" && owner = @request.auth.id",
   "createRule": "@request.auth.id != \"\" && owner = @request.auth.id",
-  "updateRule": "@request.auth.id != \"\" && owner = @request.auth.id",
+  "updateRule": "@request.auth.id != \"\" && owner = @request.auth.id && (@request.body.owner:isset = false || @request.body.owner = owner)",
   "deleteRule": "@request.auth.id != \"\" && owner = @request.auth.id",
   "fields": [
     {
@@ -296,12 +329,10 @@ COLLECTION_PAYLOAD=$(cat <<'ENDJSON'
   ]
 }
 ENDJSON
-)
 
 RESPONSE=$(curl -s -X POST "$PB_URL/api/collections" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: $TOKEN" \
-  -d "$COLLECTION_PAYLOAD")
+  --config "$COLLECTION_CURL_CONFIG" \
+  --data-binary @"$COLLECTION_PAYLOAD_FILE")
 
 # Check for success
 if echo "$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d.get('id')" 2>/dev/null; then

--- a/scripts/update-pocketbase-tasks-schema.sh
+++ b/scripts/update-pocketbase-tasks-schema.sh
@@ -4,7 +4,7 @@
 #
 # This script is idempotent:
 # - it only adds missing fields
-# - it preserves the existing collection rules, indexes, and field order
+# - it hardens owner-scoped collection rules while preserving indexes and field order
 #
 # Required environment variables:
 #   PB_ADMIN_EMAIL
@@ -34,19 +34,40 @@ if [[ -z "${PB_ADMIN_EMAIL:-}" || -z "${PB_ADMIN_PASSWORD:-}" ]]; then
   exit 1
 fi
 
-for cmd in curl jq mktemp; do
+for cmd in curl jq mktemp python3; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "Error: Required command not found: $cmd"
     exit 1
   fi
 done
 
+AUTH_PAYLOAD_FILE=$(mktemp)
+PB_CURL_CONFIG=$(mktemp)
+TMP_JSON=$(mktemp)
+chmod 600 "$AUTH_PAYLOAD_FILE" "$PB_CURL_CONFIG" "$TMP_JSON"
+trap 'rm -f "$AUTH_PAYLOAD_FILE" "$PB_CURL_CONFIG" "$TMP_JSON"' EXIT
+
 echo "==> Authenticating with PocketBase at $PB_URL..."
+
+python3 - "$AUTH_PAYLOAD_FILE" <<'PY'
+import json
+import os
+import sys
+
+with open(sys.argv[1], "w", encoding="utf-8") as handle:
+    json.dump(
+        {
+            "identity": os.environ["PB_ADMIN_EMAIL"],
+            "password": os.environ["PB_ADMIN_PASSWORD"],
+        },
+        handle,
+    )
+PY
 
 AUTH_RESPONSE=$(
   curl -fsS -X POST "$PB_URL/api/collections/_superusers/auth-with-password" \
     -H "Content-Type: application/json" \
-    -d "{\"identity\":\"$PB_ADMIN_EMAIL\",\"password\":\"$PB_ADMIN_PASSWORD\"}"
+    --data-binary @"$AUTH_PAYLOAD_FILE"
 )
 
 TOKEN=$(echo "$AUTH_RESPONSE" | jq -r '.token // empty')
@@ -57,19 +78,22 @@ if [[ -z "$TOKEN" ]]; then
   exit 1
 fi
 
+cat > "$PB_CURL_CONFIG" <<EOF
+header = "Authorization: $TOKEN"
+EOF
+
 echo "==> Fetching existing 'tasks' collection..."
 
 CURRENT_COLLECTION=$(
   curl -fsS "$PB_URL/api/collections/tasks" \
-    -H "Authorization: $TOKEN"
+    --config "$PB_CURL_CONFIG"
 )
-
-TMP_JSON=$(mktemp)
-trap 'rm -f "$TMP_JSON"' EXIT
 
 echo "$CURRENT_COLLECTION" | jq '
   def ensure_field($field):
     if any(.fields[]; .name == $field.name) then . else .fields += [$field] end;
+  def owner_rule: "@request.auth.id != \"\" && owner = @request.auth.id";
+  def immutable_owner_rule: owner_rule + " && (@request.body.owner:isset = false || @request.body.owner = owner)";
 
   ensure_field({
     "name": "notification_sent",
@@ -98,6 +122,11 @@ echo "$CURRENT_COLLECTION" | jq '
       "max": 50
     }
   })
+  | .listRule = owner_rule
+  | .viewRule = owner_rule
+  | .createRule = owner_rule
+  | .updateRule = immutable_owner_rule
+  | .deleteRule = owner_rule
   | {
       name,
       type,
@@ -116,7 +145,7 @@ echo "==> Updating 'tasks' collection schema..."
 
 RESPONSE=$(
   curl -fsS -X PATCH "$PB_URL/api/collections/tasks" \
-    -H "Authorization: $TOKEN" \
+    --config "$PB_CURL_CONFIG" \
     -H "Content-Type: application/json" \
     --data-binary @"$TMP_JSON"
 )
@@ -124,6 +153,7 @@ RESPONSE=$(
 echo "==> Verifying required fields..."
 
 FIELD_NAMES=$(echo "$RESPONSE" | jq -r '.fields[].name')
+UPDATE_RULE=$(echo "$RESPONSE" | jq -r '.updateRule // empty')
 
 for field in notification_sent last_notification_at snoozed_until; do
   if ! grep -qx "$field" <<< "$FIELD_NAMES"; then
@@ -132,9 +162,16 @@ for field in notification_sent last_notification_at snoozed_until; do
   fi
 done
 
+if [[ "$UPDATE_RULE" != *"@request.body.owner:isset = false"* || "$UPDATE_RULE" != *"@request.body.owner = owner"* ]]; then
+  echo "Error: Owner immutability rule was not applied"
+  exit 1
+fi
+
 echo "==> Success! 'tasks' collection updated."
 echo ""
 echo "Verified fields:"
 echo "  - notification_sent"
 echo "  - last_notification_at"
 echo "  - snoozed_until"
+echo "Verified rules:"
+echo "  - owner cannot be changed after create"

--- a/tests/data/security-hardening-scripts.test.ts
+++ b/tests/data/security-hardening-scripts.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+function readRepoFile(path: string): string {
+  return readFileSync(path, 'utf8');
+}
+
+describe('security hardening scripts and workflows', () => {
+  it('keeps PocketBase task ownership immutable in setup and schema updates', () => {
+    const setupScript = readRepoFile('scripts/setup-pocketbase-collections.sh');
+    const updateScript = readRepoFile('scripts/update-pocketbase-tasks-schema.sh');
+
+    expect(setupScript).toContain('@request.body.owner:isset = false');
+    expect(setupScript).toContain('@request.body.owner = owner');
+    expect(updateScript).toContain('@request.body.owner:isset = false');
+    expect(updateScript).toContain('@request.body.owner = owner');
+    expect(updateScript).toContain('Owner immutability rule was not applied');
+  });
+
+  it('does not pass PocketBase superuser secrets or tokens directly in curl argv', () => {
+    const scripts = [
+      readRepoFile('scripts/setup-pocketbase-collections.sh'),
+      readRepoFile('scripts/update-pocketbase-tasks-schema.sh'),
+    ];
+
+    for (const script of scripts) {
+      expect(script).not.toMatch(/-d\s+["'][^"']*\$PB_ADMIN_PASSWORD/s);
+      expect(script).not.toMatch(/-H\s+["']Authorization:\s*\$TOKEN["']/);
+      expect(script).toContain('--data-binary @"$AUTH_PAYLOAD_FILE"');
+      expect(script).toContain('--config');
+    }
+  });
+
+  it('requires production deploy commits to be reachable from main before AWS access', () => {
+    const workflow = readRepoFile('.github/workflows/deploy-prod.yml');
+    const ancestryCheckIndex = workflow.indexOf('Verify deployment ref is on main');
+    const awsCredentialsIndex = workflow.indexOf('Configure AWS credentials');
+
+    expect(ancestryCheckIndex).toBeGreaterThan(-1);
+    expect(awsCredentialsIndex).toBeGreaterThan(ancestryCheckIndex);
+    expect(workflow).toContain('git merge-base --is-ancestor "$DEPLOY_COMMIT" origin/main');
+    expect(workflow).toContain('fetch-depth: 0');
+  });
+
+  it('requires MCP publishes to use the reviewed release environment and main ancestry', () => {
+    const workflow = readRepoFile('.github/workflows/publish-mcp-server.yml');
+    const verifyIndex = workflow.indexOf('Verify publish ref is reviewed');
+    const publishIndex = workflow.indexOf('Publish to npm');
+
+    expect(workflow).toContain('name: mcp-release');
+    expect(verifyIndex).toBeGreaterThan(-1);
+    expect(publishIndex).toBeGreaterThan(verifyIndex);
+    expect(workflow).toContain('Manual publish must run from the main branch.');
+    expect(workflow).toContain('git merge-base --is-ancestor "$RELEASE_COMMIT" origin/main');
+    expect(workflow).toContain('fetch-depth: 0');
+  });
+});

--- a/tests/data/sync/pb-push.test.ts
+++ b/tests/data/sync/pb-push.test.ts
@@ -267,40 +267,56 @@ describe('pushLocalChanges LWW guard', () => {
     expect(await getSyncQueue().getPendingCount()).toBe(1);
   });
 
-  it('records a permanent validation error via the ERROR log branch', async () => {
+  it('records a permanent validation error via the ERROR log branch without logging raw PB content', async () => {
     // Per-item catch: a 422 validation error is non-transient and goes
     // through the ERROR log branch. The error code is still sanitized so
     // task content never leaks into the persisted lastError field.
-    const payload = makeTask('t1', '2026-05-18T12:00:00.000Z');
+    const leakedTaskTitle = 'Secret oncology follow-up';
+    const payload = {
+      ...makeTask('t1', '2026-05-18T12:00:00.000Z'),
+      title: leakedTaskTitle,
+    };
     await getSyncQueue().enqueue('update', 't1', payload);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    fetchRemoteTaskIndexMock.mockResolvedValue({
-      index: new Map([
-        ['t1', { pbRecordId: 'rec-1', clientUpdatedAt: '2026-05-18T11:00:00.000Z' }],
-      ]),
-      fetchSucceeded: true,
-    });
+    try {
+      fetchRemoteTaskIndexMock.mockResolvedValue({
+        index: new Map([
+          ['t1', { pbRecordId: 'rec-1', clientUpdatedAt: '2026-05-18T11:00:00.000Z' }],
+        ]),
+        fetchSucceeded: true,
+      });
 
-    const validationError = Object.assign(
-      new Error("422 failed to validate field 'title'"),
-      { status: 422 },
-    );
-    const updateSpy = vi.fn(async () => {
-      throw validationError;
-    });
-    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
-      collection: () => ({ create: vi.fn(), update: updateSpy, delete: vi.fn() }),
-    });
+      const validationError = Object.assign(
+        new Error(`422 failed to validate field 'title' for ${leakedTaskTitle}`),
+        { status: 422 },
+      );
+      const updateSpy = vi.fn(async () => {
+        throw validationError;
+      });
+      (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+        collection: () => ({ create: vi.fn(), update: updateSpy, delete: vi.fn() }),
+      });
 
-    const result = await pushLocalChanges();
+      const result = await pushLocalChanges();
 
-    expect(updateSpy).toHaveBeenCalledTimes(1);
-    expect(result.pushedCount).toBe(0);
-    expect(result.failedCount).toBe(1);
-    expect(result.lastError).toBe('validation_failed');
-    // Crucially, the persisted lastError must NEVER echo task field names
-    // or values that the 4xx response body might have included.
-    expect(result.lastError).not.toContain('title');
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      expect(result.pushedCount).toBe(0);
+      expect(result.failedCount).toBe(1);
+      expect(result.lastError).toBe('validation_failed');
+      // Crucially, neither the persisted lastError nor the structured log
+      // should echo task field names or values that a 4xx body may include.
+      expect(result.lastError).not.toContain('title');
+
+      const syncErrorLog = consoleErrorSpy.mock.calls.find((call) => call[0] === '[SYNC_ENGINE]');
+      expect(syncErrorLog).toBeDefined();
+      const serializedLog = JSON.stringify(syncErrorLog);
+      expect(serializedLog).toContain('validation_failed');
+      expect(serializedLog).not.toContain('title');
+      expect(serializedLog).not.toContain(leakedTaskTitle);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it('fails open and proceeds with the write when remote clientUpdatedAt is unparseable', async () => {


### PR DESCRIPTION
## Summary

- harden PocketBase task owner rules and remove PB superuser secrets/tokens from curl argv
- require production deploy and MCP publish commits to be reachable from `origin/main`, with an MCP release environment gate
- sanitize PocketBase push logging and add MCP write payload bounds in both Zod validation and advertised tool schemas
- add regression coverage for the security controls

## Validation

- `./node_modules/.bin/vitest run tests/data/security-hardening-scripts.test.ts tests/data/sync/pb-push.test.ts`
- `npm run test -- src/__tests__/tools/input-schemas.test.ts src/__tests__/tools/schemas.test.ts` from `packages/mcp-server`
- `bash -n scripts/setup-pocketbase-collections.sh && bash -n scripts/update-pocketbase-tasks-schema.sh`
- `npm run typecheck`
- `npm run build` from `packages/mcp-server`
- `git diff --check`
- `npm run lint` (passed with 2 existing warnings in generated MCP coverage files)
- `npm test`
- `npm test` from `packages/mcp-server`
- live PocketBase 0.26.6 owner-transfer validation: normal update `200`, transfer attempt `404`, second user saw `0` records, owner preserved

## Notes

- GitHub-side environment reviewer and release-tag settings still need to be configured as documented in `.github/REPOSITORY_SETTINGS.md`.
- The pre-existing local `public/sw.js` change was intentionally left out of this PR.