### PR TITLE
feat(matrix): aesthetic polish (radius, quadrant accent bars, flat-at-rest depth, completion pop)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -478,6 +478,30 @@ main {
     animation: complete-flash 0.6s ease-out;
   }
 
+  /* Completion delight: the check icon pops in with a restrained spring overshoot
+     (Inkwell "delight in moments"); auto-stilled by the reduced-motion reset below. */
+  @keyframes check-pop {
+    0% {
+      opacity: 0;
+      transform: scale(0.5);
+    }
+    60% {
+      opacity: 1;
+      transform: scale(1.15);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  .animate-check-pop {
+    /* Literal cubic-bezier (value of --ease-pop), NOT var(): a var() in the
+       `animation` shorthand defeats Lightning CSS's static name analysis, which
+       then tree-shakes the @keyframes as "unused". */
+    animation: check-pop 0.28s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  }
+
   @keyframes new-task-glow {
     0%, 100% {
       box-shadow: 0 0 0 0 var(--accent-focus-ring);

--- a/components/matrix-simplified/capture-bar.tsx
+++ b/components/matrix-simplified/capture-bar.tsx
@@ -129,8 +129,9 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
       data-testid="capture-bar"
       onSubmit={submit}
       className={cn(
-        "flex items-center gap-3 rounded-2xl border border-border bg-card px-4 py-3.5",
-        "shadow-md transition-shadow focus-within:border-foreground-muted focus-within:shadow-lg"
+        "flex items-center gap-3 rounded-xl border border-border bg-card px-4 py-3.5",
+        // Flat at rest on the hairline; lifts only when engaged (Inkwell flat-at-rest signature).
+        "transition-shadow focus-within:border-foreground-muted focus-within:shadow-lg"
       )}
     >
       <ZapIcon

--- a/components/matrix-simplified/matrix-grid.tsx
+++ b/components/matrix-simplified/matrix-grid.tsx
@@ -49,7 +49,7 @@ export function MatrixGrid({
   }, [tasks]);
 
   return (
-    <div data-testid="matrix-grid" className="grid grid-cols-1 gap-4 md:grid-cols-2 md:grid-rows-2 md:gap-0 md:overflow-hidden md:rounded-2xl md:border md:border-border md:bg-card md:shadow-sm">
+    <div data-testid="matrix-grid" className="grid grid-cols-1 gap-4 md:grid-cols-2 md:grid-rows-2 md:gap-0 md:overflow-hidden md:rounded-xl md:border md:border-border md:bg-card md:shadow-sm">
       {quadrants.map((meta, index) => (
         <QuadrantPane
           key={meta.id}

--- a/components/matrix-simplified/quadrant-pane.tsx
+++ b/components/matrix-simplified/quadrant-pane.tsx
@@ -75,7 +75,7 @@ export function QuadrantPane({
       data-testid={`quadrant-${meta.rdKey}`}
       ref={setNodeRef}
       className={cn(
-        "relative flex min-h-[280px] flex-col rounded-2xl border border-border p-5 transition-colors",
+        "relative flex min-h-[280px] flex-col rounded-xl border border-border p-5 transition-colors",
         WASH_CLASS[meta.rdKey],
         "md:rounded-none md:border-0",
         POSITION_RULES[position],
@@ -84,6 +84,22 @@ export function QuadrantPane({
       style={isOver ? { ["--tw-ring-color" as string]: accent } : undefined}
       aria-label={`${meta.title} quadrant`}
     >
+      {/* Quadrant identity: a 3px top accent bar in the quadrant hue, so the
+          four-quadrant argument reads on the merged desktop grid. Thickens via
+          scaleY (no reflow) to acknowledge an active drop target. Top corners
+          `inherit` the pane radius so the bar follows the rounded corners on
+          mobile (20px) and stays square on the md:rounded-none grid — no
+          overflow-hidden, which would clip card action menus near pane edges. */}
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 z-[1] h-[3px] origin-top transition-transform duration-150"
+        style={{
+          backgroundColor: accent,
+          transform: isOver ? "scaleY(2)" : "scaleY(1)",
+          borderTopLeftRadius: "inherit",
+          borderTopRightRadius: "inherit",
+        }}
+      />
       <header
         className={cn(
           "-mx-5 -mt-5 mb-4 flex items-baseline gap-1 border-b border-border-muted px-5 py-3",

--- a/components/task-card/index.tsx
+++ b/components/task-card/index.tsx
@@ -46,7 +46,9 @@ function TaskCardComponent({
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : undefined,
-    boxShadow: isDragging ? 'var(--shadow-card-hover)' : 'var(--shadow-card)',
+    // Flat at rest (Inkwell signature: structure is drawn with the hairline, not shadowed);
+    // elevation is reserved for the dragging state.
+    boxShadow: isDragging ? 'var(--shadow-card-hover)' : undefined,
   };
 
   return (
@@ -63,7 +65,7 @@ function TaskCardComponent({
       tabIndex={-1}
       style={style}
       className={cn(
-        "group relative flex flex-col gap-2 rounded-xl border bg-card p-3 transition-all duration-200 animate-slide-in-card",
+        "group relative flex flex-col gap-2 rounded-lg border bg-card p-3 transition-all duration-200 animate-slide-in-card",
         "border-card-border",
         task.completed ? "opacity-60" : "opacity-100 hover:-translate-y-0.5 hover:border-accent/40",
         task.completed && "animate-complete-flash",

--- a/components/task-card/task-card-header.tsx
+++ b/components/task-card/task-card-header.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { CheckCircle2Icon, CircleIcon, GripVerticalIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
@@ -27,6 +28,15 @@ export function TaskCardHeader({
   sortableListeners,
 }: TaskCardHeaderProps) {
   const completionLabel = task.completed ? "Mark as incomplete" : "Mark as complete";
+
+  // Pop the check only on the complete *moment* (false→true), never on mount —
+  // a page load showing already-done tasks is not a completion moment, and the
+  // brand reserves motion for moments, not page loads.
+  const wasCompleted = useRef(task.completed);
+  const justCompleted = task.completed && !wasCompleted.current;
+  useEffect(() => {
+    wasCompleted.current = task.completed;
+  }, [task.completed]);
 
   return (
     <div className="flex items-start justify-between gap-2">
@@ -82,7 +92,7 @@ export function TaskCardHeader({
             {task.completed ? (
               // Color lives on the icon: the button's `button-reset` (unlayered
               // color: inherit) would neutralize a text-color class on the button.
-              <CheckCircle2Icon className="h-4 w-4 shrink-0 text-status-success" />
+              <CheckCircle2Icon className={cn("h-4 w-4 shrink-0 text-status-success", justCompleted && "animate-check-pop")} />
             ) : (
               <>
                 <CircleIcon className="h-4 w-4 shrink-0" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.4.7",
+	"version": "9.5.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,6 +2,22 @@
 
 ---
 
+## In progress — 2026-06-03: Matrix aesthetic polish (4 impeccable recs)
+
+**Branch:** `feat/matrix-aesthetic-polish`
+**Tier:** Non-trivial (shared CSS + core matrix components). Visual/styling → TDD-optional per CLAUDE.md; verify via running suite + `verify-frontend-change`.
+
+- [x] **#1 Radius hierarchy** ✅ — task card `rounded-xl`→`rounded-lg`; grid/quadrant-pane/capture-bar `rounded-2xl`→`rounded-xl`. Verified computed: card 14px inside 20px panel, both themes.
+- [x] **#2 Quadrant color identity** ✅ — 3px top accent bar per pane (`quadrant-pane.tsx`). **No `overflow-hidden`** (would clip card action menus near pane edges on mobile, where the grid has no `md:overflow-hidden` mask); instead the bar's top corners `inherit` the pane radius → follow the 20px corner on mobile, square on the rounded-none desktop grid. Verified: 3px, rust=Q1, lifts to #D27468 in dark, `topLeftRadius:0` on desktop, `paneOverflow:visible`.
+- [x] **#3 Flat-at-rest depth** ✅ — capture-bar resting `shadow-md` dropped (keeps `focus-within:shadow-lg`); task-card resting boxShadow `var(--shadow-card)` (dead/undefined) → `undefined`. Verified: card+bar `shadow: none` at rest, `shadow-lg` on focus.
+- [x] **#4 Motion at sanctioned moments** ✅ — `check-pop` keyframe (literal cubic-bezier, NOT `var()` — Lightning CSS tree-shakes keyframes referenced via var() in the `animation` shorthand). **Gated to the complete *moment*** (false→true via a `useRef`, not on mount) — a page load showing done tasks is not a completion moment (brand: no page-load motion). Drop-target accent bar thickens via `scaleY(2)` (no reflow). Verified: 0 pops on load, 1 (`check-pop`) on toggle.
+
+**Verify:** `bun typecheck` ✅ · `bun run test` ✅ 1930 pass · `bun lint` ⚠ env-broken (`@typescript-eslint/utils` FlatESLint module crash, pre-existing — unrelated to these CSS/className edits) · `/verify-frontend-change` ✅ live browser, light + dark, no console errors.
+
+**Review:** All four landed and verified in the running app (light + dark) with precise computed-style evidence. No new tests (visual/styling → TDD-optional per CLAUDE.md; existing 1930 pass, none asserted the changed classes). Branch ready; not yet committed.
+
+---
+
 ## In progress — 2026-06-01: Harden pass — `components/matrix-simplified` P1s
 
 **Branch:** `fix/matrix-shell-harden`


### PR DESCRIPTION
## What & why

Four visual-craft passes on the core matrix surface, all within the Inkwell "Indigo & Cloud" system (calm & focused, restraint on pages). Origin: a `/impeccable` review of the app's overall visual appeal. Each addresses a distinct axis so they compound.

| # | Change | Effect |
|---|--------|--------|
| 1 | **Radius hierarchy** | Task cards `rounded-xl`(20px) → `rounded-lg`(14px); grid / quadrant pane / capture bar `rounded-2xl` (un-mapped 16px Tailwind default) → `rounded-xl`(20px). Establishes 20px panels > 14px cards > 8/12px controls (cards were previously *rounder* than their containers). |
| 2 | **Quadrant identity** | A 3px top accent bar per quadrant in its hue (rust/indigo/sage/amber), so the four-quadrant argument reads on the merged desktop grid. Lifts in dark mode; thickens on drag-over via `scaleY` (no reflow). |
| 3 | **Flat-at-rest depth** | Capture bar rests flat on the hairline, lifts to `shadow-lg` only on focus. Removed the dead `var(--shadow-card)` resting reference so task cards rest intentionally flat. |
| 4 | **Completion delight** | The check icon spring-pops, gated to the complete *moment* (false→true), never on page load (no page-load motion per the brand). |

Bumps version to **9.5.0**.

## How to test locally

1. `bun dev`, open the matrix with a few tasks across all four quadrants.
2. **Radius**: cards have a smaller corner radius than the panels containing them.
3. **Accent bars**: each quadrant has a 3px colored cap in its hue (light + dark via Settings → Appearance).
4. **Depth**: focus the capture bar — it lifts; otherwise everything rests flat on hairlines.
5. **Completion**: mark a task complete — the check icon pops once. Reload with completed tasks visible — no pop on load.

## Verification

- Verified in the running app (Chrome) in **light and dark** mode with computed-style evidence (card 14px / panel 20px; accent bar 3px, lifts to #D27468 in dark; capture bar flat→shadow-lg on focus; 0 check-pops on load, 1 on toggle).
- `bun typecheck` clean · `bun run test` 1930 pass · no console errors.
- `bun lint` could not run: a pre-existing env crash in `@typescript-eslint/utils` (FlatESLint), unrelated to these className/CSS edits.

## Notes

- Visual/styling change → TDD-optional per CLAUDE.md; no existing tests asserted the changed classes.
- Two non-obvious gotchas captured during this work: Lightning CSS tree-shakes `@keyframes` referenced via `var()` in the `animation` shorthand (use a literal cubic-bezier); and Turbopack reuses chunk filenames so the browser HTTP cache can serve stale CSS/JS after a service-worker reset (hard-reload to bust).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->