### PR TITLE
refactor(matrix): split 554-line MatrixSimplified into hooks + helper

### DIFF
--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -5,7 +5,6 @@ import { DndContext, DragOverlay } from "@dnd-kit/core";
 import { createTask, toggleCompleted, updateTask, deleteTask, restoreTask } from "@/lib/tasks";
 import { celebrateCompletion } from "@/lib/confetti";
 import { extractUrlsFromTitle, buildDescription } from "@/lib/capture-parser";
-import { parseShareCaptureParams } from "@/lib/share-capture";
 import { toast } from "sonner";
 import { useTasks } from "@/lib/use-tasks";
 import { useErrorHandlerWithUndo } from "@/lib/use-error-handler";
@@ -13,25 +12,11 @@ import { useDragAndDrop } from "@/lib/use-drag-and-drop";
 import { useAutoArchive } from "@/lib/use-auto-archive";
 import { useNotificationChecker } from "@/lib/use-notification-checker";
 import { TOAST_DURATION } from "@/lib/constants";
-import { applyFilters, type SmartView } from "@/lib/filters";
 import {
   SHOW_COMPLETED_EVENT,
   type ShowCompletedEventDetail,
   readShowCompleted,
 } from "@/lib/preferences/show-completed";
-import {
-  APPLY_SMART_VIEW_EVENT,
-  HIGHLIGHT_TASK_EVENT,
-  NEW_TASK_EVENT,
-  type ApplySmartViewEventDetail,
-} from "@/lib/use-shell-command-handlers";
-import {
-  APP_PREFERENCES_EVENT,
-  getAppPreferences,
-  getSmartView,
-  getSmartViews,
-  type AppPreferencesEventDetail,
-} from "@/lib/smart-views";
 import type { TaskRecord } from "@/lib/types";
 import { quadrantByRdKey, type RedesignQuadrantKey } from "@/lib/quadrants";
 import { TaskCard } from "@/components/task-card";
@@ -41,28 +26,10 @@ import { CaptureBar, type CapturePayload } from "./capture-bar";
 import { MatrixGrid } from "./matrix-grid";
 import { EditDrawer, type EditDraft } from "./edit-drawer";
 import { SmartViewStrip } from "./smart-view-strip";
