### PR TITLE
fix(dashboard): replace deadline side-stripes with full-border callouts

### DIFF
--- a/components/dashboard/upcoming-deadlines.tsx
+++ b/components/dashboard/upcoming-deadlines.tsx
@@ -115,9 +115,9 @@ function DeadlineSection({
   color,
 }: DeadlineSectionProps) {
   const borderColor = {
-    overdue: "border-l-status-overdue",
-    warning: "border-l-warning",
-    info: "border-l-sky",
+    overdue: "border-status-overdue/35",
+    warning: "border-warning/35",
+    info: "border-sky/35",
   }[color];
 
   const bgColor = {
@@ -141,7 +141,7 @@ function DeadlineSection({
             <li key={task.id}>
               <button
                 onClick={() => onTaskClick?.(task)}
-                className={`w-full cursor-pointer rounded-lg border-l-4 ${borderColor} ${bgColor} p-3 text-left transition-all hover:shadow-sm`}
+                className={`w-full cursor-pointer rounded-lg border ${borderColor} ${bgColor} p-3 text-left transition-all hover:shadow-sm`}
               >
                 <div className="flex items-start justify-between gap-2">
                   <div className="min-w-0 flex-1">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.4.2",
+	"version": "9.4.3",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## What & why

The **Upcoming Deadlines** widget rendered each row with a 4px colored left stripe (`border-l-4`) for overdue / today / this-week urgency. A one-sided accent stripe is a flagged anti-pattern — the impeccable detector`'`s `side-tab` rule, and the Inkwell `DESIGN.md` explicitly lists the `.overdue-task` left-border as "to migrate, not copy." Surfaced by an `/impeccable critique components/dashboard` pass.

This swaps the stripe for a **full 1px hairline in the status hue at 35% opacity over the existing tint** — the tinted-callout idiom already shipping in `reset-everything-dialog`. Urgency is still carried by each section`'`s heading and icon, so the cue never depended on the stripe (color independence preserved).

## How to test
1. `bun dev`, open `/dashboard` with tasks that have due dates (overdue / today / within 7 days).
2. Upcoming Deadlines rows show a soft full border + tint, no colored left stripe.
3. Section headings + icons still convey urgency.

## Verification
- `detect.mjs` on the file: clean, exit 0 (side-tab ban cleared)
- `bun typecheck`: pass
- `bun run lint`: 0 errors
- `dashboard-components.test.tsx`: 66/66 pass
- Visually confirmed in browser (light + dark, seeded data)

## Scope
First of several fixes from the dashboard critique. Card-vocabulary consistency, color-system, streak de-gamification, and Quadrant Distribution layout follow-ups are tracked as separate changes on the same branch line.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->