### PR TITLE
fix(security): sanitize sync error surfaces and auto-clean MCP setup artifact

### DIFF
--- a/lib/sync/pb-sync-engine.ts
+++ b/lib/sync/pb-sync-engine.ts
@@ -11,7 +11,7 @@ import { createLogger } from '@/lib/logger';
 import { getRetryManager } from './retry-manager';
 import { recordSyncSuccess, recordSyncError, recordSyncPartial } from '@/lib/sync-history';
 import { notifySyncSuccess, notifySyncError } from './notifications';
-import { isTransientSyncFailure } from './error-categorizer';
+import { isTransientSyncFailure, sanitizeSyncError } from './error-categorizer';
 import { getDeviceId } from './pb-sync-helpers';
 import { pushLocalChanges } from './pb-push';
 import { pullRemoteChanges } from './pb-pull';
@@ -172,13 +172,16 @@ async function reportSyncError(
   startTime: number,
 ): Promise<PBSyncResult> {
   const errorObj = error instanceof Error ? error : new Error(String(error));
+  // PB 4xx bodies can echo submitted field values (task titles), so persist
+  // and surface only the stable code; keep the raw Error for diagnostics.
+  const errorCode = sanitizeSyncError(errorObj);
   await retryManager.recordFailure(errorObj);
-  await recordSyncError(errorObj.message, deviceId, triggeredBy, Date.now() - startTime);
-  notifySyncError(errorObj.message, false);
+  await recordSyncError(errorCode, deviceId, triggeredBy, Date.now() - startTime);
+  notifySyncError(errorCode, false);
   if (isTransientSyncFailure(errorObj)) {
-    logger.warn('Full sync failed (transient)', { triggeredBy, errorMessage: errorObj.message });
+    logger.warn('Full sync failed (transient)', { triggeredBy, errorCode });
   } else {
-    logger.error('Full sync failed', errorObj, { triggeredBy });
+    logger.error('Full sync failed', errorObj, { triggeredBy, errorCode });
   }
-  return { status: 'error', error: errorObj.message };
+  return { status: 'error', error: errorCode };
 }

--- a/lib/sync/sync-coordinator.ts
+++ b/lib/sync/sync-coordinator.ts
@@ -8,7 +8,7 @@
 
 import { fullSync } from './pb-sync-engine';
 import { getRetryManager } from './retry-manager';
-import { isTransientSyncFailure } from './error-categorizer';
+import { isTransientSyncFailure, sanitizeSyncError } from './error-categorizer';
 import type { PBSyncResult, PBSyncConfig } from './types';
 import { getDb } from '@/lib/db';
 import { createLogger } from '@/lib/logger';
