### PR TITLE
chore(skills): add verify-frontend-change verification skill

### DIFF
--- a/.claude/skills/verify-frontend-change/SKILL.md
+++ b/.claude/skills/verify-frontend-change/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: verify-frontend-change
+description: Verify a frontend change actually works in the GSD Task Manager app before trusting it. Drives the running app browser-first — seeds IndexedDB, busts the PWA service-worker cache, then observes real behavior plus console/network errors — and codifies regression-worthy behavior as a Playwright spec. Use whenever you've edited a component, page, or any matrix/dashboard/settings/.tsx surface and need to confirm it renders and behaves correctly, especially before pushing or opening a PR. Critical for this repo: the service worker serves stale cached JS chunks and data surfaces render empty on a fresh load, so a naive screenshot produces false PASSes — use this skill to verify for real.
+---
+
+# verify-frontend-change
+
+Confirm a frontend change does what it's supposed to **in the running app**, not just in your head. The output is a PASS/FAIL verdict backed by evidence — never a confident guess.
+
+This skill exists because two traps in this codebase silently turn verification into theater:
+
+1. **The service worker serves stale JS chunks.** You edit `border-l-4` → `border`, reload, and still see the old UI. Your screenshot "confirms" code that isn't running.
+2. **Data surfaces render empty on a fresh load.** The dashboard and matrix have nothing to show until tasks exist. A screenshot of an empty dashboard "confirms" a layout you never actually saw.
+
+Either trap produces a *false PASS* — the most dangerous outcome, because it ends the investigation with the wrong answer. Everything below is built to make PASS mean something.
+
+**Right-size the effort.** The verification *is* the observation of the running change — the rendered result, the click working, the console staying clean. Static checks (`typecheck`, the unit suite) are a cheap *precondition*, not the verification, and they don't need to balloon: run the few that bear on *this* change, not the whole app. A CSS spacing tweak doesn't warrant the full test suite or a fresh Playwright run; it warrants eyes on the rendered card. Spending twenty minutes on static analysis to avoid two minutes of looking is the over-engineering this skill is meant to replace.
+
+## When to use
+
+Use this after editing any `.tsx`/`.jsx` under `components/` or `app/`, or any change that affects what the user sees or does — the matrix, capture bar, edit drawer, dashboard, settings, task cards. Reach for it before pushing or opening a PR on UI work.
+
+Don't use it for backend/sync-only logic (`lib/sync/**`), pure data transforms with unit-test coverage, or styling-only token tweaks already covered by `inkwell-retrofit` — those have better-fit verification.
+
+## Default dimensions
+
+Verify these two by default — they catch the most regressions per unit of effort:
+
+- **Functional behavior** — does the change do what the acceptance criteria say? The "did it actually work" check.
+- **Console & network errors** — runtime errors, failed requests, and React warnings a screenshot can't show.
+
+Accessibility and visual/Inkwell fidelity are **opt-in escalations** (see below), not part of every run. Add them when the change is a11y-sensitive (new interactive element, focus flow) or visually significant (new layout, color, spacing) — or when asked.
+
+## The flow
+
+### 1. Scope the change
+
+Identify which surface(s) changed and what "correct" means. Pull the acceptance criteria from the task/spec/PR if they exist; if they don't, state in one line what behavior you're about to confirm. Pick the verification altitude — a one-line copy fix needs a glance; a new interaction needs the full loop.
+
+### 2. Pick the loop
+
+- **`bun dev`** (localhost:3000) for normal visual/behavioral checks. Fast feedback.
+- **`bun run build && bun start`** when the change touches the service worker, PWA manifest, caching, or anything that only manifests in a production build. Dev mode won't surface those.
+
+If a dev server is already running, reuse it.
+
+### 3. Get a trustworthy render — bust the service worker
+
+**Before trusting anything you see**, clear the cached chunks. Paste `scripts/reset-app-state.js` into the page console (via the browser's JS tool), then hard-reload. This unregisters every service worker and deletes the `gsd-*` Cache API entries, so the next load pulls fresh code from the dev server.
+
+IndexedDB survives this — it's separate from the Cache API — so any seeded data persists across the reset. If you skip this step, assume every screenshot is suspect.
+
+### 4. Seed state — if the surface is data-dependent
+
+The dashboard and matrix render empty with no tasks, so there's nothing to verify on a fresh load. Inject realistic data straight into IndexedDB with `scripts/seed-tasks.js` instead of clicking through the capture bar — it's faster and deterministic.
+
+Key facts the seeder encodes so you don't have to:
+
+- Writes go straight to `objectStore.put()`, which **bypasses Zod** — so the seeder sets *every* field (including `tags: []`, `subtasks: []`, `timeEntries: []`), because a missing array crashes components that map over it.
+- `quadrant` is **derived** from `urgent`+`important` and stored denormalized — the seeder computes it with the real resolver so tasks land in the right cell.
+- **Analytics bucket by `updatedAt`, not `completedAt`** — completed-today counts, streaks, and trends all key off the `updatedAt` date. To make a task count as "done Tuesday," set `updatedAt` to Tuesday.
+- Seed ids are prefixed `seed-` so cleanup removes only seeded tasks and leaves your real dev data alone. Run `gsdSeed.clear()` when done.
+- Seed the *specific* state your change depends on — an overdue task for overdue styling, a completed history for streaks, a running timer for time analytics. Verifying a conditional style against data that never triggers it proves nothing.
+
+The script ships ready-made scenarios (`gsdSeed.dashboard()`, `gsdSeed.matrix()`) — read its header for the full field map and how to build custom specs. Seed *before* you reload to view the data: navigation wipes the `window.gsdSeed` helper (the seeded rows in IndexedDB survive), so re-paste the script before calling `gsdSeed.clear()` afterward.
+
+### 5. Observe — functional behavior + console/network
+
+Drive the app to the changed surface and exercise the behavior. Capture evidence for each default dimension:
+
+- **Functional**: perform the action the change enables and confirm the result. A screenshot of the relevant state is good evidence; describing the before/after transition is better.
+- **Console**: read console messages and confirm no new errors/warnings were introduced by the change. Filter to app logs if output is noisy.
+- **Network**: for changes that fetch/sync, confirm requests succeed and no unexpected calls fire.
+
+If you used a real browser, name the evidence (screenshot path, the console output, the network entries). Evidence you can't point to didn't happen.
+
+### 6. Codify — only if the behavior is regression-worthy
+
+Browser observation is cheap and ephemeral. A Playwright spec is durable and CI-enforced — but it costs more to write, so reserve it for behavior worth defending against future regressions (a bug you just fixed, a core interaction).
+
+When it clears that bar, extend the existing harness rather than inventing a new pattern:
+
+1. Add/extend a flow method on `tests/e2e/pages/matrix-page.ts` (page-object model — specs read like a story).
+2. Write the spec using the `clearIndexedDB` fixture; create tasks with the capture-parser shorthand (`task !!` → Q1, `task *` → Q2, `task !` → Q3, `task` → Q4; `#tag` adds a tag).
+3. Run it once — it should fail with "selector not found" if you need a new `data-testid`. Add the `data-testid` to the component *with* the test, then re-run to green.
+4. `bun run test:e2e -- --project=chromium` before considering it done.
+
+Read `tests/e2e/README.md` for the full conventions (no `waitForTimeout` for state, testid discipline).
+
+### 7. Report
+
+Close with the verdict and its evidence (template below). State which dimensions you checked and which you didn't — an unchecked dimension is a known gap, not an implied PASS.
+
+## If you don't have a live browser — degrade, never fake
+
+A real browser (and dev server) may not be available — for example, in a spawned subagent, headless CI, or a sandbox. Walk down this ladder and **report which rung you reached**:
+
+1. **Live browser** — the full flow above. Best evidence.
+2. **Served-artifact check** — fetch the actual chunk the dev server returns (the CSS/JS under `/_next/...`) and grep for the new code *and the absence of the old*. This answers "am I looking at stale code?" without a browser — it's the cheapest way to defeat the stale-chunk trap when you can't bust the SW visually. Pair it with a targeted `bun run test:e2e` spec for real behavior in a real engine (one spec, not the whole suite — see right-sizing above).
+3. **Static reasoning + deferral** — read the changed code, reason about behavior, and produce the verification *plan* (which surface, what to seed, what to click, what would prove it) — then explicitly defer execution: "Verified by inspection; runtime check pending — run steps 3–5 in a browser."
+
+Never present a lower rung as if it were rung 1. **DEFERRED beats a PASS you can't back.** The subtle failure mode isn't faking a screenshot — it's *arguing your way to a PASS* ("the build system is self-healing, so it must be fine") instead of observing the result. When you haven't seen the change run, name the dimension you couldn't verify and defer it. A plan is not a PASS.
+
+## Optional escalations
+
+- **Accessibility** — when the change adds/alters interactive elements, focus flow, labels, or contrast, hand the changed `.tsx` files to the `a11y-reviewer` agent (WCAG AA baseline, read-only). Fold its findings into the report.
+- **Visual / Inkwell fidelity** — when the change is visually significant, check it against the Inkwell system: 1.5px hairlines, the four-color quadrant language, spacing, and **both light and dark mode** (toggle via theme). The `ui-ux-pro-max`/`inkwell-retrofit` skills carry the design detail.
+
+## Verification report format
+
+Keep it short and evidence-first:
+
+```
+## Verification: <change in one line>
+
+Loop: dev | build · Evidence rung: live | served-artifact+playwright | inspection-only
+SW cache busted: yes/no/n-a · Seeded: yes (scenario) / no
+
+- Functional: PASS/FAIL — <what you did, what you saw>
+- Console/network: PASS/FAIL — <errors found, or "clean">
+- [Accessibility]: PASS/FAIL — <a11y-reviewer summary>   (if escalated)
+- [Visual]: PASS/FAIL — <light/dark notes>                (if escalated)
+
+Evidence: <screenshot paths / console excerpt / spec name>
+Codified: <spec path, or "no — not regression-worthy">
+Verdict: PASS / FAIL / DEFERRED (runtime check pending)
+```
+
+## Gotchas
+
+Living list — add failure points as you hit them.
+
+- **Stale chunks survive a dev-server restart.** Restarting `bun dev` doesn't clear the SW cache; only step 3 does. If the old UI persists after a code change, you skipped the bust.
+- **`localStorage.clear()` is a no-op in jsdom-under-Bun** — irrelevant in a real browser, but don't rely on it inside tests for state reset; use the `clearIndexedDB` fixture.
+- **First visit redirects to `/about`.** A fresh origin lands on the about page before the matrix; navigate explicitly or seed past it.
+- **`!important` in a capture string is a literal word, not an urgency flag** — tokens must be space-bounded (`task !!`), or the task silently lands in Q4.

--- a/.claude/skills/verify-frontend-change/evals/evals.json
+++ b/.claude/skills/verify-frontend-change/evals/evals.json
@@ -1,0 +1,47 @@
+{
+  "skill_name": "verify-frontend-change",
+  "evals": [
+    {
+      "id": 0,
+      "name": "dashboard-data-dependent",
+      "prompt": "I just adjusted the spacing on the dashboard's completion-trend chart and the streak indicator. Can you verify the dashboard still renders correctly before I push? I want to actually see the charts with real data, not an empty state.",
+      "expected_output": "Recognizes the dashboard is data-dependent and seeds tasks (with completed history keyed off updatedAt) before verifying; busts/flags the SW cache; checks the charts render and console is clean; gives an evidence-backed PASS/FAIL/DEFERRED, not an empty-dashboard false PASS.",
+      "assertions": [
+        "Seeds the data-dependent dashboard (or prescribes seeding) so charts render with real data, not an empty state",
+        "Notes that dashboard analytics bucket by updatedAt (not completedAt) when seeding",
+        "Prescribes busting the service worker / clearing gsd-* caches before trusting a browser render",
+        "Treats console errors as a verification dimension (checked, or explicitly deferred with reason)",
+        "Avoids a false PASS: does not claim a visually-verified result without a live browser; defers honestly"
+      ],
+      "files": []
+    },
+    {
+      "id": 1,
+      "name": "matrix-stale-build-trap",
+      "prompt": "I changed the overdue indicator on task cards from a left border-stripe to a full border (border-l-4 -> border). Verify it's actually showing up in the matrix. Last time I 'verified' a CSS change like this it turned out I'd been looking at a stale build the whole time.",
+      "expected_output": "Explicitly addresses the stale-chunk/service-worker risk (busts the SW + clears gsd-* caches before trusting the render); seeds matrix tasks so cards exist (incl. an overdue one); confirms the border style on a fresh load; refuses to PASS on a possibly-stale screenshot.",
+      "assertions": [
+        "Explicitly addresses the stale-chunk / service-worker trap and prescribes busting the SW + clearing gsd-* caches before trusting the render",
+        "Verifies the change in the actually-served/compiled artifact, not only the source file",
+        "Verdict discipline: does not over-claim a visual PASS; defers the live-browser confirmation",
+        "Treats console errors as a verification dimension (checked, or explicitly deferred with reason)",
+        "Seeds matrix tasks (incl. an overdue one) so a card actually renders for the visual check"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "settings-export-console",
+      "prompt": "Before I open a PR: confirm the Export Data button in Settings still works and doesn't throw any console errors. I refactored the export handler.",
+      "expected_output": "Drives to Settings, clicks Export Data, confirms the functional outcome (download/file), and explicitly checks the console (and network) for errors introduced by the refactor; evidence-backed verdict.",
+      "assertions": [
+        "Verifies the functional export outcome (download/file produced), not just that the code exists",
+        "Explicitly checks for console errors / network issues introduced by the refactor (the user's stated concern)",
+        "Attempts a runtime/e2e confirmation or precisely prescribes how to run it",
+        "Avoids a false PASS: backs the verdict with evidence and defers the runtime confirmation honestly",
+        "Correctly identifies the refactor scope to focus the verification"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/.claude/skills/verify-frontend-change/scripts/reset-app-state.js
+++ b/.claude/skills/verify-frontend-change/scripts/reset-app-state.js
@@ -1,0 +1,34 @@
+/*
+ * reset-app-state.js — bust the PWA service worker before trusting a render.
+ *
+ * Paste into the page console (localhost:3000) via the browser JS tool, then
+ * HARD-RELOAD. The GSD service worker (public/sw.js) cache-firsts hashed JS
+ * chunks across the gsd-immutable / gsd-pages / gsd-runtime caches, so an edit
+ * can render as the OLD UI until those are cleared. IndexedDB is untouched
+ * (separate from the Cache API), so seeded data survives.
+ *
+ * Returns a summary string so the caller can confirm what was cleared.
+ */
+(async () => {
+  let workers = 0;
+  if ("serviceWorker" in navigator) {
+    const regs = await navigator.serviceWorker.getRegistrations();
+    for (const reg of regs) {
+      await reg.unregister();
+      workers++;
+    }
+  }
+
+  let caches_cleared = 0;
+  if ("caches" in window) {
+    const keys = await caches.keys();
+    for (const key of keys) {
+      await caches.delete(key);
+      caches_cleared++;
+    }
+  }
+
+  const summary = `reset-app-state: unregistered ${workers} service worker(s), cleared ${caches_cleared} cache(s). Hard-reload now to load fresh code.`;
+  console.log(summary);
+  return summary;
+})();

--- a/.claude/skills/verify-frontend-change/scripts/seed-tasks.js
+++ b/.claude/skills/verify-frontend-change/scripts/seed-tasks.js
@@ -1,0 +1,170 @@
+/*
+ * seed-tasks.js — inject realistic tasks into IndexedDB for browser verification.
+ *
+ * Paste into the page console (localhost:3000) via the browser JS tool. Defines
+ * `window.gsdSeed`; call its methods in later JS-tool calls. useTasks() reads raw
+ * records via Dexie liveQuery, so seeded rows surface on the next reload.
+ *
+ * NOTE: `window.gsdSeed` is wiped by any navigation/reload (the seeded DATA in
+ * IndexedDB survives — only the helper object is lost). So either seed *before*
+ * reloading to view, or re-paste this script before calling clear() afterward.
+ *
+ *   gsdSeed.dashboard()   // completed-history + time-tracking + deadlines
+ *   gsdSeed.matrix()      // one task in each of the four quadrants
+ *   gsdSeed.seed([{ title: "Ship it", urgent: true, important: true }])
+ *   gsdSeed.clear()       // remove only seed-* rows; real dev tasks survive
+ *
+ * WHY this script writes every field:
+ *   objectStore.put() BYPASSES the Zod schema (validation runs only on writes
+ *   through lib/tasks.ts). So schema defaults are NOT applied — a missing
+ *   `tags`/`subtasks`/`timeEntries` array crashes components that map over it.
+ *   Every record is therefore fully populated below.
+ *
+ * TaskRecord field map (lib/schema.ts taskRecordSchema, .strict()):
+ *   required: id, title, description, urgent, important, quadrant, recurrence,
+ *             tags[], subtasks[], dependencies[], notificationEnabled,
+ *             completed, notificationSent, timeEntries[], createdAt, updatedAt
+ *   optional: dueDate, completedAt, estimatedMinutes, timeSpent, notifyBefore,
+ *             parentTaskId, lastNotificationAt, snoozedUntil
+ *
+ *   ANALYTICS BUCKET BY updatedAt, NOT completedAt — completedToday, streaks,
+ *   and trends all key off the updatedAt date (lib/analytics/). To make a task
+ *   "done on day N", set BOTH updatedAt and completedAt to day N.
+ */
+(() => {
+  const DB_NAME = "GsdTaskManager";
+  const STORE = "tasks";
+  const SEED_PREFIX = "seed-";
+
+  // Inline copy of resolveQuadrantId (lib/quadrants.ts) — quadrant is stored
+  // denormalized and indexed, so it must match urgent/important exactly.
+  const resolveQuadrant = (urgent, important) => {
+    if (urgent && important) return "urgent-important";
+    if (!urgent && important) return "not-urgent-important";
+    if (urgent && !important) return "urgent-not-important";
+    return "not-urgent-not-important";
+  };
+
+  const isoDaysAgo = (days) => {
+    const d = new Date();
+    d.setDate(d.getDate() - days);
+    return d.toISOString();
+  };
+  const isoInDays = (days) => isoDaysAgo(-days);
+
+  let seedCounter = 0;
+  const nextId = () => `${SEED_PREFIX}${seedCounter++}-${Date.now()}`;
+
+  // Friendly spec -> full TaskRecord. Spec fields are all optional except title.
+  //   { title, urgent, important, completed, daysAgo, dueInDays, tags,
+  //     estimatedMinutes, timeSpent, running }
+  const makeRecord = (spec) => {
+    const urgent = !!spec.urgent;
+    const important = !!spec.important;
+    const completed = !!spec.completed;
+    const stamp = isoDaysAgo(spec.daysAgo ?? 0);
+
+    const record = {
+      id: nextId(),
+      title: spec.title ?? "Seeded task",
+      description: spec.description ?? "",
+      urgent,
+      important,
+      quadrant: resolveQuadrant(urgent, important),
+      recurrence: "none",
+      tags: spec.tags ?? [],
+      subtasks: [],
+      dependencies: [],
+      notificationEnabled: true,
+      completed,
+      notificationSent: false,
+      timeEntries: [],
+      createdAt: isoDaysAgo((spec.daysAgo ?? 0) + 1),
+      updatedAt: stamp, // analytics bucket here
+    };
+
+    if (completed) record.completedAt = stamp;
+    if (spec.dueInDays != null) record.dueDate = isoInDays(spec.dueInDays);
+    if (spec.estimatedMinutes != null) record.estimatedMinutes = spec.estimatedMinutes;
+    if (spec.timeSpent != null) record.timeSpent = spec.timeSpent;
+    if (spec.running) {
+      // A running timer = a timeEntries entry with no endedAt.
+      record.timeEntries = [{ id: nextId(), startedAt: stamp }];
+    }
+    return record;
+  };
+
+  const withStore = (mode, fn) =>
+    new Promise((resolve, reject) => {
+      const open = indexedDB.open(DB_NAME); // no version => current (v14)
+      open.onerror = () => reject(open.error);
+      open.onsuccess = () => {
+        const db = open.result;
+        if (!db.objectStoreNames.contains(STORE)) {
+          db.close();
+          reject(new Error(
+            `'${STORE}' store missing — load the app once so Dexie creates the schema, then re-run.`
+          ));
+          return;
+        }
+        const tx = db.transaction(STORE, mode);
+        const store = tx.objectStore(STORE);
+        const result = fn(store);
+        tx.oncomplete = () => { db.close(); resolve(result); };
+        tx.onerror = () => { db.close(); reject(tx.error); };
+      };
+    });
+
+  const seed = async (specs) => {
+    const records = specs.map(makeRecord);
+    await withStore("readwrite", (store) => records.forEach((r) => store.put(r)));
+    const msg = `gsdSeed: wrote ${records.length} task(s). Reload to see them.`;
+    console.log(msg, records.map((r) => `${r.id} [${r.quadrant}]`));
+    return msg;
+  };
+
+  const clear = async () => {
+    let removed = 0;
+    await withStore("readwrite", (store) => {
+      const cursorReq = store.openCursor();
+      cursorReq.onsuccess = (e) => {
+        const cursor = e.target.result;
+        if (!cursor) return;
+        if (String(cursor.value.id).startsWith(SEED_PREFIX)) {
+          cursor.delete();
+          removed++;
+        }
+        cursor.continue();
+      };
+    });
+    const msg = `gsdSeed: removed ${removed} seed-* task(s). Reload to refresh.`;
+    console.log(msg);
+    return msg;
+  };
+
+  // --- Ready-made scenarios ---------------------------------------------
+
+  // Dashboard: a completion history (streak + trends), time tracking, and a
+  // running timer. updatedAt spread across recent days so analytics light up.
+  const dashboard = () => seed([
+    { title: "Done today", urgent: true, important: true, completed: true, daysAgo: 0, estimatedMinutes: 30, timeSpent: 25 },
+    { title: "Done yesterday", important: true, completed: true, daysAgo: 1, estimatedMinutes: 60, timeSpent: 45 },
+    { title: "Done two days ago", urgent: true, completed: true, daysAgo: 2 },
+    { title: "Done three days ago", completed: true, daysAgo: 3 },
+    { title: "In progress (timer running)", important: true, daysAgo: 0, estimatedMinutes: 90, running: true },
+    { title: "Due soon", urgent: true, important: true, dueInDays: 2 },
+    { title: "Overdue", urgent: true, important: true, dueInDays: -1 },
+    { title: "Backlog item", tags: ["someday"] },
+  ]);
+
+  // Matrix: exactly one task in each quadrant so all four cells are populated.
+  const matrix = () => seed([
+    { title: "Q1 — do first", urgent: true, important: true },
+    { title: "Q2 — schedule", important: true },
+    { title: "Q3 — delegate", urgent: true },
+    { title: "Q4 — eliminate" },
+  ]);
+
+  window.gsdSeed = { seed, clear, dashboard, matrix, makeRecord };
+  return "gsdSeed ready — try gsdSeed.dashboard(), gsdSeed.matrix(), or gsdSeed.clear().";
+})();

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ sync.md
 .claude/skills/*
 !.claude/skills/pb-collection/
 !.claude/skills/branch-preflight/
+!.claude/skills/verify-frontend-change/
 
 *.tsbuildinfo
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,9 @@ Architecture details for these subsystems live in path-scoped rules:
 - Use `data-testid` attributes on components for stable selectors
 - Page Object Model for maintainable test fixtures
 
+### Verifying UI changes in the running app
+After editing any `.tsx`/`.jsx` under `components/` or `app/` — matrix, dashboard, capture bar, settings, task cards — confirm it works in the **running app**, not just by reading the diff, before pushing or opening a PR. Use the **`verify-frontend-change`** skill (invoke explicitly with `/verify-frontend-change`): it drives the live app, seeds IndexedDB for data-dependent surfaces, and busts the PWA service-worker cache. Two repo-specific traps make a naive screenshot lie — the service worker serves **stale JS chunks** (you "verify" old code) and data surfaces **render empty on a fresh load** (you "verify" nothing) — so reach for the skill rather than eyeballing a screenshot.
+
 ## Code Style
 - **TypeScript strict mode** with Next.js typed routes
 - **Naming**: PascalCase for components/types, camelCase for functions, kebab-case for files


### PR DESCRIPTION
## What

Adds the `verify-frontend-change` Claude Code skill — a browser-first → codify workflow for verifying frontend changes in the running GSD app before pushing. Tooling only; **no app code changes**.

- **`SKILL.md`** — scope → dev/build loop → bust the service-worker cache → seed IndexedDB for data-dependent surfaces → observe functional + console/network → codify regression-worthy behavior as a Playwright spec. Defaults to functional + console/network; a11y and visual/Inkwell are opt-in escalations. Includes a served-artifact degradation rung and a "right-size the effort" guardrail.
- **`scripts/reset-app-state.js`** — unregisters the service worker and clears `gsd-*` caches (defeats the stale-chunk trap).
- **`scripts/seed-tasks.js`** — seeds tasks straight into IndexedDB. Validated against the real `taskRecordSchema`; analytics bucket by `updatedAt`; `seed-` id prefix for clean teardown.
- **`.gitignore`** — allowlists the skill (`!.claude/skills/verify-frontend-change/`), matching the existing `pb-collection` / `branch-preflight` convention.
- **`CLAUDE.md`** — pointer under *Testing Guidelines* so the skill is reached for UI work.

## Why

Two repo-specific traps silently produce false PASSes during frontend verification: the PWA service worker serves **stale JS chunks** (you "verify" old code), and data surfaces (dashboard, matrix) **render empty on a fresh load** (you "verify" nothing). The skill encodes the moves that defeat both, plus the GSD-specific seeding details.

## How it was validated

- Scripts dogfooded against the live app: SW bust + 12 seeded tasks rendered correctly in the matrix; seeder fields match `lib/schema.ts`.
- Behavior eval (with-skill vs no-skill, 3 realistic prompts × 5 assertions): **93% vs 40%**.
- Cost iteration: held 93% while cutting agent time **3.4×** (719s → 211s) and removing a 20-min outlier.
- Description triggering tested via the skill-creator optimization loop (5 iterations) — kept the original; candidate rewrites were within noise on the held-out set.

## Known limitation / follow-up

In one-shot automated triggering the skill under-fires (a capable model often assumes it can self-serve the check). The reliable entry points are the **CLAUDE.md pointer** (in this PR) and **explicit `/verify-frontend-change` invocation**. Further description tuning isn't worth it — the eval noise floor can't distinguish variants.

## Test plan

- Run `/verify-frontend-change` on a UI change, or read `.claude/skills/verify-frontend-change/SKILL.md`.
- No CI-affecting code — skill + docs only.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->