### PR TITLE
fix(settings): honor export-first gate in Reset Everything dialog

### DIFF
--- a/components/reset-everything-dialog.tsx
+++ b/components/reset-everything-dialog.tsx
@@ -21,7 +21,8 @@ import { toast } from "sonner";
 interface ResetEverythingDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	onExport: () => Promise<void>;
+	/** Export tasks to a JSON backup. Resolves `true` on success, `false` on failure. */
+	onExport: () => Promise<boolean>;
 	activeTasks: number;
 	completedTasks: number;
 	syncEnabled: boolean;
@@ -57,15 +58,10 @@ export function ResetEverythingDialog({
 	const isConfirmed = confirmText === "RESET";
 	const canReset = isConfirmed && (!exportFirst || hasExported);
 
+	// onExport (the parent's handleExport) owns its own success/error toast and reports
+	// whether the backup was actually written. Only a real success unlocks the reset gate.
 	const handleExport = async () => {
-		try {
-			await onExport();
-			setHasExported(true);
-			toast.success("Tasks exported successfully");
-		} catch (err) {
-			const errorMsg = err instanceof Error ? err.message : "Export failed";
-			toast.error(errorMsg);
-		}
+		setHasExported(await onExport());
 	};
 
 	const handleReset = async () => {

--- a/components/settings-page/index.tsx
+++ b/components/settings-page/index.tsx
@@ -322,9 +322,7 @@ export function SettingsPage() {
                     completedTasks={completedTaskCount}
                     totalTasks={tasks.length}
                     estimatedSize={estimatedKb}
-                    onExport={async () => {
-                      await handleExport();
-                    }}
+                    onExport={handleExport}
                     onImportClick={handleImportClick}
                     isLoading={isExporting || tasksLoading}
                     syncEnabled={syncEnabled}

--- a/components/settings/data-management.tsx
+++ b/components/settings/data-management.tsx
@@ -10,7 +10,8 @@ interface DataManagementProps {
 	completedTasks: number;
 	totalTasks: number;
 	estimatedSize: string;
-	onExport: () => Promise<void>;
+	/** Export tasks to a JSON backup. Resolves `true` on success, `false` on failure. */
+	onExport: () => Promise<boolean>;
 	onImportClick: () => void;
 	isLoading?: boolean;
 	syncEnabled?: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.11.0",
+	"version": "9.11.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/ui/reset-everything-dialog.test.tsx
+++ b/tests/ui/reset-everything-dialog.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
 import { ResetEverythingDialog } from "@/components/reset-everything-dialog";
 
 // ---------------------------------------------------------------------------
@@ -41,7 +42,7 @@ describe("ResetEverythingDialog", () => {
   const baseProps = {
     open: true,
     onOpenChange: vi.fn(),
-    onExport: vi.fn().mockResolvedValue(undefined),
+    onExport: vi.fn().mockResolvedValue(true),
     activeTasks: 5,
     completedTasks: 3,
     syncEnabled: false,
@@ -102,5 +103,34 @@ describe("ResetEverythingDialog", () => {
     await user.type(input, "RESET");
 
     expect(resetBtn).toBeEnabled();
+  });
+
+  it("failed export does not unlock the reset button", async () => {
+    const user = userEvent.setup();
+    const onExport = vi.fn().mockResolvedValue(false); // export failed
+    render(<ResetEverythingDialog {...baseProps} onExport={onExport} />);
+
+    await user.click(screen.getByRole("switch", { name: /export my data first/i }));
+    await user.type(screen.getByPlaceholderText("Type RESET here"), "RESET");
+    await user.click(screen.getByRole("button", { name: /export now/i }));
+
+    await waitFor(() => expect(onExport).toHaveBeenCalled());
+    // gate stays closed: export-first is on but the backup failed
+    expect(screen.getByRole("button", { name: /reset everything/i })).toBeDisabled();
+  });
+
+  it("successful export unlocks reset without a duplicate toast", async () => {
+    const user = userEvent.setup();
+    const onExport = vi.fn().mockResolvedValue(true); // parent owns the success toast
+    render(<ResetEverythingDialog {...baseProps} onExport={onExport} />);
+
+    await user.click(screen.getByRole("switch", { name: /export my data first/i }));
+    await user.type(screen.getByPlaceholderText("Type RESET here"), "RESET");
+    await user.click(screen.getByRole("button", { name: /export now/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /reset everything/i })).toBeEnabled(),
+    );
+    expect(toast.success).not.toHaveBeenCalled();
   });
 });

--- a/tests/ui/settings-components.test.tsx
+++ b/tests/ui/settings-components.test.tsx
@@ -373,7 +373,7 @@ describe('Settings Components', () => {
       completedTasks: 3,
       totalTasks: 8,
       estimatedSize: '1.2',
-      onExport: vi.fn().mockResolvedValue(undefined),
+      onExport: vi.fn().mockResolvedValue(true),
       onImportClick: vi.fn(),
     };
 
@@ -396,7 +396,7 @@ describe('Settings Components', () => {
     });
 
     it('clicking Export tasks calls onExport', () => {
-      const onExport = vi.fn().mockResolvedValue(undefined);
+      const onExport = vi.fn().mockResolvedValue(true);
       render(<DataManagement {...defaultProps} onExport={onExport} />);
       fireEvent.click(screen.getByText('Export tasks'));
       expect(onExport).toHaveBeenCalled();


### PR DESCRIPTION
## What & why

Follow-up to #361. The `ResetEverythingDialog` carries the **same export-first gate bug** that #361 fixed for the delete-account dialog — it was just out of scope there.

`ResetEverythingDialog.handleExport` ran `setHasExported(true)` **unconditionally** and emitted its own success toast. Because the parent's `handleExport` swallows errors, a **failed** export still unlocked the destructive "Reset Everything" button with no backup, and a **successful** export produced two toasts (parent's "Tasks exported" + dialog's "Tasks exported successfully").

## How

Since #361, `handleExport` already returns whether the backup was actually written (`Promise<boolean>`). This PR threads that boolean the rest of the way:

- `ResetEverythingDialog.handleExport` → `setHasExported(await onExport())`, and drops its own toast (the parent owns it). The reset button now gates on a **real** export success.
- Widen `DataManagement.onExport` to `() => Promise<boolean>` so the result reaches the dialog.
- Remove the void adapter `settings-page` added in #361 to shield these components — no longer needed now that they honor the boolean.

No behavior change for the happy path beyond removing the redundant toast; the fix is that a *failed* export no longer unlocks the gate.

## Testing

- **+2 tests** (TDD, red-confirmed): failed export keeps "Reset Everything" disabled; successful export unlocks it without a duplicate toast.
- Full suite: **1994 passed, 1 skipped**. Typecheck clean. Version bumped 9.11.0 → 9.11.1.

### How to test locally
Settings → Data & Storage → Reset Everything → toggle "Export my data first" → with a forced export failure the Reset button stays disabled; on success it enables and only one "exported" toast appears.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->