@@ -132,14 +132,16 @@ export class SyncCoordinator {
       logger.debug('Sync completed', { status: result.status });
     } catch (error) {
       const errorObj = error instanceof Error ? error : new Error(String(error));
+      // PB 4xx bodies can echo task titles — store/log only the stable code.
+      const errorCode = sanitizeSyncError(errorObj);
       if (isTransientSyncFailure(errorObj)) {
-        logger.warn('Sync failed (transient)', { errorMessage: errorObj.message });
+        logger.warn('Sync failed (transient)', { errorCode });
       } else {
-        logger.error('Sync failed', errorObj);
+        logger.error('Sync failed', errorObj, { errorCode });
       }
       this.lastResult = {
         status: 'error',
-        error: errorObj.message,
+        error: errorCode,
       };
     } finally {
       this.isRunning = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.7.0",
+	"version": "9.7.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/mcp-server/README-SECURITY.md
+++ b/packages/mcp-server/README-SECURITY.md
@@ -32,10 +32,31 @@ Your real Claude Desktop config should be at:
 
 Use `claude-config.example.json` as a template, but keep your real credentials in the Claude Desktop config location only.
 
+## Token Lifetime, Revocation, and the Setup Artifact
+
+The MCP server authenticates with your **primary PocketBase session JWT** — the
+same token your browser session uses. Anything that can read it has full
+read/write/delete access to your tasks until it expires. Know the limits:
+
+- **PocketBase has no per-token revocation.** Logging out in the browser clears
+  that browser's copy but does **not** invalidate other copies of the token.
+  The only ways to invalidate an issued token early are changing your account
+  password/identity or rotating the collection's token secret on the server.
+- **The setup wizard writes a token-bearing file** (`~/.gsd-mcp-setup.json`,
+  mode 0600) for you to copy into the Claude Desktop config. It is deleted
+  automatically the first time the MCP server starts with valid env config,
+  and any stale copy is cleared when the wizard re-runs — but delete it
+  yourself (`rm ~/.gsd-mcp-setup.json`) if you abandon setup partway.
+- **The token lives permanently in the Claude Desktop config**
+  (`claude_desktop_config.json`). Treat that file as a credential store:
+  don't back it up to shared locations, sync it, or paste it into chats.
+
 ## If You Accidentally Commit Credentials
 
 1. **Immediately revoke the exposed credentials**:
-   - For JWT tokens: Log out and log back in to get a new token
+   - For JWT tokens: logging out is **not** enough (see above) — change your
+     account password or rotate the token secret in PocketBase to invalidate
+     all outstanding tokens, then sign in again for a fresh token
 
 2. **Remove from git history**:
    ```bash

--- a/packages/mcp-server/src/__tests__/cli/setup-artifact.test.ts
+++ b/packages/mcp-server/src/__tests__/cli/setup-artifact.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const mockHomeDir = `${process.cwd()}/.tmp-setup-artifact-home`;
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return { ...actual, homedir: () => mockHomeDir };
+});
+
+import { getSetupArtifactPath, removeSetupArtifact } from '../../cli/setup-artifact.js';
+
+describe('setup-artifact', () => {
+  beforeEach(() => {
+    mkdirSync(mockHomeDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(mockHomeDir, { recursive: true, force: true });
+  });
+
+  it('should_resolve_artifact_path_inside_home_directory', () => {
+    expect(getSetupArtifactPath()).toBe(join(mockHomeDir, '.gsd-mcp-setup.json'));
+  });
+
+  it('should_remove_existing_artifact_and_return_true', () => {
+    // The wizard artifact holds a plaintext auth token; once the server
+    // starts with valid env config the artifact has served its purpose
+    // and must not linger at rest.
+    const artifactPath = getSetupArtifactPath();
+    writeFileSync(artifactPath, '{"mcpServers":{}}');
+
+    const removed = removeSetupArtifact();
+
+    expect(removed).toBe(true);
+    expect(existsSync(artifactPath)).toBe(false);
+  });
+
+  it('should_return_false_without_throwing_when_artifact_absent', () => {
+    expect(existsSync(getSetupArtifactPath())).toBe(false);
+
+    expect(removeSetupArtifact()).toBe(false);
+  });
+});

--- a/packages/mcp-server/src/__tests__/write-ops/task-operations-delete.test.ts
+++ b/packages/mcp-server/src/__tests__/write-ops/task-operations-delete.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { GsdConfig, Task } from '../../types.js';
 
+const { mockLoggerWarn } = vi.hoisted(() => ({ mockLoggerWarn: vi.fn() }));
+
+vi.mock('../../utils/logger.js', () => ({
+  createMcpLogger: () => ({
+    info: vi.fn(),
+    warn: mockLoggerWarn,
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
 vi.mock('../../tools/list-tasks.js', () => ({
   listTasks: vi.fn(),
 }));
@@ -89,5 +100,36 @@ describe('deleteTask', () => {
         dependencies: [],
       })
     );
+  });
+
+  it('should_log_cleanup_failures_via_structured_logger_without_echoing_pb_error_message', async () => {
+    // PB 422 bodies echo submitted field values (task titles). A failed
+    // dependency-cleanup write must go through the masking MCP logger with
+    // content-free context (task id + status) — never raw console.error,
+    // which would land the title in Claude Desktop's stderr log.
+    const { listTasks } = await import('../../tools/list-tasks.js');
+    const helpers = await import('../../write-ops/helpers.js');
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(listTasks).mockResolvedValueOnce([
+      makeTask('blocker'),
+      makeTask('dependent', ['blocker']),
+    ]);
+    const pbError = Object.assign(
+      new Error('422: title "Confidential: acquire MegaCorp" failed to validate'),
+      { status: 422 }
+    );
+    vi.mocked(helpers.updateTaskInPB).mockRejectedValueOnce(pbError);
+
+    const result = await deleteTask(config, 'blocker', { dryRun: false });
+
+    expect(result.dryRun).toBe(false);
+    expect(result.dependenciesCleaned).toBe(0);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+    expect(mockLoggerWarn.mock.calls[0][1]).toMatchObject({
+      taskId: 'dependent',
+      status: 422,
+    });
+    expect(JSON.stringify(mockLoggerWarn.mock.calls)).not.toContain('Confidential');
   });
 });

--- a/packages/mcp-server/src/cli/setup-artifact.ts
+++ b/packages/mcp-server/src/cli/setup-artifact.ts
@@ -1,0 +1,34 @@
+/**
+ * Setup-wizard artifact lifecycle.
+ *
+ * The wizard writes the generated Claude Desktop config snippet — including
+ * the plaintext auth token — to a chmod-600 file in the user's home
+ * directory. Deleting it was originally a manual step the user could skip,
+ * leaving the token at rest indefinitely. This module centralizes the path
+ * and best-effort removal so both the wizard (stale artifact from a prior
+ * run) and the server startup (artifact has served its purpose once env
+ * config loads) can clean it up automatically.
+ */
+
+import { unlinkSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/** Where the wizard writes the generated config snippet (mode 0600). */
+export function getSetupArtifactPath(): string {
+  return join(homedir(), '.gsd-mcp-setup.json');
+}
+
+/**
+ * Best-effort removal of the wizard artifact.
+ * Returns true if a file was removed, false if none existed (or removal
+ * failed) — callers treat cleanup as advisory and never throw on it.
+ */
+export function removeSetupArtifact(): boolean {
+  try {
+    unlinkSync(getSetupArtifactPath());
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/mcp-server/src/cli/setup-wizard.ts
+++ b/packages/mcp-server/src/cli/setup-wizard.ts
@@ -3,12 +3,11 @@
  * Guides users through PocketBase URL and auth token setup
  */
 
-import { writeFileSync, chmodSync, unlinkSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { writeFileSync, chmodSync } from 'node:fs';
 import type { GsdConfig } from '../tools.js';
 import { getSyncStatus, listTasks } from '../tools.js';
 import { prompt, promptPassword, getClaudeConfigPath } from './index.js';
+import { getSetupArtifactPath, removeSetupArtifact } from './setup-artifact.js';
 
 /** Default production PocketBase URL used as prompt default value */
 const DEFAULT_POCKETBASE_URL = process.env.GSD_POCKETBASE_URL || 'https://api.vinny.io';
@@ -81,16 +80,15 @@ async function testTaskAccess(pbUrl: string, authToken: string): Promise<void> {
   }
 }
 
-/** Where the wizard writes the generated config snippet (mode 0600). */
-const GENERATED_CONFIG_PATH = join(homedir(), '.gsd-mcp-setup.json');
-
 /**
  * Write the generated config snippet to a chmod-600 file. The token is never
  * printed to stdout (no terminal scrollback, no screenshot leak, no shell
  * history if the output is piped). The user reads the file to copy the
- * config into Claude Desktop, then deletes it.
+ * config into Claude Desktop; the file is removed automatically the first
+ * time the MCP server starts with valid env config.
  */
 function writeConfigurationFile(pbUrl: string, authToken: string): string {
+  const artifactPath = getSetupArtifactPath();
   const configJson = {
     mcpServers: {
       'gsd-tasks': {
@@ -109,11 +107,11 @@ function writeConfigurationFile(pbUrl: string, authToken: string): string {
   // initial write, and chmodSync as belt-and-braces (mode is honored on
   // Linux/macOS; on Windows the chmod is a no-op but the file lives in
   // the user's home directory under the user's ACLs).
-  writeFileSync(GENERATED_CONFIG_PATH, JSON.stringify(configJson, null, 2), {
+  writeFileSync(artifactPath, JSON.stringify(configJson, null, 2), {
     mode: 0o600,
   });
-  chmodSync(GENERATED_CONFIG_PATH, 0o600);
-  return GENERATED_CONFIG_PATH;
+  chmodSync(artifactPath, 0o600);
+  return artifactPath;
 }
 
 /**
@@ -157,27 +155,20 @@ function displayConfiguration(pbUrl: string, authToken: string): void {
  * Display next steps for user
  */
 function displayNextSteps(): void {
+  const artifactPath = getSetupArtifactPath();
   console.log('Step 4/4: Next Steps');
-  console.log(`1. Open the generated file:  cat ${GENERATED_CONFIG_PATH}`);
+  console.log(`1. Open the generated file:  cat ${artifactPath}`);
   console.log(`2. Open Claude Desktop config: ${getClaudeConfigPath()}`);
   console.log('3. Merge the "mcpServers" section into the Claude config');
-  console.log(`4. Delete the generated file:  rm ${GENERATED_CONFIG_PATH}`);
-  console.log('5. Restart Claude Desktop');
-  console.log("6. Ask Claude: \"What's my GSD sync status?\"");
+  console.log('4. Restart Claude Desktop');
+  console.log("5. Ask Claude: \"What's my GSD sync status?\"");
+  console.log();
+  console.log(
+    'The generated file is deleted automatically the first time the MCP server starts.'
+  );
+  console.log(`To remove it sooner:  rm ${artifactPath}`);
   console.log();
   console.log('✓ Setup complete! Need help? Run: npx gsd-mcp-server --help');
-}
-
-/**
- * Best-effort cleanup of the generated config file on wizard failure so a
- * partial setup does not leave a token in the user's home directory.
- */
-function cleanupGeneratedConfigOnError(): void {
-  try {
-    unlinkSync(GENERATED_CONFIG_PATH);
-  } catch {
-    // File may not exist yet — ignore.
-  }
 }
 
 /**
@@ -189,6 +180,10 @@ export async function runSetupWizard(): Promise<void> {
 
 Welcome! This wizard will help you configure the MCP server for Claude Desktop.
 `);
