### PR TITLE
feat(sync): delete account & synced data from web settings

### DIFF
--- a/components/delete-account-dialog.tsx
+++ b/components/delete-account-dialog.tsx
@@ -23,8 +23,8 @@ import { toast } from "sonner";
 interface DeleteAccountDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	/** Export the user's tasks to a JSON backup before deleting. */
-	onExport: () => Promise<void>;
+	/** Export the user's tasks to a JSON backup. Resolves `true` on success, `false` on failure. */
+	onExport: () => Promise<boolean>;
 	/** Called after a successful "keep local" deletion (so the host can refresh state). */
 	onDeleted?: () => void;
 }
@@ -61,14 +61,17 @@ export function DeleteAccountDialog({
 	const isConfirmed = confirmText === "DELETE";
 	const canDelete = isConfirmed && (!exportFirst || hasExported);
 
+	// onExport (the parent's handleExport) owns its own success/error toast and reports
+	// whether the backup was actually written. Only a real success unlocks the delete gate.
 	const handleExport = async () => {
-		try {
-			await onExport();
-			setHasExported(true);
-			toast.success("Tasks exported successfully");
-		} catch (err) {
-			toast.error(err instanceof Error ? err.message : "Export failed");
-		}
+		setHasExported(await onExport());
+	};
+
+	const resetForm = () => {
+		setConfirmText("");
+		setExportFirst(false);
+		setHasExported(false);
+		setEraseLocal(false);
 	};
 
 	const handleDelete = async () => {
@@ -93,8 +96,10 @@ export function DeleteAccountDialog({
 
 			await disableSync();
 			toast.success("Account deleted. Your tasks remain on this device.");
-			onDeleted?.();
+			setIsDeleting(false);
+			resetForm();
 			onOpenChange(false);
+			onDeleted?.();
 		} catch (err) {
 			toast.error(err instanceof Error ? err.message : "Account deletion failed");
 			setIsDeleting(false);
@@ -103,10 +108,7 @@ export function DeleteAccountDialog({
 
 	const handleClose = () => {
 		if (isDeleting) return;
-		setConfirmText("");
-		setExportFirst(false);
-		setHasExported(false);
-		setEraseLocal(false);
+		resetForm();
 		onOpenChange(false);
 	};
 

--- a/components/delete-account-dialog.tsx
+++ b/components/delete-account-dialog.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangleIcon, DownloadIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { deleteRemoteAccountAndTasks } from "@/lib/sync/pb-account-deletion";
+import type { DeleteAccountResult } from "@/lib/sync/pb-account-deletion";
+import { resetEverything, reloadAfterReset } from "@/lib/reset-everything";
+import { disableSync } from "@/lib/sync/config";
+import { UI_TIMING } from "@/lib/constants/ui";
+import { toast } from "sonner";
+
+interface DeleteAccountDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	/** Export the user's tasks to a JSON backup before deleting. */
+	onExport: () => Promise<void>;
+	/** Called after a successful "keep local" deletion (so the host can refresh state). */
+	onDeleted?: () => void;
+}
+
+/** Human-readable message for a failed remote deletion, by failure mode. */
+function failureMessage(result: DeleteAccountResult): string {
+	if (result.authRejected) {
+		return "Your session expired — sign in again to delete your account.";
+	}
+	if (result.stage === "tasks") {
+		return "Couldn't reach the server to delete your account. Check your connection and try again.";
+	}
+	return "Couldn't delete your account right now. Check your connection and try again.";
+}
+
+/**
+ * Confirmation dialog for permanently deleting the cloud account and all synced tasks.
+ *
+ * Mirrors the iOS/Mac flow: the remote delete runs first, and local data is only touched
+ * after it succeeds. The user chooses whether to also erase the local copy on this device.
+ */
+export function DeleteAccountDialog({
+	open,
+	onOpenChange,
+	onExport,
+	onDeleted,
+}: DeleteAccountDialogProps) {
+	const [confirmText, setConfirmText] = useState("");
+	const [exportFirst, setExportFirst] = useState(false);
+	const [hasExported, setHasExported] = useState(false);
+	const [eraseLocal, setEraseLocal] = useState(false);
+	const [isDeleting, setIsDeleting] = useState(false);
+
+	const isConfirmed = confirmText === "DELETE";
+	const canDelete = isConfirmed && (!exportFirst || hasExported);
+
+	const handleExport = async () => {
+		try {
+			await onExport();
+			setHasExported(true);
+			toast.success("Tasks exported successfully");
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : "Export failed");
+		}
+	};
+
+	const handleDelete = async () => {
+		if (!canDelete) return;
+		setIsDeleting(true);
+
+		try {
+			const result = await deleteRemoteAccountAndTasks();
+			if (!result.ok) {
+				toast.error(failureMessage(result));
+				setIsDeleting(false);
+				return;
+			}
+
+			// Remote account is gone. Only now do we touch local data.
+			if (eraseLocal) {
+				await resetEverything({ preserveTheme: true });
+				toast.success("Account deleted — reloading…");
+				setTimeout(() => reloadAfterReset(), UI_TIMING.RESET_RELOAD_DELAY_MS);
+				return;
+			}
+
+			await disableSync();
+			toast.success("Account deleted. Your tasks remain on this device.");
+			onDeleted?.();
+			onOpenChange(false);
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : "Account deletion failed");
+			setIsDeleting(false);
+		}
+	};
+
+	const handleClose = () => {
+		if (isDeleting) return;
+		setConfirmText("");
+		setExportFirst(false);
+		setHasExported(false);
+		setEraseLocal(false);
+		onOpenChange(false);
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={handleClose}>
+			<DialogContent className="sm:max-w-lg">
+				<DialogHeader>
+					<DialogTitle className="flex items-center gap-2 text-status-overdue">
+						<AlertTriangleIcon className="h-5 w-5" />
+						Delete Account
+					</DialogTitle>
+					<DialogDescription className="text-foreground-muted">
+						This permanently deletes your account and every task synced to it. This
+						cannot be undone.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4">
+					{/* What will be deleted */}
+					<div className="rounded-lg border border-status-overdue/35 bg-status-overdue-muted p-4">
+						<h4 className="mb-2 font-semibold text-status-overdue">
+							What will be deleted:
+						</h4>
+						<ul className="space-y-1 text-sm text-status-overdue">
+							<li>• Your cloud account on the sync server</li>
+							<li>• Every task synced to that account</li>
+							{eraseLocal && <li>• All tasks and settings on this device</li>}
+						</ul>
+					</div>
+
+					{/* Export option */}
+					<div className="flex items-start gap-3 p-3 rounded-lg border border-border">
+						<div className="flex-1 space-y-2">
+							<div className="flex items-center justify-between">
+								<Label htmlFor="export-first" className="text-sm font-medium cursor-pointer">
+									Export my tasks first (recommended)
+								</Label>
+								<Switch
+									id="export-first"
+									checked={exportFirst}
+									onCheckedChange={(checked) => {
+										setExportFirst(checked === true);
+										if (!checked) setHasExported(false);
+									}}
+									disabled={isDeleting}
+								/>
+							</div>
+							{exportFirst && !hasExported && (
+								<Button
+									variant="subtle"
+									onClick={handleExport}
+									disabled={isDeleting}
+									className="w-full text-sm h-9"
+								>
+									<DownloadIcon className="mr-2 h-4 w-4" />
+									Export Now
+								</Button>
+							)}
+							{exportFirst && hasExported && (
+								<p className="text-xs text-status-success">Exported successfully</p>
+							)}
+						</div>
+					</div>
+
+					{/* Erase local option (default off: keep tasks on this device) */}
+					<div className="flex items-center justify-between p-3 rounded-lg border border-border">
+						<Label htmlFor="erase-local" className="text-sm font-medium cursor-pointer">
+							Also erase all tasks from this browser
+						</Label>
+						<Switch
+							id="erase-local"
+							checked={eraseLocal}
+							onCheckedChange={(checked) => setEraseLocal(checked === true)}
+							disabled={isDeleting}
+						/>
+					</div>
+
+					{/* Confirmation input */}
+					<div className="space-y-2">
+						<Label htmlFor="confirm-delete" className="text-sm font-semibold">
+							Type <span className="font-mono text-status-overdue">DELETE</span> to confirm:
+						</Label>
+						<Input
+							id="confirm-delete"
+							value={confirmText}
+							onChange={(e) => setConfirmText(e.target.value)}
+							placeholder="Type DELETE here"
+							disabled={isDeleting}
+							className="font-mono"
+						/>
+					</div>
+
+					{/* Actions */}
+					<div className="flex flex-col-reverse sm:flex-row gap-2 sm:justify-end pt-2">
+						<Button variant="subtle" onClick={handleClose} disabled={isDeleting}>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							onClick={handleDelete}
+							disabled={!canDelete || isDeleting}
+						>
+							{isDeleting ? "Deleting…" : "Delete account"}
+						</Button>
+					</div>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/components/settings-page/index.tsx
+++ b/components/settings-page/index.tsx
@@ -300,7 +300,10 @@ export function SettingsPage() {
                   />
                 )}
                 {activeSection === "sync" && syncEnabled && (
-                  <SyncSettings onViewHistory={handleViewSyncHistory} />
+                  <SyncSettings
+                    onViewHistory={handleViewSyncHistory}
+                    onExport={handleExport}
+                  />
                 )}
                 {activeSection === "archive" && (
                   <ArchiveSettings onViewArchive={handleViewArchive} />

--- a/components/settings-page/index.tsx
+++ b/components/settings-page/index.tsx
@@ -166,7 +166,9 @@ export function SettingsPage() {
     [reloadNotificationSettings],
   );
 
-  const handleExport = useCallback(async () => {
+  // Returns whether the backup was actually written, so callers (e.g. the delete-account
+  // dialog's export-first gate) can refuse to proceed when the export failed.
+  const handleExport = useCallback(async (): Promise<boolean> => {
     setIsExporting(true);
     try {
       const json = await exportToJson();
@@ -178,9 +180,11 @@ export function SettingsPage() {
       link.click();
       URL.revokeObjectURL(url);
       toast.success("Tasks exported");
+      return true;
     } catch (error) {
       logger.error("Export failed", error instanceof Error ? error : undefined);
       toast.error("Failed to export tasks");
+      return false;
     } finally {
       setIsExporting(false);
     }
@@ -303,6 +307,10 @@ export function SettingsPage() {
                   <SyncSettings
                     onViewHistory={handleViewSyncHistory}
                     onExport={handleExport}
+                    onAccountDeleted={() => {
+                      setSyncEnabled(false);
+                      setPendingSync(0);
+                    }}
                   />
                 )}
                 {activeSection === "archive" && (
@@ -314,7 +322,9 @@ export function SettingsPage() {
                     completedTasks={completedTaskCount}
                     totalTasks={tasks.length}
                     estimatedSize={estimatedKb}
-                    onExport={handleExport}
+                    onExport={async () => {
+                      await handleExport();
+                    }}
                     onImportClick={handleImportClick}
                     isLoading={isExporting || tasksLoading}
                     syncEnabled={syncEnabled}

--- a/components/settings/sync-settings.tsx
+++ b/components/settings/sync-settings.tsx
@@ -14,8 +14,10 @@ const logger = createLogger("UI");
 
 interface SyncSettingsProps {
 	onViewHistory: () => void;
-	/** Export tasks to a JSON backup (offered before account deletion). */
-	onExport: () => Promise<void>;
+	/** Export tasks to a JSON backup (offered before account deletion). Resolves `true` on success. */
+	onExport: () => Promise<boolean>;
+	/** Called after a successful account deletion so the page can refresh sync state. */
+	onAccountDeleted: () => void;
 }
 
 const SYNC_INTERVAL_OPTIONS = [
@@ -33,6 +35,7 @@ const SYNC_INTERVAL_OPTIONS = [
 export function SyncSettings({
 	onViewHistory,
 	onExport,
+	onAccountDeleted,
 }: SyncSettingsProps) {
 	const [autoSyncEnabled, setAutoSyncEnabled] = useState(true);
 	const [syncInterval, setSyncInterval] = useState(2);
@@ -177,6 +180,7 @@ export function SyncSettings({
 				open={deleteDialogOpen}
 				onOpenChange={setDeleteDialogOpen}
 				onExport={onExport}
+				onDeleted={onAccountDeleted}
 			/>
 		</>
 	);

--- a/components/settings/sync-settings.tsx
+++ b/components/settings/sync-settings.tsx
@@ -1,17 +1,21 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { HistoryIcon, ZapIcon, ChevronRightIcon } from "lucide-react";
+import { HistoryIcon, ZapIcon, ChevronRightIcon, Trash2Icon } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
 import { getAutoSyncConfig, updateAutoSyncConfig } from "@/lib/sync/config";
 import { toast } from "sonner";
 import { createLogger } from "@/lib/logger";
 import { SettingsRow, SettingsSelectRow } from "./shared-components";
+import { DeleteAccountDialog } from "@/components/delete-account-dialog";
 
 const logger = createLogger("UI");
 
 interface SyncSettingsProps {
 	onViewHistory: () => void;
+	/** Export tasks to a JSON backup (offered before account deletion). */
+	onExport: () => Promise<void>;
 }
 
 const SYNC_INTERVAL_OPTIONS = [
@@ -28,10 +32,12 @@ const SYNC_INTERVAL_OPTIONS = [
  */
 export function SyncSettings({
 	onViewHistory,
+	onExport,
 }: SyncSettingsProps) {
 	const [autoSyncEnabled, setAutoSyncEnabled] = useState(true);
 	const [syncInterval, setSyncInterval] = useState(2);
 	const [isLoading, setIsLoading] = useState(false);
+	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 	const updateTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
 	useEffect(() => {
@@ -145,6 +151,33 @@ export function SyncSettings({
 				<span className="flex-1 text-sm font-medium text-foreground">Sync history</span>
 				<ChevronRightIcon className="w-4 h-4 text-foreground-muted/50" />
 			</button>
+
+			{/* Danger zone */}
+			<div className="px-4 py-3.5">
+				<div className="rounded-lg border border-status-overdue/35 bg-status-overdue-muted/40 p-4 space-y-3">
+					<div>
+						<p className="text-sm font-semibold text-status-overdue">Danger zone</p>
+						<p className="text-xs text-foreground-muted mt-1">
+							Permanently delete your account and every task synced to it. This
+							cannot be undone.
+						</p>
+					</div>
+					<Button
+						variant="destructive"
+						onClick={() => setDeleteDialogOpen(true)}
+						className="w-full sm:w-auto"
+					>
+						<Trash2Icon className="mr-2 h-4 w-4" />
+						Delete account…
+					</Button>
+				</div>
+			</div>
+
+			<DeleteAccountDialog
+				open={deleteDialogOpen}
+				onOpenChange={setDeleteDialogOpen}
+				onExport={onExport}
+			/>
 		</>
 	);
 }

--- a/lib/sync/pb-account-deletion.ts
+++ b/lib/sync/pb-account-deletion.ts
@@ -1,0 +1,114 @@
+/**
+ * Account deletion — permanently remove the signed-in user's PocketBase account
+ * and every task synced to it.
+ *
+ * Mirrors the shipped iOS/Mac flow (SyncEngine.eraseAllRemote + AuthService.deleteAccount):
+ * remote tasks are deleted FIRST, then the user record. The `owner` field on the
+ * `tasks` collection is plain `text`, not a relation, so deleting the user record does
+ * NOT cascade — skipping the task wipe would orphan every record on the server.
+ *
+ * This module performs the REMOTE operation only and returns a structured result.
+ * The caller decides what to do with local data (keep, or wipe via resetEverything),
+ * and only ever touches local state after a confirmed remote success.
+ */
+
+import { getPocketBase, getCurrentUserId } from "./pocketbase-client";
+import { refreshAuth } from "./pb-auth";
+import { fetchRemoteTaskIndex } from "./pb-sync-helpers";
+import { createLogger } from "@/lib/logger";
+
+const logger = createLogger("SYNC_AUTH");
+
+/** Default delay between remote deletes — PocketBase 429-avoidance (matches iOS). */
+const DEFAULT_THROTTLE_MS = 100;
+
+export interface DeleteAccountResult {
+  ok: boolean;
+  /** Where the flow ended: failed during task wipe, during account delete, or completed. */
+  stage: "tasks" | "account" | "done";
+  /** True on 401/403 — the session is dead and local auth should be cleared. */
+  authRejected?: boolean;
+  /** Short, sanitized error for surfacing to the user. */
+  error?: string;
+}
+
+export interface DeleteAccountOptions {
+  /** Delay between remote task deletes. Tests pass 0; production uses 100ms. */
+  throttleMs?: number;
+}
+
+/** PocketBase ClientResponseError surfaces HTTP status on `.status`. */
+function isAuthRejection(error: unknown): boolean {
+  const status = (error as { status?: number })?.status;
+  return status === 401 || status === 403;
+}
+
+function shortError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.slice(0, 200);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Delete every remote task for the current user, then delete the user account record.
+ * Aborts before deleting the account if the task wipe can't be completed, so a partial
+ * failure never leaves orphaned records behind a deleted account.
+ */
+export async function deleteRemoteAccountAndTasks(
+  options: DeleteAccountOptions = {},
+): Promise<DeleteAccountResult> {
+  const throttleMs = options.throttleMs ?? DEFAULT_THROTTLE_MS;
+
+  // Refresh the (possibly expired) token, then resolve the owner id. A dead session
+  // yields no id — report it so the UI can prompt a re-sign-in.
+  await refreshAuth();
+  const userId = getCurrentUserId();
+  if (!userId) {
+    return { ok: false, stage: "tasks", authRejected: true };
+  }
+
+  const pb = getPocketBase();
+
+  // Build the authoritative remote index. If we can't list the tasks, abort — deleting
+  // the account now would orphan whatever we failed to enumerate.
+  const { index, fetchSucceeded } = await fetchRemoteTaskIndex(userId);
+  if (!fetchSucceeded) {
+    logger.warn("Aborting account deletion: could not list remote tasks");
+    return { ok: false, stage: "tasks", error: "Could not list remote tasks" };
+  }
+
+  // Delete every remote task first (throttled). A partial failure throws and leaves the
+  // account intact, so a retry re-fetches only the survivors and continues.
+  try {
+    for (const entry of index.values()) {
+      await pb.collection("tasks").delete(entry.pbRecordId);
+      if (throttleMs > 0) await sleep(throttleMs);
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      stage: "tasks",
+      authRejected: isAuthRejection(error),
+      error: shortError(error),
+    };
+  }
+
+  // Delete the user record last — once it's gone the token is invalid and tasks can no
+  // longer be removed.
+  try {
+    await pb.collection("users").delete(userId);
+  } catch (error) {
+    return {
+      ok: false,
+      stage: "account",
+      authRejected: isAuthRejection(error),
+      error: shortError(error),
+    };
+  }
+
+  logger.info("Account and remote tasks deleted", { taskCount: index.size });
+  return { ok: true, stage: "done" };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.10.0",
+	"version": "9.11.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tasks/spec-account-deletion.md
+++ b/tasks/spec-account-deletion.md
@@ -1,0 +1,129 @@
+# Spec: Delete Account & Synced Data (web)
+
+**Status:** Approved 2026-06-17 · **Tier:** Non-trivial · **Author:** Claude (paired with Vinny)
+
+## Goal
+
+Let a signed-in web user permanently delete their cloud account and all tasks synced to
+PocketBase (`api.vinny.io`), with an option to also erase the local copy — matching the
+capability already shipped on iOS/Mac, against the same backend.
+
+## Background
+
+- iOS/Mac (`/Users/vinnycarpenter/Projects/gsd-iosapp`) already implements this and is live in
+  production. Reference flow: `SyncEngine.eraseAllRemote()` deletes every remote task, then
+  `AuthService.deleteAccount()` issues `DELETE /api/collections/users/records/{id}` with the
+  user's own JWT (no superuser). `SessionStore.deleteAccount(eraseLocalData:)` orchestrates and
+  optionally wipes local.
+- The `owner` field on the `tasks` collection is `text`, **not** a relation, so deleting the user
+  record does **not** cascade-delete tasks. Tasks MUST be deleted first, or they orphan.
+- Self-delete with the user token already works against `api.vinny.io` (proven by the live iOS
+  feature), so no PocketBase server/admin changes are required for the web port.
+
+## Inputs / Outputs
+
+**Module — `lib/sync/pb-account-deletion.ts`**
+
+```ts
+export interface DeleteAccountResult {
+  ok: boolean;
+  stage: 'tasks' | 'account' | 'done';
+  authRejected?: boolean; // true on 401/403 — session is dead, auth should be cleared
+  error?: string;         // sanitized, short
+}
+
+// Performs the REMOTE operation only. Does NOT touch local data — the caller decides that.
+export async function deleteRemoteAccountAndTasks(): Promise<DeleteAccountResult>;
+```
+
+Behaviour (mirrors iOS ordering exactly):
+
+1. `refreshAuth()` (best-effort); resolve `userId` via `getCurrentUserId()`.
+   - No `userId` / not authenticated → `{ ok:false, stage:'tasks', authRejected:true }`.
+2. `fetchRemoteTaskIndex(userId)` (existing helper, `lib/sync/pb-sync-helpers.ts`).
+   - `fetchSucceeded === false` → `{ ok:false, stage:'tasks', error }` (ABORT — never orphan).
+3. For each indexed record: `pb.collection('tasks').delete(pbRecordId)`, **throttled 100ms** between
+   deletes (PocketBase 429-avoidance, matches iOS).
+   - Any delete throws → ABORT `{ ok:false, stage:'tasks', authRejected?, error }`. Auth kept unless 401/403.
+4. `pb.collection('users').delete(userId)`.
+   - 401/403 → `{ ok:false, stage:'account', authRejected:true }`.
+   - Other error → `{ ok:false, stage:'account', error }`.
+5. Success → `{ ok:true, stage:'done' }`.
+
+**UI — `components/delete-account-dialog.tsx`** (adapted from `reset-everything-dialog.tsx`)
+
+- Props: `{ open: boolean; onOpenChange: (open: boolean) => void; onDeleted?: () => void }`.
+- Rust warning banner; "what will be deleted" list (cloud account + all synced tasks).
+- `exportFirst` checkbox + "Export Now" (reuses existing export path).
+- `eraseLocal` checkbox **"Also erase all tasks from this browser"** — default **OFF** (keep local).
+- Typed confirmation `<input>` gating the delete button on the literal string `DELETE`.
+- On confirm → `deleteRemoteAccountAndTasks()`, then on `ok`:
+  - `eraseLocal === true` → `resetEverything({ preserveTheme: true })` then `reloadAfterReset()`.
+  - `eraseLocal === false` → `disableSync()` (clears auth + sync state; tasks stay → local-only),
+    then `onDeleted?.()` and close.
+
+**Settings — `components/settings/sync-settings.tsx`**
+
+- A red **"Danger zone"** block at the bottom, rendered only when signed in, with a destructive
+  "Delete account…" button that opens the dialog.
+
+## Constraints
+
+- Remote delete MUST complete fully before any local data is touched (offline-first safety
+  invariant). A network blip must never wipe local while leaving tasks on the server.
+- Throttle remote deletes ~100ms (documented PB rule + iOS parity).
+- No PocketBase server-side hooks/admin token. User's own session only.
+- File size < ~400 lines; functions < ~40 lines (coding-standards).
+- Reuse existing seams: `fetchRemoteTaskIndex`, `getCurrentUserId`, `refreshAuth`, `getPocketBase`,
+  `disableSync`, `resetEverything`, `reloadAfterReset`, `Dialog`, `Button`, `sonner` toasts.
+
+## Edge Cases
+
+- Zero remote tasks → skip the loop, delete account, succeed.
+- Task index fetch fails → abort, account NOT deleted, auth kept, retry works.
+- Mid-loop delete failure → abort at stage `tasks`, account NOT deleted; retry re-fetches only
+  survivors (idempotent).
+- Account delete 401/403 → session dead; clear auth, surface "session expired".
+- Account delete transient (5xx/network) → keep auth, allow retry.
+- Local wipe failure after remote success → best-effort; remote is already gone, user is committed.
+- Not signed in (no token) → `authRejected`, nothing attempted.
+
+## Out of Scope
+
+- No PocketBase server-side hook or cascade delete (tasks deleted client-side — matches iOS).
+- No new settings navigation section (placement is the sync "Danger zone").
+- No iOS/Mac changes.
+- No revocation of the Google/GitHub OAuth grant itself (only the PB user record — matches iOS).
+- Re-signup later remains possible (`deviceId` preserved by `resetEverything`).
+- No bulk/transactional PocketBase batch API (individual throttled deletes — matches iOS, proven).
+
+## Acceptance Criteria
+
+1. `deleteRemoteAccountAndTasks()` deletes every remote task **then** the user record, in that order.
+2. When the task index fetch fails, the user record is NOT deleted and `ok` is false.
+3. When a task delete fails mid-loop, the user record is NOT deleted and `stage === 'tasks'`.
+4. When not authenticated (no `userId`), it returns `authRejected` without hitting the network.
+5. When the user-record delete returns 401/403, the result is `authRejected` with `stage === 'account'`.
+6. With zero remote tasks, it deletes the account and returns `ok` (no task deletes attempted).
+7. Remote deletes are throttled (delete called once per record).
+8. Dialog: the delete button is disabled until `DELETE` is typed.
+9. Dialog: on success with `eraseLocal` checked, `resetEverything` is invoked; unchecked, `disableSync`.
+10. Dialog: on a failed remote delete, an error toast shows and the dialog stays open.
+11. Sync settings shows the "Delete account…" entry only when signed in.
+
+## Test Stubs
+
+`tests/data/pb-account-deletion.test.ts`
+- `deletes_all_remote_tasks_then_the_user_record_in_order`
+- `aborts_without_deleting_account_when_task_index_fetch_fails`
+- `aborts_at_stage_tasks_when_a_task_delete_fails`
+- `returns_authRejected_when_not_authenticated`
+- `returns_authRejected_when_user_delete_is_forbidden`
+- `succeeds_with_zero_remote_tasks`
+- `deletes_each_remote_task_exactly_once`
+
+`tests/ui/delete-account-dialog.test.tsx`
+- `delete_button_disabled_until_DELETE_is_typed`
+- `erase_local_checked_calls_resetEverything_on_success`
+- `keep_local_calls_disableSync_on_success`
+- `shows_error_toast_and_stays_open_on_remote_failure`

--- a/tests/data/pb-account-deletion.test.ts
+++ b/tests/data/pb-account-deletion.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type PocketBase from 'pocketbase';
+import { deleteRemoteAccountAndTasks } from '@/lib/sync/pb-account-deletion';
+import { getPocketBase, getCurrentUserId } from '@/lib/sync/pocketbase-client';
+import { refreshAuth } from '@/lib/sync/pb-auth';
+import { fetchRemoteTaskIndex } from '@/lib/sync/pb-sync-helpers';
+
+vi.mock('@/lib/sync/pocketbase-client');
+vi.mock('@/lib/sync/pb-auth');
+vi.mock('@/lib/sync/pb-sync-helpers');
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+/** Record-id keyed index entry shape produced by fetchRemoteTaskIndex. */
+function indexOf(...recordIds: string[]) {
+  const index = new Map<string, { pbRecordId: string; clientUpdatedAt: string | null }>();
+  recordIds.forEach((id, i) => index.set(`task-${i}`, { pbRecordId: id, clientUpdatedAt: null }));
+  return index;
+}
+
+describe('deleteRemoteAccountAndTasks', () => {
+  let callOrder: string[];
+  let tasksDelete: ReturnType<typeof vi.fn>;
+  let usersDelete: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    callOrder = [];
+
+    tasksDelete = vi.fn(async (id: string) => {
+      callOrder.push(`task:${id}`);
+    });
+    usersDelete = vi.fn(async (id: string) => {
+      callOrder.push(`user:${id}`);
+    });
+
+    const fakePb = {
+      collection: (name: string) => ({
+        delete: name === 'tasks' ? tasksDelete : usersDelete,
+      }),
+    };
+
+    vi.mocked(getPocketBase).mockReturnValue(fakePb as unknown as PocketBase);
+    vi.mocked(getCurrentUserId).mockReturnValue('user-123');
+    vi.mocked(refreshAuth).mockResolvedValue(true);
+    vi.mocked(fetchRemoteTaskIndex).mockResolvedValue({
+      index: indexOf('rec-a', 'rec-b'),
+      fetchSucceeded: true,
+    });
+  });
+
+  it('deletes_all_remote_tasks_then_the_user_record_in_order', async () => {
+    const result = await deleteRemoteAccountAndTasks({ throttleMs: 0 });
+
+    expect(result).toEqual({ ok: true, stage: 'done' });
+    expect(callOrder).toEqual(['task:rec-a', 'task:rec-b', 'user:user-123']);
+  });
+
+  it('aborts_without_deleting_account_when_task_index_fetch_fails', async () => {
+    vi.mocked(fetchRemoteTaskIndex).mockResolvedValue({
+      index: new Map(),
+      fetchSucceeded: false,
+    });
+
+    const result = await deleteRemoteAccountAndTasks({ throttleMs: 0 });
+
+    expect(result.ok).toBe(false);
+    expect(result.stage).toBe('tasks');
+    expect(tasksDelete).not.toHaveBeenCalled();
+    expect(usersDelete).not.toHaveBeenCalled();
+  });
+
+  it('aborts_at_stage_tasks_when_a_task_delete_fails', async () => {
+    tasksDelete.mockRejectedValueOnce(new Error('network down'));
+
+    const result = await deleteRemoteAccountAndTasks({ throttleMs: 0 });
+
+    expect(result.ok).toBe(false);
+    expect(result.stage).toBe('tasks');
+    expect(usersDelete).not.toHaveBeenCalled();
+  });
+
+  it('returns_authRejected_when_not_authenticated', async () => {
+    vi.mocked(getCurrentUserId).mockReturnValue(null);
+
+    const result = await deleteRemoteAccountAndTasks({ throttleMs: 0 });
+
+    expect(result.ok).toBe(false);
+    expect(result.authRejected).toBe(true);
+    expect(fetchRemoteTaskIndex).not.toHaveBeenCalled();
+    expect(tasksDelete).not.toHaveBeenCalled();
+    expect(usersDelete).not.toHaveBeenCalled();
+  });
+
+  it('returns_authRejected_when_user_delete_is_forbidden', async () => {
+    vi.mocked(fetchRemoteTaskIndex).mockResolvedValue({ index: new Map(), fetchSucceeded: true });
+    usersDelete.mockRejectedValueOnce(Object.assign(new Error('forbidden'), { status: 403 }));
+
+    const result = await deleteRemoteAccountAndTasks({ throttleMs: 0 });
+
+    expect(result.ok).toBe(false);
+    expect(result.stage).toBe('account');
+    expect(result.authRejected).toBe(true);
+  });
+
+  it('succeeds_with_zero_remote_tasks', async () => {
+    vi.mocked(fetchRemoteTaskIndex).mockResolvedValue({ index: new Map(), fetchSucceeded: true });
+
+    const result = await deleteRemoteAccountAndTasks({ throttleMs: 0 });
+
+    expect(result).toEqual({ ok: true, stage: 'done' });
+    expect(tasksDelete).not.toHaveBeenCalled();
+    expect(usersDelete).toHaveBeenCalledWith('user-123');
+  });
+
+  it('deletes_each_remote_task_exactly_once', async () => {
+    vi.mocked(fetchRemoteTaskIndex).mockResolvedValue({
+      index: indexOf('rec-a', 'rec-b', 'rec-c'),
+      fetchSucceeded: true,
+    });
+
+    await deleteRemoteAccountAndTasks({ throttleMs: 0 });
+
+    expect(tasksDelete).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/ui/delete-account-dialog.test.tsx
+++ b/tests/ui/delete-account-dialog.test.tsx
@@ -37,7 +37,7 @@ describe("DeleteAccountDialog", () => {
   const baseProps = {
     open: true,
     onOpenChange: vi.fn(),
-    onExport: vi.fn().mockResolvedValue(undefined),
+    onExport: vi.fn().mockResolvedValue(true),
     onDeleted: vi.fn(),
   };
 
@@ -101,5 +101,50 @@ describe("DeleteAccountDialog", () => {
     expect(disableSync).not.toHaveBeenCalled();
     // dialog stays open
     expect(screen.getByRole("heading", { name: /delete account/i })).toBeInTheDocument();
+  });
+
+  it("failed_export_does_not_unlock_delete_button", async () => {
+    const user = userEvent.setup();
+    const onExport = vi.fn().mockResolvedValue(false); // export failed
+    render(<DeleteAccountDialog {...baseProps} onExport={onExport} />);
+
+    await user.click(screen.getByRole("switch", { name: /export my tasks first/i }));
+    await user.type(screen.getByPlaceholderText("Type DELETE here"), "DELETE");
+    await user.click(screen.getByRole("button", { name: /export now/i }));
+
+    await waitFor(() => expect(onExport).toHaveBeenCalled());
+    // gate stays closed: export-first is on but the export failed, so no backup exists
+    expect(screen.getByRole("button", { name: /^delete account$/i })).toBeDisabled();
+  });
+
+  it("successful_export_unlocks_delete_button_without_duplicate_toast", async () => {
+    const user = userEvent.setup();
+    const onExport = vi.fn().mockResolvedValue(true); // export succeeded (parent owns the toast)
+    render(<DeleteAccountDialog {...baseProps} onExport={onExport} />);
+
+    await user.click(screen.getByRole("switch", { name: /export my tasks first/i }));
+    await user.type(screen.getByPlaceholderText("Type DELETE here"), "DELETE");
+    await user.click(screen.getByRole("button", { name: /export now/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^delete account$/i })).toBeEnabled(),
+    );
+    // the parent's handleExport already toasts; the dialog must not toast again
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("resets_confirmation_after_keep_local_success", async () => {
+    const user = userEvent.setup();
+    vi.mocked(deleteRemoteAccountAndTasks).mockResolvedValue({ ok: true, stage: "done" });
+    render(<DeleteAccountDialog {...baseProps} />);
+
+    const input = screen.getByPlaceholderText("Type DELETE here");
+    await user.type(input, "DELETE");
+    await user.click(screen.getByRole("button", { name: /^delete account$/i }));
+
+    await waitFor(() => expect(disableSync).toHaveBeenCalled());
+    // internal state must reset so a reopen isn't stuck with isDeleting/confirmText set
+    expect(input).toHaveValue("");
+    expect(screen.getByRole("button", { name: /^delete account$/i })).toBeDisabled();
   });
 });

--- a/tests/ui/delete-account-dialog.test.tsx
+++ b/tests/ui/delete-account-dialog.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DeleteAccountDialog } from "@/components/delete-account-dialog";
+import { deleteRemoteAccountAndTasks } from "@/lib/sync/pb-account-deletion";
+import { resetEverything } from "@/lib/reset-everything";
+import { disableSync } from "@/lib/sync/config";
+import { toast } from "sonner";
+
+vi.mock("@/lib/sync/pb-account-deletion", () => ({
+  deleteRemoteAccountAndTasks: vi.fn(),
+}));
+
+vi.mock("@/lib/reset-everything", () => ({
+  resetEverything: vi.fn().mockResolvedValue({
+    success: true,
+    clearedTables: [],
+    clearedLocalStorage: [],
+    errors: [],
+  }),
+  reloadAfterReset: vi.fn(),
+}));
+
+vi.mock("@/lib/sync/config", () => ({
+  disableSync: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+describe("DeleteAccountDialog", () => {
+  const baseProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    onExport: vi.fn().mockResolvedValue(undefined),
+    onDeleted: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("delete_button_disabled_until_DELETE_is_typed", async () => {
+    const user = userEvent.setup();
+    render(<DeleteAccountDialog {...baseProps} />);
+
+    const deleteBtn = screen.getByRole("button", { name: /^delete account$/i });
+    expect(deleteBtn).toBeDisabled();
+
+    await user.type(screen.getByPlaceholderText("Type DELETE here"), "DELETE");
+
+    expect(deleteBtn).toBeEnabled();
+  });
+
+  it("erase_local_checked_calls_resetEverything_on_success", async () => {
+    const user = userEvent.setup();
+    vi.mocked(deleteRemoteAccountAndTasks).mockResolvedValue({ ok: true, stage: "done" });
+    render(<DeleteAccountDialog {...baseProps} />);
+
+    await user.click(screen.getByRole("switch", { name: /erase all tasks/i }));
+    await user.type(screen.getByPlaceholderText("Type DELETE here"), "DELETE");
+    await user.click(screen.getByRole("button", { name: /^delete account$/i }));
+
+    await waitFor(() => expect(deleteRemoteAccountAndTasks).toHaveBeenCalled());
+    expect(resetEverything).toHaveBeenCalledWith({ preserveTheme: true });
+    expect(disableSync).not.toHaveBeenCalled();
+  });
+
+  it("keep_local_calls_disableSync_on_success", async () => {
+    const user = userEvent.setup();
+    vi.mocked(deleteRemoteAccountAndTasks).mockResolvedValue({ ok: true, stage: "done" });
+    render(<DeleteAccountDialog {...baseProps} />);
+
+    await user.type(screen.getByPlaceholderText("Type DELETE here"), "DELETE");
+    await user.click(screen.getByRole("button", { name: /^delete account$/i }));
+
+    await waitFor(() => expect(disableSync).toHaveBeenCalled());
+    expect(resetEverything).not.toHaveBeenCalled();
+    expect(baseProps.onDeleted).toHaveBeenCalled();
+  });
+
+  it("shows_error_toast_and_stays_open_on_remote_failure", async () => {
+    const user = userEvent.setup();
+    vi.mocked(deleteRemoteAccountAndTasks).mockResolvedValue({
+      ok: false,
+      stage: "tasks",
+      error: "network down",
+    });
+    render(<DeleteAccountDialog {...baseProps} />);
+
+    await user.type(screen.getByPlaceholderText("Type DELETE here"), "DELETE");
+    await user.click(screen.getByRole("button", { name: /^delete account$/i }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(resetEverything).not.toHaveBeenCalled();
+    expect(disableSync).not.toHaveBeenCalled();
+    // dialog stays open
+    expect(screen.getByRole("heading", { name: /delete account/i })).toBeInTheDocument();
+  });
+});

--- a/tests/ui/sync-settings-danger-zone.test.tsx
+++ b/tests/ui/sync-settings-danger-zone.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SyncSettings } from "@/components/settings/sync-settings";
+
+vi.mock("@/lib/sync/config", () => ({
+  getAutoSyncConfig: vi.fn().mockResolvedValue({ enabled: true, intervalMinutes: 2 }),
+  updateAutoSyncConfig: vi.fn().mockResolvedValue(undefined),
+  disableSync: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/sync/pb-account-deletion", () => ({
+  deleteRemoteAccountAndTasks: vi.fn(),
+}));
+
+vi.mock("@/lib/reset-everything", () => ({
+  resetEverything: vi.fn(),
+  reloadAfterReset: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock("@/lib/logger", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+describe("SyncSettings danger zone", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("opens_delete_account_dialog_from_danger_zone", async () => {
+    const user = userEvent.setup();
+    render(
+      <SyncSettings
+        onViewHistory={vi.fn()}
+        onExport={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    const trigger = await screen.findByRole("button", { name: /delete account/i });
+    await user.click(trigger);
+
+    expect(
+      screen.getByRole("heading", { name: /delete account/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/ui/sync-settings-danger-zone.test.tsx
+++ b/tests/ui/sync-settings-danger-zone.test.tsx
@@ -32,7 +32,8 @@ describe("SyncSettings danger zone", () => {
     render(
       <SyncSettings
         onViewHistory={vi.fn()}
-        onExport={vi.fn().mockResolvedValue(undefined)}
+        onExport={vi.fn().mockResolvedValue(true)}
+        onAccountDeleted={vi.fn()}
       />,
     );
 


### PR DESCRIPTION
## What & why

Adds a **Delete account** flow to the web app, mirroring the capability already shipped and tested on iOS/Mac against the same PocketBase backend (`api.vinny.io`). A signed-in user can permanently delete their cloud account and every task synced to it, with an option to also erase the local copy on this device.

Closes the web side of feature parity with the native apps.

## How it works

The flow preserves the iOS safety invariant exactly — **local data is never touched unless the remote delete fully succeeds:**

1. `refreshAuth()` → resolve the owner id (dead session → `authRejected`).
2. `fetchRemoteTaskIndex(userId)` — abort if it can't enumerate (never orphan).
3. Delete every remote task **first**, throttled 100ms (the `owner` field is `text`, not a relation, so deleting the user record does *not* cascade).
4. Delete the user record (`pb.collection('users').delete(id)`) — last, since the token dies with it.
5. Only then, in the dialog: `resetEverything({preserveTheme:true})` if "erase local" is checked, else `disableSync()` (tasks stay, local-only mode).

Uses the user's own session token — no superuser, no PocketBase server-side changes (the live iOS feature proves the `users` collection permits self-delete on this backend).

## Files

- **`lib/sync/pb-account-deletion.ts`** (new) — `deleteRemoteAccountAndTasks()`, the remote-only core returning a structured `{ ok, stage, authRejected?, error? }`.
- **`components/delete-account-dialog.tsx`** (new) — typed-`DELETE` confirmation, export-first safety net, "also erase local" toggle (default off = keep tasks on this device).
- **`components/settings/sync-settings.tsx`** — red "Danger zone" trigger, shown inside the sync section (only renders when signed in).
- **`components/settings-page/index.tsx`** — threads the existing export handler into `SyncSettings`.
- **`tasks/spec-account-deletion.md`** — the approved spec.

## Testing

- **12 new tests** (TDD, red-confirmed first): ordering invariant (tasks→account), abort-on-failure (no orphans), `authRejected` on 401/403, zero-task path, dialog routing (erase vs keep) and typed-confirm gating.
- Full suite: **1989 passed, 1 skipped** — no regressions.
- `bun typecheck`: clean. No new dependencies. Version bumped 9.10.0 → 9.11.0.
- `bun lint`: the pre-existing ESLint 10 startup crash on `main` (unrelated to this change).

### How to test locally
1. Sign in to sync with a **throwaway** Google/GitHub account (this flow is irreversible).
2. Settings → Sync → **Danger zone → Delete account…**
3. Optionally toggle export-first and "erase local", type `DELETE`, confirm.
4. Verify: cloud tasks gone in the PocketBase admin (`/_/`), user record gone, and either a clean reload (erase) or local-only tasks remaining (keep).

> ⚠️ Live end-to-end verification was intentionally **not** automated — one confirmed click permanently deletes a real account. Behavior is covered by unit tests; the dialog reuses the shipped `ResetEverythingDialog` layout/primitives.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->