### PR TITLE
fix(dashboard): use the brand eyebrow for the page header

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -160,7 +160,7 @@ export default function DashboardPage() {
       <div className="space-y-8 pb-10">
           <div className="border-b border-border/60 bg-gradient-to-b from-background to-background-muted/40 px-4 py-8 sm:px-6 sm:py-10">
             <div className="mx-auto max-w-7xl">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-foreground-muted">
+              <p className="eyebrow">
                 Workspace Insights
               </p>
               <h1 className="rd-serif mt-2 text-3xl tracking-tight text-foreground sm:text-4xl">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.4.6",
+	"version": "9.4.7",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## What & why

Fifth (minor) item from the `/impeccable critique components/dashboard` pass.

The dashboard header kicker used an ad-hoc uppercase label (`text-[11px] tracking-[0.16em]`) that matched neither the stat cards (`text-label`, 0.04em) nor the brand's defined `.eyebrow`. This promotes it to the **`.eyebrow`** element — mono uppercase with a leading 24px indigo rule. The stat and streak cards keep `text-label`, so the eyebrow remains the single deliberate kicker per DESIGN.md's One Eyebrow Rule.

## Dropped: the `.rd-serif` migration
The critique also flagged migrating the "deprecated" `.rd-serif`. On investigation that was a false alarm: `.rd-serif` is a **sanctioned global serif utility** (per its own definition comment) used consistently app-wide — dashboard, matrix, about, settings — not a deprecated `.rd-*` component class. DESIGN.md's blanket `.rd-*` deprecation note does not apply to it, and migrating only the dashboard would have *created* drift. No change made.

## Verification
- `bun typecheck`: pass · `bun run lint`: 0 errors · no tests reference the header copy
- Visually confirmed: header renders the mono kicker + leading indigo rule above the serif title

## Status
This completes the dashboard critique fixes (P1–P3 + both P2s shipped earlier; this is the last minor item). Remaining optional follow-up: `/impeccable audit` for a couple of a11y spot-checks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->