### PR TITLE
chore: set up Cursor Cloud dev environment

### DIFF
--- a/.claude/hooks/no-main-commits.sh
+++ b/.claude/hooks/no-main-commits.sh
@@ -6,6 +6,15 @@ set -uo pipefail
 
 input="$(cat)"
 
+# Only act on actual `git commit` commands. The matcher `if` in settings.json is
+# meant to scope this hook to commits, but not all runners honor it — so we also
+# inspect the command here to avoid blocking unrelated Bash (e.g. branch creation).
+command="$(printf '%s' "$input" | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d);process.stdout.write(j.tool_input?.command||'')}catch(e){}})")"
+case "$command" in
+  *"git commit"*) ;;
+  *) exit 0 ;;
+esac
+
 cwd="$(printf '%s' "$input" | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{const j=JSON.parse(d);process.stdout.write(j.cwd||'')}catch(e){}})")"
 [ -z "$cwd" ] && cwd="$(pwd)"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+Operating notes for AI agents working in this repository. General project
+guidance, architecture, and the canonical command list live in `CLAUDE.md` and
+`coding-standards.md` — read those first. This file only adds Cursor Cloud
+environment caveats.
+
+## Cursor Cloud specific instructions
+
+**Runtime / package manager.** This project uses **Bun** (lockfile `bun.lock`,
+Bun workspaces include `packages/*`). Bun is installed by the startup update
+script (it is not on the base image) and is on `PATH` via `~/.bashrc`. The
+standard dev/test/build commands are documented in `CLAUDE.md` (`bun dev`,
+`bun run test`, `bun typecheck`, `bun lint`, `bun run build`). Use `bun run test`
+(not `bun test`, which invokes Bun's own runner instead of Vitest).
+
+**Dev server.** `bun dev` serves at http://localhost:3000. The app is 100%
+client-side (every component is `"use client"`; no SSR/API routes; static
+export). On first load the root URL redirects to `/about` (onboarding); enter the
+matrix via the onboarding "Open App" CTA. All data lives in the browser's
+IndexedDB (Dexie), so a fresh browser profile starts empty — there is no backend
+to seed for basic task CRUD.
+
+**Optional backend (PocketBase) is NOT required for local dev.** Cloud sync,
+realtime SSE, OAuth, and the `packages/mcp-server` workspace only matter when a
+PocketBase instance is reachable (`NEXT_PUBLIC_POCKETBASE_URL`, defaults to
+`http://127.0.0.1:8090` on localhost). The core product runs and is testable
+fully local-only without it.
+
+**`bun lint` is currently broken on `main` (pre-existing, also red in CI).**
+`@typescript-eslint/utils@8.53.1` references ESLint's removed `FlatESLint`
+export, so ESLint 10 throws `Class extends value undefined`. This is a repo
+dependency issue, not an environment setup problem — do not try to fix it as
+part of environment work. `bun typecheck`, `bun run test`, and `bun run build`
+all pass.
+
+**Build is self-contained.** `bun run build` first runs
+`scripts/generate-build-info.cjs`, which generates the gitignored `.build-env.sh`
+that the build then sources — so a missing `.build-env.sh` is normal and the
+build does not need any manual setup. CI builds with `NEXT_DISABLE_SWC_BINARY=1`
+and a writable `NEXT_CACHE_DIR`; mirror that if a build behaves oddly.
+
+**Generated files to leave uncommitted.** `next dev`/`next build` rewrite
+`next-env.d.ts` (toggling `.next/types` vs `.next/dev/types`) and bump
+`lib/build-info.json` / the service-worker version. Revert these unless the
+change is intentional.
+
+**Verifying frontend changes.** The PWA service worker can serve stale JS chunks
+and data surfaces render empty on a fresh load — use the `verify-frontend-change`
+skill rather than a naive screenshot (see `CLAUDE.md`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the GSD Task Manager (Next.js 16 / React 19 PWA, Bun + Vitest + Playwright) so Cursor Cloud agents can install, test, build, and run the app.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting durable, non-obvious caveats (Bun runtime, client-only app, optional PocketBase backend, build self-generates `.build-env.sh`, generated files to leave uncommitted, and the pre-existing `bun lint` breakage).
- Fixes `.claude/hooks/no-main-commits.sh` so it only blocks actual `git commit` commands. The hook relied on the `settings.json` matcher `if: "Bash(git commit*)"`, but that gate is not honored by all hook runners, so on `main` it blocked **every** Bash command (even `git checkout -b`), creating a catch-22 that prevented the required branch workflow. The protection (no commits on `main`) is preserved.

The configured startup update script installs Bun (if missing) and runs `bun install`.

## Verification

| Check | Command | Result |
|---|---|---|
| Typecheck | `bun typecheck` | ✅ pass |
| Tests | `bun run test` | ✅ 1987 passed, 1 skipped |
| Build | `bun run build` | ✅ static export of 8 routes |
| Dev server | `bun dev` | ✅ ready at :3000, HTTP 200 |
| Lint | `bun lint` | ⚠️ pre-existing failure (also red in CI on `main`): `@typescript-eslint/utils@8.53.1` references ESLint's removed `FlatESLint` export — repo dependency issue, not an environment problem |

### Hello-world demo

Created a task in the running app and confirmed it renders in the Eisenhower matrix ("Do First" quadrant), exercising core CRUD + IndexedDB persistence.

[gsd_create_task_demo.mp4](https://cursor.com/agents/bc-e9ee6b7a-3e0a-4648-b396-a8f406eca1e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgsd_create_task_demo.mp4)

[Task created in Do First quadrant](https://cursor.com/agents/bc-e9ee6b7a-3e0a-4648-b396-a8f406eca1e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgsd_task_created.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9ee6b7a-3e0a-4648-b396-a8f406eca1e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9ee6b7a-3e0a-4648-b396-a8f406eca1e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