+
+  // A previous run (including one aborted mid-wizard via process.exit) may
+  // have left a token-bearing artifact behind — clear it before prompting.
+  removeSetupArtifact();
 
   try {
     // Step 1: PocketBase URL
@@ -210,7 +205,8 @@ Welcome! This wizard will help you configure the MCP server for Claude Desktop.
     // Step 4: Next Steps
     displayNextSteps();
   } catch (error) {
-    cleanupGeneratedConfigOnError();
+    // Best-effort cleanup so a partial setup does not leave a token at rest.
+    removeSetupArtifact();
     console.error('\n✗ Setup failed:', error instanceof Error ? error.message : 'Unknown error');
     process.exit(1);
   }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -2,6 +2,7 @@
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { parseCLIArgs, showHelp, runSetupWizard, runValidation } from './cli.js';
+import { removeSetupArtifact } from './cli/setup-artifact.js';
 import { loadConfig } from './server/config.js';
 import { createServer, registerHandlers } from './server/setup.js';
 import { createMcpLogger } from './utils/logger.js';
@@ -45,6 +46,11 @@ async function main() {
   } catch {
     process.exit(1);
   }
+
+  // The setup-wizard artifact (~/.gsd-mcp-setup.json) holds the same token
+  // we just loaded from env — once the server boots with valid config it
+  // has served its purpose. Best-effort; never blocks startup.
+  removeSetupArtifact();
 
   // Create MCP server
   const server = createServer();

