### PR TITLE
fix(matrix): collapse overflowing smart-view pills into a More menu

### DIFF
--- a/components/matrix-simplified/smart-view-strip.tsx
+++ b/components/matrix-simplified/smart-view-strip.tsx
@@ -1,7 +1,16 @@
 "use client";
 
+import * as React from "react";
+import { ChevronDownIcon, CheckIcon } from "lucide-react";
 import type { SmartView } from "@/lib/filters";
 import { cn } from "@/lib/utils";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useSmartViewOverflow } from "./use-smart-view-overflow";
 
 interface SmartViewStripProps {
   views: SmartView[];
@@ -10,32 +19,87 @@ interface SmartViewStripProps {
   onClearView: () => void;
 }
 
+/** Shared pill geometry so inline pills, the More button, and the ghost match. */
+const PILL_BASE =
+  "inline-flex h-9 shrink-0 items-center gap-1.5 rounded-full border px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2";
+
+function pillVariant(active: boolean): string {
+  return active
+    ? "border-accent/40 bg-accent/10 text-foreground"
+    : "border-border bg-card text-foreground-muted hover:bg-background-muted hover:text-foreground";
+}
+
+const noop = () => {};
+
 export function SmartViewStrip({
   views,
   activeViewId,
   onSelectView,
   onClearView,
 }: SmartViewStripProps) {
+  const { containerRef, ghostRef, visibleCount } = useSmartViewOverflow(views.length);
+
   if (views.length === 0) return null;
 
+  const inlineViews = views.slice(0, visibleCount);
+  const overflowViews = views.slice(visibleCount);
+
   return (
-    <div
-      className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-      aria-label="Smart views"
-    >
-      <SmartViewButton active={!activeViewId} label="All tasks" onClick={onClearView} />
-      {views.map((view) => (
-        <SmartViewButton
-          key={view.id}
-          active={view.id === activeViewId}
-          label={view.name}
-          icon={view.icon}
-          onClick={() => onSelectView(view.id)}
-        />
-      ))}
+    <div ref={containerRef} className="relative">
+      {/* role="group" — aria-label on a bare div (generic role) is dropped by AT. */}
+      <div className="flex flex-nowrap gap-2" role="group" aria-label="Smart views">
+        <SmartViewButton active={!activeViewId} label="All tasks" onClick={onClearView} />
+        {inlineViews.map((view) => (
+          <SmartViewButton
+            key={view.id}
+            active={view.id === activeViewId}
+            label={view.name}
+            icon={view.icon}
+            onClick={() => onSelectView(view.id)}
+          />
+        ))}
+        {overflowViews.length > 0 ? (
+          <SmartViewOverflowMenu
+            views={overflowViews}
+            activeViewId={activeViewId}
+            onSelectView={onSelectView}
+          />
+        ) : null}
+      </div>
+      <SmartViewGhost ref={ghostRef} views={views} />
     </div>
   );
 }
+
+/**
+ * Hidden measurement row. Renders every pill at natural width so the overflow
+ * hook can read stable widths. `inert` keeps its buttons out of the tab order
+ * and the accessibility tree; `invisible` (not `hidden`) preserves layout so
+ * `offsetWidth` is non-zero. Child order is the contract the hook relies on:
+ * [lead, ...views, more]. The `overflow-hidden` wrapper clips the (often
+ * wider-than-container) row so it can't trigger a horizontal page scrollbar.
+ */
+const SmartViewGhost = React.forwardRef<HTMLDivElement, { views: SmartView[] }>(
+  function SmartViewGhost({ views }, ref) {
+    return (
+      <div aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div ref={ref} inert className="invisible flex w-max flex-nowrap gap-2">
+          <SmartViewButton active={false} label="All tasks" onClick={noop} />
+          {views.map((view) => (
+            <SmartViewButton
+              key={view.id}
+              active={false}
+              label={view.name}
+              icon={view.icon}
+              onClick={noop}
+            />
+          ))}
+          <MoreButton count={views.length} />
+        </div>
+      </div>
+    );
+  }
+);
 
 function SmartViewButton({
   active,
@@ -53,16 +117,71 @@ function SmartViewButton({
       type="button"
       onClick={onClick}
       aria-pressed={active}
-      className={cn(
-        "inline-flex h-9 shrink-0 items-center gap-1.5 rounded-full border px-3 text-xs font-medium transition-colors",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
-        active
-          ? "border-accent/40 bg-accent/10 text-foreground"
-          : "border-border bg-card text-foreground-muted hover:bg-background-muted hover:text-foreground",
-      )}
+      className={cn(PILL_BASE, pillVariant(active))}
     >
       {icon ? <span aria-hidden>{icon}</span> : null}
       <span>{label}</span>
     </button>
+  );
+}
+
+/** The "More" pill — used both as the menu trigger and inside the ghost. */
+const MoreButton = React.forwardRef<
+  HTMLButtonElement,
+  { count: number; activeLabel?: string } & React.ButtonHTMLAttributes<HTMLButtonElement>
+>(function MoreButton({ count, activeLabel, className, ...props }, ref) {
+  const label = activeLabel
+    ? `More smart views (${count}), ${activeLabel} active`
+    : `More smart views (${count})`;
+  return (
+    <button
+      ref={ref}
+      type="button"
+      aria-label={label}
+      className={cn(PILL_BASE, pillVariant(Boolean(activeLabel)), className)}
+      {...props}
+    >
+      <span>More</span>
+      <ChevronDownIcon className="h-3.5 w-3.5" aria-hidden />
+    </button>
+  );
+});
+
+export function SmartViewOverflowMenu({
+  views,
+  activeViewId,
+  onSelectView,
+}: {
+  views: SmartView[];
+  activeViewId?: string | null;
+  onSelectView: (viewId: string) => void;
+}) {
+  const activeView = views.find((view) => view.id === activeViewId);
+
+  // Menu items use aria-current (not the aria-pressed used by inline pills):
+  // Radix renders role="menuitem", which does not support aria-pressed.
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <MoreButton count={views.length} activeLabel={activeView?.name} />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="max-h-[60vh] overflow-y-auto">
+        {views.map((view) => {
+          const isActive = view.id === activeViewId;
+          return (
+            <DropdownMenuItem
+              key={view.id}
+              onSelect={() => onSelectView(view.id)}
+              aria-current={isActive ? "true" : undefined}
+              className={cn("gap-2", isActive && "bg-accent/10 text-foreground")}
+            >
+              {view.icon ? <span aria-hidden>{view.icon}</span> : null}
+              <span className="flex-1">{view.name}</span>
+              {isActive ? <CheckIcon className="h-3.5 w-3.5 text-accent" aria-hidden /> : null}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/components/matrix-simplified/use-smart-view-overflow.ts
+++ b/components/matrix-simplified/use-smart-view-overflow.ts
@@ -1,0 +1,109 @@
+"use client";
+
+import * as React from "react";
+
+/** Gap between pills, in px. Must match the Tailwind `gap-2` on the strip rows. */
+const GAP_PX = 8;
+
+export interface VisibleCountParams {
+  /** Natural width (px) of each overflow-eligible view pill, in order. */
+  viewWidths: number[];
+  /** Width (px) of the pinned "All tasks" pill, which is always shown inline. */
+  leadWidth: number;
+  /** Width (px) of the "More" button, reserved only when the row overflows. */
+  moreWidth: number;
+  /** Available width (px) of the strip container. */
+  available: number;
+  /** Gap (px) between pills. */
+  gap: number;
+}
+
+/**
+ * Greedily decide how many view pills fit inline before the rest must collapse
+ * into the "More" menu. Pure and synchronous so it is fully unit-testable; the
+ * hook below supplies the measured widths.
+ */
+export function computeVisibleViewCount({
+  viewWidths,
+  leadWidth,
+  moreWidth,
+  available,
+  gap,
+}: VisibleCountParams): number {
+  // Does the whole row fit without needing a More button at all?
+  let full = leadWidth;
+  for (const w of viewWidths) full += gap + w;
+  if (full <= available) return viewWidths.length;
+
+  // Overflowing: reserve room for the More button *and* the gap that sits
+  // between it and the last inline pill, then fit pills greedily.
+  const budget = available - moreWidth - gap;
+  let used = leadWidth;
+  let count = 0;
+  for (const w of viewWidths) {
+    used += gap + w;
+    if (used > budget) break;
+    count += 1;
+  }
+  return count;
+}
+
+export interface SmartViewOverflow {
+  /** Attach to the strip wrapper; its clientWidth is the available space. */
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  /** Attach to the hidden measurement row: [lead, ...views, more]. */
+  ghostRef: React.RefObject<HTMLDivElement | null>;
+  /** How many view pills to render inline; the rest go in the More menu. */
+  visibleCount: number;
+}
+
+/**
+ * Measure available space against a hidden ghost row and report how many view
+ * pills fit inline. The ghost renders every pill at natural width, so the
+ * measurement is stable regardless of the current inline/overflow split — no
+ * feedback loop. Recomputes on mount and whenever the container resizes.
+ */
+export function useSmartViewOverflow(viewCount: number): SmartViewOverflow {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const ghostRef = React.useRef<HTMLDivElement>(null);
+  const [visibleCount, setVisibleCount] = React.useState(viewCount);
+
+  // useLayoutEffect (not useEffect) so the measured split is applied before
+  // first paint — otherwise the row flashes the pre-measurement state. Safe
+  // because this app is client-only (no SSR).
+  React.useLayoutEffect(() => {
+    const container = containerRef.current;
+    const ghost = ghostRef.current;
+    if (!container || !ghost) return;
+
+    const measure = () => {
+      // No measurable width yet (initial layout, hidden ancestor, or a
+      // no-layout environment like jsdom): show every pill inline rather than
+      // collapsing them all into the menu. A real width arrives via the
+      // observer and corrects this before the user can interact.
+      const available = container.clientWidth;
+      if (available <= 0) {
+        setVisibleCount(viewCount);
+        return;
+      }
+      // Ghost children are rendered in a fixed order: [lead, ...views, more].
+      const children = Array.from(ghost.children) as HTMLElement[];
+      if (children.length !== viewCount + 2) return;
+      const leadWidth = children[0].offsetWidth;
+      const moreWidth = children[children.length - 1].offsetWidth;
+      const viewWidths = children.slice(1, -1).map((el) => el.offsetWidth);
+      setVisibleCount(
+        computeVisibleViewCount({ viewWidths, leadWidth, moreWidth, available, gap: GAP_PX })
+      );
+    };
+
+    measure();
+
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [viewCount]);
+
+  return { containerRef, ghostRef, visibleCount };
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,6 +2,41 @@
 
 ---
 
+## In progress — 2026-05-31: Smart-view strip overflow → "More" menu
+
+**Problem:** `SmartViewStrip` renders 10 pills in a single `overflow-x-auto` row with a hidden scrollbar. The last pills clip off-screen with no affordance (see screenshot). User chose the **"More" overflow menu** fix.
+
+**Tier:** Standard (one component subtree, no new public contract; real measurement logic → test-first).
+
+**Design:**
+- "All tasks" pill pinned inline first. As many view pills as fit render inline; the rest collapse into a Radix `DropdownMenu` triggered by a "More ▾" button.
+- Measurement via a hidden, `aria-hidden` ghost row rendering all pills at natural width → read offsetWidths → pure greedy `computeVisibleViewCount()` decides the inline count. Recompute on mount + `ResizeObserver`.
+- Reuse `components/ui/dropdown-menu.tsx` (Radix → free keyboard nav / focus / Escape / click-outside / `role=menu`).
+- If the active view lives in the overflow set, mark the "More" button active so users see their filter is still applied.
+
+**Files:**
+- `components/matrix-simplified/use-smart-view-overflow.ts` — pure `computeVisibleViewCount` + `useSmartViewOverflow` hook.
+- `components/matrix-simplified/smart-view-strip.tsx` — rewrite to use the hook + ghost + More menu.
+- `tests/ui/smart-view-strip.test.tsx` — pure-fn algorithm cases + render/interaction tests.
+
+**Acceptance:**
+- [x] No pill clips off-screen at any container width; overflow pills are reachable via the More menu.
+- [x] Selecting a view (inline or in menu) applies it; "All tasks" clears.
+- [x] Active overflow view reflected on the More button.
+- [x] Ghost layer is `aria-hidden` + `inert`; no duplicate buttons for AT.
+- [x] `computeVisibleViewCount` covered: all-fit, none-fit, exact boundary, reserve-more boundary, empty.
+
+**Review (2026-05-31 — done):**
+- Implemented test-first (red/green/refactor): pure `computeVisibleViewCount` + presentational `SmartViewOverflowMenu` + strip behaviors + a faked-layout test driving the real measurement path.
+- Verified in **real Chromium** (the gate jsdom can't own): at 1400px → 8 inline + "More (2)"; at 760px → 4 inline + "More (6)"; menu reveals overflow views w/ icons; selection applies; active-overflow filter surfaced in the More button's accessible name; **no horizontal page scrollbar** (scrollWidth === clientWidth).
+- a11y-reviewer: 0 blocking. Fixed IMPORTANT (`role="group"` on the pill row — `aria-label` on a bare div is dropped by AT) + nit (comment on `aria-current` vs `aria-pressed`).
+- Graceful degradation: unmeasured/zero-width container → show all inline (fixed a broken matrix-simplified test that relied on inline pills under jsdom's no-layout).
+- Coverage: strip 96% / hook 95% (both >80% DoD). Full suite 1920 pass, typecheck 0, lint 0.
+- Files: `smart-view-strip.tsx` (rewrite), `use-smart-view-overflow.ts` (new), `tests/ui/smart-view-strip.test.tsx` (new).
+- **Not committed** — awaiting user go-ahead.
+
+---
+
 ## Pending plan — 2026-05-18: GitHub Actions CI/CD deploy pipeline
 
 Move dev + prod app deploys off laptops into GitHub Actions (OIDC, no long-lived keys), wire the `typecheck`/`lint`/`test`/`build` PR status checks already declared in `REPOSITORY_SETTINGS.md`, and gate CloudFront infra changes behind manual approval. 5-phase rollout, one PR per phase.

--- a/tests/ui/smart-view-strip.test.tsx
+++ b/tests/ui/smart-view-strip.test.tsx
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { SmartView } from "@/lib/filters";
+import {
+  SmartViewStrip,
+  SmartViewOverflowMenu,
+} from "@/components/matrix-simplified/smart-view-strip";
+import { computeVisibleViewCount } from "@/components/matrix-simplified/use-smart-view-overflow";
+
+// Render the Radix dropdown flat so menu items are always queryable in jsdom,
+// matching the convention in task-card-subcomponents.test.tsx. The real
+// keyboard/focus behavior is owned by Radix + the e2e suite.
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div role="menu">{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    ...props
+  }: {
+    children: React.ReactNode;
+    onSelect?: () => void;
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" role="menuitem" onClick={onSelect} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+// The overflow hook observes the strip container; jsdom lacks ResizeObserver.
+if (typeof global.ResizeObserver === "undefined") {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
+function makeView(id: string, name: string): SmartView {
+  return {
+    id,
+    name,
+    icon: "✨",
+    criteria: {},
+    isBuiltIn: true,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("computeVisibleViewCount", () => {
+  it("returns every view when they all fit with room to spare", () => {
+    const count = computeVisibleViewCount({
+      viewWidths: [100, 100, 100],
+      leadWidth: 80,
+      moreWidth: 60,
+      available: 1000,
+      gap: 8,
+    });
+    expect(count).toBe(3);
+  });
+
+  it("returns every view when they fit the available width exactly (no More reserved)", () => {
+    // lead(80) + gap(8) + view(100) = 188
+    const count = computeVisibleViewCount({
+      viewWidths: [100],
+      leadWidth: 80,
+      moreWidth: 60,
+      available: 188,
+      gap: 8,
+    });
+    expect(count).toBe(1);
+  });
+
+  it("returns 0 when only the pinned lead pill fits", () => {
+    const count = computeVisibleViewCount({
+      viewWidths: [100, 100],
+      leadWidth: 80,
+      moreWidth: 60,
+      available: 100,
+      gap: 8,
+    });
+    expect(count).toBe(0);
+  });
+
+  it("reserves room for the More button, pushing a pill into the menu that would otherwise fit", () => {
+    // Both views fit a bare row exactly at 100 (0 + 50 + 50). At 99 the row
+    // overflows, so More(20) must be reserved → budget 79 → only one pill fits.
+    const count = computeVisibleViewCount({
+      viewWidths: [50, 50],
+      leadWidth: 0,
+      moreWidth: 20,
+      available: 99,
+      gap: 0,
+    });
+    expect(count).toBe(1);
+  });
+
+  it("reserves the gap before the More button at narrow boundary widths", () => {
+    // Rendered overflow row = lead + (gap + view) + gap + More.
+    // 80 + (8 + 100) + 8 + 60 = 256 > 248, so one inline view would clip the
+    // row by 8px. The correct answer is 0 inline — there is no room for a view
+    // pill *and* the More button (with the gap between them).
+    const count = computeVisibleViewCount({
+      viewWidths: [100, 100],
+      leadWidth: 80,
+      moreWidth: 60,
+      available: 248,
+      gap: 8,
+    });
+    expect(count).toBe(0);
+  });
+
+  it("returns 0 for an empty view list", () => {
+    const count = computeVisibleViewCount({
+      viewWidths: [],
+      leadWidth: 80,
+      moreWidth: 60,
+      available: 1000,
+      gap: 8,
+    });
+    expect(count).toBe(0);
+  });
+
+  it("returns 0 when nothing has been measured yet (zero available width)", () => {
+    const count = computeVisibleViewCount({
+      viewWidths: [0, 0],
+      leadWidth: 0,
+      moreWidth: 0,
+      available: 0,
+      gap: 8,
+    });
+    expect(count).toBe(0);
+  });
+});
+
+describe("<SmartViewOverflowMenu>", () => {
+  const overflow = [makeView("a", "Recurring Tasks"), makeView("b", "Ready to Work")];
+
+  it("renders a trigger whose accessible name carries the overflow count", () => {
+    render(
+      <SmartViewOverflowMenu views={overflow} activeViewId={null} onSelectView={vi.fn()} />
+    );
+    expect(screen.getByRole("button", { name: /more/i })).toHaveAccessibleName(/2/);
+  });
+
+  it("names the active view in the trigger when the active filter is hidden in the menu", () => {
+    render(
+      <SmartViewOverflowMenu views={overflow} activeViewId="b" onSelectView={vi.fn()} />
+    );
+    // Conveyed to AT via the accessible name, not by color alone.
+    expect(screen.getByRole("button", { name: /more/i })).toHaveAccessibleName(
+      /Ready to Work/
+    );
+  });
+
+  it("lists each overflow view as a menu item", () => {
+    render(
+      <SmartViewOverflowMenu views={overflow} activeViewId={null} onSelectView={vi.fn()} />
+    );
+    expect(screen.getByRole("menuitem", { name: /Recurring Tasks/ })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /Ready to Work/ })).toBeInTheDocument();
+  });
+
+  it("calls onSelectView with the view id when a menu item is chosen", async () => {
+    const onSelectView = vi.fn();
+    render(
+      <SmartViewOverflowMenu views={overflow} activeViewId={null} onSelectView={onSelectView} />
+    );
+    await userEvent.click(screen.getByRole("menuitem", { name: /Ready to Work/ }));
+    expect(onSelectView).toHaveBeenCalledWith("b");
+  });
+
+  it("marks the active view's menu item with aria-current", () => {
+    render(
+      <SmartViewOverflowMenu views={overflow} activeViewId="b" onSelectView={vi.fn()} />
+    );
+    expect(screen.getByRole("menuitem", { name: /Ready to Work/ })).toHaveAttribute(
+      "aria-current",
+      "true"
+    );
+  });
+});
+
+describe("<SmartViewStrip>", () => {
+  it("renders nothing when there are no views", () => {
+    const { container } = render(
+      <SmartViewStrip views={[]} onSelectView={vi.fn()} onClearView={vi.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("always shows the pinned 'All tasks' pill and clears the filter when clicked", async () => {
+    const onClearView = vi.fn();
+    render(
+      <SmartViewStrip
+        views={[makeView("a", "Recurring Tasks")]}
+        activeViewId="a"
+        onSelectView={vi.fn()}
+        onClearView={onClearView}
+      />
+    );
+    await userEvent.click(screen.getByRole("button", { name: "All tasks" }));
+    expect(onClearView).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes the pill row as a group labeled for assistive tech", () => {
+    render(
+      <SmartViewStrip
+        views={[makeView("a", "Recurring Tasks")]}
+        onSelectView={vi.fn()}
+        onClearView={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("group", { name: "Smart views" })).toBeInTheDocument();
+  });
+
+  it("applies a smart view when its inline pill is clicked", async () => {
+    const onSelectView = vi.fn();
+    render(
+      <SmartViewStrip
+        views={[makeView("a", "Recurring Tasks")]}
+        activeViewId={null}
+        onSelectView={onSelectView}
+        onClearView={vi.fn()}
+      />
+    );
+    await userEvent.click(screen.getByRole("button", { name: /Recurring Tasks/ }));
+    expect(onSelectView).toHaveBeenCalledWith("a");
+  });
+
+  it("marks 'All tasks' as pressed when no smart view is active", () => {
+    render(
+      <SmartViewStrip
+        views={[makeView("a", "Recurring Tasks")]}
+        activeViewId={null}
+        onSelectView={vi.fn()}
+        onClearView={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("button", { name: "All tasks" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
+});
+
+describe("<SmartViewStrip> measurement (faked layout)", () => {
+  // jsdom has no layout engine, so fake fixed element dimensions to drive the
+  // real measurement path. With a 250px container and 100px pills, only the
+  // pinned "All tasks" pill + the More button fit — every view collapses.
+  const realOffset = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetWidth");
+  const realClient = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientWidth");
+
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      configurable: true,
+      get: () => 100,
+    });
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      get: () => 250,
+    });
+  });
+
+  afterAll(() => {
+    if (realOffset) Object.defineProperty(HTMLElement.prototype, "offsetWidth", realOffset);
+    if (realClient) Object.defineProperty(HTMLElement.prototype, "clientWidth", realClient);
+  });
+
+  it("collapses overflowing views into the More menu when the row is too narrow", () => {
+    const views = [makeView("a", "View A"), makeView("b", "View B"), makeView("c", "View C")];
+    render(
+      <SmartViewStrip
+        views={views}
+        activeViewId={null}
+        onSelectView={vi.fn()}
+        onClearView={vi.fn()}
+      />
+    );
+    // All three views collapse → the More button reports the full overflow count.
+    expect(
+      screen.getByRole("button", { name: /More smart views \(3\)/ })
+    ).toBeInTheDocument();
+    // ...and no view renders as an inline pill.
+    expect(screen.queryByRole("button", { name: "View A" })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What & why

The re-introduced smart-view strip rendered all 10 pills in a single `overflow-x-auto` row with a **hidden** scrollbar. On any viewport narrower than the pill row (which includes the default desktop matrix column), the trailing pills (`Recurring Tasks`, `Ready to Work`) clipped off-screen with no scrollbar, fade, or any affordance signalling there was more — so those filters were effectively unreachable.

![before — pills run off the right edge](https://github.com/user-attachments/assets)

## Change

Replace the scroll row with a **responsive overflow menu**:
- `All tasks` is pinned inline; as many view pills as fit render inline.
- The rest collapse into a Radix `DropdownMenu` triggered by a **More ⌄** button (reuses `components/ui/dropdown-menu.tsx` → keyboard nav, focus mgmt, Escape, click-outside, `role=menu` for free).
- A hidden, `inert` **ghost row** renders every pill at natural width so the overflow hook reads stable widths regardless of the current split (no feedback loop). A pure, fully-unit-tested `computeVisibleViewCount` decides the inline count, reserving the More button **and the gap before it** so nothing clips at boundary widths.
- `useLayoutEffect` + `ResizeObserver` keep it correct on resize, before paint (no flash).

### Accessibility
- When the active filter is hidden in the menu, the More button's accessible name says so (e.g. *"More smart views (2), Ready to Work active"*) and the menu item carries `aria-current` + a decorative check — not color alone.
- `role="group"` on the pill row (`aria-label` on a bare `div` is dropped by AT).
- Ghost row is `inert` + `aria-hidden` + clipped, so its duplicate buttons never reach AT, the tab order, or trigger a horizontal page scrollbar.

## How to test locally
1. Settings → Features → enable **Smart views**.
2. On the matrix, narrow the window: pills collapse into **More ⌄**; open it to reach the rest. No clipping, no horizontal scrollbar at any width.

Verified in real Chromium: 1400px → 8 inline + More (2); 760px → 4 inline + More (6).

## Tests
- TDD throughout (red→green→refactor).
- `tests/ui/smart-view-strip.test.tsx`: algorithm boundaries (incl. the gap-before-More fencepost), menu interaction, faked-layout collapse, labeled group.
- Coverage: strip 96% / hook 95% (>80% DoD). Full suite (1921) + typecheck + lint green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->