-
-function isEditable(el: Element | null): boolean {
-  if (!(el instanceof HTMLElement)) return false;
-  const t = el.tagName;
-  return t === "INPUT" || t === "TEXTAREA" || el.isContentEditable;
-}
-
-function filterTasks(tasks: TaskRecord[], trimmedQuery: string): TaskRecord[] {
-  if (!trimmedQuery) return tasks;
-  const q = trimmedQuery.toLowerCase();
-  return tasks.filter((t) => {
-    const hay = [
-      t.title,
-      t.description ?? "",
-      (t.tags ?? []).join(" "),
-      (t.subtasks ?? []).map((s) => s.title).join(" "),
-    ]
-      .join(" ")
-      .toLowerCase();
-    return hay.includes(q);
-  });
-}
+import { deriveMatrixView } from "./matrix-view";
+import { useSmartViews } from "./use-smart-views";
+import { useTaskHighlight } from "./use-task-highlight";
+import { useMatrixWindowEvents } from "./use-matrix-window-events";
 
 export function MatrixSimplified() {
   const { all } = useTasks();
@@ -81,71 +48,16 @@ export function MatrixSimplified() {
   const [createInitial, setCreateInitial] = useState<Partial<EditDraft> | undefined>(undefined);
   const [mounted, setMounted] = useState(false);
   const [showCompleted, setShowCompleted] = useState(false);
-  const [smartViewsEnabled, setSmartViewsEnabled] = useState(false);
-  const [smartViews, setSmartViews] = useState<SmartView[]>([]);
-  const [activeSmartView, setActiveSmartView] = useState<SmartView | null>(null);
   const [sharingTask, setSharingTask] = useState<TaskRecord | null>(null);
-  const [highlightedTaskId, setHighlightedTaskId] = useState<string | null>(null);
-  const taskRefs = useRef(new Map<string, HTMLElement>());
-  const clearHighlightTimerRef = useRef<number | null>(null);
+
+  const clearSearch = useCallback(() => setSearchQuery(""), []);
+  const { smartViewsEnabled, smartViews, activeSmartView, applySmartViewById, clearSmartView } =
+    useSmartViews(clearSearch);
 
   useEffect(() => {
     setMounted(true); // eslint-disable-line react-hooks/set-state-in-effect -- canonical SSR-safe pattern for static export
     setShowCompleted(readShowCompleted());
   }, []);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const loadSmartViewPreference = async () => {
-      const preferences = await getAppPreferences();
-      if (!cancelled) {
-        setSmartViewsEnabled(preferences.smartViewsEnabled);
-      }
-    };
-
-    loadSmartViewPreference().catch(() => {
-      if (!cancelled) {
-        setSmartViewsEnabled(false);
-      }
-    });
-
-    const onPreferencesChange = (event: Event) => {
-      const preferences = (event as CustomEvent<AppPreferencesEventDetail>).detail?.preferences;
-      if (!preferences) return;
-      setSmartViewsEnabled(preferences.smartViewsEnabled);
-      if (!preferences.smartViewsEnabled) {
-        setActiveSmartView(null);
-      }
-    };
-
-    window.addEventListener(APP_PREFERENCES_EVENT, onPreferencesChange);
-    return () => {
-      cancelled = true;
-      window.removeEventListener(APP_PREFERENCES_EVENT, onPreferencesChange);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!smartViewsEnabled) return;
-
-    let cancelled = false;
-    getSmartViews()
-      .then((views) => {
-        if (!cancelled) {
-          setSmartViews(views);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setSmartViews([]);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [smartViewsEnabled]);
 
   useEffect(() => {
     const handler = (e: Event) => {
@@ -156,144 +68,15 @@ export function MatrixSimplified() {
     return () => window.removeEventListener(SHOW_COMPLETED_EVENT, handler);
   }, []);
 
-  // URL-driven actions: PWA shortcut focuses the capture bar; bookmarklet
-  // (`?action=capture&title=…&url=…&tags=…`) materializes a task in the
-  // Eliminate quadrant. Both clean their params off the URL afterward.
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const action = params.get("action");
-    if (!action) return;
+  const { visibleTasks, total, completed, overdue } = useMemo(
+    () => deriveMatrixView({ all, showCompleted, smartViewsEnabled, activeSmartView, searchQuery }),
+    [activeSmartView, all, showCompleted, smartViewsEnabled, searchQuery]
+  );
 
-    if (action === "new-task") {
-      setTimeout(() => captureInputRef.current?.focus(), 50);
-    } else if (action === "capture") {
-      const draft = parseShareCaptureParams(params);
-      if (draft) {
-        createTask(draft)
-          .then(() => toast.success("Task captured", { duration: TOAST_DURATION.SHORT }))
-          .catch(() => toast.error("Failed to capture task", { duration: TOAST_DURATION.LONG }));
-      }
-    } else {
-      return;
-    }
-
-    ["action", "title", "url", "tags"].forEach((k) => params.delete(k));
-    const next = params.toString();
-    window.history.replaceState({}, "", `${window.location.pathname}${next ? `?${next}` : ""}`);
-  }, []);
-
-  // Global "/" focuses search; "n" handled by CaptureBar; "?" opens help
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (isEditable(document.activeElement) || e.metaKey || e.ctrlKey || e.altKey) return;
-      if (e.key === "/") {
-        e.preventDefault();
-        searchInputRef.current?.focus();
-      } else if (e.key === "?") {
-        e.preventDefault();
-        window.dispatchEvent(new CustomEvent("gsd:open-help"));
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, []);
-
-  const handleTaskRef = useCallback((taskId: string, element: HTMLElement | null) => {
-    if (element) {
-      taskRefs.current.set(taskId, element);
-    } else {
-      taskRefs.current.delete(taskId);
-    }
-  }, []);
-
-  const scrollTaskIntoView = useCallback((taskId: string) => {
-    const node = taskRefs.current.get(taskId);
-    if (!node) return;
-
-    const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
-    node.scrollIntoView({
-      block: "center",
-      behavior: reduceMotion ? "auto" : "smooth",
-    });
-    node.focus({ preventScroll: true });
-  }, []);
-
-  const highlightTaskById = useCallback((taskId: string) => {
-    if (!taskId) return;
-
-    setSearchQuery("");
-    setHighlightedTaskId(taskId);
-
-    if (clearHighlightTimerRef.current) {
-      window.clearTimeout(clearHighlightTimerRef.current);
-    }
-    clearHighlightTimerRef.current = window.setTimeout(() => {
-      setHighlightedTaskId((current) => (current === taskId ? null : current));
-      clearHighlightTimerRef.current = null;
-    }, 3500);
-  }, []);
-
-  const applySmartViewById = useCallback(async (viewId: string) => {
-    const view = await getSmartView(viewId);
-    if (!view) {
-      toast.error("Smart view not found", { duration: TOAST_DURATION.SHORT });
-      return;
-    }
-    setSearchQuery("");
-    setActiveSmartView(view);
-  }, []);
-
-  const handleClearSmartView = useCallback(() => {
-    setActiveSmartView(null);
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (clearHighlightTimerRef.current) {
-        window.clearTimeout(clearHighlightTimerRef.current);
-      }
-    };
-  }, []);
-
-  const trimmedSearchQuery = searchQuery.trim();
-  const { visibleTasks, total, completed, overdue } = useMemo(() => {
-    const todayIso = new Date().toISOString().slice(0, 10);
-    let completedCount = 0;
-    let overdueCount = 0;
-    const activeTasks: TaskRecord[] = [];
-
-    for (const task of all) {
-      if (task.completed) {
-        completedCount += 1;
-      } else {
-        activeTasks.push(task);
-        if (task.dueDate && task.dueDate < todayIso) {
-          overdueCount += 1;
-        }
-      }
-    }
-
-    const effectiveSmartView = smartViewsEnabled ? activeSmartView : null;
-    const base = effectiveSmartView ? all : showCompleted ? all : activeTasks;
-    const smartViewTasks = effectiveSmartView
-      ? applyFilters(base, effectiveSmartView.criteria, all)
-      : base;
-    return {
-      visibleTasks: filterTasks(smartViewTasks, trimmedSearchQuery),
-      total: all.length,
-      completed: completedCount,
-      overdue: overdueCount,
-    };
-  }, [activeSmartView, all, showCompleted, smartViewsEnabled, trimmedSearchQuery]);
-
-  useEffect(() => {
-    if (!highlightedTaskId) return;
-
-    const frame = window.requestAnimationFrame(() => {
-      scrollTaskIntoView(highlightedTaskId);
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [highlightedTaskId, scrollTaskIntoView, visibleTasks]);
+  const { highlightedTaskId, handleTaskRef, highlightTaskById } = useTaskHighlight(
+    visibleTasks,
+    clearSearch
+  );
 
   const handleCapture = useCallback(
     async ({ title, urgent, important, tags }: CapturePayload) => {
@@ -373,53 +156,13 @@ export function MatrixSimplified() {
     setCreateDrawerOpen(true);
   }, []);
 
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const taskId = params.get("highlight");
-    const smartViewId = params.get("smartView");
-    if (!taskId && !smartViewId) return;
-
-    const frame = window.requestAnimationFrame(() => {
-      if (taskId) {
-        highlightTaskById(taskId);
-      }
-      if (smartViewId) {
-        void applySmartViewById(smartViewId);
-      }
-    });
-    params.delete("highlight");
-    params.delete("smartView");
-    const next = params.toString();
-    window.history.replaceState({}, "", `${window.location.pathname}${next ? `?${next}` : ""}`);
-    return () => window.cancelAnimationFrame(frame);
-  }, [applySmartViewById, highlightTaskById]);
-
-  useEffect(() => {
-    const openNewTask = () => handleOpenCreateDrawer();
-    const highlightTask = (event: Event) => {
-      const taskId = (event as CustomEvent<{ taskId?: string }>).detail?.taskId;
-      if (taskId) {
-        highlightTaskById(taskId);
-      }
-    };
-    const applySmartView = (event: Event) => {
-      const viewId = (event as CustomEvent<ApplySmartViewEventDetail>).detail?.viewId;
-      if (viewId) {
-        void applySmartViewById(viewId);
-      }
-    };
-
-    window.addEventListener(NEW_TASK_EVENT, openNewTask);
-    window.addEventListener(HIGHLIGHT_TASK_EVENT, highlightTask);
-    window.addEventListener(APPLY_SMART_VIEW_EVENT, applySmartView);
-    window.addEventListener("highlightTask", highlightTask);
-    return () => {
-      window.removeEventListener(NEW_TASK_EVENT, openNewTask);
-      window.removeEventListener(HIGHLIGHT_TASK_EVENT, highlightTask);
-      window.removeEventListener(APPLY_SMART_VIEW_EVENT, applySmartView);
-      window.removeEventListener("highlightTask", highlightTask);
-    };
-  }, [applySmartViewById, handleOpenCreateDrawer, highlightTaskById]);
+  useMatrixWindowEvents({
+    searchInputRef,
+    captureInputRef,
+    openCreateDrawer: handleOpenCreateDrawer,
+    highlightTaskById,
+    applySmartViewById,
+  });
 
   const handleCreateClose = useCallback(() => {
     setCreateDrawerOpen(false);
@@ -498,7 +241,7 @@ export function MatrixSimplified() {
                 views={smartViews}
                 activeViewId={activeSmartView?.id}
                 onSelectView={applySmartViewById}
-                onClearView={handleClearSmartView}
+                onClearView={clearSmartView}
               />
             </div>
           ) : null}

--- a/components/matrix-simplified/matrix-view.ts
+++ b/components/matrix-simplified/matrix-view.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure data derivation for the matrix view.
+ *
+ * Extracted from the MatrixSimplified component so the "which tasks are visible
+ * and what are the header counts" logic can be unit-tested in isolation and the
+ * component stays focused on wiring/rendering.
+ */
+
+import { applyFilters, type SmartView } from "@/lib/filters";
+import type { TaskRecord } from "@/lib/types";
+
+/** Case-insensitive search across title, description, tags, and subtasks. */
+export function filterTasks(tasks: TaskRecord[], query: string): TaskRecord[] {
+  const trimmed = query.trim();
+  if (!trimmed) return tasks;
+  const q = trimmed.toLowerCase();
+  return tasks.filter((t) => {
+    const hay = [
+      t.title,
+      t.description ?? "",
+      (t.tags ?? []).join(" "),
+      (t.subtasks ?? []).map((s) => s.title).join(" "),
+    ]
+      .join(" ")
+      .toLowerCase();
+    return hay.includes(q);
+  });
+}
+
+export interface MatrixViewInput {
+  all: TaskRecord[];
+  showCompleted: boolean;
+  smartViewsEnabled: boolean;
+  activeSmartView: SmartView | null;
+  searchQuery: string;
+}
+
+export interface MatrixView {
+  visibleTasks: TaskRecord[];
+  total: number;
+  completed: number;
+  overdue: number;
+}
+
+/**
+ * Derive the visible task list and header counts.
+ *
+ * Base set: an active smart view (when the feature is enabled) filters the full
+ * task set; otherwise the base is all tasks when "show completed" is on, or just
+ * the active (incomplete) tasks. The search query is applied last.
+ */
+export function deriveMatrixView({
+  all,
+  showCompleted,
+  smartViewsEnabled,
+  activeSmartView,
+  searchQuery,
+}: MatrixViewInput): MatrixView {
+  const todayIso = new Date().toISOString().slice(0, 10);
+  let completed = 0;
+  let overdue = 0;
+  const activeTasks: TaskRecord[] = [];
+
+  for (const task of all) {
+    if (task.completed) {
+      completed += 1;
+    } else {
+      activeTasks.push(task);
+      if (task.dueDate && task.dueDate < todayIso) {
+        overdue += 1;
+      }
+    }
+  }
+
+  const effectiveSmartView = smartViewsEnabled ? activeSmartView : null;
+  const base = effectiveSmartView ? all : showCompleted ? all : activeTasks;
+  const smartViewTasks = effectiveSmartView
+    ? applyFilters(base, effectiveSmartView.criteria, all)
+    : base;
+
+  return {
+    visibleTasks: filterTasks(smartViewTasks, searchQuery),
+    total: all.length,
+    completed,
+    overdue,
+  };
+}

--- a/components/matrix-simplified/use-matrix-window-events.ts
+++ b/components/matrix-simplified/use-matrix-window-events.ts
@@ -1,0 +1,132 @@
+/**
+ * Wires window/URL inputs to matrix actions: global keyboard shortcuts, the
+ * PWA/bookmarklet URL action params, deep-link highlight/smart-view params, and
+ * shell command events. Extracted from MatrixSimplified so the component body
+ * isn't dominated by event-subscription boilerplate.
+ */
+
+import { useEffect, type RefObject } from "react";
+import { toast } from "sonner";
+import { createTask } from "@/lib/tasks";
+import { parseShareCaptureParams } from "@/lib/share-capture";
+import { TOAST_DURATION } from "@/lib/constants";
+import {
+  APPLY_SMART_VIEW_EVENT,
+  HIGHLIGHT_TASK_EVENT,
+  NEW_TASK_EVENT,
+  type ApplySmartViewEventDetail,
+} from "@/lib/use-shell-command-handlers";
+
+function isEditable(el: Element | null): boolean {
+  if (!(el instanceof HTMLElement)) return false;
+  const t = el.tagName;
+  return t === "INPUT" || t === "TEXTAREA" || el.isContentEditable;
+}
+
+export interface MatrixWindowEventsDeps {
+  searchInputRef: RefObject<HTMLInputElement | null>;
+  captureInputRef: RefObject<HTMLInputElement | null>;
+  openCreateDrawer: () => void;
+  highlightTaskById: (taskId: string) => void;
+  applySmartViewById: (viewId: string) => Promise<void>;
+}
+
+export function useMatrixWindowEvents({
+  searchInputRef,
+  captureInputRef,
+  openCreateDrawer,
+  highlightTaskById,
+  applySmartViewById,
+}: MatrixWindowEventsDeps): void {
+  // URL-driven actions: PWA shortcut focuses the capture bar; bookmarklet
+  // (`?action=capture&title=…&url=…&tags=…`) materializes a task in the
+  // Eliminate quadrant. Both clean their params off the URL afterward.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const action = params.get("action");
+    if (!action) return;
+
+    if (action === "new-task") {
+      setTimeout(() => captureInputRef.current?.focus(), 50);
+    } else if (action === "capture") {
+      const draft = parseShareCaptureParams(params);
+      if (draft) {
+        createTask(draft)
+          .then(() => toast.success("Task captured", { duration: TOAST_DURATION.SHORT }))
+          .catch(() => toast.error("Failed to capture task", { duration: TOAST_DURATION.LONG }));
+      }
+    } else {
+      return;
+    }
+
+    ["action", "title", "url", "tags"].forEach((k) => params.delete(k));
+    const next = params.toString();
+    window.history.replaceState({}, "", `${window.location.pathname}${next ? `?${next}` : ""}`);
+  }, [captureInputRef]);
+
+  // Global "/" focuses search; "n" handled by CaptureBar; "?" opens help
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (isEditable(document.activeElement) || e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key === "/") {
+        e.preventDefault();
+        searchInputRef.current?.focus();
+      } else if (e.key === "?") {
+        e.preventDefault();
+        window.dispatchEvent(new CustomEvent("gsd:open-help"));
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [searchInputRef]);
+
+  // Deep-link params: ?highlight=<taskId> and ?smartView=<viewId>.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const taskId = params.get("highlight");
+    const smartViewId = params.get("smartView");
+    if (!taskId && !smartViewId) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      if (taskId) {
+        highlightTaskById(taskId);
+      }
+      if (smartViewId) {
+        void applySmartViewById(smartViewId);
+      }
+    });
+    params.delete("highlight");
+    params.delete("smartView");
+    const next = params.toString();
+    window.history.replaceState({}, "", `${window.location.pathname}${next ? `?${next}` : ""}`);
+    return () => window.cancelAnimationFrame(frame);
+  }, [applySmartViewById, highlightTaskById]);
+
+  // Shell command events (⌘K palette, etc.).
+  useEffect(() => {
+    const openNewTask = () => openCreateDrawer();
+    const highlightTask = (event: Event) => {
+      const taskId = (event as CustomEvent<{ taskId?: string }>).detail?.taskId;
+      if (taskId) {
+        highlightTaskById(taskId);
+      }
+    };
+    const applySmartView = (event: Event) => {
+      const viewId = (event as CustomEvent<ApplySmartViewEventDetail>).detail?.viewId;
+      if (viewId) {
+        void applySmartViewById(viewId);
+      }
+    };
+
+    window.addEventListener(NEW_TASK_EVENT, openNewTask);
+    window.addEventListener(HIGHLIGHT_TASK_EVENT, highlightTask);
+    window.addEventListener(APPLY_SMART_VIEW_EVENT, applySmartView);
+    window.addEventListener("highlightTask", highlightTask);
+    return () => {
+      window.removeEventListener(NEW_TASK_EVENT, openNewTask);
+      window.removeEventListener(HIGHLIGHT_TASK_EVENT, highlightTask);
+      window.removeEventListener(APPLY_SMART_VIEW_EVENT, applySmartView);
+      window.removeEventListener("highlightTask", highlightTask);
+    };
+  }, [applySmartViewById, highlightTaskById, openCreateDrawer]);
+}