--- a/packages/mcp-server/src/write-ops/task-operations.ts
+++ b/packages/mcp-server/src/write-ops/task-operations.ts
@@ -25,6 +25,9 @@ import {
 import { extractUrlsFromTitle, buildDescription } from '../text/capture-parser.js';
 import { ConflictError } from '../errors.js';
 import { getTaskCache } from '../cache.js';
+import { createMcpLogger } from '../utils/logger.js';
+
+const logger = createMcpLogger('TASK_OPS');
 
 /**
  * Create task result with dry-run information
@@ -346,11 +349,14 @@ export async function deleteTask(
         dependenciesCleaned++;
       } catch (error) {
         // Log but don't throw — the primary delete already succeeded.
-        console.error(
-          `Failed to clean dependency reference on task ${affected.id}: ${
-            error instanceof Error ? error.message : 'Unknown error'
-          }`
-        );
+        // PB 4xx messages can echo field values (task titles), so log only
+        // content-free context: the affected task id and the HTTP status.
+        const status = (error as { status?: unknown }).status;
+        logger.warn('Failed to clean dependency reference after delete', {
+          taskId: affected.id,
+          ...(typeof status === 'number' ? { status } : {}),
+          errorName: error instanceof Error ? error.name : typeof error,
+        });
       }
     }
   }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,7 +2,27 @@
 
 ---
 
-## In progress — 2026-06-05: Standalone `/privacy` policy page + `/about` accuracy fix
+## In progress — 2026-06-10: Fix 3 medium security-review findings
+
+**Branch:** `fix/security-medium-findings`
+**Tier:** Standard (3 bounded fixes across webapp sync + MCP server; no new public contract). TDD per CLAUDE.md.
+
+**Findings (from full-codebase security review, 2026-06-09):**
+- **M1** — `reportSyncError()` (`lib/sync/pb-sync-engine.ts:167-184`) persists/toasts/logs raw `errorObj.message`; PB 4xx bodies can echo task titles into `db.syncHistory`, toasts, and log metadata. Fix: route through existing `sanitizeSyncError()` → stable `SyncErrorCode`, matching the push path and `reportPartialFailure` precedent. Keep raw `errorObj` only in `logger.error` for diagnostics (pre-existing app-wide policy).
+- **M3** — `deleteTask` dependency-cleanup (`packages/mcp-server/src/write-ops/task-operations.ts:349`) uses raw `console.error` with `error.message`, bypassing the structured MCP logger; PB 422 can echo titles into stderr. Fix: log via `createMcpLogger` with content-free context (taskId + numeric status), not the raw message.
+- **M2** — Setup wizard artifact `~/.gsd-mcp-setup.json` holds the plaintext JWT until the user manually deletes it. Fix: new `src/cli/setup-artifact.ts` with `removeSetupArtifact()`; call it (a) at wizard start to clear stale artifacts and (b) at MCP-server startup once env config loads (artifact has served its purpose). Update wizard step-4 copy + README-SECURITY revocation note.
+
+**Cycles (TDD — red first):**
+- [x] **C1 (M1)** ✅ — red test in `tests/data/sync/pb-sync-engine.test.ts` (4 failures, raw title leaking) → `reportSyncError` now routes through `sanitizeSyncError()` → green 15/15. Updated 3 existing assertions that pinned the leaky behavior.
+- [x] **C2 (M3)** ✅ — red test in `packages/mcp-server/src/__tests__/write-ops/task-operations-delete.test.ts` (console.error called) → `deleteTask` cleanup now logs via `createMcpLogger('TASK_OPS')` with `{taskId, status, errorName}` only → green 3/3.
+- [x] **C3 (M2)** ✅ — red test for new `src/cli/setup-artifact.ts` (`getSetupArtifactPath`/`removeSetupArtifact`, homedir mocked) → green 3/3. Wired: wizard start (stale-artifact cleanup), wizard error path, `index.ts` MCP mode after `loadConfig()`. Wizard step-4 copy updated; README-SECURITY gained "Token Lifetime, Revocation, and the Setup Artifact" + corrected the "log out to revoke" advice (PB has no per-token revocation).
+- [x] **C4 (reviewer nit)** ✅ — `pb-sync-reviewer` approved C1 but flagged `sync-coordinator.ts:142` (dead-in-practice re-throw path storing raw message, bypassing the new sanitization). Red: 4 updated + 1 new assertion in `tests/sync/sync-coordinator.test.ts` → green 18/18. Same `sanitizeSyncError` shim in `executeSync`'s catch.
+
+**Verify:** root `bun run test` ✅ 1953 pass / 1 skip · mcp-server vitest ✅ 140 pass + `tsc --noEmit` ✅ · root `bun typecheck` ✅ · `bun lint` ❌ **pre-existing breakage on main** (ESLint 10.4.1 vs `@typescript-eslint/utils` "Class extends value undefined" crash — verified identical with all changes stashed; introduced by `3c6e810 Ran bun update --latest`, unrelated to this branch) · `pb-sync-reviewer` ✅ APPROVE (0 blocking, 1 nit → fixed as C4).
+
+---
+
+## Done — 2026-06-05: Standalone `/privacy` policy page + `/about` accuracy fix
 
 **Branch:** `feat/privacy-policy-page`
 **Tier:** Standard (new route + one content component + small `/about` fix + tests; bounded, no new public contract). Lightweight plan + TDD per CLAUDE.md.

--- a/tests/data/sync/pb-sync-engine.test.ts
+++ b/tests/data/sync/pb-sync-engine.test.ts
@@ -244,7 +244,7 @@ describe('pb-sync-engine', () => {
       const result = await fullSync();
 
       expect(result.status).toBe('error');
-      expect(result.error).toContain('Connection refused');
+      expect(result.error).toBe('network_error');
       expect(mockRetryManager.recordFailure).toHaveBeenCalled();
     });
 
@@ -260,7 +260,7 @@ describe('pb-sync-engine', () => {
       const result = await fullSync();
 
       expect(result.status).toBe('error');
-      expect(result.error).toContain('422 Unprocessable Entity');
+      expect(result.error).toBe('validation_failed');
       expect(mockRetryManager.recordFailure).toHaveBeenCalled();
     });
 
@@ -277,8 +277,33 @@ describe('pb-sync-engine', () => {
       const result = await fullSync();
 
       expect(result.status).toBe('error');
-      expect(result.error).toBe('Something went wrong.');
+      expect(result.error).toBe('network_error');
       expect(mockRetryManager.recordFailure).toHaveBeenCalled();
+    });
+
+    it('should_sanitize_unexpected_sync_errors_to_stable_codes_so_task_content_never_reaches_history_or_toasts', async () => {
+      // PB 4xx validation bodies echo submitted field values. An exception
+      // escaping fullSync must be reduced to a stable SyncErrorCode before
+      // it is persisted to syncHistory, shown in a toast, or returned —
+      // mirroring what the push path already does via sanitizeSyncError().
+      const { pushLocalChanges } = await import('@/lib/sync/pb-push');
+      const { recordSyncError } = await import('@/lib/sync-history');
+      const { notifySyncError } = await import('@/lib/sync/notifications');
+      const secretTitle = 'Confidential: acquire MegaCorp';
+      vi.mocked(pushLocalChanges).mockRejectedValueOnce(
+        new Error(`422 Unprocessable Entity: title "${secretTitle}" failed to validate`),
+      );
+
+      const result = await fullSync('user');
+
+      expect(result.status).toBe('error');
+      expect(result.error).toBe('validation_failed');
+      expect(vi.mocked(recordSyncError)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(recordSyncError).mock.calls[0][0]).toBe('validation_failed');
+      expect(vi.mocked(notifySyncError)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(notifySyncError).mock.calls[0][0]).toBe('validation_failed');
+      expect(JSON.stringify(vi.mocked(recordSyncError).mock.calls)).not.toContain(secretTitle);
+      expect(JSON.stringify(vi.mocked(notifySyncError).mock.calls)).not.toContain(secretTitle);
     });
   });
 });

--- a/tests/sync/sync-coordinator.test.ts
+++ b/tests/sync/sync-coordinator.test.ts
@@ -270,7 +270,7 @@ describe('SyncCoordinator', () => {
       const status = await coordinator.getStatus();
 
       expect(status.lastResult?.status).toBe('error');
-      expect(status.lastError).toBe('Network failure');
+      expect(status.lastError).toBe('network_error');
     });
 
     it('records non-transient errors with full status / error message', async () => {
@@ -284,7 +284,7 @@ describe('SyncCoordinator', () => {
       const status = await coordinator.getStatus();
 
       expect(status.lastResult?.status).toBe('error');
-      expect(status.lastError).toBe('400 Bad Request: invalid');
+      expect(status.lastError).toBe('validation_failed');
     });
 
     it('records transient PB ClientResponseError status 0 (network fault)', async () => {
@@ -301,7 +301,7 @@ describe('SyncCoordinator', () => {
       const status = await coordinator.getStatus();
 
       expect(status.lastResult?.status).toBe('error');
-      expect(status.lastError).toBe('Something went wrong.');
+      expect(status.lastError).toBe('network_error');
     });
 
     it('handles non-Error thrown values from fullSync', async () => {
@@ -314,7 +314,25 @@ describe('SyncCoordinator', () => {
       const status = await coordinator.getStatus();
 
       expect(status.lastResult?.status).toBe('error');
-      expect(status.lastError).toBe('plain string failure');
+      expect(status.lastError).toBe('unknown_error');
+    });
+
+    it('should_sanitize_rethrown_sync_errors_so_task_content_never_reaches_last_result', async () => {
+      // Defense-in-depth: fullSync catches its own errors in practice, but
+      // if it ever re-throws (e.g. a future refactor), the coordinator's
+      // catch must not store a raw PB 4xx message — those echo task titles.
+      const secretTitle = 'Confidential: acquire MegaCorp';
+      mockFullSync.mockRejectedValueOnce(
+        new Error(`422 Unprocessable Entity: title "${secretTitle}" failed to validate`)
+      );
+
+      await coordinator.requestSync('user');
+
+      const status = await coordinator.getStatus();
+
+      expect(status.lastResult?.status).toBe('error');
+      expect(status.lastError).toBe('validation_failed');
+      expect(JSON.stringify(status)).not.toContain(secretTitle);
     });
   });
 });


### PR DESCRIPTION
## What & why

Fixes the three **Medium** findings from the 2026-06-09 full-codebase security review. Root cause shared by all of M1/M3: PocketBase 4xx bodies echo submitted field values (task titles), so any surface that persists or prints raw error messages is a task-content egress path.

### M1 — Sync errors persisted/toasted raw PB messages
`reportSyncError()` (`lib/sync/pb-sync-engine.ts`) now routes escaped exceptions through the existing `sanitizeSyncError()` → stable `SyncErrorCode` before they reach `db.syncHistory`, the toast, log metadata, and `PBSyncResult.error`. The raw `Error` is kept only for `logger.error` diagnostics. This matches what the push path and `reportPartialFailure` already do. The `pb-sync-reviewer` agent approved and flagged one nit — the coordinator's dead-in-practice re-throw catch (`lib/sync/sync-coordinator.ts`) bypassed the new sanitization — fixed the same way.

### M3 — MCP delete-cleanup logged raw PB messages to stderr
The dependency-cleanup loop in `deleteTask` (`packages/mcp-server/src/write-ops/task-operations.ts`) used raw `console.error` with `error.message`, landing PB 422 echoes in Claude Desktop's stderr log. Now logs via `createMcpLogger('TASK_OPS')` with content-free context only (`taskId`, numeric `status`, `errorName`) — the MCP logger masks secrets, not content, so logging the raw message through it would have relocated the leak rather than fixed it.

### M2 — Token-bearing setup artifact persisted indefinitely
The wizard's `~/.gsd-mcp-setup.json` (plaintext JWT, mode 0600) required a manual delete the user could skip. New `src/cli/setup-artifact.ts` removes it automatically: at MCP server startup once env config loads (the moment it becomes redundant), at wizard re-run (stale artifacts from aborted runs), and on wizard failure. Wizard step-4 copy updated. README-SECURITY gains a "Token Lifetime, Revocation, and the Setup Artifact" section and corrects the prior "log out and back in" revocation advice — PocketBase has no per-token revocation; only a password change or token-secret rotation invalidates outstanding JWTs.

## How to test

- `bun run test` — root suite (includes new leak-prevention tests in `tests/data/sync/pb-sync-engine.test.ts` and `tests/sync/sync-coordinator.test.ts` that inject a fake confidential title into a PB 422 and assert it is absent from every persisted/notified surface)
- `cd packages/mcp-server && bun run test` — includes new `setup-artifact` tests and the structured-logging delete-cleanup test
- `bun typecheck` and `npx tsc --noEmit` in `packages/mcp-server`

All written test-first (red confirmed before green; 4 webapp + 4 coordinator assertions that pinned the leaky behavior were updated to the sanitized codes).

## Notes

- UI impact of M1: the sync-button tooltip now shows stable codes (`validation_failed`, `network_error`) instead of raw PB messages — consistent with what the partial-failure path already displayed. Auth detection (`isAuthError` substring match on `unauthorized`) verified unaffected by the reviewer.
- `bun lint` crashes repo-wide on **main** (ESLint 10.4.1 vs `@typescript-eslint/utils`, introduced by `3c6e810 Ran bun update --latest`) — verified identical with this branch's changes stashed; needs its own chore PR.
- Version bumped 9.7.0 → 9.7.1 (patch).