### PR TITLE
fix(dashboard): de-gamify the streak indicator

### DIFF
--- a/components/dashboard/streak-indicator.tsx
+++ b/components/dashboard/streak-indicator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FlameIcon, TrophyIcon } from "lucide-react";
+import { CalendarCheckIcon } from "lucide-react";
 import type { StreakData } from "@/lib/analytics";
 
 interface StreakIndicatorProps {
@@ -9,88 +9,62 @@ interface StreakIndicatorProps {
 
 const DAY_LABELS = ["6d", "5d", "4d", "3d", "2d", "1d", "Today"];
 
-function getStreakMessage(current: number): string {
-  if (current === 0) return "Start fresh today!";
-  if (current <= 3) return "Building momentum...";
-  if (current < 7) return "Great consistency!";
-  return "On fire! Keep going!";
-}
-
-function getMilestone(current: number): { label: string; reached: boolean } | null {
-  if (current >= 100) return { label: "100 days", reached: true };
-  if (current >= 30) return { label: "30 days", reached: true };
-  if (current >= 7) return { label: "7 days", reached: true };
-  return null;
-}
-
 /**
- * Compact streak indicator designed for the dashboard top row.
- * Shows current streak, 7-day activity dots, and milestone badges.
+ * Streak indicator for the dashboard top row. Shows the current streak, a
+ * 7-day activity strip, and the personal best. Composed and factual to match
+ * the calm dashboard voice — no flame, milestone badges, or cheerleading copy.
  */
 export function StreakIndicator({ streakData }: StreakIndicatorProps) {
   const { current, longest, last7Days } = streakData;
-  const milestone = getMilestone(current);
 
   return (
     <div
       className="flex h-full flex-col justify-between rounded-lg border-hair border-border bg-card p-6"
       style={{ boxShadow: "var(--shadow-column)" }}
     >
-      {/* Top: icon + streak count */}
-      <div className="flex items-center gap-3">
-        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-warning-tint">
-          <FlameIcon className="h-6 w-6 text-warning" />
-        </div>
+      {/* Top: eyebrow + count, with a calm icon matching the other stat cards */}
+      <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
-          <p className="text-eyebrow text-foreground-muted">
+          <p className="text-label font-semibold uppercase text-foreground-muted">
             Streak
           </p>
-          <div className="flex items-center gap-2">
-            <p className="text-4xl font-bold tabular-nums tracking-tight text-foreground">
+          <div className="mt-3 flex items-baseline gap-2">
+            <span className="rd-serif text-[48px] leading-none tabular-nums tracking-tight text-foreground">
               {current}
-            </p>
+            </span>
             <span className="text-sm text-foreground-muted">
               {current === 1 ? "day" : "days"}
             </span>
           </div>
         </div>
-      </div>
-
-      {/* Middle: 7-day activity dots */}
-      <div className="mt-4">
-        <div className="flex items-center gap-1.5">
-          {last7Days.map((active, index) => (
-            <div key={index} className="flex flex-col items-center gap-1">
-              <div
-                className={`h-3 w-3 rounded-full transition-colors ${
-                  active
-                    ? "bg-warning shadow-sm shadow-warning-tint"
-                    : "bg-background-muted"
-                }`}
-                title={`${DAY_LABELS[index]}: ${active ? "Completed" : "No completions"}`}
-              />
-              <span className="text-[9px] text-foreground-muted/60">
-                {DAY_LABELS[index]}
-              </span>
-            </div>
-          ))}
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent/10">
+          <CalendarCheckIcon className="h-4 w-4 text-accent" aria-hidden />
         </div>
       </div>
 
-      {/* Bottom: milestone or longest streak or message */}
-      <div className="mt-3 flex items-center justify-between">
-        <p className="text-xs text-foreground-muted">{getStreakMessage(current)}</p>
-        {milestone ? (
-          <span className="inline-flex items-center gap-1 rounded-full bg-warning-tint px-2 py-0.5 text-[10px] font-semibold text-warning-dark">
-            <TrophyIcon className="h-2.5 w-2.5" />
-            {milestone.label}
-          </span>
-        ) : longest > 0 ? (
-          <span className="text-[10px] text-foreground-muted">
-            Best: {longest}d
-          </span>
-        ) : null}
+      {/* Middle: 7-day activity strip — olive marks a completed day */}
+      <div className="mt-4 flex items-center gap-1.5">
+        {last7Days.map((active, index) => (
+          <div key={index} className="flex flex-col items-center gap-1">
+            <div
+              className={`h-3 w-3 rounded-full transition-colors ${
+                active ? "bg-status-success" : "bg-background-muted"
+              }`}
+              title={`${DAY_LABELS[index]}: ${active ? "Completed" : "No completions"}`}
+            />
+            <span className="text-[10px] text-foreground-muted">
+              {DAY_LABELS[index]}
+            </span>
+          </div>
+        ))}
       </div>
+
+      {/* Bottom: factual personal best */}
+      <p className="mt-4 text-xs text-foreground-muted">
+        {longest > 0
+          ? `Best ${longest} ${longest === 1 ? "day" : "days"}`
+          : "No streak yet"}
+      </p>
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.4.5",
+	"version": "9.4.6",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/ui/dashboard-components.test.tsx
+++ b/tests/ui/dashboard-components.test.tsx
@@ -117,7 +117,7 @@ describe('Dashboard Components', () => {
       render(<StreakIndicator streakData={{ current: 0, longest: 0, lastCompletionDate: null, last7Days: [false, false, false, false, false, false, false] }} />);
 
       expect(screen.getByText('0')).toBeInTheDocument();
-      expect(screen.getByText(/start fresh today/i)).toBeInTheDocument();
+      expect(screen.getByText(/no streak yet/i)).toBeInTheDocument();
       // No "Best" label when longest is 0
       expect(screen.queryByText(/best/i)).not.toBeInTheDocument();
     });
@@ -136,22 +136,12 @@ describe('Dashboard Components', () => {
       expect(screen.getByText('1d')).toBeInTheDocument();
     });
 
-    it('should show 7-day milestone badge', () => {
-      render(<StreakIndicator streakData={{ current: 7, longest: 10, lastCompletionDate: null, last7Days: [true, true, true, true, true, true, true] }} />);
-
-      expect(screen.getByText('7 days')).toBeInTheDocument();
-    });
-
-    it('should show 30-day milestone badge', () => {
-      render(<StreakIndicator streakData={{ current: 30, longest: 30, lastCompletionDate: null, last7Days: [true, true, true, true, true, true, true] }} />);
-
-      expect(screen.getByText('30 days')).toBeInTheDocument();
-    });
-
-    it('should show 100-day milestone badge', () => {
+    it('should not render gamified milestone badges', () => {
       render(<StreakIndicator streakData={{ current: 100, longest: 100, lastCompletionDate: null, last7Days: [true, true, true, true, true, true, true] }} />);
 
-      expect(screen.getByText('100 days')).toBeInTheDocument();
+      // Milestone trophy badges were removed for the calm dashboard voice.
+      expect(screen.queryByText('100 days')).not.toBeInTheDocument();
+      expect(screen.getByText('100')).toBeInTheDocument();
     });
 
     it('should show singular "day" for streak of 1', () => {
@@ -159,24 +149,6 @@ describe('Dashboard Components', () => {
 
       expect(screen.getByText('1')).toBeInTheDocument();
       expect(screen.getByText('day')).toBeInTheDocument();
-    });
-
-    it('should show "Building momentum..." for streak 1-3', () => {
-      render(<StreakIndicator streakData={{ current: 2, longest: 5, lastCompletionDate: null, last7Days: [false, false, false, false, false, true, true] }} />);
-
-      expect(screen.getByText(/building momentum/i)).toBeInTheDocument();
-    });
-
-    it('should show "Great consistency!" for streak 4-6', () => {
-      render(<StreakIndicator streakData={{ current: 5, longest: 10, lastCompletionDate: null, last7Days: [false, false, true, true, true, true, true] }} />);
-
-      expect(screen.getByText(/great consistency/i)).toBeInTheDocument();
-    });
-
-    it('should show "On fire!" for streak 7+', () => {
-      render(<StreakIndicator streakData={{ current: 8, longest: 10, lastCompletionDate: null, last7Days: [true, true, true, true, true, true, true] }} />);
-
-      expect(screen.getByText(/on fire/i)).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## What & why

Fourth fix from the `/impeccable critique components/dashboard` pass (P2: brand-personality break).

The streak card used a flame icon, trophy milestone badges (7/30/100 days), and exclamation cheerleading ("On fire! Keep going!"). That is the gamified-todo-toy + exclamation-point voice `PRODUCT.md` explicitly lists as anti-references, and it broke the calm, never-nagged personality the whole app is built around.

**Kept:** the streak number, the 7-day activity strip, and the personal best.
**Dropped:** the flame, the milestone badges, the hype copy.
**Calmed:** activity dots recolored amber → olive (success, matching the dashboard's completed language), and the card now follows the sibling stat-card rhythm — eyebrow + serif hero number + an accent-tinted `CalendarCheck` icon. Bottom line is factual ("Best N days" / "No streak yet").

## How to test
1. `bun dev`, open `/dashboard` with a few days of completed tasks (to build a streak).
2. Streak card shows the count, olive 7-day dots, and "Best N days" — no flame, no trophy, no exclamation.
3. It now visually matches the other three cards in the top row, light and dark.

## Verification
- `bun typecheck`: pass · `bun run lint`: 0 errors · `dashboard-components.test.tsx`: **61/61**
- Visually confirmed in browser, light + dark (seeded streak data)

## Notes
- Removed 6 tests for the deleted gamified features (3 milestone badges, 3 hype messages), added 1 assertion that milestone badges are gone, updated the zero-streak copy test.
- Flat PR off the now-merged dashboard stack. Remaining critique items: typography (`.rd-serif` migration, label unification) and a11y nits.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->