### PR TITLE
feat(design): editorial visual language for web (de-blue + warm paper)

### DIFF
--- a/app/css/inkwell-tokens.css
+++ b/app/css/inkwell-tokens.css
@@ -1,7 +1,8 @@
 /* =====================================================================
    Inkwell — design tokens & dark-mode cascade.
    Version: 1.3.1
-   Default palette: Indigo & Cloud (cool stone + deep indigo).
+   Brand palette: GSD Editorial (warm paper + graphite ink + tide accent).
+   The four quadrant pigments are the only strong color; system-blue is retired.
 
    This file contains ONLY:
      • :root custom-property declarations
@@ -21,44 +22,49 @@
    ===================================================================== */
 
 :root {
-  /* ---------- Surfaces ---------- */
-  --ivory: #F4F4F0;       /* page background — cool stone, barely warm */
+  /* ---------- Surfaces (warm editorial paper) ---------- */
+  --ivory: #F4F1E9;       /* page background — warm paper */
   --paper: #FFFFFF;       /* card / panel surface */
-  --slate: #13141B;       /* primary text, slight cool undertone */
-  --oat:   #DDDCDF;       /* tertiary surface, hover thumbnails */
+  --slate: #211E1A;       /* primary text — warm graphite ink */
+  --oat:   #FBF9F3;       /* secondary raised surface */
 
-  /* ---------- Accent (saturated indigo) ---------- */
-  --accent:               #3B4A8C;
-  --accent-d:             #2A3768;                /* hover/pressed */
-  --accent-tint:          rgba(59, 74, 140, 0.14); /* badge bg, periwinkle on cool paper */
-  --accent-focus-ring:    rgba(59, 74, 140, 0.18); /* input focus halo */
-  --accent-strong-border: rgba(59, 74, 140, 0.5);  /* tinted chip border */
+  /* ---------- Accent (editorial tide — the single interactive tint) ---------- */
+  --accent:               #2C6680;
+  --accent-d:             #234F63;                /* hover/pressed */
+  --accent-tint:          rgba(44, 102, 128, 0.14); /* badge bg, tide on warm paper */
+  --accent-focus-ring:    rgba(44, 102, 128, 0.18); /* input focus halo */
+  --accent-strong-border: rgba(44, 102, 128, 0.5);  /* tinted chip border */
 
   /* ---------- Semantic ---------- */
-  --olive:        #788C5D;                         /* success, additions */
-  --olive-tint:   rgba(120, 140, 93, 0.16);
-  --olive-strong-border: rgba(120, 140, 93, 0.45); /* tinted success border */
-  --rust:         #B04A3F;                         /* danger, deletions */
-  --rust-d:       #9A3F3F;                         /* rust hover/pressed */
-  --rust-tint:    rgba(176, 74, 63, 0.10);        /* danger alert background */
-  --rust-tint-border: rgba(176, 74, 63, 0.45);    /* danger alert border */
-  --rust-focus-ring:  rgba(176, 74, 63, 0.18);    /* danger input focus halo */
+  --olive:        #3E7D52;                          /* success, additions — forest green */
+  --olive-tint:   rgba(62, 125, 82, 0.16);
+  --olive-strong-border: rgba(62, 125, 82, 0.45);   /* tinted success border */
+  --rust:         #B23A2E;                          /* danger, deletions — also q1/alert */
+  --rust-d:       #98301F;                          /* rust hover/pressed */
+  --rust-tint:    rgba(178, 58, 46, 0.10);          /* danger alert background */
+  --rust-tint-border: rgba(178, 58, 46, 0.45);      /* danger alert border */
+  --rust-focus-ring:  rgba(178, 58, 46, 0.18);      /* danger input focus halo */
   --warning:      #C78E3F;
   --warning-dark: #A06A2A;                         /* warning text (darker for contrast) */
   --warning-tint: rgba(199, 142, 63, 0.16);
   --warning-strong-border: rgba(199, 142, 63, 0.45); /* tinted warning border */
-  --info:         #5C7CA3;                         /* informational */
-  --sky:          #6A8CAF;                         /* alt info / data viz */
+  --info:         #2C6680;                         /* informational — tide */
+  --sky:          #4E7E96;                         /* alt info / data viz — lighter tide */
 
-  /* ---------- Neutral scale (cool putty) ---------- */
-  --gray-100: #EDEDEA;
-  --gray-200: #E1E1DE;
-  --gray-300: #CFCFCC;
-  --gray-500: #6F6F75;  /* WCAG AA: 5.05:1 on --paper, 4.64:1 on --ivory */
-  --gray-700: #3A3B41;
+  /* ---------- Tertiary ink (quiet labels, dotted chart lines) ---------- */
+  --ink-3: #A49B8D;
+
+  /* ---------- Neutral scale (warm taupe) ---------- */
+  --gray-100: #ECE7DC;  /* sunken / inset fill */
+  --gray-200: #E3DDD0;  /* hairline */
+  --gray-300: #D8D1C1;  /* hairline-strong / border */
+  --gray-500: #6E6760;  /* WCAG AA: 5.6:1 on --paper, 4.9:1 on --ivory */
+  --gray-700: #3A372F;
 
   /* ---------- Typography ---------- */
-  --serif: ui-serif, Georgia, "Times New Roman", Times, serif;
+  /* Newsreader (loaded via next/font, exposed as --font-newsreader on <html>) is the
+     cross-platform stand-in for Apple's New York; falls back to Georgia if unloaded. */
+  --serif: ui-serif, "New York", var(--font-newsreader, Georgia), Georgia, "Times New Roman", Times, serif;
   --sans:  system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --mono:  ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
 
@@ -146,37 +152,39 @@
   :root:not([data-theme="light"]) {
     color-scheme: dark;
 
-    --ivory: #0F1018;
-    --paper: #181A24;
-    --slate: #E8E8EE;
-    --oat:   #2B2D38;
+    --ivory: #17150F;       /* page background — warm dark paper */
+    --paper: #221E17;       /* card / panel surface */
+    --slate: #F1ECE2;       /* primary text — warm light ink */
+    --oat:   #1B1812;       /* secondary raised surface */
 
-    --accent:               #7A8AD1;                 /* lifted indigo → periwinkle */
-    --accent-d:             #6273C0;
-    --accent-tint:          rgba(122, 138, 209, 0.18);
-    --accent-focus-ring:    rgba(122, 138, 209, 0.28);
-    --accent-strong-border: rgba(122, 138, 209, 0.6);
+    --accent:               #6FAACB;                 /* lifted tide */
+    --accent-d:             #5A93B5;
+    --accent-tint:          rgba(111, 170, 203, 0.18);
+    --accent-focus-ring:    rgba(111, 170, 203, 0.28);
+    --accent-strong-border: rgba(111, 170, 203, 0.6);
 
-    --olive:        #9CB07A;                         /* lifted */
-    --olive-tint:   rgba(156, 176, 122, 0.18);
-    --olive-strong-border: rgba(156, 176, 122, 0.6); /* lifted tinted success border */
-    --rust:         #D27468;
-    --rust-d:       #C96B5F;                         /* lifted rust hover/pressed */
-    --rust-tint:    rgba(210, 116, 104, 0.18);       /* lifted danger alert background */
-    --rust-tint-border: rgba(210, 116, 104, 0.6);    /* lifted danger alert border */
-    --rust-focus-ring:  rgba(210, 116, 104, 0.28);   /* lifted danger input focus halo */
+    --olive:        #6FB07F;                          /* lifted success */
+    --olive-tint:   rgba(111, 176, 127, 0.18);
+    --olive-strong-border: rgba(111, 176, 127, 0.6); /* lifted tinted success border */
+    --rust:         #E0705F;                          /* lifted — also q1/alert */
+    --rust-d:       #D5614F;                           /* lifted rust hover/pressed */
+    --rust-tint:    rgba(224, 112, 95, 0.18);         /* lifted danger alert background */
+    --rust-tint-border: rgba(224, 112, 95, 0.6);      /* lifted danger alert border */
+    --rust-focus-ring:  rgba(224, 112, 95, 0.28);     /* lifted danger input focus halo */
     --warning:      #D9A55F;
     --warning-dark: #D9A55F;                         /* lifted warning text (same as warning for contrast) */
     --warning-tint: rgba(217, 165, 95, 0.18);
     --warning-strong-border: rgba(217, 165, 95, 0.6); /* lifted tinted warning border */
-    --info:         #7C9FD2;
-    --sky:          #85A6CB;
+    --info:         #6FAACB;                         /* informational — lifted tide */
+    --sky:          #7FB0CB;                          /* alt info / data viz — lifted tide */
 
-    --gray-100: #1E1F29;
-    --gray-200: #262732;
-    --gray-300: #34363F;
-    --gray-500: #9A9AA0;
-    --gray-700: #C0C0C7;
+    --ink-3: #6F685B;
+
+    --gray-100: #1B1812;  /* sunken / inset fill (dark) */
+    --gray-200: #2A2620;  /* hairline (dark) */
+    --gray-300: #322D24;  /* hairline-strong / border (dark) */
+    --gray-500: #A79F92;  /* ink-2 (dark) */
+    --gray-700: #C8C0B2;
 
     --shadow-sm:         0 1px 2px  rgba(0, 0, 0, 0.45);
     --shadow-md:         0 4px 14px rgba(0, 0, 0, 0.50);
@@ -193,44 +201,46 @@
    lifted gray-500 color. These overrides carry higher specificity than the base
    rule, ensuring the dark chevron always wins regardless of cascade order. */
 :root:not([data-theme="light"]) .select {
-    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'><path d='M1 1.5L6 6.5L11 1.5' stroke='%239A9AA0' stroke-width='1.5' stroke-linecap='round'/></svg>");
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'><path d='M1 1.5L6 6.5L11 1.5' stroke='%23A79F92' stroke-width='1.5' stroke-linecap='round'/></svg>");
   }
 }
 
 :root[data-theme="dark"] {
   color-scheme: dark;
 
-  --ivory: #0F1018;
-  --paper: #181A24;
-  --slate: #E8E8EE;
-  --oat:   #2B2D38;
+  --ivory: #17150F;
+  --paper: #221E17;
+  --slate: #F1ECE2;
+  --oat:   #1B1812;
 
-  --accent:               #7A8AD1;
-  --accent-d:             #6273C0;
-  --accent-tint:          rgba(122, 138, 209, 0.18);
-  --accent-focus-ring:    rgba(122, 138, 209, 0.28);
-  --accent-strong-border: rgba(122, 138, 209, 0.6);
+  --accent:               #6FAACB;
+  --accent-d:             #5A93B5;
+  --accent-tint:          rgba(111, 170, 203, 0.18);
+  --accent-focus-ring:    rgba(111, 170, 203, 0.28);
+  --accent-strong-border: rgba(111, 170, 203, 0.6);
 
-  --olive:        #9CB07A;
-  --olive-tint:   rgba(156, 176, 122, 0.18);
-  --olive-strong-border: rgba(156, 176, 122, 0.6); /* lifted tinted success border */
-  --rust:         #D27468;
-  --rust-d:       #C96B5F;                         /* lifted rust hover/pressed */
-  --rust-tint:    rgba(210, 116, 104, 0.18);       /* lifted danger alert background */
-  --rust-tint-border: rgba(210, 116, 104, 0.6);    /* lifted danger alert border */
-  --rust-focus-ring:  rgba(210, 116, 104, 0.28);   /* lifted danger input focus halo */
+  --olive:        #6FB07F;
+  --olive-tint:   rgba(111, 176, 127, 0.18);
+  --olive-strong-border: rgba(111, 176, 127, 0.6); /* lifted tinted success border */
+  --rust:         #E0705F;
+  --rust-d:       #D5614F;                          /* lifted rust hover/pressed */
+  --rust-tint:    rgba(224, 112, 95, 0.18);         /* lifted danger alert background */
+  --rust-tint-border: rgba(224, 112, 95, 0.6);      /* lifted danger alert border */
+  --rust-focus-ring:  rgba(224, 112, 95, 0.28);     /* lifted danger input focus halo */
   --warning:      #D9A55F;
   --warning-dark: #D9A55F;                         /* lifted warning text (same as warning for contrast) */
   --warning-tint: rgba(217, 165, 95, 0.18);
   --warning-strong-border: rgba(217, 165, 95, 0.6); /* lifted tinted warning border */
-  --info:         #7C9FD2;
-  --sky:          #85A6CB;
+  --info:         #6FAACB;
+  --sky:          #7FB0CB;
 
-  --gray-100: #1E1F29;
-  --gray-200: #262732;
-  --gray-300: #34363F;
-  --gray-500: #9A9AA0;
-  --gray-700: #C0C0C7;
+  --ink-3: #6F685B;
+
+  --gray-100: #1B1812;
+  --gray-200: #2A2620;
+  --gray-300: #322D24;
+  --gray-500: #A79F92;
+  --gray-700: #C8C0B2;
 
   --shadow-sm:         0 1px 2px  rgba(0, 0, 0, 0.45);
   --shadow-md:         0 4px 14px rgba(0, 0, 0, 0.50);
@@ -243,5 +253,5 @@
 }
 /* Select chevron dark-mode override: see comment above in @media section for rationale */
 :root[data-theme="dark"] .select {
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'><path d='M1 1.5L6 6.5L11 1.5' stroke='%239A9AA0' stroke-width='1.5' stroke-linecap='round'/></svg>");
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'><path d='M1 1.5L6 6.5L11 1.5' stroke='%23A79F92' stroke-width='1.5' stroke-linecap='round'/></svg>");
 }

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -94,7 +94,9 @@ export default function GlobalError({
               onClick={reset}
               style={{
                 padding: "0.5rem 1rem",
-                background: "#3B4A8C",
+                /* Editorial tide (--accent). Hard-coded: global-error renders outside
+                   the root layout, so the token cascade isn't available here. */
+                background: "#2C6680",
                 color: "#fff",
                 border: "none",
                 borderRadius: "0.375rem",

--- a/app/globals.css
+++ b/app/globals.css
@@ -111,28 +111,37 @@
    via the imports above; everything below is GSD-only.
    ===================================================================== */
 :root {
-  /* Quadrant fill hues — Inkwell's lifted dark-mode values reused on light
-     surfaces. Dark mode rebinds to the canonical tokens below. */
-  --q1-fill: #D27468;  /* coral       — lifted --rust    */
-  --q2-fill: #7A8AD1;  /* periwinkle  — lifted --accent  */
-  --q3-fill: #9CB07A;  /* sage        — lifted --olive   */
-  --q4-fill: #D9A55F;  /* amber       — lifted --warning */
+  /* Quadrant pigments — the only strong color (editorial). First-class and
+     decoupled from semantic tokens: q3 is ochre (NOT --olive, which is now
+     success-green) and q4 is slate (NOT --warning/amber). Dark values rebind
+     below. The matrix is the argument, so these four carry it. */
+  --q1: #B23A2E;  /* Do First  — rust  */
+  --q2: #2C6680;  /* Schedule  — tide  */
+  --q3: #8A6A22;  /* Delegate  — ochre */
+  --q4: #6F685F;  /* Eliminate — slate */
+  --q1-wash: #F4E4E0;
+  --q2-wash: #E1ECF1;
+  --q3-wash: #F0E9D8;
+  --q4-wash: #ECE9E3;
 
-  /* Quadrant fills — Eisenhower matrix backdrops, derived from fill tokens. */
-  --quadrant-focus:    color-mix(in srgb, var(--q1-fill) 18%, var(--paper));
-  --quadrant-schedule: color-mix(in srgb, var(--q2-fill) 17%, var(--paper));
-  --quadrant-delegate: color-mix(in srgb, var(--q3-fill) 20%, var(--paper));
-  --quadrant-eliminate: color-mix(in srgb, var(--q4-fill) 22%, var(--paper));
-  --q1: var(--rust);
-  --q2: var(--accent);
-  --q3: var(--olive);
-  --q4: var(--warning);
+  /* Wash/header component classes mix off these; repointed to the pigments so
+     the matrix backdrops follow the four-color language automatically. */
+  --q1-fill: var(--q1);
+  --q2-fill: var(--q2);
+  --q3-fill: var(--q3);
+  --q4-fill: var(--q4);
+
+  /* Eisenhower matrix pane backdrops — the exact editorial washes. */
+  --quadrant-focus:     var(--q1-wash);
+  --quadrant-schedule:  var(--q2-wash);
+  --quadrant-delegate:  var(--q3-wash);
+  --quadrant-eliminate: var(--q4-wash);
 
   /* Chart / quadrant accent slots used by recharts and matrix headers. */
-  --gradient-focus:     var(--rust);
-  --gradient-schedule:  var(--accent);
-  --gradient-delegate:  var(--olive);
-  --gradient-eliminate: var(--warning);
+  --gradient-focus:     var(--q1);
+  --gradient-schedule:  var(--q2);
+  --gradient-delegate:  var(--q3);
+  --gradient-eliminate: var(--q4);
   --chart-series-2:     var(--sky);
 
   /* Task-status palette — derived from Inkwell semantic tokens. */
@@ -155,21 +164,18 @@
   --duration-normal: var(--t-slow);
 }
 
-/* Dark-mode fill rebinding — canonical tokens carry through any future
-   Inkwell palette swap. Follows the dual-cascade pattern from inkwell-tokens. */
+/* Dark-mode pigment + wash rebinding (handoff warm-dark values). --q*-fill and
+   --quadrant-* reference these, so the matrix follows automatically. Dual-cascade
+   pattern from inkwell-tokens: auto via prefers-color-scheme, manual via data-theme. */
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
-    --q1-fill: var(--rust);
-    --q2-fill: var(--accent);
-    --q3-fill: var(--olive);
-    --q4-fill: var(--warning);
+    --q1: #E0705F; --q2: #6FAACB; --q3: #CFB266; --q4: #A9A096;
+    --q1-wash: #3A211D; --q2-wash: #173039; --q3-wash: #322B17; --q4-wash: #2A2620;
   }
 }
 :root[data-theme="dark"] {
-  --q1-fill: var(--rust);
-  --q2-fill: var(--accent);
-  --q3-fill: var(--olive);
-  --q4-fill: var(--warning);
+  --q1: #E0705F; --q2: #6FAACB; --q3: #CFB266; --q4: #A9A096;
+  --q1-wash: #3A211D; --q2-wash: #173039; --q3-wash: #322B17; --q4-wash: #2A2620;
 }
 
 /* =====================================================================
@@ -196,6 +202,14 @@
   --color-canvas-foreground: var(--gray-100);
   --color-muted:            var(--gray-500);
   --color-muted-foreground: var(--gray-500);
+
+  /* Quadrant pigments + tertiary ink as utilities (text-q1, bg-q2, text-ink-3),
+     so the chrome and charts can reference the four-color language directly. */
+  --color-q1: var(--q1);
+  --color-q2: var(--q2);
+  --color-q3: var(--q3);
+  --color-q4: var(--q4);
+  --color-ink-3: var(--ink-3);
 
   /* Quadrant + status palettes — Eisenhower matrix backdrops and task
      state colors, both derived from Inkwell semantic tokens. */
@@ -355,15 +369,17 @@ main {
     @apply text-sm text-foreground-muted;
   }
 
-  .quadrant-wash-q1 { background-color: color-mix(in srgb, var(--q1-fill) 18%, var(--paper)); }
-  .quadrant-wash-q2 { background-color: color-mix(in srgb, var(--q2-fill) 17%, var(--paper)); }
-  .quadrant-wash-q3 { background-color: color-mix(in srgb, var(--q3-fill) 20%, var(--paper)); }
-  .quadrant-wash-q4 { background-color: color-mix(in srgb, var(--q4-fill) 22%, var(--paper)); }
+  /* Pane backdrops use the exact editorial washes; --q*-wash is dark-aware
+     (rebinds under [data-theme="dark"]), so light + .dark share one value. */
+  .quadrant-wash-q1 { background-color: var(--q1-wash); }
+  .quadrant-wash-q2 { background-color: var(--q2-wash); }
+  .quadrant-wash-q3 { background-color: var(--q3-wash); }
+  .quadrant-wash-q4 { background-color: var(--q4-wash); }
 
-  .dark .quadrant-wash-q1 { background-color: color-mix(in srgb, var(--q1-fill) 18%, transparent); }
-  .dark .quadrant-wash-q2 { background-color: color-mix(in srgb, var(--q2-fill) 17%, transparent); }
-  .dark .quadrant-wash-q3 { background-color: color-mix(in srgb, var(--q3-fill) 20%, transparent); }
-  .dark .quadrant-wash-q4 { background-color: color-mix(in srgb, var(--q4-fill) 22%, transparent); }
+  .dark .quadrant-wash-q1 { background-color: var(--q1-wash); }
+  .dark .quadrant-wash-q2 { background-color: var(--q2-wash); }
+  .dark .quadrant-wash-q3 { background-color: var(--q3-wash); }
+  .dark .quadrant-wash-q4 { background-color: var(--q4-wash); }
 
   .quadrant-header-q1 { background-color: color-mix(in srgb, var(--q1-fill) 10%, var(--paper)); }
   .quadrant-header-q2 { background-color: color-mix(in srgb, var(--q2-fill) 10%, var(--paper)); }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { Newsreader } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { ToastProvider } from "@/components/ui/toast";
@@ -44,6 +45,19 @@ const connectSrc = process.env.NODE_ENV === "development"
       "https://github.com",
       "https://*.ingest.us.sentry.io",
     ].join(" ");
+
+// Apple's "New York" serif (used for editorial headlines) only exists on Apple
+// devices; Newsreader is the cross-platform stand-in with near-identical
+// proportions. next/font self-hosts it (no runtime Google Fonts request, so no
+// CSP/connect-src change) and emits the @font-face at build time under output:export.
+// Exposed as --font-newsreader, which the --serif token chain references.
+const newsreader = Newsreader({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  style: ["normal", "italic"],
+  variable: "--font-newsreader",
+  display: "swap",
+});
 
 const contentSecurityPolicy = [
   "default-src 'self'",
@@ -108,7 +122,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className={newsreader.variable} suppressHydrationWarning>
       <head>
         <meta httpEquiv="Content-Security-Policy" content={contentSecurityPolicy} />
         <link rel="preconnect" href="https://api.vinny.io" />

--- a/components/command-palette/command-item.tsx
+++ b/components/command-palette/command-item.tsx
@@ -20,7 +20,8 @@ export function CommandActionItem({ action, onSelect }: CommandActionItemProps) 
       onSelect={onSelect}
       className={cn(
         "relative flex cursor-pointer select-none items-center rounded-md px-3 py-2 text-sm outline-none",
-        "hover:bg-accent/10 data-[selected]:bg-accent/10"
+        // Editorial chrome: row highlight is a neutral sunken fill, not a tint.
+        "hover:bg-background-muted data-[selected]:bg-background-muted"
       )}
     >
       <span className="text-foreground">{action.label}</span>

--- a/components/command-palette/task-item.tsx
+++ b/components/command-palette/task-item.tsx
@@ -10,12 +10,13 @@ interface TaskItemProps {
   onSelect: () => void;
 }
 
-// Quadrant badge styles
+// Quadrant badge styles — the editorial four-color pigments (dark-aware tokens),
+// replacing the old hard-coded system-blue/red/amber Tailwind palette swatches.
 const quadrantStyles = {
-  "urgent-important": "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
-  "not-urgent-important": "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
-  "urgent-not-important": "bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300",
-  "not-urgent-not-important": "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
+  "urgent-important": "bg-q1/15 text-q1",
+  "not-urgent-important": "bg-q2/15 text-q2",
+  "urgent-not-important": "bg-q3/15 text-q3",
+  "not-urgent-not-important": "bg-q4/15 text-q4",
 } as const;
 
 /**
@@ -34,13 +35,14 @@ export function TaskItem({ task, onSelect }: TaskItemProps) {
       onSelect={onSelect}
       className={cn(
         "relative flex cursor-pointer select-none items-center rounded-md px-3 py-2 text-sm outline-none",
-        "hover:bg-accent/10 data-[selected]:bg-accent/10"
+        // Editorial chrome: row highlight is a neutral sunken fill, not a tint.
+        "hover:bg-background-muted data-[selected]:bg-background-muted"
       )}
     >
       <CheckIcon
         className={cn(
           "mr-2 h-4 w-4 shrink-0",
-          task.completed ? "text-green-500" : "text-foreground-muted/30"
+          task.completed ? "text-status-success" : "text-foreground-muted/30"
         )}
       />
       <div className="flex-1 min-w-0 space-y-1">

--- a/components/dashboard/completion-chart.tsx
+++ b/components/dashboard/completion-chart.tsx
@@ -2,7 +2,8 @@
 
 import { useMemo } from "react";
 import {
-  LineChart,
+  ComposedChart,
+  Area,
   Line,
   XAxis,
   YAxis,
@@ -17,10 +18,10 @@ interface CompletionChartProps {
 }
 
 /**
- * Line chart showing task completion vs creation. Encoding:
- *   Completed → solid green (status-success), strokeWidth 2
- *   Created   → dotted indigo (accent), strokeWidth 1.6
- * No fills — keeps the comparison legible at small sizes.
+ * Trend chart showing task completion vs creation (editorial encoding):
+ *   Completed → solid forest-green (status-success) line + ~8% area fill
+ *   Created   → dotted graphite (ink-3), strokeWidth 1.6 — de-blued from the old accent
+ * The single soft area anchors "completed" without crowding the comparison.
  */
 export function CompletionChart({ data }: CompletionChartProps) {
   const chartData = useMemo(() => {
@@ -46,19 +47,19 @@ export function CompletionChart({ data }: CompletionChartProps) {
           <span className="h-[2px] w-3 rounded-full bg-status-success" />
           <span className="text-xs font-medium text-foreground-muted">Completed</span>
           <span
-            className="ml-2 h-[2px] w-3 rounded-full bg-accent"
+            className="ml-2 h-[2px] w-3 rounded-full"
             style={{
               backgroundImage: "linear-gradient(to right, currentColor 50%, transparent 50%)",
               backgroundSize: "4px 2px",
               backgroundColor: "transparent",
-              color: "var(--accent)",
+              color: "var(--ink-3)",
             }}
           />
           <span className="text-xs font-medium text-foreground-muted">Created</span>
         </div>
       </div>
       <ResponsiveContainer width="100%" height={280}>
-        <LineChart data={chartData}>
+        <ComposedChart data={chartData}>
           <CartesianGrid
             strokeDasharray="3 3"
             stroke="currentColor"
@@ -92,24 +93,26 @@ export function CompletionChart({ data }: CompletionChartProps) {
             }}
             cursor={{ stroke: "var(--gray-500)", strokeOpacity: 0.3 }}
           />
-          <Line
+          <Area
             type="monotone"
             dataKey="Completed"
             stroke="var(--status-success)"
             strokeWidth={2}
+            fill="var(--status-success)"
+            fillOpacity={0.08}
             dot={false}
             activeDot={{ r: 5, fill: "var(--status-success)", stroke: "var(--paper)", strokeWidth: 2 }}
           />
           <Line
             type="monotone"
             dataKey="Created"
-            stroke="var(--accent)"
+            stroke="var(--ink-3)"
             strokeWidth={1.6}
             strokeDasharray="3 3"
             dot={false}
-            activeDot={{ r: 5, fill: "var(--accent)", stroke: "var(--paper)", strokeWidth: 2 }}
+            activeDot={{ r: 5, fill: "var(--ink-3)", stroke: "var(--paper)", strokeWidth: 2 }}
           />
-        </LineChart>
+        </ComposedChart>
       </ResponsiveContainer>
     </div>
   );

--- a/components/dashboard/tag-analytics.tsx
+++ b/components/dashboard/tag-analytics.tsx
@@ -56,12 +56,12 @@ export function TagAnalytics({ tagStats, maxTags = 10 }: TagAnalyticsProps) {
                 </div>
               </div>
               <div className="relative h-2 w-full overflow-hidden rounded-full bg-background-muted">
-                {/* Total tasks for this tag — neutral, encodes frequency */}
+                {/* Total tasks for this tag — q2 tide at ~82%, the editorial Top Tags bar color */}
                 <div
-                  className="absolute inset-y-0 left-0 rounded-full bg-gray-300 transition-all"
+                  className="absolute inset-y-0 left-0 rounded-full bg-q2/80 transition-all"
                   style={{ width: `${barWidth}%` }}
                 />
-                {/* Completed portion — success olive, matching the dashboard's completed language */}
+                {/* Completed portion — success green, matching the dashboard's completed language */}
                 <div
                   className="absolute inset-y-0 left-0 rounded-full bg-status-success transition-all"
                   style={{

--- a/components/matrix-simplified/icon-rail.tsx
+++ b/components/matrix-simplified/icon-rail.tsx
@@ -161,7 +161,7 @@ function RailButton({
           disabled && "cursor-wait opacity-60"
         )}
       >
-        <Icon className="h-5 w-5" aria-hidden />
+        <Icon className={cn("h-5 w-5", active && "text-q1")} aria-hidden />
       </button>
     );
   }
@@ -179,12 +179,12 @@ function RailButton({
         "relative flex h-10 w-full items-center gap-3 rounded-xl pl-2.5 pr-3 text-body transition-colors",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1",
         active
-          ? "text-foreground before:absolute before:inset-y-1.5 before:left-0 before:w-[2px] before:rounded-full before:bg-accent before:content-['']"
+          ? "bg-background-muted text-foreground"
           : "text-foreground-muted hover:bg-background-muted/60 hover:text-foreground",
         disabled && "cursor-wait opacity-60"
       )}
     >
-      <Icon className="h-5 w-5 shrink-0" aria-hidden />
+      <Icon className={cn("h-5 w-5 shrink-0", active && "text-q1")} aria-hidden />
       <span
         className={cn(
           "whitespace-nowrap transition-opacity duration-150",

--- a/components/matrix-simplified/smart-view-strip.tsx
+++ b/components/matrix-simplified/smart-view-strip.tsx
@@ -24,8 +24,10 @@ const PILL_BASE =
   "inline-flex h-9 shrink-0 items-center gap-1.5 rounded-full border px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2";
 
 function pillVariant(active: boolean): string {
+  // Editorial chrome: selection is a neutral sunken fill + ink, not a tinted pill.
+  // The tide tint is reserved for true actions, not for "active view" state.
   return active
-    ? "border-accent/40 bg-accent/10 text-foreground"
+    ? "border-border bg-background-muted text-foreground"
     : "border-border bg-card text-foreground-muted hover:bg-background-muted hover:text-foreground";
 }
 
@@ -173,11 +175,11 @@ export function SmartViewOverflowMenu({
               key={view.id}
               onSelect={() => onSelectView(view.id)}
               aria-current={isActive ? "true" : undefined}
-              className={cn("gap-2", isActive && "bg-accent/10 text-foreground")}
+              className={cn("gap-2", isActive && "bg-background-muted text-foreground")}
             >
               {view.icon ? <span aria-hidden>{view.icon}</span> : null}
               <span className="flex-1">{view.name}</span>
-              {isActive ? <CheckIcon className="h-3.5 w-3.5 text-accent" aria-hidden /> : null}
+              {isActive ? <CheckIcon className="h-3.5 w-3.5 text-foreground-muted" aria-hidden /> : null}
             </DropdownMenuItem>
           );
         })}

--- a/components/sync/sync-button.tsx
+++ b/components/sync/sync-button.tsx
@@ -122,7 +122,7 @@ export function SyncButton() {
               {isEnabled && !hasAuthError && pendingCount > 0 && (
                 <Badge
                   variant="default"
-                  className="absolute -top-1 -right-1 h-5 min-w-[20px] px-1 bg-blue-500 text-white text-xs"
+                  className="absolute -top-1 -right-1 h-5 min-w-[20px] px-1 bg-accent text-white text-xs"
                 >
                   {pendingCount}
                 </Badge>

--- a/lib/quadrants.ts
+++ b/lib/quadrants.ts
@@ -2,20 +2,22 @@ import type { QuadrantId } from "@/lib/types";
 
 export type RedesignQuadrantKey = "q1" | "q2" | "q3" | "q4";
 
-/** Canonical accent token per quadrant - single source of truth for charts, panes, and inline styles. */
+/** Canonical accent token per quadrant - single source of truth for charts, panes, and inline styles.
+ *  References the first-class quadrant pigments (the editorial four-color language), decoupled from
+ *  semantic tokens: q3 is ochre (not --olive/success-green) and q4 is slate (not --warning/amber). */
 export const QUADRANT_ACCENT: Record<RedesignQuadrantKey, string> = {
-  q1: "var(--rust)",
-  q2: "var(--accent)",
-  q3: "var(--olive)",
-  q4: "var(--warning)",
+  q1: "var(--q1)",
+  q2: "var(--q2)",
+  q3: "var(--q3)",
+  q4: "var(--q4)",
 };
 
 /** Same palette keyed by QuadrantId for components that reference the long-form id. */
 export const QUADRANT_ACCENT_BY_ID: Record<QuadrantId, string> = {
-  "urgent-important": "var(--rust)",
-  "not-urgent-important": "var(--accent)",
-  "urgent-not-important": "var(--olive)",
-  "not-urgent-not-important": "var(--warning)",
+  "urgent-important": "var(--q1)",
+  "not-urgent-important": "var(--q2)",
+  "urgent-not-important": "var(--q3)",
+  "not-urgent-not-important": "var(--q4)",
 };
 export type RedesignIconKey = "flame" | "calendar" | "users" | "trash";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.5.0",
+	"version": "9.6.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tasks/editorial-web-redesign-spec.md
+++ b/tasks/editorial-web-redesign-spec.md
@@ -1,0 +1,57 @@
+# Spec: Editorial visual language for GSD Web
+
+Source: `design_handoff_web/README.md` + `design_handoff_web/styles/tokens.css`.
+Tier: Non-trivial (shared design tokens). Approach approved by user 2026-06-04.
+
+## Goal
+Bring the GSD editorial design language to the web app: retire system-blue from
+chrome and charts, shift the neutral ramp warm, and run headlines in a
+cross-platform serif. **Visual/style only** — no feature, routing, or data changes.
+
+## Approved decisions
+1. **Chrome de-blue = editorial treatment** (not a token swap). Graphite/ink by
+   default; tide tint reserved for true actions (capture submit) + focus rings;
+   selection state uses neutral `sunken` fill + ink, with a quadrant pigment for the
+   rail icon.
+2. **Add Newsreader** via `next/font/google` (weights 400/500/600 + italic 500),
+   inserted into the `--serif` chain after `ui-serif`/"New York".
+3. **Colors-only** — keep current Inkwell radii/spacing/shadows. No shape changes.
+
+## Token strategy (why not paste the handoff)
+The handoff names `--paper` = *page bg*; Inkwell names `--paper` = *card surface*.
+Pasting raw would clobber every card. Instead retune Inkwell's brand-layer tokens
+in place (the documented variants/ mechanism), keeping Inkwell's vocabulary.
+
+Mapping (light → warm editorial):
+- `--ivory` page bg → `#F4F1E9` · `--paper` card → `#FFFFFF` · `--oat` sunken → `#ECE7DC`
+- `--slate` ink → `#211E1A` · gray ramp → warm taupe (gray-100 `#ECE7DC` sunken,
+  gray-200 `#E3DDD0` hairline, gray-300 `#D8D1C1` hairline-strong, gray-500 `#6E6760`
+  ink-2 (AA: 5.6:1 on white / 4.9:1 on paper), gray-700 `#3A372F`)
+- `--accent` indigo → tide `#2C6680` (+ derived d/tint/focus/border) — **the de-blue lever**
+- `--olive` → forest success `#3E7D52` (decoupled from q3) · `--rust` → `#B23A2E`
+- `--info`/`--sky` cool-steel blues → tide family (no raw system-blue survives)
+- New `--ink-3` `#A49B8D` (chart "Created" dotted line)
+
+Quadrant pigments become first-class, decoupled from semantic colors:
+`--q1 #B23A2E · --q2 #2C6680 · --q3 #8A6A22 (ochre, NOT olive) · --q4 #6F685F`
++ washes; matrix backdrops repoint via `--q*-fill`. `lib/quadrants.ts`
+`QUADRANT_ACCENT*` maps repoint to `var(--q1..q4)`. Dark mode mirrors in all three
+dark blocks (the two inkwell-tokens dark blocks + globals `--q*-fill`).
+
+## Charts (component edits, not just color swaps)
+- completion-chart: Created line → `--ink-3` dotted (was `--accent`); add ~8%
+  `--success` area under Completed.
+- tag-analytics: bars → `--q2` on `--sunken` tracks.
+- quadrant-distribution / donut: four pigments (follows token repoint).
+- upcoming-deadlines: overdue already `--alert`; the `--sky` "later" group de-blues via token.
+
+## Out of scope
+Task-card state restyle, settings/empty-state reskin, command-palette internals
+(not wired into v9 shell), shape/radius changes, mobile bottom-tab redesign.
+
+## Acceptance
+- No `#3B4A8C`/indigo or `#6A8CAF`/steel-blue visible in chrome or charts (light + dark).
+- Rail/smart-view selection = sunken + ink (+ q1 icon on rail), not tinted.
+- Headlines render in Newsreader on non-Apple browsers.
+- `bun run test`, `bun typecheck`, `bun lint` green. Verified in running app via
+  verify-frontend-change (seeded IndexedDB, busted SW cache), light + dark.

--- a/tests/ui/app-pages.test.tsx
+++ b/tests/ui/app-pages.test.tsx
@@ -14,6 +14,7 @@ vi.mock('next/font/google', () => ({
   Geist: () => ({ className: 'mock-geist', variable: '--font-sans' }),
   Geist_Mono: () => ({ className: 'mock-geist-mono', variable: '--font-mono' }),
   Instrument_Serif: () => ({ className: 'mock-instrument', variable: '--font-instrument-serif' }),
+  Newsreader: () => ({ className: 'mock-newsreader', variable: '--font-newsreader' }),
 }));
 
 vi.mock('@/components/theme-provider', () => ({


### PR DESCRIPTION
## What & why

Implements `design_handoff_web/README.md` — a **visual/style-only** redesign that brings the GSD editorial design language to the web app so the brand reads identically across iOS, iPadOS, and web. The single biggest change is **retiring system-blue** (indigo `#3B4A8C`) from the chrome and charts, and shifting the app onto warm editorial paper with graphite ink. No feature, routing, or data changes.

Version bumped 9.5.0 → 9.6.0.

### Tokens (`inkwell-tokens.css` + `globals.css`)
- Retune the Inkwell brand layer to warm paper + graphite ink; accent indigo `#3B4A8C` → editorial **tide** `#2C6680`. Both dark cascades (`prefers-color-scheme` + `[data-theme="dark"]`) mirrored.
- Decouple the four quadrant pigments into **first-class tokens** — q1 rust, q2 tide, q3 **ochre**, q4 **slate**. q3 no longer aliases success-green and q4 no longer aliases warning-amber; `--olive` becomes a true forest-green success.
- De-blue the cool extras (`--info`/`--sky` → tide family); add `--ink-3`.
- Add **Newsreader** via `next/font/google` as the cross-platform editorial serif (Apple's "New York" only exists on Apple devices). Self-hosted, so no CSP change.

### Chrome (editorial treatment: graphite default, tint only for true actions)
- Icon-rail selected item → **sunken fill + rust (q1) icon + ink label** (was a tide bar).
- Smart-view active pill + command-palette rows → sunken fill + ink.
- Command-palette quadrant badges → pigment language (were hard-coded `bg-blue/red/amber`).
- Sync-button pending badge `bg-blue-500` → `bg-accent`; global-error button inline `#3B4A8C` → tide.

### Charts
- **Completion Trend:** Created → graphite dotted (`--ink-3`); Completed gains a ~8% success area.
- **Top Tags:** bars carry the q2 tide pigment.
- **Quadrant Distribution / donut** follow the repointed pigments automatically.

## How to test locally
1. `bun dev`, open `http://localhost:3000`. (If the matrix/dashboard render empty or stale, bust the SW cache and seed via the `verify-frontend-change` skill scripts.)
2. Matrix: confirm warm-paper panes, rust/tide/ochre/slate quadrant headers, and the active rail item is a sunken pill with a **rust** icon — no indigo.
3. Dashboard: Completion Trend "Created" line is **graphite dotted** (not blue) with a faint green area; Quadrant Distribution shows the four pigments; Top Tags bars are tide.
4. Toggle dark mode (Settings → Appearance) — palette stays warm, no indigo/steel-blue.

Verified in the running app (light + dark): live computed tokens, chart SVG strokes, and console all confirmed; full `grep` sweep for hard-coded blue is clean.

## Checks
- ✅ `bun typecheck` — clean
- ✅ `bun run test` — **1930 passed, 1 skipped**
- ⚠️ `bun lint` — **cannot run in this environment**: installed `eslint@10.4.1` vs the `9.39.4` pinned in `package.json` crashes `@typescript-eslint/utils` at bootstrap (before reading any file). Pre-existing dependency drift, not from this change. Fix: `bun install` to restore the pinned version.

> Note: `design_handoff_web/` (the design reference bundle) is intentionally left untracked and is not part of this PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->