### PR TITLE
fix(dashboard): unify card vocabulary, quadrant distribution, and color tokens

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -176,7 +176,7 @@ export default function DashboardPage() {
             {isLoading ? (
               <DashboardSkeleton />
             ) : tasks.length === 0 ? (
-              <div className="rounded-xl border border-border bg-card p-12 text-center shadow-sm">
+              <div className="rounded-lg border-hair border-border bg-card p-12 text-center shadow-sm">
                 <ListTodoIcon className="mx-auto h-12 w-12 text-foreground-muted" />
                 <h2 className="mt-4 text-xl font-semibold text-foreground">
                   No tasks yet
@@ -260,7 +260,7 @@ export default function DashboardPage() {
                   {metrics.tagStats.length > 0 ? (
                     <TagAnalytics tagStats={metrics.tagStats} maxTags={8} />
                   ) : (
-                    <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
+                    <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
                       <h3 className="mb-4 text-lg font-semibold text-foreground">
                         Top Tags
                       </h3>

--- a/components/dashboard/completion-chart.tsx
+++ b/components/dashboard/completion-chart.tsx
@@ -32,7 +32,7 @@ export function CompletionChart({ data }: CompletionChartProps) {
   }, [data]);
 
   return (
-    <div className="rounded-3xl border border-border/70 bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
+    <div className="rounded-lg border-hair border-border bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
       <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
         <div>
           <h3 className="rd-serif text-title text-foreground">

--- a/components/dashboard/dashboard-skeleton.tsx
+++ b/components/dashboard/dashboard-skeleton.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 function StatsCardSkeleton() {
   return (
     <div
-      className="rounded-3xl border border-border/70 bg-card p-6"
+      className="rounded-lg border-hair border-border bg-card p-6"
       style={{ boxShadow: "var(--shadow-column)" }}
     >
       <div className="flex items-start justify-between gap-4">
@@ -30,7 +30,7 @@ function StatsCardSkeleton() {
 
 function ChartSkeleton() {
   return (
-    <div className="rounded-3xl border border-border/70 bg-card p-6 space-y-4" style={{ boxShadow: "var(--shadow-column)" }}>
+    <div className="rounded-lg border-hair border-border bg-card p-6 space-y-4" style={{ boxShadow: "var(--shadow-column)" }}>
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-2">
           <Skeleton className="h-5 w-40" />
@@ -45,7 +45,7 @@ function ChartSkeleton() {
 
 function DonutSkeleton() {
   return (
-    <div className="rounded-3xl border border-border/70 bg-card p-6 space-y-4" style={{ boxShadow: "var(--shadow-column)" }}>
+    <div className="rounded-lg border-hair border-border bg-card p-6 space-y-4" style={{ boxShadow: "var(--shadow-column)" }}>
       <Skeleton className="h-5 w-44" />
       <Skeleton className="h-4 w-44" />
       <div className="flex items-center justify-center py-4">
@@ -62,7 +62,7 @@ function DonutSkeleton() {
 
 function ListSkeleton() {
   return (
-    <div className="rounded-xl border border-border bg-card p-6 shadow-sm space-y-4">
+    <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm space-y-4">
       <Skeleton className="h-5 w-40" />
       {Array.from({ length: 4 }, (_, i) => (
         <Skeleton key={i} className="h-14 w-full rounded-lg" />

--- a/components/dashboard/quadrant-distribution.tsx
+++ b/components/dashboard/quadrant-distribution.tsx
@@ -39,7 +39,7 @@ export function QuadrantDistribution({ distribution }: QuadrantDistributionProps
   }, [distribution]);
 
   return (
-    <div className="rounded-3xl border border-border/70 bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
+    <div className="rounded-lg border-hair border-border bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
       <div className="flex items-baseline justify-between gap-3">
         <div>
           <h3 className="rd-serif text-title text-foreground">
@@ -55,26 +55,11 @@ export function QuadrantDistribution({ distribution }: QuadrantDistributionProps
       </div>
 
       {segments.length === 0 ? (
-        <div className="mt-6 flex h-[120px] items-center justify-center rounded-xl border border-dashed border-border/70 bg-background-muted/30">
+        <div className="mt-6 flex h-[120px] items-center justify-center rounded-lg border border-dashed border-border bg-background-muted/30">
           <p className="text-sm text-foreground-muted">No active tasks to display</p>
         </div>
       ) : (
-        <div className="mt-6 space-y-3">
-          <div className="grid gap-2" style={{ gridTemplateColumns: segments.map((s) => `${s.value}fr`).join(" ") }}>
-            {segments.map((segment) => {
-              const pct = Math.round((segment.value / total) * 100);
-              return (
-                <div key={segment.id} className="min-w-0 text-xs">
-                  <div className="flex items-baseline gap-1.5 truncate">
-                    <span className="font-medium text-foreground">{segment.shortName}</span>
-                    <span className="tabular-nums text-foreground-muted">{segment.value}</span>
-                    <span className="tabular-nums text-foreground-muted/70">·</span>
-                    <span className="tabular-nums text-foreground-muted">{pct}%</span>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
+        <div className="mt-6 space-y-5">
           <div
             className="flex h-3 overflow-hidden rounded-full"
             role="img"
@@ -92,6 +77,27 @@ export function QuadrantDistribution({ distribution }: QuadrantDistributionProps
               );
             })}
           </div>
+          <ul className="space-y-2.5">
+            {segments.map((segment) => {
+              const pct = Math.round((segment.value / total) * 100);
+              return (
+                <li key={segment.id} className="flex items-center gap-2.5 text-sm">
+                  <span
+                    className="h-2.5 w-2.5 shrink-0 rounded-full"
+                    style={{ backgroundColor: segment.color }}
+                    aria-hidden
+                  />
+                  <span className="flex-1 truncate font-medium text-foreground">
+                    {segment.shortName}
+                  </span>
+                  <span className="tabular-nums text-foreground-muted">{segment.value}</span>
+                  <span className="w-12 text-right tabular-nums text-foreground-muted">
+                    {pct}%
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
         </div>
       )}
     </div>

--- a/components/dashboard/stats-card.tsx
+++ b/components/dashboard/stats-card.tsx
@@ -46,7 +46,7 @@ export function StatsCard({
   return (
     <div
       className={cn(
-        "relative overflow-hidden rounded-[20px] border border-border bg-card p-6",
+        "relative overflow-hidden rounded-lg border-hair border-border bg-card p-6",
         className
       )}
       style={{ boxShadow: "var(--shadow-card)" }}

--- a/components/dashboard/streak-indicator.tsx
+++ b/components/dashboard/streak-indicator.tsx
@@ -33,7 +33,7 @@ export function StreakIndicator({ streakData }: StreakIndicatorProps) {
 
   return (
     <div
-      className="flex h-full flex-col justify-between rounded-2xl border-2 border-border/80 bg-card p-6"
+      className="flex h-full flex-col justify-between rounded-lg border-hair border-border bg-card p-6"
       style={{ boxShadow: "var(--shadow-column)" }}
     >
       {/* Top: icon + streak count */}

--- a/components/dashboard/tag-analytics.tsx
+++ b/components/dashboard/tag-analytics.tsx
@@ -8,19 +8,6 @@ interface TagAnalyticsProps {
   maxTags?: number;
 }
 
-const BAR_COLORS = [
-  "bg-accent",
-  "bg-olive",
-  "bg-warning",
-  "bg-rust",
-  "bg-sky",
-  "bg-accent-d",
-  "bg-info",
-  "bg-gray-500",
-  "bg-olive",
-  "bg-warning-dark",
-];
-
 /**
  * Horizontal bar visualization showing tag usage and completion rates.
  * Replaces the previous table layout with a more visual, dashboard-friendly design.
@@ -50,9 +37,8 @@ export function TagAnalytics({ tagStats, maxTags = 10 }: TagAnalyticsProps) {
     <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
       <h3 className="mb-4 rd-serif text-title text-foreground">Top Tags</h3>
       <div className="space-y-3">
-        {displayTags.map((stat, index) => {
+        {displayTags.map((stat) => {
           const barWidth = Math.max((stat.count / maxCount) * 100, 4);
-          const barColor = BAR_COLORS[index % BAR_COLORS.length];
 
           return (
             <div key={stat.tag} className="group">
@@ -70,14 +56,14 @@ export function TagAnalytics({ tagStats, maxTags = 10 }: TagAnalyticsProps) {
                 </div>
               </div>
               <div className="relative h-2 w-full overflow-hidden rounded-full bg-background-muted">
-                {/* Total tasks bar (full width relative to max) */}
+                {/* Total tasks for this tag — neutral, encodes frequency */}
                 <div
-                  className={`absolute inset-y-0 left-0 rounded-full opacity-25 transition-all ${barColor}`}
+                  className="absolute inset-y-0 left-0 rounded-full bg-gray-300 transition-all"
                   style={{ width: `${barWidth}%` }}
                 />
-                {/* Completed portion (filled) */}
+                {/* Completed portion — success olive, matching the dashboard's completed language */}
                 <div
-                  className={`absolute inset-y-0 left-0 rounded-full transition-all ${barColor}`}
+                  className="absolute inset-y-0 left-0 rounded-full bg-status-success transition-all"
                   style={{
                     width: `${barWidth * (stat.completionRate / 100)}%`,
                   }}

--- a/components/dashboard/tag-analytics.tsx
+++ b/components/dashboard/tag-analytics.tsx
@@ -37,7 +37,7 @@ export function TagAnalytics({ tagStats, maxTags = 10 }: TagAnalyticsProps) {
 
   if (displayTags.length === 0) {
     return (
-      <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
+      <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
         <h3 className="mb-4 rd-serif text-title text-foreground">Top Tags</h3>
         <p className="text-sm text-foreground-muted">
           No tags to display. Add tags to your tasks to see analytics here.
@@ -47,7 +47,7 @@ export function TagAnalytics({ tagStats, maxTags = 10 }: TagAnalyticsProps) {
   }
 
   return (
-    <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
+    <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
       <h3 className="mb-4 rd-serif text-title text-foreground">Top Tags</h3>
       <div className="space-y-3">
         {displayTags.map((stat, index) => {

--- a/components/dashboard/time-analytics.tsx
+++ b/components/dashboard/time-analytics.tsx
@@ -67,11 +67,11 @@ function EstimationInsights({ overCount, underCount }: { overCount: number; unde
       <h4 className="text-sm font-medium text-foreground">Estimation Insights</h4>
       <div className="mt-2 flex gap-6 text-sm">
         <div>
-          <span className="text-red-600 font-medium">{overCount}</span>
+          <span className="text-status-overdue font-medium">{overCount}</span>
           <span className="text-foreground-muted"> tasks over estimate</span>
         </div>
         <div>
-          <span className="text-green-600 font-medium">{underCount}</span>
+          <span className="text-status-success font-medium">{underCount}</span>
           <span className="text-foreground-muted"> tasks under estimate</span>
         </div>
       </div>
@@ -122,7 +122,7 @@ export function TimeAnalytics({ summary, quadrantDistribution, className }: Time
           label="Running Timers"
           value={summary.tasksWithRunningTimers}
           subtitle={summary.tasksWithRunningTimers > 0 ? "active now" : "none active"}
-          valueColor={summary.tasksWithRunningTimers > 0 ? "text-green-600" : undefined}
+          valueColor={summary.tasksWithRunningTimers > 0 ? "text-status-success" : undefined}
         />
       </div>
 
@@ -175,7 +175,7 @@ function getAccuracyLabel(accuracy: number): string {
 
 function getAccuracyColor(accuracy: number): string | undefined {
   if (accuracy === 0) return undefined;
-  if (accuracy >= 80 && accuracy <= 120) return "text-green-600";
-  if (accuracy > 150 || accuracy < 50) return "text-red-600";
-  return "text-amber-600";
+  if (accuracy >= 80 && accuracy <= 120) return "text-status-success";
+  if (accuracy > 150 || accuracy < 50) return "text-status-overdue";
+  return "text-warning-dark";
 }

--- a/components/dashboard/time-analytics.tsx
+++ b/components/dashboard/time-analytics.tsx
@@ -22,7 +22,7 @@ const QUADRANT_LABELS: Record<string, { name: string }> = {
 /** Empty state when no time tracking data exists */
 function EmptyState({ className }: { className?: string }) {
   return (
-    <div className={cn("rounded-xl border border-border bg-card p-6 shadow-sm", className)}>
+    <div className={cn("rounded-lg border-hair border-border bg-card p-6 shadow-sm", className)}>
       <h3 className="flex items-center gap-2 rd-serif text-title text-foreground">
         <ClockIcon className="h-5 w-5 text-accent" />
         Time Tracking
@@ -90,7 +90,7 @@ export function TimeAnalytics({ summary, quadrantDistribution, className }: Time
   }
 
   return (
-    <div className={cn("rounded-xl border border-border bg-card p-6 shadow-sm", className)}>
+    <div className={cn("rounded-lg border-hair border-border bg-card p-6 shadow-sm", className)}>
       <h3 className="flex items-center gap-2 rd-serif text-title text-foreground">
         <ClockIcon className="h-5 w-5 text-accent" />
         Time Tracking

--- a/components/dashboard/upcoming-deadlines.tsx
+++ b/components/dashboard/upcoming-deadlines.tsx
@@ -51,7 +51,7 @@ export function UpcomingDeadlines({ tasks, onTaskClick }: UpcomingDeadlinesProps
   }, [tasks]);
 
   return (
-    <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
+    <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
       <h3 className="mb-4 rd-serif text-title text-foreground">
         Upcoming Deadlines
       </h3>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.4.4",
+	"version": "9.4.5",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.4.3",
+	"version": "9.4.4",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/ui/dashboard-components.test.tsx
+++ b/tests/ui/dashboard-components.test.tsx
@@ -577,8 +577,8 @@ describe('Dashboard Components', () => {
         <TimeAnalytics summary={summary} quadrantDistribution={emptyDistribution} />
       );
 
-      // Should render with red accuracy color
-      const accuracyValue = container.querySelector('.text-red-600');
+      // Should render with the danger (overdue) accuracy color
+      const accuracyValue = container.querySelector('.text-status-overdue');
       expect(accuracyValue).toBeInTheDocument();
     });
 
@@ -594,7 +594,7 @@ describe('Dashboard Components', () => {
         <TimeAnalytics summary={summary} quadrantDistribution={emptyDistribution} />
       );
 
-      const accuracyValue = container.querySelector('.text-amber-600');
+      const accuracyValue = container.querySelector('.text-warning-dark');
       expect(accuracyValue).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
> **Re-targeted to `main`.** Originally stacked under #346, but #346 merged into its base branch (the #345 branch) rather than main, so its changes never reached main. This PR is rebased onto current main and now carries **both** the #346 (card vocabulary + Quadrant Distribution) and #347 (color tokens) changes. #345 is already on main and excluded from this diff.

## What & why (two fixes from `/impeccable critique components/dashboard`)

**P1 — card vocabulary.** Panels had drifted to four radii (12/16/20/24px) and three border treatments (1px/1.5px/2px). Unified every panel, skeleton, and empty state on the canonical card spec: `rounded-lg` (14px) + `border-hair` (1.5px signature hairline) + full-opacity `border-border`, matching the `.card` primitive and DESIGN.md. Resting `shadow-sm` kept (documented resting elevation).

**P3 — Quadrant Distribution.** The proportional label row truncated labels (`Delegat`) and left a void below the bar. Now: segmented bar + a full vertical legend (swatch + full label + count + %).

**P2 — color tokens.** time-analytics used raw `green-600`/`red-600`/`amber-600` that stayed fixed in dark mode; swapped to `status-success`/`status-overdue`/`warning-dark` (they lift correctly). tag-analytics cycled the quadrant quartet as decorative bar colors; replaced with a neutral track + olive success fill.

## Verification
- `bun typecheck`: pass · `bun run lint`: 0 errors · `dashboard-components.test.tsx`: 66/66
- Visually confirmed in browser, light + dark (seeded data)

## Note on the stack
`fix/dashboard-card-consistency` and `fix/dashboard-impeccable-remediation` branches still exist on origin (now redundant); safe to delete after this merges. PR #346 shows cosmetically merged.