### PR TITLE
fix(matrix): remediate matrix-simplified critique — delete-undo, a11y, palette, de-clutter

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -911,3 +911,14 @@ main {
   .task-card-mobile-actions { display: flex; }
   .task-card-desktop-actions { display: none; }
 }
+
+/* Enforce the 44px touch-target floor (WCAG 2.5.5) on coarse pointers for the
+   compact v9 controls (task complete, quadrant add) that stay small on
+   mouse-driven desktops. The legacy .redesign-scope rule above doesn't reach
+   the v9 shell, which uses Tailwind utilities. */
+@media (pointer: coarse) {
+  .touch-target {
+    min-width: 44px;
+    min-height: 44px;
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -901,10 +901,6 @@ main {
   }
 }
 
-.overdue-task {
-  border-left-color: var(--rust);
-}
-
 /* Touch-primary devices (iPad, iPhone): show always-visible mobile actions instead of
    hover-only desktop actions. Unlayered rules override Tailwind's @layer utilities. */
 @media (hover: none) {

--- a/components/matrix-simplified/edit-drawer.tsx
+++ b/components/matrix-simplified/edit-drawer.tsx
@@ -7,6 +7,7 @@ import { quadrants, QUADRANT_ACCENT } from "@/lib/quadrants";
 import { resolveDuePreset, DUE_PRESETS, type DuePreset } from "@/lib/due-date-presets";
 import { cn } from "@/lib/utils";
 import { DrawerHint } from "@/components/ui/drawer-hint";
+import { useDialogFocus } from "./use-dialog-focus";
 
 export interface EditDraft {
   title: string;
@@ -62,6 +63,7 @@ function formatChipDate(iso: string): string {
 
 export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: EditDrawerProps) {
   const titleRef = useRef<HTMLInputElement>(null);
+  const drawerRef = useRef<HTMLFormElement>(null);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [urgent, setUrgent] = useState(false);
@@ -71,6 +73,7 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
   const [showCustomDateInput, setShowCustomDateInput] = useState(false);
   const [tags, setTags] = useState<string[]>([]);
   const [tagInput, setTagInput] = useState("");
+  const trapKeyDown = useDialogFocus(open, drawerRef);
 
   // The drawer owns draft state while open, then rehydrates from the selected task.
   /* eslint-disable react-hooks/set-state-in-effect */
@@ -148,7 +151,11 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
     <div onClick={onClose} onKeyDown={(e) => { if (e.key === 'Escape') onClose(); }} role="presentation" className="fixed inset-0 z-[60] flex justify-end bg-black/30 animate-drawer-overlay">
       <form
         data-testid="edit-drawer"
+        ref={drawerRef}
+        role="dialog"
+        aria-modal="true"
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={trapKeyDown}
         onSubmit={submit}
         className="flex h-full w-full max-w-[520px] flex-col border-l border-border bg-card shadow-2xl animate-drawer-slide-in"
         aria-label={isCreateMode ? "New task" : "Edit task"}
@@ -168,7 +175,7 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
             type="button"
             onClick={onClose}
             aria-label="Close"
-            className="ml-auto inline-flex h-8 w-8 items-center justify-center rounded-md text-foreground-muted hover:bg-background-muted"
+            className="touch-target ml-auto inline-flex h-8 w-8 items-center justify-center rounded-md text-foreground-muted hover:bg-background-muted"
           >
             <XIcon className="h-4 w-4" />
           </button>

--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DndContext, DragOverlay } from "@dnd-kit/core";
-import { createTask, toggleCompleted, updateTask, deleteTask } from "@/lib/tasks";
+import { createTask, toggleCompleted, updateTask, deleteTask, restoreTask } from "@/lib/tasks";
 import { celebrateCompletion } from "@/lib/confetti";
 import { extractUrlsFromTitle, buildDescription } from "@/lib/capture-parser";
 import { parseShareCaptureParams } from "@/lib/share-capture";
@@ -66,7 +66,7 @@ function filterTasks(tasks: TaskRecord[], trimmedQuery: string): TaskRecord[] {
 
 export function MatrixSimplified() {
   const { all } = useTasks();
-  const { handleError } = useErrorHandlerWithUndo();
+  const { handleError, handleSuccess } = useErrorHandlerWithUndo();
   const { sensors, activeId, handleDragStart, handleDragEnd } = useDragAndDrop(handleError);
 
   useAutoArchive();
@@ -341,11 +341,13 @@ export function MatrixSimplified() {
     async (task: TaskRecord) => {
       try {
         await deleteTask(task.id);
+        // Faithful undo: restore the exact original record (id/timestamps intact).
+        handleSuccess("Task deleted", () => restoreTask(task));
       } catch {
         toast.error("Failed to delete task", { duration: TOAST_DURATION.LONG });
       }
     },
-    []
+    [handleSuccess]
   );
 
   const handleEditOpen = useCallback((task: TaskRecord) => setEditingTask(task), []);

--- a/components/matrix-simplified/quadrant-pane.tsx
+++ b/components/matrix-simplified/quadrant-pane.tsx
@@ -104,7 +104,7 @@ export function QuadrantPane({
           type="button"
           onClick={() => onAddInQuadrant(meta.rdKey)}
           aria-label={`Add to ${meta.title}`}
-          className="inline-flex h-7 w-7 items-center justify-center rounded-md text-foreground-muted hover:bg-background-muted hover:text-foreground"
+          className="touch-target inline-flex h-7 w-7 items-center justify-center rounded-md text-foreground-muted hover:bg-background-muted hover:text-foreground"
         >
           <PlusIcon className="h-3.5 w-3.5" />
         </button>

--- a/components/matrix-simplified/sync-status-display.tsx
+++ b/components/matrix-simplified/sync-status-display.tsx
@@ -34,16 +34,21 @@ export function SyncStatusDisplay({
             Last sync: {formatRelativeTime(lastSyncTime)}
           </span>
           {retryCountdown !== null && retryCountdown > 0 ? (
-            <span className="text-orange-500 font-medium">
+            <span className="inline-flex items-center gap-1.5 font-medium text-foreground">
+              <span className="h-1.5 w-1.5 rounded-full bg-warning" aria-hidden />
               Retry in {retryCountdown}s (attempt {retryCount + 1})
             </span>
           ) : pendingCount > 0 ? (
-            <span className="text-blue-500 font-medium">
+            <span className="inline-flex items-center gap-1.5 font-medium text-foreground">
+              <span className="h-1.5 w-1.5 rounded-full bg-info" aria-hidden />
               {pendingCount} pending operation
               {pendingCount !== 1 ? "s" : ""}
             </span>
           ) : (
-            <span className="text-green-500">All synced</span>
+            <span className="inline-flex items-center gap-1.5 text-foreground-muted">
+              <span className="h-1.5 w-1.5 rounded-full bg-status-success" aria-hidden />
+              All synced
+            </span>
           )}
         </div>
       ) : (

--- a/components/matrix-simplified/use-dialog-focus.ts
+++ b/components/matrix-simplified/use-dialog-focus.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useRef, type KeyboardEvent, type RefObject } from "react";
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Modal-dialog focus management for a hand-rolled overlay:
+ *  - captures the element focused before open and restores it when open flips false,
+ *  - returns an `onKeyDown` handler that traps Tab / Shift+Tab inside `ref`.
+ *
+ * Pair with `role="dialog"` + `aria-modal="true"` on the same element.
+ */
+export function useDialogFocus(
+  open: boolean,
+  ref: RefObject<HTMLElement | null>
+): (event: KeyboardEvent<HTMLElement>) => void {
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+    return () => {
+      previouslyFocused.current?.focus?.();
+    };
+  }, [open]);
+
+  return useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (event.key !== "Tab") return;
+      const nodes = ref.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      if (!nodes || nodes.length === 0) return;
+      const first = nodes[0];
+      const last = nodes[nodes.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    },
+    [ref]
+  );
+}

--- a/components/task-card/index.tsx
+++ b/components/task-card/index.tsx
@@ -68,7 +68,7 @@ function TaskCardComponent({
         task.completed ? "opacity-60" : "opacity-100 hover:-translate-y-0.5 hover:border-accent/40",
         task.completed && "animate-complete-flash",
         isDragging && "cursor-grabbing",
-        taskIsOverdue && "overdue-task border-l-[3px] border-l-status-overdue",
+        taskIsOverdue && "border-status-overdue",
         selectionMode && isSelected && "ring-2 ring-accent ring-offset-2",
         isHighlighted && "animate-pulse-highlight ring-4 ring-accent ring-offset-2"
       )}

--- a/components/task-card/task-card-actions.tsx
+++ b/components/task-card/task-card-actions.tsx
@@ -41,7 +41,7 @@ export function TaskCardActions({
     <div className="flex items-center justify-between gap-2 text-xs text-foreground-muted">
       <div className="flex items-center gap-2">
         {taskIsDueToday && !taskIsOverdue ? (
-          <span className="flex items-center gap-1 rounded-full bg-amber-50 dark:bg-amber-950/40 px-2 py-0.5 text-amber-600 dark:text-amber-400 font-medium">
+          <span className="flex items-center gap-1 rounded-full bg-warning-tint px-2 py-0.5 text-warning-dark font-medium">
             <AlertCircleIcon className="h-3 w-3" />
             Due today
           </span>
@@ -142,7 +142,7 @@ function DesktopActions({ task, onEdit, onDelete, onShare, onDuplicate, onSnooze
             data-testid="delete-task"
             type="button"
             onClick={() => onDelete(task)}
-            className="rounded px-1.5 py-0.5 flex items-center justify-center text-red-500 hover:bg-red-50 dark:hover:bg-red-950/40 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+            className="rounded px-1.5 py-0.5 flex items-center justify-center text-rust hover:bg-rust-tint hover:text-rust-d transition-colors"
             aria-label="Delete task"
           >
             <Trash2Icon className="h-3 w-3" />
@@ -198,7 +198,7 @@ function MobileActions({ task, onEdit, onDelete, onShare, onDuplicate }: MobileA
               Duplicate
             </DropdownMenuItem>
           )}
-          <DropdownMenuItem data-testid="delete-task" onClick={() => onDelete(task)} className="text-red-600 dark:text-red-400 focus:text-red-600 dark:focus:text-red-400">
+          <DropdownMenuItem data-testid="delete-task" onClick={() => onDelete(task)} className="text-rust focus:text-rust">
             <Trash2Icon className="mr-2 h-4 w-4" />
             Delete
           </DropdownMenuItem>

--- a/components/task-card/task-card-actions.tsx
+++ b/components/task-card/task-card-actions.tsx
@@ -88,7 +88,7 @@ interface DesktopActionsProps {
 
 function DesktopActions({ task, onEdit, onDelete, onShare, onDuplicate, onSnooze }: DesktopActionsProps) {
   return (
-    <div className="task-card-desktop-actions hidden sm:flex items-center gap-0.5 opacity-0 transition group-hover:opacity-100">
+    <div className="task-card-desktop-actions hidden sm:flex items-center gap-0.5 opacity-0 transition group-hover:opacity-100 group-focus-within:opacity-100">
       {onShare && (
         <Tooltip>
           <TooltipTrigger asChild>

--- a/components/task-card/task-card-header.tsx
+++ b/components/task-card/task-card-header.tsx
@@ -80,7 +80,9 @@ export function TaskCardHeader({
             aria-label={completionLabel}
           >
             {task.completed ? (
-              <CheckCircle2Icon className="h-4 w-4 shrink-0" />
+              // Color lives on the icon: the button's `button-reset` (unlayered
+              // color: inherit) would neutralize a text-color class on the button.
+              <CheckCircle2Icon className="h-4 w-4 shrink-0 text-status-success" />
             ) : (
               <>
                 <CircleIcon className="h-4 w-4 shrink-0" />

--- a/components/task-card/task-card-header.tsx
+++ b/components/task-card/task-card-header.tsx
@@ -42,7 +42,7 @@ export function TaskCardHeader({
         ) : (
           <button
             type="button"
-            className="cursor-grab touch-none shrink-0 rounded p-1.5 opacity-0 transition group-hover:opacity-100 hover:bg-background-muted"
+            className="cursor-grab touch-none shrink-0 rounded p-1.5 opacity-0 transition group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-background-muted"
             aria-label="Drag to move task"
             {...sortableAttributes}
             {...sortableListeners}
@@ -71,7 +71,7 @@ export function TaskCardHeader({
             type="button"
             onClick={() => onToggleComplete(task, !task.completed)}
             className={cn(
-              "button-reset relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border transition-all duration-200 sm:h-9 sm:w-9",
+              "button-reset touch-target relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border transition-all duration-200 sm:h-9 sm:w-9",
               task.completed
                 ? "border-emerald-400 bg-emerald-500/15 text-emerald-600 shadow-sm shadow-emerald-500/10 dark:border-emerald-500 dark:text-emerald-400"
                 : "border-border bg-background/90 text-foreground-muted shadow-sm shadow-black/[0.04] hover:border-accent hover:text-accent hover:bg-accent/5 hover:scale-105 hover:shadow-accent/10"

--- a/components/task-card/task-card-header.tsx
+++ b/components/task-card/task-card-header.tsx
@@ -73,7 +73,7 @@ export function TaskCardHeader({
             className={cn(
               "button-reset touch-target relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border transition-all duration-200 sm:h-9 sm:w-9",
               task.completed
-                ? "border-emerald-400 bg-emerald-500/15 text-emerald-600 shadow-sm shadow-emerald-500/10 dark:border-emerald-500 dark:text-emerald-400"
+                ? "border-status-success bg-status-success-muted text-status-success shadow-sm"
                 : "border-border bg-background/90 text-foreground-muted shadow-sm shadow-black/[0.04] hover:border-accent hover:text-accent hover:bg-accent/5 hover:scale-105 hover:shadow-accent/10"
             )}
             aria-pressed={task.completed}

--- a/components/task-card/task-card-metadata.tsx
+++ b/components/task-card/task-card-metadata.tsx
@@ -52,14 +52,14 @@ export function TaskCardMetadata({
             <div
               className={cn(
                 "h-full rounded-full transition-all duration-500",
-                completedSubtasks === totalSubtasks ? "bg-emerald-500" : "bg-accent"
+                completedSubtasks === totalSubtasks ? "bg-status-success" : "bg-accent"
               )}
               style={{ width: `${(completedSubtasks / totalSubtasks) * 100}%` }}
             />
           </div>
           <span className={cn(
             "shrink-0 tabular-nums",
-            completedSubtasks === totalSubtasks ? "text-emerald-600 dark:text-emerald-400 font-medium" : "text-foreground-muted"
+            completedSubtasks === totalSubtasks ? "text-foreground font-medium" : "text-foreground-muted"
           )}>
             {completedSubtasks}/{totalSubtasks}
           </span>

--- a/lib/tasks.ts
+++ b/lib/tasks.ts
@@ -18,6 +18,7 @@ export {
   updateTask,
   toggleCompleted,
   deleteTask,
+  restoreTask,
   moveTaskToQuadrant,
   clearTasks,
   duplicateTask,

--- a/lib/tasks/crud.ts
+++ b/lib/tasks/crud.ts
@@ -14,6 +14,7 @@ export {
   updateTask,
   toggleCompleted,
   deleteTask,
+  restoreTask,
   moveTaskToQuadrant,
   duplicateTask,
   snoozeTask,

--- a/lib/tasks/crud/index.ts
+++ b/lib/tasks/crud/index.ts
@@ -22,6 +22,9 @@ export { toggleCompleted } from "./toggle";
 // Delete operation
 export { deleteTask } from "./delete";
 
+// Restore operation (undo delete)
+export { restoreTask } from "./restore";
+
 // Move to quadrant (drag-and-drop)
 export { moveTaskToQuadrant } from "./move";
 

--- a/lib/tasks/crud/restore.ts
+++ b/lib/tasks/crud/restore.ts
@@ -1,0 +1,35 @@
+import { getDb } from "@/lib/db";
+import { createLogger } from "@/lib/logger";
+import { formatErrorMessage } from "@/lib/utils";
+import type { TaskRecord } from "@/lib/types";
+import { enqueueSyncOperation, getSyncContext } from "./helpers";
+
+const logger = createLogger("TASK_CRUD");
+
+/**
+ * Restore a previously deleted task by re-inserting the exact record.
+ *
+ * Unlike createTask, this preserves the original id, completed state, and
+ * timestamps so an "undo delete" is faithful (and any references that still
+ * point at this id resolve again). Enqueues a "create" sync op, symmetric to
+ * deleteTask's "delete", so synced devices re-create the task.
+ *
+ * Limitation: inbound dependency edges that removeDependencyReferences stripped
+ * on delete are not restored here.
+ */
+export async function restoreTask(task: TaskRecord): Promise<void> {
+  try {
+    const db = getDb();
+    await db.tasks.add(task);
+
+    logger.info("Task restored", { taskId: task.id, title: task.title });
+
+    const { syncConfig } = await getSyncContext();
+    await enqueueSyncOperation("create", task.id, task, syncConfig?.enabled ?? false);
+  } catch (error) {
+    logger.error("Failed to restore task", error instanceof Error ? error : undefined, {
+      taskId: task.id,
+    });
+    throw new Error(`Failed to restore task: ${formatErrorMessage(error)}`);
+  }
+}

--- a/lib/use-drag-and-drop.ts
+++ b/lib/use-drag-and-drop.ts
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { useSensors, useSensor, PointerSensor, TouchSensor, DragStartEvent, DragEndEvent } from "@dnd-kit/core";
+import { useSensors, useSensor, PointerSensor, TouchSensor, KeyboardSensor, DragStartEvent, DragEndEvent } from "@dnd-kit/core";
+import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import type { QuadrantId } from "@/lib/types";
 import { moveTaskToQuadrant } from "@/lib/tasks";
 import { DND_CONFIG } from "@/lib/constants";
@@ -26,7 +27,9 @@ export type DragErrorHandler = (
 export function useDragAndDrop(onError: DragErrorHandler) {
   const [activeId, setActiveId] = useState<string | null>(null);
 
-  // Configure sensors for drag-and-drop (mouse + touch)
+  // Configure sensors for drag-and-drop (mouse + touch + keyboard).
+  // KeyboardSensor makes the drag handle operable without a pointer (WCAG 2.1.1);
+  // sortableKeyboardCoordinates drives arrow-key movement within the sortable list.
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
@@ -38,6 +41,9 @@ export function useDragAndDrop(onError: DragErrorHandler) {
         delay: DND_CONFIG.TOUCH_DELAY,
         tolerance: DND_CONFIG.TOUCH_TOLERANCE,
       },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
     })
   );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.4.1",
+	"version": "9.4.2",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -19,7 +19,10 @@
 - `restoreTask`'s local `db.tasks.add` + `enqueueSyncOperation` are not in one Dexie transaction (pb-sync-reviewer nit, rule 12): a crash between the two awaits leaves the task locally visible but unprotected from the next reconcile pull. Low-probability; matches the existing non-transactional `create`/`delete` pattern. Follow-up issue, not gold-plated here.
 
 **a11y-reviewer follow-ups (deferred from this pass):**
-- **IMPORTANT — keyboard drag-and-drop:** `lib/use-drag-and-drop.ts` wires only Pointer+Touch sensors; the (now keyboard-visible) drag handle is a false affordance (WCAG 2.1.1). Fix = add `KeyboardSensor` + `sortableKeyboardCoordinates`. Distinct cycle in the DnD layer — pre-existed C3 (the handle was always focusable). Top follow-up candidate.
+- **DONE — keyboard drag-and-drop:** wired `KeyboardSensor` + `sortableKeyboardCoordinates` into `lib/use-drag-and-drop.ts` (TDD). Drag handle is now keyboard-operable.
+- **DONE — colorize (P2):** card/sync layer realigned to Inkwell tokens (delete→rust, due→warning, subtask bar→status-success, sync→warning/info/success dots; completed check→sage at icon level).
+- **DONE — distill (P3):** banned overdue side-stripe → full rust hairline border; dead `.overdue-task` CSS removed.
+- **NEW follow-up — completion button `button-reset`:** its unlayered `color: inherit` neutralizes text/bg/border token classes ON the button (only the icon color renders). For a full sage ring+tint on the completed button, restyle the toggle (drop `button-reset`, add `appearance-none`) — affects both states, its own change.
 - nit: `Field` component (edit-drawer) wraps button groups (Quadrant, Due date) in a `<label>` — replace with `role="group" aria-label` for those two (keep `<label>` for title/description). Pre-existing.
 - nit: edit-drawer dialog could use `aria-labelledby` → the `<h2>` instead of `aria-label`; and `inert`/`aria-hidden` on background siblings for NVDA/Firefox virtual-cursor (aria-modal mitigates in Chrome/VoiceOver).
 - nit: `use-dialog-focus` restore targets the captured node; if the originating card re-renders/moves quadrant, the node detaches and focus drops to `<body>`. Edge case.
@@ -29,7 +32,7 @@
 
 **Process:** never commit on `main` (hook); `restoreTask` is a sync write path → `pb-sync-reviewer` before refactor; component edits → `a11y-reviewer` before refactor; `bun run test` (not `bun test`).
 
-**Resuming from here:** ALL 5 cycles COMPLETE + verified. Harden pass = delete-safety (C1+C2, TDD + pb-sync-reviewed) + keyboard a11y (C3 focus reveal, C4 edit-drawer modal semantics, TDD) + touch targets (C5). Full suite 1934 pass, typecheck clean, lint clean (2 pre-existing generated-file warnings only). a11y-reviewer: 0 blocking, 1 important (KeyboardSensor — deferred follow-up), nits deferred/pre-existing. **Live-verified in real Chrome:** delete→Undo-toast→restore confirmed end-to-end; IndexedDB restore preserves the original id (verified count 4→delete→5-on-undo→back to 4 on cleanup). Ready to commit. KeyboardSensor is the recommended immediate follow-up.
+**Resuming from here:** COMPLETE + SHIPPED to PR #343 (3 commits on `fix/matrix-shell-harden`). Full critique remediation P1–P3: delete-safety (C1+C2) + keyboard a11y (C3/C4 + KeyboardSensor) + touch targets (C5) + colorize (P2) + distill (P3). Full suite 1935 pass, typecheck/lint clean. pb-sync-reviewer + a11y-reviewer: 0 blocking. **Live-verified in Chrome:** delete→Undo→restore (id preserved); completed check computes to sage `rgb(120,140,93)`. Impeccable setup (PRODUCT/DESIGN/.impeccable/CSP) shipped separately as PR #344. Remaining = the deferred follow-ups above (button-reset toggle restyle, dependency-edge restore, coverage-include `.ts`, Field role=group + other a11y nits).
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,6 +2,37 @@
 
 ---
 
+## In progress — 2026-06-01: Harden pass — `components/matrix-simplified` P1s
+
+**Branch:** `fix/matrix-shell-harden`
+**Contract:** critique snapshot `.impeccable/critique/2026-06-01T02-41-23Z__components-matrix-simplified.md` + approved plan (delete safety + keyboard a11y + touch targets, as one harden pass). Tier: Non-trivial; this todo + snapshot stand in for a spec.
+
+**Cycles (one behavior each, TDD where testable):**
+- [x] **C1 — data `restoreTask(record)`** ✅ — `lib/tasks/crud/restore.ts`, re-exported through the 3 barrels. 4 tests green, full suite 1925 pass, typecheck clean. `pb-sync-reviewer`: 0 blocking (verified delete→restore re-creates by `task_id`; keep original timestamp — do NOT bump, that would clobber concurrent edits under LWW).
+- [x] **C2 — UI delete→Undo** ✅ — `index.tsx` `handleDelete` now calls `handleSuccess("Task deleted", () => restoreTask(task))` after delete; captures the exact record in the closure. Test in `matrix-simplified.test.tsx` green; full suite 1926 pass, typecheck clean. Logic-only change (no markup) → a11y-reviewer deferred to C3–C5.
+- [x] **C3 — focus reveal** ✅ — `group-focus-within:opacity-100` on `DesktopActions` (task-card-actions.tsx) + drag handle (task-card-header.tsx). CSS-only.
+- [x] **C4 — edit-drawer dialog semantics** ✅ — chose surgical harden (not Radix rebuild). New `use-dialog-focus.ts` hook (capture+restore focus, Tab trap) + `role="dialog"`/`aria-modal` on the form. 2 tests green (role/aria-modal + focus-restore); Tab-trap verified by a11y-reviewer (jsdom can't assert wrapping).
+- [x] **C5 — touch targets ≥44px** ✅ — new `.touch-target` utility (globals.css, coarse-pointer gated) on the complete button, quadrant-add, and edit-drawer Close button. CSS-only.
+
+**Known limitations / follow-ups (not this pass):**
+- `restoreTask` restores the record but not inbound dependency edges stripped by `removeDependencyReferences` on delete. Undo copy must not over-promise.
+- `restoreTask`'s local `db.tasks.add` + `enqueueSyncOperation` are not in one Dexie transaction (pb-sync-reviewer nit, rule 12): a crash between the two awaits leaves the task locally visible but unprotected from the next reconcile pull. Low-probability; matches the existing non-transactional `create`/`delete` pattern. Follow-up issue, not gold-plated here.
+
+**a11y-reviewer follow-ups (deferred from this pass):**
+- **IMPORTANT — keyboard drag-and-drop:** `lib/use-drag-and-drop.ts` wires only Pointer+Touch sensors; the (now keyboard-visible) drag handle is a false affordance (WCAG 2.1.1). Fix = add `KeyboardSensor` + `sortableKeyboardCoordinates`. Distinct cycle in the DnD layer — pre-existed C3 (the handle was always focusable). Top follow-up candidate.
+- nit: `Field` component (edit-drawer) wraps button groups (Quadrant, Due date) in a `<label>` — replace with `role="group" aria-label` for those two (keep `<label>` for title/description). Pre-existing.
+- nit: edit-drawer dialog could use `aria-labelledby` → the `<h2>` instead of `aria-label`; and `inert`/`aria-hidden` on background siblings for NVDA/Firefox virtual-cursor (aria-modal mitigates in Chrome/VoiceOver).
+- nit: `use-dialog-focus` restore targets the captured node; if the originating card re-renders/moves quadrant, the node detaches and focus drops to `<body>`. Edge case.
+- nit: edit-drawer initial focus uses `setTimeout(50)`; a `requestAnimationFrame` would close a tiny Tab-escape window (not changed — risks reintroducing this file's historic timer flakiness).
+
+**Coverage-config gap (follow-up):** `vitest.config.ts` coverage `include` is `components/**/*.tsx` — so `.ts` files under `components/` (`use-dialog-focus.ts`, `use-smart-view-overflow.ts`) and `components/**/index.tsx` are never instrumented. Their logic IS tested (the trap hook has 5 passing tests; the delete→undo wiring in `index.tsx` is tested) — coverage just doesn't count it. Add `components/**/*.ts` to the include glob so these are measured.
+
+**Process:** never commit on `main` (hook); `restoreTask` is a sync write path → `pb-sync-reviewer` before refactor; component edits → `a11y-reviewer` before refactor; `bun run test` (not `bun test`).
+
+**Resuming from here:** ALL 5 cycles COMPLETE + verified. Harden pass = delete-safety (C1+C2, TDD + pb-sync-reviewed) + keyboard a11y (C3 focus reveal, C4 edit-drawer modal semantics, TDD) + touch targets (C5). Full suite 1934 pass, typecheck clean, lint clean (2 pre-existing generated-file warnings only). a11y-reviewer: 0 blocking, 1 important (KeyboardSensor — deferred follow-up), nits deferred/pre-existing. **Live-verified in real Chrome:** delete→Undo-toast→restore confirmed end-to-end; IndexedDB restore preserves the original id (verified count 4→delete→5-on-undo→back to 4 on cleanup). Ready to commit. KeyboardSensor is the recommended immediate follow-up.
+
+---
+
 ## In progress — 2026-05-31: Smart-view strip overflow → "More" menu
 
 **Problem:** `SmartViewStrip` renders 10 pills in a single `overflow-x-auto` row with a hidden scrollbar. The last pills clip off-screen with no affordance (see screenshot). User chose the **"More" overflow menu** fix.

--- a/tests/data/tasks/crud.test.ts
+++ b/tests/data/tasks/crud.test.ts
@@ -4,6 +4,7 @@ import {
   createTask,
   updateTask,
   deleteTask,
+  restoreTask,
   toggleCompleted,
   moveTaskToQuadrant,
   duplicateTask,
@@ -516,6 +517,69 @@ describe('Task CRUD Operations', () => {
       mockDb.tasks.get.mockRejectedValue(new Error('DB connection lost'));
 
       await expect(deleteTask('task-1')).rejects.toThrow('Failed to delete task');
+    });
+  });
+
+  describe('restoreTask', () => {
+    const deletedRecord: TaskRecord = {
+      ...baseDraft,
+      id: 'task-restore-1',
+      quadrant: 'urgent-important',
+      completed: true,
+      completedAt: '2025-01-15T10:00:00Z',
+      createdAt: '2025-01-10T08:00:00Z',
+      updatedAt: '2025-01-15T10:00:00Z',
+      notificationSent: false,
+    };
+
+    it('should re-insert the exact record, preserving id, completed state, and createdAt', async () => {
+      mockDb.tasks.add.mockResolvedValue(undefined);
+
+      await restoreTask(deletedRecord);
+
+      expect(mockDb.tasks.add).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'task-restore-1',
+          completed: true,
+          completedAt: '2025-01-15T10:00:00Z',
+          createdAt: '2025-01-10T08:00:00Z',
+        })
+      );
+    });
+
+    it('should not regenerate the id (faithful restore, not a new task)', async () => {
+      mockDb.tasks.add.mockResolvedValue(undefined);
+
+      await restoreTask(deletedRecord);
+
+      const added = mockDb.tasks.add.mock.calls[0][0];
+      expect(added.id).toBe('task-restore-1');
+    });
+
+    it('should enqueue a create sync operation when sync is enabled', async () => {
+      (getSyncConfig as ReturnType<typeof vi.fn>).mockResolvedValue({
+        enabled: true,
+        deviceId: 'test-device',
+      });
+      mockDb.tasks.add.mockResolvedValue(undefined);
+
+      await restoreTask(deletedRecord);
+
+      expect(mockEnqueue).toHaveBeenCalledWith('create', 'task-restore-1', deletedRecord);
+    });
+
+    it('should not enqueue sync when sync is disabled', async () => {
+      mockDb.tasks.add.mockResolvedValue(undefined);
+
+      await restoreTask(deletedRecord);
+
+      expect(mockEnqueue).not.toHaveBeenCalled();
+    });
+
+    it('should throw a wrapped error when the database add fails', async () => {
+      mockDb.tasks.add.mockRejectedValue(new Error('Constraint violation'));
+
+      await expect(restoreTask(deletedRecord)).rejects.toThrow('Failed to restore task');
     });
   });
 

--- a/tests/data/use-drag-and-drop.test.ts
+++ b/tests/data/use-drag-and-drop.test.ts
@@ -3,6 +3,7 @@ import { renderHook } from "@testing-library/react";
 import { useDragAndDrop } from "@/lib/use-drag-and-drop";
 import { moveTaskToQuadrant } from "@/lib/tasks";
 import { ErrorActions, ErrorMessages } from "@/lib/error-logger";
+import { KeyboardSensor, useSensor } from "@dnd-kit/core";
 import type { DragEndEvent } from "@dnd-kit/core";
 
 vi.mock("@/lib/tasks", () => ({
@@ -33,6 +34,15 @@ describe("useDragAndDrop", () => {
     expect(result.current).toHaveProperty("sensors");
     expect(result.current).toHaveProperty("handleDragEnd");
     expect(typeof result.current.handleDragEnd).toBe("function");
+  });
+
+  it("configures a KeyboardSensor with sortable coordinates for accessible drag-and-drop", () => {
+    renderHook(() => useDragAndDrop(mockOnError));
+
+    expect(useSensor).toHaveBeenCalledWith(
+      KeyboardSensor,
+      expect.objectContaining({ coordinateGetter: expect.any(Function) })
+    );
   });
 
   it("moves task to new quadrant on drag end", async () => {

--- a/tests/ui/edit-drawer.test.tsx
+++ b/tests/ui/edit-drawer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { EditDrawer } from "@/components/matrix-simplified/edit-drawer";
 import type { TaskRecord } from "@/lib/types";
@@ -163,6 +163,37 @@ describe("<EditDrawer>", () => {
 
       const submitted = onSubmit.mock.calls.at(-1)?.[0];
       expect(submitted?.dueDate?.slice(0, 10)).toBe("2026-05-12");
+    });
+  });
+
+  describe("dialog semantics (a11y)", () => {
+    it("exposes the drawer as a modal dialog (role=dialog, aria-modal)", () => {
+      render(<EditDrawer open task={mockTask} onClose={vi.fn()} onSubmit={vi.fn()} />);
+      const dialog = screen.getByRole("dialog", { name: /edit task/i });
+      expect(dialog).toHaveAttribute("aria-modal", "true");
+    });
+
+    it("restores focus to the trigger element when the drawer closes", async () => {
+      function Harness({ open }: { open: boolean }) {
+        return (
+          <>
+            <button data-testid="trigger">Open</button>
+            <EditDrawer open={open} task={mockTask} onClose={vi.fn()} onSubmit={vi.fn()} />
+          </>
+        );
+      }
+      const { rerender } = render(<Harness open={false} />);
+      const trigger = screen.getByTestId("trigger");
+      trigger.focus();
+      expect(trigger).toHaveFocus();
+
+      // Opening moves focus into the drawer (autofocused title).
+      rerender(<Harness open />);
+      await waitFor(() => expect(screen.getByLabelText(/title/i)).toHaveFocus());
+
+      // Closing must return focus to the trigger, not drop it to <body>.
+      rerender(<Harness open={false} />);
+      await waitFor(() => expect(trigger).toHaveFocus());
     });
   });
 });

--- a/tests/ui/matrix-simplified.test.tsx
+++ b/tests/ui/matrix-simplified.test.tsx
@@ -9,6 +9,7 @@ const smartViewsFixture = vi.hoisted(() => ({
   enabled: false,
   current: [] as SmartView[],
 }));
+const handleSuccessSpy = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/use-tasks", () => ({
   useTasks: () => ({
@@ -49,6 +50,7 @@ vi.mock("@/lib/tasks", () => ({
   toggleCompleted: vi.fn().mockResolvedValue(undefined),
   updateTask: vi.fn().mockResolvedValue(undefined),
   deleteTask: vi.fn().mockResolvedValue(undefined),
+  restoreTask: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@/lib/smart-views", () => ({
@@ -95,7 +97,7 @@ vi.mock("@/components/ui/toast", () => ({
 
 // useErrorHandlerWithUndo uses useToast internally
 vi.mock("@/lib/use-error-handler", () => ({
-  useErrorHandlerWithUndo: () => ({ handleError: vi.fn() }),
+  useErrorHandlerWithUndo: () => ({ handleError: vi.fn(), handleSuccess: handleSuccessSpy }),
 }));
 
 // useDragAndDrop sets up DnD sensors — stub it out to avoid pointer-sensor issues in jsdom
@@ -120,7 +122,7 @@ vi.mock("@/components/matrix-simplified/app-shell", () => ({
 }));
 
 import { MatrixSimplified } from "@/components/matrix-simplified";
-import { createTask, toggleCompleted } from "@/lib/tasks";
+import { createTask, toggleCompleted, deleteTask, restoreTask } from "@/lib/tasks";
 import { celebrateCompletion } from "@/lib/confetti";
 
 describe("<MatrixSimplified>", () => {
@@ -135,6 +137,9 @@ describe("<MatrixSimplified>", () => {
     }
     vi.mocked(celebrateCompletion).mockClear();
     vi.mocked(toggleCompleted).mockClear();
+    vi.mocked(deleteTask).mockClear();
+    vi.mocked(restoreTask).mockClear();
+    handleSuccessSpy.mockClear();
   });
 
   describe("completion celebration", () => {
@@ -324,6 +329,24 @@ describe("<MatrixSimplified>", () => {
       // Pre-selected quadrant button should be Do First (urgent + important).
       const doFirstQuadrant = screen.getByRole("button", { name: /^do first$/i, pressed: true });
       expect(doFirstQuadrant).toBeInTheDocument();
+    });
+  });
+
+  describe("delete + undo", () => {
+    it("offers an Undo toast that restores the deleted task", async () => {
+      const user = userEvent.setup();
+      tasksFixture.current = [makeTask({ id: "del-1", title: "Delete me" })];
+      render(<MatrixSimplified />);
+
+      await user.click(screen.getByRole("button", { name: /delete task/i }));
+
+      await waitFor(() => expect(deleteTask).toHaveBeenCalledWith("del-1"));
+      expect(handleSuccessSpy).toHaveBeenCalledWith("Task deleted", expect.any(Function));
+
+      // Invoking the toast's undo action restores the exact original task record.
+      const undoAction = handleSuccessSpy.mock.calls[0][1] as () => Promise<void>;
+      await undoAction();
+      expect(restoreTask).toHaveBeenCalledWith(expect.objectContaining({ id: "del-1" }));
     });
   });
 });

--- a/tests/ui/task-card-states.test.tsx
+++ b/tests/ui/task-card-states.test.tsx
@@ -176,8 +176,8 @@ describe("TaskCard states", () => {
     });
 
     expect(screen.getByText("2/2")).toBeInTheDocument();
-    // The progress bar should have the emerald class
-    const progressBar = container.querySelector(".bg-emerald-500");
+    // The progress bar should use the success token (sage) when fully complete
+    const progressBar = container.querySelector(".bg-status-success");
     expect(progressBar).toBeInTheDocument();
   });
 

--- a/tests/ui/task-card.test.tsx
+++ b/tests/ui/task-card.test.tsx
@@ -183,8 +183,8 @@ describe("TaskCard", () => {
     const { container } = render(<TaskCard task={overdueTask} allTasks={[overdueTask]} {...mockHandlers} />);
 
     const article = container.querySelector("article");
-    // Polish v0.9.2: 3px left edge in status-overdue, no pink fill.
-    expect(article).toHaveClass("overdue-task", "border-l-status-overdue");
+    // Overdue cards get a full rust hairline border (replaces the banned side-stripe).
+    expect(article).toHaveClass("border-status-overdue");
   });
 
   it("does not show overdue warning for completed tasks", () => {

--- a/tests/ui/use-dialog-focus.test.tsx
+++ b/tests/ui/use-dialog-focus.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { type KeyboardEvent } from "react";
+import { useDialogFocus } from "@/components/matrix-simplified/use-dialog-focus";
+
+function makeContainer(html: string): HTMLDivElement {
+  const container = document.createElement("div");
+  container.innerHTML = html;
+  document.body.appendChild(container);
+  return container;
+}
+
+function tabEvent(shiftKey: boolean): {
+  event: KeyboardEvent<HTMLElement>;
+  preventDefault: ReturnType<typeof vi.fn>;
+} {
+  const preventDefault = vi.fn();
+  return {
+    event: { key: "Tab", shiftKey, preventDefault } as unknown as KeyboardEvent<HTMLElement>,
+    preventDefault,
+  };
+}
+
+describe("useDialogFocus — Tab trap", () => {
+  it("wraps Tab from the last focusable back to the first", () => {
+    const container = makeContainer('<button id="a">A</button><button id="b">B</button>');
+    const { result } = renderHook(() => useDialogFocus(true, { current: container }));
+    const a = container.querySelector<HTMLElement>("#a")!;
+    container.querySelector<HTMLElement>("#b")!.focus();
+
+    const { event, preventDefault } = tabEvent(false);
+    result.current(event);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(a).toHaveFocus();
+    document.body.removeChild(container);
+  });
+
+  it("wraps Shift+Tab from the first focusable to the last", () => {
+    const container = makeContainer('<button id="a">A</button><button id="b">B</button>');
+    const { result } = renderHook(() => useDialogFocus(true, { current: container }));
+    const b = container.querySelector<HTMLElement>("#b")!;
+    container.querySelector<HTMLElement>("#a")!.focus();
+
+    const { event, preventDefault } = tabEvent(true);
+    result.current(event);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(b).toHaveFocus();
+    document.body.removeChild(container);
+  });
+
+  it("does not trap when focus is mid-list (lets the browser advance)", () => {
+    const container = makeContainer(
+      '<button id="a">A</button><button id="b">B</button><button id="c">C</button>'
+    );
+    const { result } = renderHook(() => useDialogFocus(true, { current: container }));
+    const a = container.querySelector<HTMLElement>("#a")!;
+    a.focus();
+
+    const { event, preventDefault } = tabEvent(false); // forward from first, not last → no wrap
+    result.current(event);
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(a).toHaveFocus();
+    document.body.removeChild(container);
+  });
+
+  it("excludes disabled controls when computing first/last", () => {
+    const container = makeContainer(
+      '<button id="a">A</button><button id="b">B</button><button id="c" disabled>C</button>'
+    );
+    const { result } = renderHook(() => useDialogFocus(true, { current: container }));
+    const a = container.querySelector<HTMLElement>("#a")!;
+    container.querySelector<HTMLElement>("#b")!.focus(); // b is the last ENABLED control
+
+    const { event, preventDefault } = tabEvent(false);
+    result.current(event);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(a).toHaveFocus();
+    document.body.removeChild(container);
+  });
+
+  it("ignores non-Tab keys", () => {
+    const container = makeContainer('<button id="a">A</button>');
+    const { result } = renderHook(() => useDialogFocus(true, { current: container }));
+    const preventDefault = vi.fn();
+
+    result.current({
+      key: "Enter",
+      shiftKey: false,
+      preventDefault,
+    } as unknown as KeyboardEvent<HTMLElement>);
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    document.body.removeChild(container);
+  });
+});


### PR DESCRIPTION
Remediates the P1–P3 findings from the `/impeccable critique` of `components/matrix-simplified` (snapshot lives in PR #344's `.impeccable/critique/`). Built TDD-first; reviewed by `pb-sync-reviewer` and `a11y-reviewer`; key behaviors live-verified in Chrome.

## P1 — delete safety
Deleting a task was a permanent, unrecoverable IndexedDB removal (no confirm, no undo) in a local-first app with no server backup. Now delete shows a "Task deleted / Undo" toast that restores the **exact** record via a new `restoreTask()` primitive — preserves `id` + timestamps, enqueues a symmetric `create` sync op. **Live-verified**: delete → Undo → restore round-trips, restored record keeps its original id.

## P1 — keyboard a11y
- Hover-only card actions + the drag handle now reveal on `group-focus-within` (were invisible to keyboard users).
- The edit drawer is a proper modal dialog: `role=dialog`/`aria-modal`, focus trap + focus restoration via a new `useDialogFocus` hook.
- **KeyboardSensor** wired into the DnD sensors (`sortableKeyboardCoordinates`) so the now-visible drag handle is actually operable by keyboard (WCAG 2.1.1).

## P1 — touch targets
Complete / quadrant-add / drawer-close controls now meet the 44px floor on coarse pointers via a `.touch-target` utility (were 28–32px).

## P2 — palette alignment (colorize)
Realigned the card/sync layer from raw Tailwind colors to Inkwell tokens (which carry dark mode automatically): delete → rust, due-today → warning, subtask bar → status-success, sync states → warning/info/success **dots with readable text** (also fixes a color-alone a11y nit). The completed check renders in **sage** — note it's colored at the icon level because the button's `button-reset` (unlayered `color: inherit`) neutralizes a text-color class on the button itself.

## P3 — overdue de-clutter (distill)
Replaced the banned 3px overdue side-stripe with a full rust hairline border; removed the now-dead `.overdue-task` CSS rule. Overdue is signaled by the border + the informative corner label (color-independent).

## Verification
`bun run test` (1935 pass), `bun typecheck` clean, `bun lint` clean (2 pre-existing generated-file warnings). Version 9.4.1 → 9.4.2.

## Deferred follow-ups
- The completion button's `button-reset` neutralizes its `bg`/`border` token classes (only the icon color renders); fully styling it (sage ring + tint) means restyling the toggle — its own change.
- `restoreTask` doesn't rebuild inbound dependency edges stripped on delete; `restoreTask` add + enqueue aren't in one Dexie transaction (low-probability crash window).
- Coverage `include` omits `.ts` files under `components/`.