### PR TITLE
chore(impeccable): design context, visual system docs, and live-mode config

### DIFF
--- a/.impeccable/critique/2026-06-01T02-41-23Z__components-matrix-simplified.md
+++ b/.impeccable/critique/2026-06-01T02-41-23Z__components-matrix-simplified.md
@@ -1,0 +1,99 @@
+---
+target: components/matrix-simplified
+total_score: 28
+p0_count: 0
+p1_count: 3
+timestamp: 2026-06-01T02-41-23Z
+slug: components-matrix-simplified
+---
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | Strong: active/done/overdue count pills, sync status, drag-over ring, live capture preview. Gap: failure toasts are generic ("Failed to create task"). |
+| 2 | Match System / Real World | 4 | Eisenhower vocabulary (Do First / Schedule / Delegate / Eliminate), plain-language empty states, "Saved locally" reassurance. |
+| 3 | User Control and Freedom | 2 | Esc/cancel on drawers, drag is undoable, but task delete has no undo and no recovery. |
+| 4 | Consistency and Standards | 2 | Shell is consistent; the card/sync/edit-drawer layers diverge (off-palette colors, two different dialog implementations). |
+| 5 | Error Prevention | 1 | Permanent delete with no confirm, no undo, no archive fallback. Textbook failure. |
+| 6 | Recognition Rather Than Recall | 3 | Live capture quadrant preview + thorough help drawer. Gap: capture syntax (`!`/`!!`/`*`/`#`) is recall-only, surfaced only in help. |
+| 7 | Flexibility and Efficiency | 4 | n, /, ?, Shift+N, Tab-to-cycle, ⌘K palette, drag-to-reclassify, per-quadrant add, due-date presets. |
+| 8 | Aesthetic and Minimalist Design | 3 | Calm, uncluttered shell. Dinged by dense card action cluster and triple-signaled overdue state. |
+| 9 | Error Recovery | 2 | Toasts name the problem but not the fix; sync errors explained only in the help drawer, not at the failure point. |
+| 10 | Help and Documentation | 4 | Thorough, well-structured help drawer (matrix / syntax / shortcuts / sync / privacy). |
+| **Total** | | **28/40** | **Good (bottom of band) — propped up by excellent Match/Flexibility/Help; harbors a P1 data-loss bug the aggregate score structurally under-weights.** |
+
+## Anti-Patterns Verdict
+
+**Does this look AI-generated? Mixed — and the seam is visible.** The matrix *shell* is genuinely on-brand and intentional; the *card and sync layers* betray it.
+
+**LLM assessment:** The shell (capture bar, quadrant grid, empty states, topbar) is disciplined: correct type pairing, the 1.5px hairline border architecture, quadrant washes, no gradient text, no hero-metric template, no purple gradients, no mascots. But below the shell the Inkwell system dissolves into raw Tailwind defaults — the "inconsistent component vocabulary screen-to-screen" tell:
+- **Off-palette colors:** completion button = `emerald` (task-card-header.tsx:76), not the system's sage — and completion is *the one sanctioned delight moment*. Delete = `red-500` (task-card-actions.tsx:145), due-today = `amber-50/600` (L44), sync status = `orange/blue/green-500` (sync-status-display.tsx) — all bypass the AA-tuned `status-*` tokens.
+- **Banned >1px side-stripe:** `border-l-[3px] border-l-status-overdue` on overdue cards (task-card/index.tsx:71) — the exact pattern DESIGN.md §6 names "migrate away from." It also ships a redundant "ND Overdue" corner label, so the stripe carries no unique meaning.
+- **Stacked glassmorphism:** both topbar (topbar.tsx:34) and the sticky capture-bar wrapper (index.tsx:491) apply `backdrop-blur-xl backdrop-saturate-150` — two translucent blur layers, an explicit DESIGN.md ban.
+
+**Deterministic scan:** `detect.mjs` over `components/matrix-simplified` + `components/task-card` returned **0 findings (exit 0, clean)**. This is a weak signal here: the detector matches rendered-markup/CSS patterns, not Tailwind utility strings inside JSX, so it cannot see the `border-l-[3px]` stripe or the stacked blur. Treat the clean scan as "no HTML/CSS-level slop," not a green light — the substantive issues are the design-review findings above.
+
+**Visual overlays:** No live browser pass was run. The target renders task cards from IndexedDB, so a faithful pass needs a running dev server with seeded data (none was running); an empty grid would critique the empty state, not the real UX. Reported as a fallback, not skipped silently — a live pass is offered as a follow-up.
+
+## Overall Impression
+
+A calm, intentional matrix shell whose strongest element — the capture bar — is genuinely excellent, undermined by three P1 issues that all converge on one theme: **the v9 refactor quietly dropped guarantees the design system still advertises** (touch targets, focus visibility, data safety). The single biggest opportunity: make destructive delete recoverable. It's a small diff (the undo infrastructure already exists in the repo) that closes the worst emotional valley and fixes two heuristics at once.
+
+## What's Working
+
+1. **The capture bar is the best-designed element in the app** (capture-bar.tsx). It compresses a 4-way priority decision into one live-previewing pill: the Zap icon and pill tint shift to the predicted quadrant as you type, Tab cycles an explicit override (with a `·fixed` marker), Enter commits, Esc clears. It sidesteps the >4-option trap entirely and embodies "the matrix is the argument" — you *see* where a task lands before committing.
+2. **Empty states respect the user's emotional state** (quadrant-pane.tsx:115-135). Each quadrant gets a tailored serif headline, a supporting line capped at 26ch, and an accent-colored dashed CTA scoped to that quadrant. Four empty boxes become four invitations, in the calm editorial voice the brand asks for.
+3. **The matrix grid's border architecture is elegant** (quadrant-pane.tsx:32-37). `POSITION_RULES` lets the outer container own the perimeter while each pane contributes only internal dividing rules on md+, collapsing to individually-bordered stacked cards on mobile. The 1.5px-hairline "structure is drawn, not boxed" signature, clean across breakpoints, no doubled borders.
+
+## Priority Issues
+
+**[P1] Permanent, unguarded task deletion with no undo or recovery**
+- **Why it matters:** `handleDelete` → `deleteTask` → `db.tasks.delete(id)` is a hard IndexedDB removal (index.tsx:340-349) with no confirm, no undo toast, no archive fallback — on both desktop (task-card-actions.tsx:144) and the mobile overflow menu (L201). In a privacy-first, local-only app there is no server backup, so one mis-tap on a 12px trash glyph = irreversible loss. Directly breaks PRODUCT.md's "feels in control" and "owns their data." The reversible action (complete) is protected by auto-archive; the irreversible one is not.
+- **Fix:** Route delete through the existing `useErrorHandlerWithUndo` pattern (optimistic delete + "Task deleted — Undo" toast at `TOAST_DURATION.LONG`), or send single deletes to the `archivedTasks` table so they're recoverable from the archive page. The undo route reuses code already in the repo.
+- **Suggested command:** `/impeccable harden`
+
+**[P1] Hover-only card actions are invisible to keyboard users (desktop)**
+- **Why it matters:** `DesktopActions` (task-card-actions.tsx:91) and the drag handle (task-card-header.tsx:45) are `opacity-0 group-hover:opacity-100` with no `group-focus-within` reveal. The buttons stay in the tab order but are visually invisible without a hovering mouse — so a sighted keyboard user tabs into Share / Duplicate / Edit / **Delete** they cannot see, and the first invisible one is the irreversible delete. WCAG 2.4.7 (Focus Visible) failure on the highest-stakes control. Related: the edit-drawer is a hand-rolled overlay with no focus trap, no `role="dialog"`/`aria-modal`, and no focus restoration (edit-drawer.tsx), unlike the Radix-based help-drawer.
+- **Fix:** Add `group-focus-within:opacity-100` to the desktop-actions wrapper and drag handle; give the edit-drawer a focus trap + `role="dialog"` + focus restoration (or rebuild it on the Radix Dialog the help-drawer already uses).
+- **Suggested command:** `/impeccable harden`
+
+**[P1] Most-used touch targets fall below the 44px floor the design system promises**
+- **Why it matters:** The complete button is `h-8 w-8` (32px, task-card-header.tsx:74) and the quadrant-add is `h-7 w-7` (28px, quadrant-pane.tsx:107) — both below WCAG 2.5.5 on touch, and complete is the single most-tapped control. The 44px coarse-pointer enforcement (globals.css:877) is scoped to legacy `.redesign-scope .rd-*` classes the v9 shell abandoned, so it never reaches these controls — even though PRODUCT.md and DESIGN.md both assert ≥44px "by construction." (The mobile overflow menu correctly hits 44px at L172/182 — follow that precedent.)
+- **Fix:** Add a `pointer: coarse` rule for the v9 card/control selectors, or bump complete + quadrant-add to `min-h-[44px] min-w-[44px]` on touch.
+- **Suggested command:** `/impeccable adapt`
+
+**[P2] Card and sync color vocabulary diverges from the Inkwell system**
+- **Why it matters:** emerald (completion + subtask progress), amber-50/600 (due-today), red-500 (delete), orange/blue/green-500 (sync) are raw Tailwind, bypassing the sage / amber-ink / rust / slate-blue tokens and their annotated AA contrast. Reads as a different author than the shell and risks AA on grounds the tokens were tuned for. Workaround exists (it's still legible), hence P2.
+- **Fix:** Replace generic Tailwind palette refs with the `status-*` / quadrant tokens already in globals.css. Highest priority: the completion button → sage, since completion is the brand's signature moment.
+- **Suggested command:** `/impeccable colorize`
+
+**[P3] Overdue state is over-signaled (and uses a banned pattern)**
+- **Why it matters:** Overdue cards get a 3px left stripe (the DESIGN.md-banned side-border) *plus* a corner "ND Overdue" label *plus* a color-shifted due chip — three signals for one state, visual noise on a surface meant to be calm.
+- **Fix:** Drop the `border-l-[3px]` stripe; keep the corner label (which also satisfies color-independence) and optionally a full-hairline rust border or background tint.
+- **Suggested command:** `/impeccable distill`
+
+## Persona Red Flags
+
+**Alex (power user):** Well-served — n / Shift+N / Tab / Enter / `/` / `?` / ⌘K all work, drag-to-reclassify with 8px activation. Red flags: (1) capture syntax (`!`/`!!`/`*`/`#`) must be memorized, no inline reference; (2) no bulk-select / multi-task ops in the v9 shell (the card has `selectionMode` props but nothing drives them here), so triaging 50 tasks means 50 individual risky deletes. (Note: ⌘K *is* wired in — this contradicts the stale CLAUDE.md claim that the command palette is "not wired into the v9 shell.")
+
+**Sam (accessibility / keyboard / screen reader):** The worst-served persona. (1) Tabs into invisible hover-only Share/Edit/Delete (P1). (2) The edit-drawer isn't announced as a modal, has no focus trap (Tab escapes to the page behind the scrim), and doesn't restore focus on close — while the help-drawer (Radix) does all three, an inconsistency a screen-reader user feels. (3) Sync status leans on color-alone (green/blue/orange) for "synced / pending / retry." (The quadrants themselves are fine — always label + position.)
+
+**Casey (distracted, one-handed mobile):** (1) The 32px complete button — most-tapped control — is hardest to hit (P1). (2) The primary capture action sits at the *top* of the screen (`sticky top-[60px]`, index.tsx:491), the hardest one-handed thumb reach; bottom nav is reachable but core capture isn't. (3) Edit-drawer Cancel/Save are small text buttons (`py-1.5`) below 44px at the bottom of a scrolling form — easy to fat-finger.
+
+**Morgan (the local-only minimalist — project-specific persona):** Chose GSD *because* data never leaves the device and there's no account. Red flags: the unguarded permanent delete is uniquely devastating for Morgan — there is no server backup and no undo, so a mis-tap is gone forever, the exact opposite of the "you own your data" promise that won them over. The app carefully reassures about *privacy* ("Saved locally" pill) but offers zero reassurance against *self-inflicted loss*. JSON export is the only safety net, and it's manual.
+
+## Minor Observations
+
+- Capture-bar disabled "Add" uses `bg-accent/15 text-accent` (capture-bar.tsx:204) — faint indigo-on-indigo-tint that doesn't read as clearly disabled. (The Enter path *is* guarded by `if (!parsed.title) return`, so it won't submit empty — the issue is purely the visual affordance.)
+- Edit-drawer Save is `bg-foreground` (ink-slate near-black, edit-drawer.tsx:354), not the deep-indigo system primary — reads as neutral, conflicting with the One Accent Rule.
+- Help-drawer is built with inline `style={}` + `var(--ink-*)` (`redesign-scope`) rather than the Tailwind/token vocabulary the rest of the shell uses — another authorship seam.
+- Tag chips drop the `#` for a leading dot on cards (task-card-metadata.tsx:41) but keep a faded `#` in the edit-drawer (L308) — same concept, two representations.
+- `quadrant-pane.tsx` rows share height on `md:grid-rows-2`; a lopsided distribution (many tasks in one quadrant, few in others) can leave large dead space.
+
+## Questions to Consider
+
+1. Completing a task auto-archives it recoverably, but deleting one destroys it permanently with no guard. Why is the *reversible* action protected and the *irreversible* one not? Where's the evidence users read the trash icon as "I'm certain" before losing data?
+2. The one sanctioned delight moment — completion — renders in emerald, not the system's sage. Was that moment ever actually checked against the design system, or did it inherit a Tailwind default?
+3. The 44px touch guarantee is real in CSS but scoped to a legacy class the v9 shell dropped. Did the refactor knowingly drop touch-target enforcement, or did it fall through the cracks when the class system changed?
+4. If a "focused personal tool" omits bulk ops and undo from the matrix, is manual JSON re-import really an acceptable floor for "owns their data" after a triage session gone wrong?
+5. Two stacked backdrop-blur layers is glassmorphism the system bans. Is the sticky-translucent treatment earning its keep, or would a solid `bg-background` + hairline bottom border be both more on-brand and cheaper to composite on a low-end phone?

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,174 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-05-31",
+  "title": "Design System: GSD Task Manager",
+  "extensions": {
+    "colorMeta": {
+      "deep-indigo": {
+        "role": "primary",
+        "displayName": "Deep Indigo",
+        "canonical": "#3B4A8C",
+        "tonalRamp": ["oklch(0.16 0.06 270)", "oklch(0.27 0.09 270)", "oklch(0.40 0.10 270)", "oklch(0.52 0.10 270)", "oklch(0.63 0.09 270)", "oklch(0.74 0.07 270)", "oklch(0.85 0.04 270)", "oklch(0.95 0.02 270)"]
+      },
+      "rust": {
+        "role": "secondary",
+        "displayName": "Rust",
+        "canonical": "#B04A3F",
+        "tonalRamp": ["oklch(0.18 0.05 28)", "oklch(0.30 0.08 28)", "oklch(0.42 0.11 28)", "oklch(0.53 0.13 28)", "oklch(0.64 0.12 28)", "oklch(0.75 0.09 28)", "oklch(0.86 0.05 28)", "oklch(0.95 0.02 28)"]
+      },
+      "sage": {
+        "role": "secondary",
+        "displayName": "Sage",
+        "canonical": "#788C5D",
+        "tonalRamp": ["oklch(0.20 0.04 130)", "oklch(0.32 0.06 130)", "oklch(0.44 0.07 130)", "oklch(0.56 0.08 130)", "oklch(0.67 0.08 130)", "oklch(0.77 0.06 130)", "oklch(0.87 0.04 130)", "oklch(0.95 0.02 130)"]
+      },
+      "amber": {
+        "role": "secondary",
+        "displayName": "Amber",
+        "canonical": "#C78E3F",
+        "tonalRamp": ["oklch(0.22 0.05 75)", "oklch(0.34 0.08 75)", "oklch(0.46 0.10 75)", "oklch(0.58 0.11 75)", "oklch(0.69 0.10 75)", "oklch(0.79 0.08 75)", "oklch(0.88 0.05 75)", "oklch(0.95 0.02 75)"]
+      },
+      "cool-stone": {
+        "role": "neutral",
+        "displayName": "Cool Stone",
+        "canonical": "#F4F4F0",
+        "tonalRamp": ["oklch(0.18 0.004 110)", "oklch(0.30 0.004 110)", "oklch(0.42 0.004 110)", "oklch(0.55 0.004 110)", "oklch(0.68 0.004 110)", "oklch(0.80 0.004 110)", "oklch(0.90 0.004 110)", "oklch(0.96 0.004 110)"]
+      },
+      "ink-slate": {
+        "role": "neutral",
+        "displayName": "Ink Slate",
+        "canonical": "#13141B",
+        "tonalRamp": ["oklch(0.13 0.012 270)", "oklch(0.24 0.012 270)", "oklch(0.36 0.010 270)", "oklch(0.48 0.008 270)", "oklch(0.60 0.006 270)", "oklch(0.72 0.005 270)", "oklch(0.85 0.004 270)", "oklch(0.95 0.003 270)"]
+      }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display", "purpose": "Largest editorial moments (About, marketing). Serif, fixed 48px." },
+      "headline": { "displayName": "Headline", "purpose": "Page and section titles (H1/H2). Serif." },
+      "title": { "displayName": "Title", "purpose": "Card and panel headings. Serif 19px / sans 18px." },
+      "body": { "displayName": "Body", "purpose": "Running text and UI copy. System sans, weight 430." },
+      "label": { "displayName": "Label", "purpose": "Eyebrows, keyboard chips, micro-labels. Mono, uppercase, 0.12em tracking." }
+    },
+    "shadows": [
+      { "name": "shadow-sm", "value": "0 1px 2px rgba(20,20,19,0.06)", "purpose": "Resting card/column elevation; switch thumbs." },
+      { "name": "shadow-md", "value": "0 4px 14px rgba(20,20,19,0.08)", "purpose": "Dropdowns and popovers." },
+      { "name": "shadow-lg", "value": "0 12px 28px rgba(20,20,19,0.12)", "purpose": "Dialogs and the edit drawer." },
+      { "name": "shadow-card-hover", "value": "0 10px 30px rgba(20,20,19,0.10)", "purpose": "Card hover lift, paired with translateY(-3px)." }
+    ],
+    "motion": [
+      { "name": "t-fast", "value": "120ms", "purpose": "Button/border state transitions." },
+      { "name": "t-base", "value": "150ms", "purpose": "Default component transitions." },
+      { "name": "t-slow", "value": "300ms", "purpose": "Drawer slide-in, view transitions." },
+      { "name": "ease-out", "value": "cubic-bezier(0.2, 0.8, 0.2, 1)", "purpose": "Default easing for state transitions." },
+      { "name": "ease-pop", "value": "cubic-bezier(0.34, 1.56, 0.64, 1)", "purpose": "Sparing pop emphasis (quadrant pill entrance)." }
+    ],
+    "breakpoints": [
+      { "name": "mobile", "value": "720px" },
+      { "name": "tablet", "value": "900px" },
+      { "name": "desktop", "value": "1024px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The default call to action. Deep-indigo fill, used once per context.",
+      "html": "<button class=\"ds-btn-primary\">Add task</button>",
+      "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; gap: 8px; height: 38px; padding: 0 16px; font: 500 14px system-ui, sans-serif; color: #FFFFFF; background: #3B4A8C; border: 1.5px solid transparent; border-radius: 8px; cursor: pointer; transition: background 120ms ease, transform 120ms ease; } .ds-btn-primary:hover { background: #2A3768; } .ds-btn-primary:focus-visible { outline: none; box-shadow: 0 0 0 2px #F4F4F0, 0 0 0 4px #3B4A8C; } .ds-btn-primary:active { transform: scale(0.97); }"
+    },
+    {
+      "name": "Secondary Button",
+      "kind": "button",
+      "refersTo": "button-secondary",
+      "description": "Subtle action. Cloud-white fill with the signature hairline border.",
+      "html": "<button class=\"ds-btn-secondary\">Cancel</button>",
+      "css": ".ds-btn-secondary { display: inline-flex; align-items: center; justify-content: center; gap: 8px; height: 38px; padding: 0 16px; font: 500 14px system-ui, sans-serif; color: #13141B; background: #FFFFFF; border: 1.5px solid #CFCFCC; border-radius: 8px; cursor: pointer; transition: background 120ms ease, border-color 120ms ease, transform 120ms ease; } .ds-btn-secondary:hover { background: #EDEDEA; } .ds-btn-secondary:focus-visible { outline: none; box-shadow: 0 0 0 2px #F4F4F0, 0 0 0 4px #3B4A8C; } .ds-btn-secondary:active { transform: scale(0.97); }"
+    },
+    {
+      "name": "Ghost Button",
+      "kind": "button",
+      "refersTo": "button-ghost",
+      "description": "Lowest-emphasis action; borderless until hovered.",
+      "html": "<button class=\"ds-btn-ghost\">Skip</button>",
+      "css": ".ds-btn-ghost { display: inline-flex; align-items: center; justify-content: center; gap: 8px; height: 38px; padding: 0 16px; font: 500 14px system-ui, sans-serif; color: #3A3B41; background: transparent; border: 1.5px solid transparent; border-radius: 8px; cursor: pointer; transition: background 120ms ease, transform 120ms ease; } .ds-btn-ghost:hover { background: #EDEDEA; } .ds-btn-ghost:focus-visible { outline: none; box-shadow: 0 0 0 2px #F4F4F0, 0 0 0 4px #3B4A8C; } .ds-btn-ghost:active { transform: scale(0.97); }"
+    },
+    {
+      "name": "Text Input",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "Single-line field. Hairline border, indigo focus halo.",
+      "html": "<input class=\"ds-input\" type=\"text\" placeholder=\"What needs doing?\" />",
+      "css": ".ds-input { width: 280px; height: 38px; padding: 0 12px; font: 14px system-ui, sans-serif; color: #13141B; background: #FFFFFF; border: 1.5px solid #CFCFCC; border-radius: 8px; outline: none; transition: border-color 120ms ease, box-shadow 120ms ease; } .ds-input::placeholder { color: #6F6F75; } .ds-input:focus { border-color: #3B4A8C; box-shadow: 0 0 0 3px rgba(59,74,140,0.18); }"
+    },
+    {
+      "name": "Accent Badge",
+      "kind": "chip",
+      "refersTo": "badge-accent",
+      "description": "Pill label. Tinted background of the hue's own color, never gray text on a tint.",
+      "html": "<span class=\"ds-badge-accent\">Schedule</span>",
+      "css": ".ds-badge-accent { display: inline-flex; align-items: center; height: 22px; padding: 0 9px; font: 500 12px system-ui, sans-serif; color: #3B4A8C; background: rgba(59,74,140,0.14); border-radius: 999px; }"
+    },
+    {
+      "name": "Card",
+      "kind": "card",
+      "refersTo": "card",
+      "description": "Cloud-white panel on the cool-stone ground. Flat at rest; lifts as a link.",
+      "html": "<div class=\"ds-card\"><div class=\"ds-card-title\">Quarterly review</div><div class=\"ds-card-body\">Draft the deck and circulate before Friday.</div></div>",
+      "css": ".ds-card { background: #FFFFFF; border: 1.5px solid #CFCFCC; border-radius: 14px; padding: 24px; transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease; } .ds-card:hover { transform: translateY(-3px); box-shadow: 0 10px 30px rgba(20,20,19,0.10); border-color: #13141B; } .ds-card-title { font: 500 19px ui-serif, Georgia, serif; letter-spacing: -0.008em; color: #13141B; margin-bottom: 8px; } .ds-card-body { font: 430 16px/1.55 system-ui, sans-serif; color: #3A3B41; }"
+    },
+    {
+      "name": "Checkbox",
+      "kind": "custom",
+      "refersTo": "checkbox",
+      "description": "Task completion control. Hairline square that fills indigo when checked.",
+      "html": "<label class=\"ds-checkbox\"><input type=\"checkbox\" checked /> Done</label>",
+      "css": ".ds-checkbox { display: inline-flex; align-items: center; gap: 10px; font: 430 16px system-ui, sans-serif; color: #13141B; cursor: pointer; user-select: none; } .ds-checkbox input { appearance: none; width: 18px; height: 18px; border: 1.5px solid #CFCFCC; border-radius: 5px; background: #FFFFFF; position: relative; cursor: pointer; transition: background 120ms, border-color 120ms; } .ds-checkbox input:checked { background: #3B4A8C; border-color: #3B4A8C; } .ds-checkbox input:checked::after { content: \"\"; position: absolute; left: 5px; top: 1px; width: 5px; height: 10px; border: solid #FFFFFF; border-width: 0 2px 2px 0; transform: rotate(45deg); }"
+    },
+    {
+      "name": "Quadrant Pane (Do First)",
+      "kind": "custom",
+      "refersTo": "quadrant-pane",
+      "description": "Signature component: an Eisenhower quadrant. Hue wash over cloud-white, 3px top accent bar, tinted header. Shown here as Q1 / Do First (rust).",
+      "html": "<section class=\"ds-quadrant\"><header class=\"ds-quadrant-head\"><span class=\"ds-quadrant-eyebrow\">Urgent · Important</span><h3 class=\"ds-quadrant-title\">Do First</h3></header><div class=\"ds-quadrant-body\">Crises, deadlines, emergencies.</div></section>",
+      "css": ".ds-quadrant { position: relative; width: 300px; background: color-mix(in srgb, #B04A3F 18%, #FFFFFF); border: 1.5px solid #CFCFCC; border-radius: 14px; overflow: hidden; box-shadow: 0 1px 2px rgba(20,20,19,0.06); } .ds-quadrant::before { content: \"\"; position: absolute; top: 0; left: 0; right: 0; height: 3px; background: #B04A3F; } .ds-quadrant-head { padding: 16px 20px 12px; background: color-mix(in srgb, #B04A3F 10%, #FFFFFF); } .ds-quadrant-eyebrow { display: inline-block; font: 500 11px ui-monospace, monospace; letter-spacing: 0.12em; text-transform: uppercase; color: #6F6F75; margin-bottom: 6px; } .ds-quadrant-title { margin: 0; font: 500 19px ui-serif, Georgia, serif; letter-spacing: -0.008em; color: #13141B; } .ds-quadrant-body { padding: 14px 20px 18px; font: 430 16px/1.55 system-ui, sans-serif; color: #3A3B41; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Strategist's Matrix",
+    "overview": "GSD is built around one act: deciding what matters before doing anything. The interface should feel like a strategist's well-ordered planning surface, not a cockpit of dials. Everything is calm, deliberate, and legible at a glance; the four-quadrant Eisenhower grid is the argument the whole system makes, and the visual language exists to make that prioritization decision feel obvious rather than busy. The Inkwell 'Indigo & Cloud' system carries this: a cool-stone paper ground, a single deep-indigo accent for intent, serif headings that lend authority without shouting, and a 1.5px hairline that draws structure with the lightest possible touch. The personality is calm and focused. Surfaces are quiet, type does the talking, and the one saturated color is spent only where it means something. Delight is reserved for genuine moments (completing a task) and never spread across the surface.",
+    "keyCharacteristics": [
+      "Cool-stone editorial ground; cloud-white panels; deep indigo as the sole accent.",
+      "Serif headings (Georgia family) against a system-sans body: a contrast pairing, not two competing sans.",
+      "The 1.5px hairline is the signature border; structure is drawn, not boxed in shadow.",
+      "Four fixed quadrant hues (rust / indigo / sage / amber), always paired with label + position.",
+      "Flat at rest; surfaces lift only in response to state. Motion is 120–300ms, ease-out, never decorative.",
+      "First-class dark mode (Pattern B), WCAG-AA contrast by construction."
+    ],
+    "rules": [
+      { "name": "The Quadrant Quartet Rule", "body": "Rust = Do First, Indigo = Schedule, Sage = Delegate, Amber = Eliminate. These four assignments are fixed. Never reassign a quadrant hue, and never convey a quadrant by color alone; always pair it with its label and grid position.", "section": "colors" },
+      { "name": "The One Accent Rule", "body": "Deep indigo is spent only on intent: primary actions, current selection, focus, links. It is never a decorative fill or a gradient. If indigo appears somewhere that isn't an action or a state, remove it.", "section": "colors" },
+      { "name": "The Serif-Up Rule", "body": "Serif climbs (display to title), sans holds the body and the working UI. Never set body copy in the serif, and never set a display heading in the sans. The contrast between the two faces is the hierarchy.", "section": "typography" },
+      { "name": "The One Eyebrow Rule", "body": "The mono uppercase eyebrow with its leading 24px indigo rule is a deliberate, named brand element used sparingly. A single signature kicker, never a tracked-uppercase label stamped above every section.", "section": "typography" },
+      { "name": "The Flat-at-Rest Rule", "body": "Surfaces are flat until they respond. Shadow is the language of state (hover, focus, float, overlay), not a default decoration. If a resting element has a shadow but no interaction, it should probably be a hairline border instead.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do use the 1.5px hairline (#CFCFCC) as the default border. It is the brand; structure is drawn, not shadowed.",
+      "Do reserve the serif (Georgia) for display and headings and the system sans for body and working UI: the contrast pairing is the hierarchy.",
+      "Do spend deep indigo only on intent: primary actions, current selection, focus rings, links. Keep it on 10% or less of any screen.",
+      "Do pair every quadrant hue with its label and grid position, so the matrix reads in grayscale and for color-blind users.",
+      "Do keep surfaces flat at rest and lift them only on interaction (hover translateY(-3px), focus halo, dialog shadow).",
+      "Do honor prefers-reduced-motion with an instant/crossfade fallback on every animation, and keep touch targets 44px or larger on coarse pointers.",
+      "Do hold muted text at gray-500 (#6F6F75) or darker (the AA floor), never a lighter 'elegant' gray."
+    ],
+    "donts": [
+      "Don't ship the flashy AI-startup look: no purple gradients, no glassmorphism as default, no background-clip:text gradient text, no buzzword copy (supercharge / streamline / seamless).",
+      "Don't drift toward a gamified todo toy: no mascots, no points or badge economies, no juvenile illustration. One tasteful completion confetti is the deliberate exception, not a license.",
+      "Don't build a dense enterprise PM tool: no overwhelming toolbars, no deeply nested settings, no feature soup. GSD is a focused personal tool.",
+      "Don't fall into the generic SaaS dashboard: no cookie-cutter card grids, no hero-metric template (big number + small label + gradient accent).",
+      "Don't use border-left/border-right greater than 1px as a colored accent stripe. The legacy .stat-card.warn and .overdue-task left-borders are anti-patterns to migrate, not to copy.",
+      "Don't extend the deprecated .matrix-card or .rd-* (redesign-scope) class systems. Build on components/ui/* and the Inkwell primitives.",
+      "Don't introduce a web font or a third type family. Three system stacks (serif / sans / mono) carry everything.",
+      "Don't set fluid clamp() headings in product UI. The type scale is fixed px on purpose."
+    ]
+  }
+}

--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["app/layout.tsx"],
+  "insertBefore": "</body>",
+  "commentSyntax": "jsx",
+  "cspChecked": true
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,15 @@ GSD Task Manager is a privacy-first Eisenhower matrix task manager built with Ne
 - `.claude/rules/sw-cache.md` — Service worker multi-cache strategy (ADR 0012)
 - `.claude/rules/mcp-server.md` — MCP server package conventions and tool layout
 
+## Design Context
+
+Strategic design intent lives in `PRODUCT.md` (root). Read it before UI/UX work or when running any `/impeccable` command.
+
+- **Register:** `product` — design serves the task (the matrix, capture bar, settings, dashboard), not a marketing surface.
+- **Personality:** calm & focused. Anti-references: flashy-AI startup, gamified todo toy, dense enterprise PM, generic SaaS dashboard.
+- **Principles:** tool disappears into the task · privacy is the foundation · the matrix is the argument · earned familiarity over novelty · delight in moments, restraint on pages.
+- **Visual system:** Inkwell 1.3.1 "Indigo & Cloud" — tokens in `app/css/inkwell-tokens.css`, signature 1.5px hairline, four-color quadrant language, WCAG-AA baseline. A `DESIGN.md` capturing this is planned (run `/impeccable document`).
+
 ## Core Commands
 
 ### Development

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,244 @@
+---
+name: GSD Task Manager
+description: Inkwell "Indigo & Cloud", a calm editorial system for an Eisenhower-matrix task manager.
+colors:
+  cool-stone: "#F4F4F0"
+  cloud-white: "#FFFFFF"
+  ink-slate: "#13141B"
+  oat: "#DDDCDF"
+  deep-indigo: "#3B4A8C"
+  deep-indigo-pressed: "#2A3768"
+  sage: "#788C5D"
+  rust: "#B04A3F"
+  rust-pressed: "#9A3F3F"
+  amber: "#C78E3F"
+  amber-ink: "#A06A2A"
+  slate-blue: "#5C7CA3"
+  sky: "#6A8CAF"
+  gray-100: "#EDEDEA"
+  gray-300: "#CFCFCC"
+  gray-500: "#6F6F75"
+  gray-700: "#3A3B41"
+typography:
+  display:
+    fontFamily: "ui-serif, Georgia, 'Times New Roman', Times, serif"
+    fontSize: "48px"
+    fontWeight: 500
+    lineHeight: 1.1
+    letterSpacing: "-0.02em"
+  headline:
+    fontFamily: "ui-serif, Georgia, 'Times New Roman', Times, serif"
+    fontSize: "32px"
+    fontWeight: 500
+    lineHeight: 1.2
+    letterSpacing: "-0.01em"
+  title:
+    fontFamily: "ui-serif, Georgia, 'Times New Roman', Times, serif"
+    fontSize: "19px"
+    fontWeight: 500
+    lineHeight: 1.22
+    letterSpacing: "-0.008em"
+  body:
+    fontFamily: "system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+    fontSize: "16px"
+    fontWeight: 430
+    lineHeight: 1.55
+  label:
+    fontFamily: "ui-monospace, 'SF Mono', Menlo, Monaco, Consolas, monospace"
+    fontSize: "11px"
+    fontWeight: 500
+    lineHeight: 1
+    letterSpacing: "0.12em"
+rounded:
+  xs: "4px"
+  sm: "8px"
+  md: "12px"
+  lg: "14px"
+  xl: "20px"
+  full: "999px"
+spacing:
+  micro: "4px"
+  xs: "8px"
+  sm: "12px"
+  md: "16px"
+  lg: "24px"
+  xl: "32px"
+  "2xl": "48px"
+  "3xl": "64px"
+components:
+  button-primary:
+    backgroundColor: "{colors.deep-indigo}"
+    textColor: "{colors.cloud-white}"
+    rounded: "{rounded.sm}"
+    padding: "0 16px"
+    height: "38px"
+  button-primary-hover:
+    backgroundColor: "{colors.deep-indigo-pressed}"
+  button-secondary:
+    backgroundColor: "{colors.cloud-white}"
+    textColor: "{colors.ink-slate}"
+    rounded: "{rounded.sm}"
+    padding: "0 16px"
+    height: "38px"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "{colors.gray-700}"
+    rounded: "{rounded.sm}"
+  button-danger:
+    backgroundColor: "{colors.rust}"
+    textColor: "{colors.cloud-white}"
+    rounded: "{rounded.sm}"
+  input:
+    backgroundColor: "{colors.cloud-white}"
+    textColor: "{colors.ink-slate}"
+    rounded: "{rounded.sm}"
+    padding: "0 12px"
+    height: "38px"
+  card:
+    backgroundColor: "{colors.cloud-white}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.lg}"
+  badge-neutral:
+    backgroundColor: "{colors.gray-100}"
+    textColor: "{colors.gray-700}"
+    rounded: "{rounded.full}"
+---
+
+# Design System: GSD Task Manager
+
+## 1. Overview
+
+**Creative North Star: "The Strategist's Matrix"**
+
+GSD is built around one act: deciding what matters before doing anything. The interface should feel like a strategist's well-ordered planning surface, not a cockpit of dials. Everything is calm, deliberate, and legible at a glance; the four-quadrant Eisenhower grid is the argument the whole system makes, and the visual language exists to make that prioritization decision feel obvious rather than busy. The Inkwell "Indigo & Cloud" system carries this: a cool-stone paper ground, a single deep-indigo accent for intent, serif headings that lend authority without shouting, and a 1.5px hairline that draws structure with the lightest possible touch.
+
+The personality is calm and focused. Surfaces are quiet (cool stone, cloud-white panels), type does the talking, and the one saturated color (deep indigo) is spent only where it means something: a primary action, the current selection, a focus ring. Color carries meaning, never decoration. The four quadrant hues (rust, indigo, sage, amber) are a fixed vocabulary, paired always with a label and a position so the matrix reads even in grayscale.
+
+This system explicitly rejects the four traps named in PRODUCT.md: the flashy AI-startup look (purple gradients, glassmorphism, gradient text, buzzword copy); the gamified todo toy (mascots, points, badge economies); the dense enterprise PM tool (Jira/Asana toolbars and feature soup); and the generic SaaS dashboard (cookie-cutter card grids and the hero-metric template). Delight is reserved for genuine moments (completing a task) and never spread across the surface.
+
+**Key Characteristics:**
+- Cool-stone editorial ground; cloud-white panels; deep indigo as the sole accent.
+- Serif headings (Georgia family) against a system-sans body: a contrast pairing, not two competing sans.
+- The 1.5px hairline is the signature border; structure is drawn, not boxed in shadow.
+- Four fixed quadrant hues (rust / indigo / sage / amber), always paired with label + position.
+- Flat at rest; surfaces lift only in response to state. Motion is 120–300ms, ease-out, never decorative.
+- First-class dark mode (Pattern B), WCAG-AA contrast by construction.
+
+## 2. Colors
+
+A cool, restrained palette: stone-and-cloud neutrals carrying a single deep-indigo accent, with four semantic hues that double as the Eisenhower quadrant language.
+
+### Primary
+- **Deep Indigo** (#3B4A8C): The one accent. Primary buttons, the current selection, focus rings, links, the eyebrow rule, and Q2 (Schedule) in the matrix. Pressed/hover deepens to **Deep Indigo Pressed** (#2A3768). In dark mode it lifts to a periwinkle (#7A8AD1) to hold contrast.
+
+### Secondary
+- **Sage** (#788C5D): Success, additions, and Q3 (Delegate). Paired with a 16%-tint background for success surfaces.
+- **Rust** (#B04A3F): Danger, deletions, overdue state, and Q1 (Do First). Pressed deepens to #9A3F3F.
+- **Amber** (#C78E3F): Warning, blocked state, and Q4 (Eliminate). Amber text darkens to **Amber Ink** (#A06A2A) for AA contrast on light surfaces.
+
+### Tertiary
+- **Slate Blue** (#5C7CA3): Informational state.
+- **Sky** (#6A8CAF): Alternate info and the second data-viz series in dashboard charts.
+
+### Neutral
+- **Cool Stone** (#F4F4F0): The page ground: a barely-warm cool stone, never a cream or sand.
+- **Cloud White** (#FFFFFF): Card and panel surfaces, raised one step above the stone ground.
+- **Ink Slate** (#13141B): Primary text; a near-black with a slight cool undertone.
+- **Oat** (#DDDCDF): Tertiary surfaces, hover thumbnails, link underlines at rest.
+- **Putty Grays** (#EDEDEA / #CFCFCC / #6F6F75 / #3A3B41): The cool-putty neutral ramp. #CFCFCC is the default hairline border; #6F6F75 (gray-500) is the muted-text floor, annotated at 5.05:1 on cloud-white and 4.64:1 on cool-stone so muted text never drifts below AA.
+
+### Named Rules
+**The Quadrant Quartet Rule.** Rust = Do First, Indigo = Schedule, Sage = Delegate, Amber = Eliminate. These four assignments are fixed. Never reassign a quadrant hue, and never convey a quadrant by color alone; always pair it with its label and grid position.
+
+**The One Accent Rule.** Deep indigo is spent only on intent: primary actions, current selection, focus, links. It is never a decorative fill or a gradient. If indigo appears somewhere that isn't an action or a state, remove it.
+
+## 3. Typography
+
+**Display Font:** Georgia (via `ui-serif, Georgia, "Times New Roman", Times, serif`)
+**Body Font:** System UI (via `system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif`)
+**Label/Mono Font:** System mono (via `ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace`)
+
+**Character:** A serif-plus-sans contrast pairing. The serif (Georgia at weight 500) lends headings quiet authority and an editorial calm; the system sans keeps the working UI native, fast, and familiar. Mono is reserved for labels, keyboard chips, eyebrows, and code: small functional moments, never prose. No web fonts are loaded; every face is a system stack, which keeps the app instant and offline-first.
+
+### Hierarchy
+- **Display** (serif, 500, 48px, line-height 1.1, letter-spacing −0.02em): Reserved for the largest editorial moments (About page, marketing surfaces). Fixed px, never fluid clamp.
+- **Headline** (serif, 500, 32px → 24px, line-height 1.2–1.3, letter-spacing −0.01em): Page and section titles (H1/H2).
+- **Title** (serif, 500, 19px, line-height 1.22; or 18px sans for compact UI titles): Card and panel headings.
+- **Body** (system-sans, 430, 16px, line-height 1.55): All running text and most UI copy. Cap prose at 65–75ch.
+- **Label** (mono, 500, 11px, line-height 1, letter-spacing 0.12em, uppercase): Eyebrows, keyboard chips, micro-labels.
+
+### Named Rules
+**The Serif-Up Rule.** Serif climbs (display → title), sans holds the body and the working UI. Never set body copy in the serif, and never set a display heading in the sans. The contrast between the two faces is the hierarchy.
+
+**The One Eyebrow Rule.** The mono uppercase eyebrow with its leading 24px indigo rule (`.eyebrow`) is a deliberate, named brand element used sparingly. It is the exception that proves the ban: a single signature kicker, never a tracked-uppercase label stamped above every section.
+
+## 4. Elevation
+
+A hybrid system that leans on borders, not shadow, for structure. The 1.5px hairline draws every panel, card, and field; shadows are warm, low-spread, and reserved almost entirely for *response to state* (hover lift, the floating action button, dialogs). At rest the interface is flat (stone ground, cloud-white panels, hairline separation), and depth appears only when something is interacted with.
+
+### Shadow Vocabulary
+- **shadow-sm** (`box-shadow: 0 1px 2px rgba(20,20,19,0.06)`): Resting card/column elevation; switch thumbs.
+- **shadow-md** (`box-shadow: 0 4px 14px rgba(20,20,19,0.08)`): Dropdowns, popovers.
+- **shadow-lg** (`box-shadow: 0 12px 28px rgba(20,20,19,0.12)`): Dialogs and the edit drawer.
+- **shadow-card-hover** (`box-shadow: 0 10px 30px rgba(20,20,19,0.10)`): Card hover lift, paired with a small `translateY(-3px)`.
+
+In dark mode the same roles switch to pure-black-based shadows (`rgba(0,0,0,0.45–0.55)`) since warm low-alpha shadows vanish on dark surfaces.
+
+### Named Rules
+**The Flat-at-Rest Rule.** Surfaces are flat until they respond. Shadow is the language of state (hover, focus, float, overlay), not a default decoration. If a resting element has a shadow but no interaction, it should probably be a hairline border instead.
+
+## 5. Components
+
+Components are **refined and restrained**: understated, hairline-bordered, with subtle hover lifts and a quiet active press. Every interactive primitive carries default / hover / focus / active / disabled states. The canonical layer is the React `components/ui/*` set composing the Inkwell `.btn` / `.input` / `.badge` / `.card` primitives; the legacy `.matrix-card` and `.rd-*` (redesign-scope) classes are deprecated and should not be extended.
+
+### Buttons
+- **Shape:** Gently rounded (8px, `rounded.sm`), 38px tall, 1.5px transparent border, mono-free 14px/500 sans label.
+- **Primary:** Deep-indigo fill, cloud-white text; hover deepens to #2A3768.
+- **Secondary (`subtle`):** Cloud-white fill, ink-slate text, gray-300 hairline; hover fills gray-100.
+- **Ghost:** Transparent, gray-700 text; hover fills gray-100.
+- **Destructive:** Rust fill, cloud-white text; hover deepens to #9A3F3F.
+- **Hover / Focus / Active:** 120ms background/border transition; focus shows a 2px indigo ring with a 2px offset; active presses to `scale(0.97)`.
+
+### Chips / Badges
+- **Style:** Pill (`rounded.full`), 22px tall, 12px/500 text.
+- **Variants:** Neutral (gray-100 / gray-700), Accent (indigo-tint / indigo), Success (sage-tint / sage), Warning (amber-tint / amber-ink), Danger (rust fill / cloud-white). Tinted variants use a ~14–16% tint of the hue's own color, never gray text on a colored ground.
+
+### Cards / Containers
+- **Corner Style:** 14px (`rounded.lg`); stat cards use 12px (`rounded.md`).
+- **Background:** Cloud-white on the cool-stone ground.
+- **Shadow Strategy:** Flat at rest (hairline border only); link cards lift `translateY(-3px)` with `shadow-card-hover` and an ink-slate border on hover.
+- **Border:** The 1.5px gray-300 hairline. This is the signature; it replaces shadow as the default separator.
+- **Internal Padding:** 24px (`spacing.lg`) for cards, 20–22px for stat cards.
+
+### Inputs / Fields
+- **Style:** Cloud-white fill, 1.5px gray-300 hairline, 8px radius, 38px tall, 14px sans. Placeholder uses gray-500 (AA-compliant, never lighter).
+- **Focus:** Border shifts to deep indigo with a 3px indigo focus halo (`0 0 0 3px` of `accent-focus-ring`).
+- **Error / Disabled:** Error shifts border + halo to rust; disabled fills gray-100 with gray-500 text and `not-allowed` cursor.
+- **Field group:** Label (13px/500 ink-slate), control, then help (12px gray-500) or error (12px/500 rust), stacked with 6px gaps.
+
+### Navigation
+- **Style:** A persistent top bar plus an icon rail in the v9 single-matrix shell; full-page settings use a sidebar that collapses below 1024px. Active state is carried by the indigo accent; hover by a gray-100 fill. Touch targets expand to ≥44px on coarse pointers.
+
+### Signature Component: The Eisenhower Matrix Grid
+The four-quadrant grid is the product's defining surface. Each quadrant pane carries a ~17–22% color-mix wash of its quadrant hue over cloud-white (rust / indigo / sage / amber), a 3px top accent bar, and a header tinted ~10–14%. In dark mode the washes switch from `mix-with-paper` to `mix-with-transparent` so they read on the dark ground. The grid is two columns on desktop, single-column stacked on mobile.
+
+## 6. Do's and Don'ts
+
+### Do:
+- **Do** use the 1.5px hairline (`#CFCFCC`) as the default border. It is the brand; structure is drawn, not shadowed.
+- **Do** reserve the serif (Georgia) for display and headings and the system sans for body and working UI: the contrast pairing is the hierarchy.
+- **Do** spend deep indigo only on intent: primary actions, current selection, focus rings, links. Keep it on ≤10% of any screen.
+- **Do** pair every quadrant hue with its label and grid position, so the matrix reads in grayscale and for color-blind users.
+- **Do** keep surfaces flat at rest and lift them only on interaction (hover `translateY(-3px)`, focus halo, dialog shadow).
+- **Do** honor `prefers-reduced-motion` with an instant/crossfade fallback on every animation, and keep touch targets ≥44px on coarse pointers.
+- **Do** hold muted text at gray-500 (#6F6F75) or darker (the AA floor), never a lighter "elegant" gray.
+
+### Don't:
+- **Don't** ship the flashy AI-startup look: no purple gradients, no glassmorphism as default, no `background-clip: text` gradient text, no buzzword copy (supercharge / streamline / seamless).
+- **Don't** drift toward a gamified todo toy: no mascots, no points or badge economies, no juvenile illustration. One tasteful completion confetti is the deliberate exception, not a license.
+- **Don't** build a dense enterprise PM tool: no overwhelming toolbars, no deeply nested settings, no feature soup. GSD is a focused personal tool.
+- **Don't** fall into the generic SaaS dashboard: no cookie-cutter card grids, no hero-metric template (big number + small label + gradient accent).
+- **Don't** use `border-left`/`border-right` greater than 1px as a colored accent stripe. The legacy `.stat-card.warn` (`border-left: 4px`) and `.overdue-task` left-border are anti-patterns to migrate, not to copy. Use a full hairline, a background tint, or a leading icon instead.
+- **Don't** extend the deprecated `.matrix-card` or `.rd-*` (redesign-scope) class systems. Build on `components/ui/*` and the Inkwell primitives.
+- **Don't** introduce a web font or a third type family. Three system stacks (serif / sans / mono) carry everything; more reads as indecision.
+- **Don't** set fluid `clamp()` headings in product UI. The type scale is fixed px on purpose; a heading that shrinks in a sidebar looks worse, not better.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,58 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Individuals managing their own work and life, not teams running shared projects. They reach for GSD when a flat to-do list has stopped helping and they need to decide *what actually matters* before doing anything. The defining trait is a desire for control over both their priorities and their data: many choose GSD specifically because it runs locally and asks for nothing.
+
+Context of use is varied and often quick: a desktop browser during a planning block, a phone as an installed PWA between meetings, occasionally Claude Desktop via the MCP server for natural-language task capture. The job to be done is always the same underneath: *triage by urgency and importance, then focus on the one quadrant that deserves it.*
+
+## Product Purpose
+
+GSD Task Manager turns the Eisenhower Matrix into a working surface. Tasks are sorted into four quadrants by two booleans (urgent, important): Do First, Schedule, Delegate, and Eliminate. Prioritization becomes a structural decision the app makes visible, not a label the user has to remember.
+
+It is privacy-first by construction: all data lives in the browser via IndexedDB, with JSON export/import for backups and an *optional* self-hosted PocketBase sync for multi-device users. It works fully offline as a PWA. Around the core matrix sit dependencies, recurring tasks, subtasks, tags, batch operations, and a dashboard of completion and quadrant analytics.
+
+Success looks like a user who spends less time in Q1 (reactive firefighting) and more in Q2 (strategic, important-but-not-urgent work), and who trusts the tool enough to keep their real life in it because nothing leaves their device unless they say so.
+
+## Brand Personality
+
+**Calm and focused.** GSD should feel like a quiet desk, not a cockpit. The interface is unhurried and low-noise; the editorial restraint of the Inkwell system (serif display against a system sans, a single indigo accent, the 1.5px hairline, cool-stone surfaces) is the personality made visible.
+
+- **Emotional goal:** the user feels clear-headed and in control: never overwhelmed, never behind, never nagged.
+- **Voice:** plain and direct. Respects the reader's attention and intelligence. Names what the product literally does. No productivity hype, no buzzwords, no exclamation-point cheerleading.
+- **Tone:** encouraging without being saccharine. Completion is worth a brief celebration; everything else stays composed.
+
+## Anti-references
+
+GSD should explicitly NOT look or feel like:
+
+- **A flashy AI startup:** no purple gradients, glassmorphism-by-default, gradient text, or supercharge/streamline/seamless copy. Substance over shine.
+- **A gamified todo toy:** no cartoon mascots, no points/badges economy, no juvenile illustration. (One tasteful completion confetti is the deliberate exception, not a license for toy aesthetics.)
+- **A dense enterprise PM tool:** not Jira/Asana. No overwhelming toolbars, deeply nested settings, or feature soup. GSD is a focused *personal* tool; complexity is a failure, not a feature.
+- **A generic SaaS dashboard:** no cookie-cutter card grids, no hero-metric template (big number + small label + gradient accent), no interchangeable enterprise-app sameness.
+
+## Design Principles
+
+1. **The tool disappears into the task.** Calm and focused means minimal chrome and no decoration competing with content. Users come to decide and act, not to admire the UI. When in doubt, remove.
+
+2. **Privacy is the foundation, not a feature to advertise.** Local-first by default, sync strictly opt-in, no tracking, no dark patterns. Every flow should make it obvious the user owns their data, and never pressure them out of that ownership.
+
+3. **The matrix is the argument.** GSD exists to make the urgent/important distinction tangible. Design should reinforce prioritization (the four-quadrant color language, washes, and accents carry meaning) rather than flattening tasks back into a generic list.
+
+4. **Earned familiarity over novelty.** Drag-and-drop, command palette, keyboard shortcuts, and standard form controls, all done well. Don't reinvent standard affordances for flavor; a focused personal tool wins on trust and muscle memory, not surprise.
+
+5. **Delight in moments, restraint on pages.** Reserve celebration and personality for genuine moments (task completion). Keep every other surface composed. This is the line between "calm & focused" and the gamified/flashy traps above.
+
+## Accessibility & Inclusion
+
+WCAG 2.1 AA is the baseline, enforced by construction and review (see `coding-standards.md` Part 2 and the `a11y-reviewer` agent):
+
+- **Contrast:** body text ≥4.5:1, large text ≥3:1. Neutral tokens carry annotated contrast ratios (e.g. `--gray-500` at 5.05:1 on paper) so muted text never drifts below the floor.
+- **Motion:** every animation has a `prefers-reduced-motion: reduce` fallback (crossfade or instant). Reveals enhance already-visible content; they never gate visibility.
+- **Touch:** interactive targets expand to ≥44px on coarse pointers (WCAG 2.5.5) while staying compact on mouse-driven desktops.
+- **Color independence:** the four-quadrant language pairs color with labels and position, never relying on hue alone to convey quadrant or task state.
+- **Dark mode:** first-class (Inkwell Pattern B: system preference with manual override), with lifted hues tuned to hold contrast on dark surfaces.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,13 +18,16 @@ import { FirstTimeRedirect } from "@/components/first-time-redirect";
 
 // The current static Next export emits inline hydration/RSC scripts. Keep
 // production inline script allowance until a deploy-time hash pipeline exists.
+// The dev-only http://localhost:8400 entries below allow the impeccable
+// live-mode picker; they are stripped from the production CSP.
 const scriptSrc = process.env.NODE_ENV === "development"
-  ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+  ? "script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:8400"
   : "script-src 'self' 'unsafe-inline'";
 
 const connectSrc = process.env.NODE_ENV === "development"
   ? [
       "connect-src 'self'",
+      "http://localhost:8400",
       "http://127.0.0.1:8090",
       "http://localhost:8090",
       "ws://127.0.0.1:8090",


### PR DESCRIPTION
## What & why
Sets up the impeccable design workflow for the repo (output of `/impeccable init`, `document`, and `critique`). Docs + dev-tooling only — no runtime app behavior changes.

- **PRODUCT.md** — strategic design spec: `product` register, "calm & focused" personality, four anti-references, 5 design principles, WCAG-AA baseline.
- **DESIGN.md** — the Inkwell "Indigo & Cloud" visual system in the Stitch six-section format, plus the `.impeccable/design.json` sidecar (tonal ramps, shadows, motion, component snippets).
- **.impeccable/** — live-mode config and the `components/matrix-simplified` critique snapshot (the backlog the harden PR #343 worked from).
- **CLAUDE.md** — a short Design Context pointer to PRODUCT.md so future agent sessions discover the design intent.
- **app/layout.tsx** — a dev-only CSP allowance for `http://localhost:8400` so the impeccable live picker can load. Guarded by `NODE_ENV === "development"`; stripped from the production CSP.

## How to test
- No runtime change. `bun run test`, `bun typecheck`, `bun lint` unaffected.
- The CSP edit only adds `http://localhost:8400` to the **dev** `script-src`/`connect-src` (mirrors the existing dev-only `:8090` PocketBase allowances); production CSP is byte-for-byte unchanged.

## Notes
- Independent of #343 (harden pass) — disjoint files, no merge conflict.
- If `.impeccable/critique/*` snapshots shouldn't be version-controlled long-term, they can be gitignored in a follow-up; committed here so the critique backlog is shareable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->