--- a/components/matrix-simplified/use-smart-views.ts
+++ b/components/matrix-simplified/use-smart-views.ts
@@ -1,0 +1,107 @@
+/**
+ * Smart-view state for the matrix: whether the feature is enabled, the loaded
+ * views, the active view, and apply/clear actions. Extracted from
+ * MatrixSimplified to keep the component focused.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { TOAST_DURATION } from "@/lib/constants";
+import { type SmartView } from "@/lib/filters";
+import {
+  APP_PREFERENCES_EVENT,
+  getAppPreferences,
+  getSmartView,
+  getSmartViews,
+  type AppPreferencesEventDetail,
+} from "@/lib/smart-views";
+
+export interface SmartViewsState {
+  smartViewsEnabled: boolean;
+  smartViews: SmartView[];
+  activeSmartView: SmartView | null;
+  applySmartViewById: (viewId: string) => Promise<void>;
+  clearSmartView: () => void;
+}
+
+/**
+ * @param clearSearch invoked when a smart view is applied, so applying a view
+ *   also clears any active search (matching the matrix's existing behavior).
+ */
+export function useSmartViews(clearSearch: () => void): SmartViewsState {
+  const [smartViewsEnabled, setSmartViewsEnabled] = useState(false);
+  const [smartViews, setSmartViews] = useState<SmartView[]>([]);
+  const [activeSmartView, setActiveSmartView] = useState<SmartView | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadSmartViewPreference = async () => {
+      const preferences = await getAppPreferences();
+      if (!cancelled) {
+        setSmartViewsEnabled(preferences.smartViewsEnabled);
+      }
+    };
+
+    loadSmartViewPreference().catch(() => {
+      if (!cancelled) {
+        setSmartViewsEnabled(false);
+      }
+    });
+
+    const onPreferencesChange = (event: Event) => {
+      const preferences = (event as CustomEvent<AppPreferencesEventDetail>).detail?.preferences;
+      if (!preferences) return;
+      setSmartViewsEnabled(preferences.smartViewsEnabled);
+      if (!preferences.smartViewsEnabled) {
+        setActiveSmartView(null);
+      }
+    };
+
+    window.addEventListener(APP_PREFERENCES_EVENT, onPreferencesChange);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(APP_PREFERENCES_EVENT, onPreferencesChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!smartViewsEnabled) return;
+
+    let cancelled = false;
+    getSmartViews()
+      .then((views) => {
+        if (!cancelled) {
+          setSmartViews(views);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSmartViews([]);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [smartViewsEnabled]);
+
+  const applySmartViewById = useCallback(
+    async (viewId: string) => {
+      const view = await getSmartView(viewId);
+      if (!view) {
+        toast.error("Smart view not found", { duration: TOAST_DURATION.SHORT });
+        return;
+      }
+      clearSearch();
+      setActiveSmartView(view);
+    },
+    [clearSearch]
+  );
+
+  const clearSmartView = useCallback(() => {
+    setActiveSmartView(null);
+  }, []);
+
+  return { smartViewsEnabled, smartViews, activeSmartView, applySmartViewById, clearSmartView };
+}

--- a/components/matrix-simplified/use-task-highlight.ts
+++ b/components/matrix-simplified/use-task-highlight.ts
@@ -1,0 +1,89 @@
+/**
+ * Transient "highlight + scroll to" behavior for a single task — used when a
+ * deep link or shell command points at a specific task. Extracted from
+ * MatrixSimplified so the ref-tracking and timer lifecycle live in one place.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { TaskRecord } from "@/lib/types";
+
+/** How long a task stays visually highlighted after being targeted. */
+const HIGHLIGHT_DURATION_MS = 3500;
+
+export interface TaskHighlight {
+  highlightedTaskId: string | null;
+  handleTaskRef: (taskId: string, element: HTMLElement | null) => void;
+  highlightTaskById: (taskId: string) => void;
+}
+
+/**
+ * @param visibleTasks re-triggers the scroll once the targeted task has
+ *   (re)rendered into the list.
+ * @param clearSearch clears any active search so the highlighted task is not
+ *   hidden by a stale filter (matches the matrix's existing behavior).
+ */
+export function useTaskHighlight(
+  visibleTasks: TaskRecord[],
+  clearSearch: () => void
+): TaskHighlight {
+  const [highlightedTaskId, setHighlightedTaskId] = useState<string | null>(null);
+  const taskRefs = useRef(new Map<string, HTMLElement>());
+  const clearHighlightTimerRef = useRef<number | null>(null);
+
+  const handleTaskRef = useCallback((taskId: string, element: HTMLElement | null) => {
+    if (element) {
+      taskRefs.current.set(taskId, element);
+    } else {
+      taskRefs.current.delete(taskId);
+    }
+  }, []);
+
+  const scrollTaskIntoView = useCallback((taskId: string) => {
+    const node = taskRefs.current.get(taskId);
+    if (!node) return;
+
+    const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    node.scrollIntoView({
+      block: "center",
+      behavior: reduceMotion ? "auto" : "smooth",
+    });
+    node.focus({ preventScroll: true });
+  }, []);
+
+  const highlightTaskById = useCallback(
+    (taskId: string) => {
+      if (!taskId) return;
+
+      clearSearch();
+      setHighlightedTaskId(taskId);
+
+      if (clearHighlightTimerRef.current) {
+        window.clearTimeout(clearHighlightTimerRef.current);
+      }
+      clearHighlightTimerRef.current = window.setTimeout(() => {
+        setHighlightedTaskId((current) => (current === taskId ? null : current));
+        clearHighlightTimerRef.current = null;
+      }, HIGHLIGHT_DURATION_MS);
+    },
+    [clearSearch]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (clearHighlightTimerRef.current) {
+        window.clearTimeout(clearHighlightTimerRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!highlightedTaskId) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      scrollTaskIntoView(highlightedTaskId);
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [highlightedTaskId, scrollTaskIntoView, visibleTasks]);
+
+  return { highlightedTaskId, handleTaskRef, highlightTaskById };
+}

--- a/tests/data/matrix-view.test.ts
+++ b/tests/data/matrix-view.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { deriveMatrixView, filterTasks } from "@/components/matrix-simplified/matrix-view";
+import type { TaskRecord } from "@/lib/types";
+import type { SmartView } from "@/lib/filters";
+
+function makeTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    id: overrides.id ?? `task-${Math.random().toString(36).slice(2)}`,
+    title: "Task",
+    description: "",
+    urgent: false,
+    important: false,
+    quadrant: "not-urgent-not-important",
+    completed: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    recurrence: "none",
+    tags: [],
+    subtasks: [],
+    dependencies: [],
+    notificationEnabled: false,
+    notificationSent: false,
+    ...overrides,
+  };
+}
+
+const completedView: SmartView = {
+  id: "built-in-completed",
+  name: "All Completed",
+  icon: "✅",
+  criteria: { status: "completed" },
+  isBuiltIn: true,
+  createdAt: "2025-01-01T00:00:00.000Z",
+  updatedAt: "2025-01-01T00:00:00.000Z",
+};
+
+describe("filterTasks", () => {
+  it("returns all tasks for an empty query", () => {
+    const tasks = [makeTask(), makeTask()];
+    expect(filterTasks(tasks, "")).toHaveLength(2);
+  });
+
+  it("matches title, description, tags, and subtasks case-insensitively", () => {
+    const byTitle = makeTask({ id: "t", title: "Ship Release" });
+    const byDesc = makeTask({ id: "d", description: "needs the SHIP done" });
+    const byTag = makeTask({ id: "g", tags: ["shipping"] });
+    const bySub = makeTask({ id: "s", subtasks: [{ id: "x", title: "Ship it", completed: false }] });
+    const noMatch = makeTask({ id: "n", title: "unrelated" });
+
+    const result = filterTasks([byTitle, byDesc, byTag, bySub, noMatch], "ship");
+
+    expect(result.map((t) => t.id).sort()).toEqual(["d", "g", "s", "t"]);
+  });
+});
+
+describe("deriveMatrixView", () => {
+  const active = makeTask({ id: "active", title: "Active alpha", completed: false });
+  const done = makeTask({ id: "done", title: "Done bravo", completed: true });
+  const overdue = makeTask({ id: "od", title: "Overdue", completed: false, dueDate: "2000-01-01" });
+
+  it("counts total, completed, and overdue", () => {
+    const view = deriveMatrixView({
+      all: [active, done, overdue],
+      showCompleted: false,
+      smartViewsEnabled: false,
+      activeSmartView: null,
+      searchQuery: "",
+    });
+    expect(view.total).toBe(3);
+    expect(view.completed).toBe(1);
+    expect(view.overdue).toBe(1);
+  });
+
+  it("hides completed tasks when showCompleted is false and no smart view is active", () => {
+    const view = deriveMatrixView({
+      all: [active, done],
+      showCompleted: false,
+      smartViewsEnabled: false,
+      activeSmartView: null,
+      searchQuery: "",
+    });
+    expect(view.visibleTasks.map((t) => t.id)).toEqual(["active"]);
+  });
+
+  it("shows completed tasks when showCompleted is true", () => {
+    const view = deriveMatrixView({
+      all: [active, done],
+      showCompleted: true,
+      smartViewsEnabled: false,
+      activeSmartView: null,
+      searchQuery: "",
+    });
+    expect(view.visibleTasks.map((t) => t.id).sort()).toEqual(["active", "done"]);
+  });
+
+  it("applies an active smart view over the full task set when enabled", () => {
+    const view = deriveMatrixView({
+      all: [active, done],
+      showCompleted: false,
+      smartViewsEnabled: true,
+      activeSmartView: completedView,
+      searchQuery: "",
+    });
+    expect(view.visibleTasks.map((t) => t.id)).toEqual(["done"]);
+  });
+
+  it("ignores the active smart view when the feature is disabled", () => {
+    const view = deriveMatrixView({
+      all: [active, done],
+      showCompleted: false,
+      smartViewsEnabled: false,
+      activeSmartView: completedView,
+      searchQuery: "",
+    });
+    expect(view.visibleTasks.map((t) => t.id)).toEqual(["active"]);
+  });
+
+  it("applies the search query on top of the visible set", () => {
+    const view = deriveMatrixView({
+      all: [active, makeTask({ id: "other", title: "zzz" })],
+      showCompleted: false,
+      smartViewsEnabled: false,
+      activeSmartView: null,
+      searchQuery: "  alpha  ",
+    });
+    expect(view.visibleTasks.map((t) => t.id)).toEqual(["active"]);
+  });
+});


### PR DESCRIPTION
## Summary

S1 from the security/correctness/standards review: `components/matrix-simplified/index.tsx` was **554 lines**, over the ~400-line cap in `coding-standards.md`. This splits it into cohesive, independently-testable pieces with **no behavior change**.

`index.tsx`: **554 → 297 lines**. Every new module is under 350.

| File | Lines | Responsibility |
|------|------:|----------------|
| `index.tsx` | 297 | shell wiring + render |
| `matrix-view.ts` | 87 | pure `filterTasks` / `deriveMatrixView` (visible tasks + header counts) |
| `use-matrix-window-events.ts` | 132 | keyboard shortcuts + URL action params + deep-link + shell command events |
| `use-smart-views.ts` | 107 | smart-view enabled/load/active state + apply/clear |
| `use-task-highlight.ts` | 89 | highlight state + scroll-into-view lifecycle |

## How to test

- `bun run test` — 2000 pass / 1 skip (8 new `matrix-view` unit tests, TDD'd; existing 14 matrix integration tests unchanged and green)
- `bun typecheck` — clean
- Browser-verified on a real engine (dev): matrix renders all four quadrants with tasks in the correct cells, `/` focuses the search input, `gsd:new-task` opens the create drawer, console clean (no errors/hydration warnings)

## Notes

- **No version bump** — internal refactor with no user-facing change; leaving `package.json` untouched also guarantees a clean merge with PR #368 (which bumps to `9.11.2`).
- Independent of #368 (different files); branched off `main`.
- Out of scope: `edit-drawer.tsx` (392 lines) is the next-largest file but was not part of S1.

https://claude.ai/code/session_01CP3vwC7nH19pvZcw4JzScV
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->