### PR TITLE
fix(dashboard): standardize card vocabulary and fix quadrant distribution layout

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -176,7 +176,7 @@ export default function DashboardPage() {
             {isLoading ? (
               <DashboardSkeleton />
             ) : tasks.length === 0 ? (
-              <div className="rounded-xl border border-border bg-card p-12 text-center shadow-sm">
+              <div className="rounded-lg border-hair border-border bg-card p-12 text-center shadow-sm">
                 <ListTodoIcon className="mx-auto h-12 w-12 text-foreground-muted" />
                 <h2 className="mt-4 text-xl font-semibold text-foreground">
                   No tasks yet
@@ -260,7 +260,7 @@ export default function DashboardPage() {
                   {metrics.tagStats.length > 0 ? (
                     <TagAnalytics tagStats={metrics.tagStats} maxTags={8} />
                   ) : (
-                    <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
+                    <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
                       <h3 className="mb-4 text-lg font-semibold text-foreground">
                         Top Tags
                       </h3>

--- a/components/dashboard/completion-chart.tsx
+++ b/components/dashboard/completion-chart.tsx
@@ -32,7 +32,7 @@ export function CompletionChart({ data }: CompletionChartProps) {
   }, [data]);
 
   return (
-    <div className="rounded-3xl border border-border/70 bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
+    <div className="rounded-lg border-hair border-border bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
       <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
         <div>
           <h3 className="rd-serif text-title text-foreground">

--- a/components/dashboard/dashboard-skeleton.tsx
+++ b/components/dashboard/dashboard-skeleton.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 function StatsCardSkeleton() {
   return (
     <div
-      className="rounded-3xl border border-border/70 bg-card p-6"
+      className="rounded-lg border-hair border-border bg-card p-6"
       style={{ boxShadow: "var(--shadow-column)" }}
     >
       <div className="flex items-start justify-between gap-4">
@@ -30,7 +30,7 @@ function StatsCardSkeleton() {
 
 function ChartSkeleton() {
   return (
-    <div className="rounded-3xl border border-border/70 bg-card p-6 space-y-4" style={{ boxShadow: "var(--shadow-column)" }}>
+    <div className="rounded-lg border-hair border-border bg-card p-6 space-y-4" style={{ boxShadow: "var(--shadow-column)" }}>
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-2">
           <Skeleton className="h-5 w-40" />
@@ -45,7 +45,7 @@ function ChartSkeleton() {
 
 function DonutSkeleton() {
   return (
-    <div className="rounded-3xl border border-border/70 bg-card p-6 space-y-4" style={{ boxShadow: "var(--shadow-column)" }}>
+    <div className="rounded-lg border-hair border-border bg-card p-6 space-y-4" style={{ boxShadow: "var(--shadow-column)" }}>
       <Skeleton className="h-5 w-44" />
       <Skeleton className="h-4 w-44" />
       <div className="flex items-center justify-center py-4">
@@ -62,7 +62,7 @@ function DonutSkeleton() {
 
 function ListSkeleton() {
   return (
-    <div className="rounded-xl border border-border bg-card p-6 shadow-sm space-y-4">
+    <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm space-y-4">
       <Skeleton className="h-5 w-40" />
       {Array.from({ length: 4 }, (_, i) => (
         <Skeleton key={i} className="h-14 w-full rounded-lg" />

--- a/components/dashboard/quadrant-distribution.tsx
+++ b/components/dashboard/quadrant-distribution.tsx
@@ -39,7 +39,7 @@ export function QuadrantDistribution({ distribution }: QuadrantDistributionProps
   }, [distribution]);
 
   return (
-    <div className="rounded-3xl border border-border/70 bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
+    <div className="rounded-lg border-hair border-border bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
       <div className="flex items-baseline justify-between gap-3">
         <div>
           <h3 className="rd-serif text-title text-foreground">
@@ -55,26 +55,11 @@ export function QuadrantDistribution({ distribution }: QuadrantDistributionProps
       </div>
 
       {segments.length === 0 ? (
-        <div className="mt-6 flex h-[120px] items-center justify-center rounded-xl border border-dashed border-border/70 bg-background-muted/30">
+        <div className="mt-6 flex h-[120px] items-center justify-center rounded-lg border border-dashed border-border bg-background-muted/30">
           <p className="text-sm text-foreground-muted">No active tasks to display</p>
         </div>
       ) : (
-        <div className="mt-6 space-y-3">
-          <div className="grid gap-2" style={{ gridTemplateColumns: segments.map((s) => `${s.value}fr`).join(" ") }}>
-            {segments.map((segment) => {
-              const pct = Math.round((segment.value / total) * 100);
-              return (
-                <div key={segment.id} className="min-w-0 text-xs">
-                  <div className="flex items-baseline gap-1.5 truncate">
-                    <span className="font-medium text-foreground">{segment.shortName}</span>
-                    <span className="tabular-nums text-foreground-muted">{segment.value}</span>
-                    <span className="tabular-nums text-foreground-muted/70">·</span>
-                    <span className="tabular-nums text-foreground-muted">{pct}%</span>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
+        <div className="mt-6 space-y-5">
           <div
             className="flex h-3 overflow-hidden rounded-full"
             role="img"
@@ -92,6 +77,27 @@ export function QuadrantDistribution({ distribution }: QuadrantDistributionProps
               );
             })}
           </div>
+          <ul className="space-y-2.5">
+            {segments.map((segment) => {
+              const pct = Math.round((segment.value / total) * 100);
+              return (
+                <li key={segment.id} className="flex items-center gap-2.5 text-sm">
+                  <span
+                    className="h-2.5 w-2.5 shrink-0 rounded-full"
+                    style={{ backgroundColor: segment.color }}
+                    aria-hidden
+                  />
+                  <span className="flex-1 truncate font-medium text-foreground">
+                    {segment.shortName}
+                  </span>
+                  <span className="tabular-nums text-foreground-muted">{segment.value}</span>
+                  <span className="w-12 text-right tabular-nums text-foreground-muted">
+                    {pct}%
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
         </div>
       )}
     </div>

--- a/components/dashboard/stats-card.tsx
+++ b/components/dashboard/stats-card.tsx
@@ -46,7 +46,7 @@ export function StatsCard({
   return (
     <div
       className={cn(
-        "relative overflow-hidden rounded-[20px] border border-border bg-card p-6",
+        "relative overflow-hidden rounded-lg border-hair border-border bg-card p-6",
         className
       )}
       style={{ boxShadow: "var(--shadow-card)" }}

--- a/components/dashboard/streak-indicator.tsx
+++ b/components/dashboard/streak-indicator.tsx
@@ -33,7 +33,7 @@ export function StreakIndicator({ streakData }: StreakIndicatorProps) {
 
   return (
     <div
-      className="flex h-full flex-col justify-between rounded-2xl border-2 border-border/80 bg-card p-6"
+      className="flex h-full flex-col justify-between rounded-lg border-hair border-border bg-card p-6"
       style={{ boxShadow: "var(--shadow-column)" }}
     >
       {/* Top: icon + streak count */}

--- a/components/dashboard/tag-analytics.tsx
+++ b/components/dashboard/tag-analytics.tsx
@@ -37,7 +37,7 @@ export function TagAnalytics({ tagStats, maxTags = 10 }: TagAnalyticsProps) {
 
   if (displayTags.length === 0) {
     return (
-      <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
+      <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
         <h3 className="mb-4 rd-serif text-title text-foreground">Top Tags</h3>
         <p className="text-sm text-foreground-muted">
           No tags to display. Add tags to your tasks to see analytics here.
@@ -47,7 +47,7 @@ export function TagAnalytics({ tagStats, maxTags = 10 }: TagAnalyticsProps) {
   }
 
   return (
-    <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
+    <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
       <h3 className="mb-4 rd-serif text-title text-foreground">Top Tags</h3>
       <div className="space-y-3">
         {displayTags.map((stat, index) => {

--- a/components/dashboard/time-analytics.tsx
+++ b/components/dashboard/time-analytics.tsx
@@ -22,7 +22,7 @@ const QUADRANT_LABELS: Record<string, { name: string }> = {
 /** Empty state when no time tracking data exists */
 function EmptyState({ className }: { className?: string }) {
   return (
-    <div className={cn("rounded-xl border border-border bg-card p-6 shadow-sm", className)}>
+    <div className={cn("rounded-lg border-hair border-border bg-card p-6 shadow-sm", className)}>
       <h3 className="flex items-center gap-2 rd-serif text-title text-foreground">
         <ClockIcon className="h-5 w-5 text-accent" />
         Time Tracking
@@ -90,7 +90,7 @@ export function TimeAnalytics({ summary, quadrantDistribution, className }: Time
   }
 
   return (
-    <div className={cn("rounded-xl border border-border bg-card p-6 shadow-sm", className)}>
+    <div className={cn("rounded-lg border-hair border-border bg-card p-6 shadow-sm", className)}>
       <h3 className="flex items-center gap-2 rd-serif text-title text-foreground">
         <ClockIcon className="h-5 w-5 text-accent" />
         Time Tracking

--- a/components/dashboard/upcoming-deadlines.tsx
+++ b/components/dashboard/upcoming-deadlines.tsx
@@ -51,7 +51,7 @@ export function UpcomingDeadlines({ tasks, onTaskClick }: UpcomingDeadlinesProps
   }, [tasks]);
 
   return (
-    <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
+    <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
       <h3 className="mb-4 rd-serif text-title text-foreground">
         Upcoming Deadlines
       </h3>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.4.3",
+	"version": "9.4.4",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
> **Stacked on #345.** Base is `fix/dashboard-impeccable-remediation`, not `main`. Merge #345 first; this diff shows only the card-vocabulary change.

## What & why

Second fix from the `/impeccable critique components/dashboard` pass (P1: inconsistent card vocabulary + P3: Quadrant Distribution layout).

Dashboard panels had drifted to **four card radii** (12/16/20/24px) and **three border treatments** (1px, 1.5px, 2px), so the surface read as assembled pieces rather than one system. This unifies every panel, skeleton, and empty state on the canonical card spec — `rounded-lg` (14px) + `border-hair` (1.5px signature hairline) + full-opacity `border-border` — matching the `.card` primitive and DESIGN.md. Resting `shadow-sm` is kept (it is the documented resting card elevation).

**Quadrant Distribution** also got a body fix: the proportional label row truncated narrow labels (`Delegat`) and left a large void below the bar. It is now the segmented bar followed by a full vertical legend (color swatch + full label + count + %), which fixes truncation and fills the card.

## How to test
1. `bun dev`, open `/dashboard` with a mix of tasks (varied quadrants, due dates, tags).
2. Every card shares one radius (14px) and a 1.5px hairline; the streak card no longer has a heavier border.
3. Quadrant Distribution shows a full legend with no truncated labels and no empty void.

## Verification
- `bun typecheck`: pass
- `bun run lint`: 0 errors
- `dashboard-components.test.tsx`: 66/66 pass
- Visually confirmed in browser (seeded data, SW cache busted)

## Scope
Card vocabulary + Quadrant Distribution only. Off-brand color systems (green-600/red-600, decorative quadrant-hue tag bars), streak de-gamification, and minor typography/a11y nits are separate follow-ups.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->