### PR TITLE
fix(sync): dedupe stacked sync-health toasts

### DIFF
--- a/components/sync/sync-button.tsx
+++ b/components/sync/sync-button.tsx
@@ -25,8 +25,11 @@ export function SyncButton() {
 
   useSyncHealth({
     isEnabled,
-    onHealthIssue: (message, action, duration) => {
+    onHealthIssue: ({ id, message, action, duration }) => {
+      // The stable `id` lets sonner replace a recurring health toast in place
+      // instead of stacking duplicates (e.g. after a wake-from-sleep burst).
       toast(message, {
+        id,
         duration,
         action: action ? { label: action.label, onClick: action.onClick } : undefined,
       });

--- a/components/sync/use-sync-health.ts
+++ b/components/sync/use-sync-health.ts
@@ -1,21 +1,74 @@
 "use client";
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { getHealthMonitor, type HealthIssue } from '@/lib/sync/health-monitor';
 import { SYNC_CONFIG, SYNC_TOAST_DURATION } from '@/lib/constants/sync';
 
+/** A health notification ready to be handed to a toast. */
+export interface HealthNotification {
+  /** Stable per-issue-type id so repeat checks replace rather than stack the toast. */
+  id: string;
+  message: string;
+  action?: { label: string; onClick: () => void };
+  duration: number;
+}
+
 interface SyncHealthOptions {
   isEnabled: boolean;
-  onHealthIssue: (message: string, action?: { label: string; onClick: () => void }, duration?: number) => void;
+  onHealthIssue: (notification: HealthNotification) => void;
   onSync: () => void;
 }
 
 /**
- * Hook for monitoring sync health and showing notifications
- * Checks health periodically and displays toasts for issues
+ * Build a toast notification for a health issue, or null if the issue should be
+ * shown silently. The id is keyed on the issue type so that a recurring issue
+ * (e.g. a stale queue surfaced on every periodic check) collapses to a single
+ * toast instead of stacking duplicates.
+ */
+function buildNotification(
+  issue: HealthIssue,
+  onSync: () => void,
+): HealthNotification | null {
+  const id = `sync-health-${issue.type}`;
+
+  if (issue.severity === 'error') {
+    return {
+      id,
+      message: `${issue.message}. ${issue.suggestedAction}`,
+      duration: SYNC_TOAST_DURATION.LONG,
+    };
+  }
+
+  if (issue.type === 'stale_queue') {
+    return {
+      id,
+      message: issue.message,
+      action: { label: 'Sync Now', onClick: onSync },
+      duration: SYNC_TOAST_DURATION.LONG,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Hook for monitoring sync health and showing notifications.
+ *
+ * Checks health periodically and surfaces a toast per issue. The cooldown and
+ * the consumer callbacks live in refs, so frequent status-poll re-renders (which
+ * hand the hook fresh callback identities) never re-arm the timers — a single
+ * wake-from-sleep would otherwise fire several overlapping checks at once.
  */
 export function useSyncHealth({ isEnabled, onHealthIssue, onSync }: SyncHealthOptions) {
-  const [lastNotificationTime, setLastNotificationTime] = useState(0);
+  const lastNotificationTimeRef = useRef(0);
+  const onHealthIssueRef = useRef(onHealthIssue);
+  const onSyncRef = useRef(onSync);
+
+  // Keep the latest callbacks without retriggering the timer effect below.
+  useEffect(() => {
+    onHealthIssueRef.current = onHealthIssue;
+    onSyncRef.current = onSync;
+  });
 
   useEffect(() => {
     if (!isEnabled) {
@@ -25,68 +78,38 @@ export function useSyncHealth({ isEnabled, onHealthIssue, onSync }: SyncHealthOp
     const checkHealthAndNotify = async () => {
       const now = Date.now();
 
-      // Avoid notification spam
-      if (now - lastNotificationTime < SYNC_CONFIG.NOTIFICATION_COOLDOWN_MS) {
+      // Avoid notification spam. Reading/writing a ref keeps this immune to the
+      // re-render churn that an effect-dependency state value would suffer.
+      if (now - lastNotificationTimeRef.current < SYNC_CONFIG.NOTIFICATION_COOLDOWN_MS) {
         return;
       }
 
-      const healthMonitor = getHealthMonitor();
-      const report = await healthMonitor.check();
-
-      // Show toast for health issues
-      if (!report.healthy && report.issues.length > 0) {
-        handleHealthIssues(report.issues, now);
+      const report = await getHealthMonitor().check();
+      if (report.healthy || report.issues.length === 0) {
+        return;
       }
-    };
 
-    const handleHealthIssues = (issues: HealthIssue[], now: number) => {
-      for (const issue of issues) {
-        if (shouldShowErrorIssue(issue)) {
-          showErrorIssue(issue);
-          setLastNotificationTime(now);
-        } else if (shouldShowStaleQueueWarning(issue)) {
-          showStaleQueueWarning(issue);
-          setLastNotificationTime(now);
+      for (const issue of report.issues) {
+        const notification = buildNotification(issue, onSyncRef.current);
+        if (notification) {
+          onHealthIssueRef.current(notification);
+          lastNotificationTimeRef.current = now;
         }
       }
     };
 
-    const shouldShowErrorIssue = (issue: HealthIssue) => {
-      return issue.severity === 'error';
-    };
-
-    const shouldShowStaleQueueWarning = (issue: HealthIssue) => {
-      return issue.severity === 'warning' && issue.type === 'stale_queue';
-    };
-
-    const showErrorIssue = (issue: HealthIssue) => {
-      const message = `${issue.message}. ${issue.suggestedAction}`;
-      onHealthIssue(message, undefined, SYNC_TOAST_DURATION.LONG);
-    };
-
-    const showStaleQueueWarning = (issue: HealthIssue) => {
-      onHealthIssue(
-        issue.message,
-        {
-          label: 'Sync Now',
-          onClick: onSync,
-        },
-        SYNC_TOAST_DURATION.LONG
-      );
-    };
-
-    // Check health periodically
-    const interval = setInterval(checkHealthAndNotify, SYNC_CONFIG.HEALTH_CHECK_INTERVAL_MS);
-
-    // Run initial check after delay
+    const interval = setInterval(
+      checkHealthAndNotify,
+      SYNC_CONFIG.HEALTH_CHECK_INTERVAL_MS,
+    );
     const initialTimeout = setTimeout(
       checkHealthAndNotify,
-      SYNC_CONFIG.INITIAL_HEALTH_CHECK_DELAY_MS
+      SYNC_CONFIG.INITIAL_HEALTH_CHECK_DELAY_MS,
     );
 
     return () => {
       clearInterval(interval);
       clearTimeout(initialTimeout);
     };
-  }, [isEnabled, lastNotificationTime, onHealthIssue, onSync]);
+  }, [isEnabled]);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.11.2",
+	"version": "9.11.3",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,6 +2,30 @@
 
 ---
 
+## In progress — 2026-06-20: Fix stacked sync-health toasts (TDD)
+
+**Branch:** `fix/sync-health-toast-dedup` · **Tier:** Standard (one hook + its single consumer; internal callback contract change; TDD).
+
+**Problem:** On wake-from-sleep, multiple identical "N pending operations are older than 1 hour" toasts stack (user screenshot: 3 at once). Two root causes in `components/sync/use-sync-health.ts`:
+1. `toast()` is called with no stable `id`, so sonner stacks duplicates instead of replacing (the user-visible defect).
+2. The cooldown lives in React state (`lastNotificationTime`) that is also an effect dependency, alongside unstable `onHealthIssue`/`onSync` callbacks. Every status-poll re-render tears down and re-arms the health-check timers, so on wake several checks fire before the cooldown settles.
+
+**Plan (TDD):**
+- [x] RED: `useSyncHealth` passes a stable `id` (`sync-health-<type>`) + Sync Now action for a stale-queue warning. (3 RED failures confirmed: hook called `(message, action, duration)` positionally.)
+- [x] RED: error issues pass `sync-health-<type>` and no action; non-stale warnings are ignored.
+- [x] GREEN #1: derive a stable `id` from `issue.type` in a `buildNotification` helper; thread it to `toast({ id })` in `sync-button.tsx`.
+- [x] GREEN #2: cooldown moved to a `useRef`; callbacks held in refs; effect depends only on `isEnabled` (no timer re-arm churn).
+- [x] Guard: cooldown holds within window and across callback-identity changes; disabled + non-stale-warning branches covered.
+- [x] Verify: `bun run test` ✅ 2013 pass / 1 skip · `bun typecheck` ✅ · `bun run test -- tests/ui/sync-button.test.tsx` ✅ 5 pass (consumer unaffected).
+
+**Out of scope:** the underlying stuck sync operation itself (the message is legitimate; Sync Now flushes it). Only the duplicate-toast behavior.
+
+**Files:** `components/sync/use-sync-health.ts` (rewrite: stable id + ref cooldown), `components/sync/sync-button.tsx` (pass `id` to `toast`), `tests/ui/use-sync-health.test.tsx` (new, 7 tests).
+
+**Note on live verification:** no visual change (SyncButton renders identically); the fix is toast-dedup behavior under a wake-from-sleep timer race that requires sync-enabled + auth + a queued op stuck >1h to stage — impractical in a live browser and equally hard to drive via Playwright. Verified via deterministic fake-timer unit tests, which are the correct surface for this timing logic.
+
+---
+
 ## In progress — 2026-06-19: Review-findings fixes (TDD)
 
 **Branch:** `chore/refactor-review-refine` · **Tier:** Standard (bounded fixes across sync, import/export, MCP, db migrations; no new public contract). TDD per CLAUDE.md.

--- a/tests/ui/use-sync-health.test.tsx
+++ b/tests/ui/use-sync-health.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { SYNC_CONFIG, SYNC_TOAST_DURATION } from "@/lib/constants/sync";
+import type { HealthIssue, HealthReport } from "@/lib/sync/health-monitor";
+
+const mockCheck = vi.fn<() => Promise<HealthReport>>();
+
+vi.mock("@/lib/sync/health-monitor", () => ({
+  getHealthMonitor: () => ({ check: mockCheck }),
+}));
+
+import { useSyncHealth } from "@/components/sync/use-sync-health";
+
+const staleQueueIssue: HealthIssue = {
+  type: "stale_queue",
+  severity: "warning",
+  message: "1 pending operations are older than 1 hour",
+  suggestedAction: "Try syncing manually to clear pending operations",
+};
+
+const failedItemsIssue: HealthIssue = {
+  type: "failed_items",
+  severity: "error",
+  message: "2 sync operations have failed and need attention",
+  suggestedAction:
+    "Review failed items in sync history. They will not retry automatically until cleared.",
+};
+
+function unhealthy(issues: HealthIssue[]): HealthReport {
+  return { healthy: false, issues, timestamp: 0 };
+}
+
+async function advance(ms: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe("useSyncHealth", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockCheck.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows a stale-queue warning with a stable id and a Sync Now action", async () => {
+    mockCheck.mockResolvedValue(unhealthy([staleQueueIssue]));
+    const onHealthIssue = vi.fn();
+
+    renderHook(() =>
+      useSyncHealth({ isEnabled: true, onHealthIssue, onSync: vi.fn() }),
+    );
+    await advance(SYNC_CONFIG.INITIAL_HEALTH_CHECK_DELAY_MS);
+
+    expect(onHealthIssue).toHaveBeenCalledTimes(1);
+    expect(onHealthIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "sync-health-stale_queue",
+        message: "1 pending operations are older than 1 hour",
+        duration: SYNC_TOAST_DURATION.LONG,
+        action: expect.objectContaining({ label: "Sync Now" }),
+      }),
+    );
+  });
+
+  it("wires the Sync Now action to onSync", async () => {
+    mockCheck.mockResolvedValue(unhealthy([staleQueueIssue]));
+    const onHealthIssue = vi.fn();
+    const onSync = vi.fn();
+
+    renderHook(() => useSyncHealth({ isEnabled: true, onHealthIssue, onSync }));
+    await advance(SYNC_CONFIG.INITIAL_HEALTH_CHECK_DELAY_MS);
+
+    const notification = onHealthIssue.mock.calls[0][0];
+    notification.action.onClick();
+    expect(onSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an error issue with a stable id and no action", async () => {
+    mockCheck.mockResolvedValue(unhealthy([failedItemsIssue]));
+    const onHealthIssue = vi.fn();
+
+    renderHook(() =>
+      useSyncHealth({ isEnabled: true, onHealthIssue, onSync: vi.fn() }),
+    );
+    await advance(SYNC_CONFIG.INITIAL_HEALTH_CHECK_DELAY_MS);
+
+    expect(onHealthIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "sync-health-failed_items",
+        message: `${failedItemsIssue.message}. ${failedItemsIssue.suggestedAction}`,
+        duration: SYNC_TOAST_DURATION.LONG,
+      }),
+    );
+    expect(onHealthIssue.mock.calls[0][0].action).toBeUndefined();
+  });
+
+  it("does not notify again within the cooldown window", async () => {
+    mockCheck.mockResolvedValue(unhealthy([staleQueueIssue]));
+    const onHealthIssue = vi.fn();
+
+    renderHook(() =>
+      useSyncHealth({ isEnabled: true, onHealthIssue, onSync: vi.fn() }),
+    );
+
+    await advance(SYNC_CONFIG.INITIAL_HEALTH_CHECK_DELAY_MS);
+    expect(onHealthIssue).toHaveBeenCalledTimes(1);
+
+    // The periodic check fires again but is gated by the cooldown.
+    await advance(
+      SYNC_CONFIG.NOTIFICATION_COOLDOWN_MS -
+        SYNC_CONFIG.INITIAL_HEALTH_CHECK_DELAY_MS,
+    );
+    expect(onHealthIssue).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the cooldown when callbacks change identity between renders", async () => {
+    mockCheck.mockResolvedValue(unhealthy([staleQueueIssue]));
+    const onHealthIssue = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ cb }: { cb: () => void }) =>
+        useSyncHealth({ isEnabled: true, onHealthIssue, onSync: cb }),
+      { initialProps: { cb: () => {} } },
+    );
+
+    await advance(SYNC_CONFIG.INITIAL_HEALTH_CHECK_DELAY_MS);
+    expect(onHealthIssue).toHaveBeenCalledTimes(1);
+
+    // A status-poll re-render hands the hook fresh callback identities. This
+    // must not re-arm the timers and replay the notification.
+    rerender({ cb: () => {} });
+    rerender({ cb: () => {} });
+
+    await advance(
+      SYNC_CONFIG.NOTIFICATION_COOLDOWN_MS -
+        SYNC_CONFIG.INITIAL_HEALTH_CHECK_DELAY_MS,
+    );
+    expect(onHealthIssue).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores warnings that are not a stale queue", async () => {
+    mockCheck.mockResolvedValue(
+      unhealthy([{ ...staleQueueIssue, type: "server_unreachable" }]),
+    );
+    const onHealthIssue = vi.fn();
+
+    renderHook(() =>
+      useSyncHealth({ isEnabled: true, onHealthIssue, onSync: vi.fn() }),
+    );
+    await advance(SYNC_CONFIG.INITIAL_HEALTH_CHECK_DELAY_MS);
+
+    expect(onHealthIssue).not.toHaveBeenCalled();
+  });
+
+  it("does not check health when sync is disabled", async () => {
+    mockCheck.mockResolvedValue(unhealthy([staleQueueIssue]));
+    const onHealthIssue = vi.fn();
+
+    renderHook(() =>
+      useSyncHealth({ isEnabled: false, onHealthIssue, onSync: vi.fn() }),
+    );
+    await advance(SYNC_CONFIG.INITIAL_HEALTH_CHECK_DELAY_MS);
+
+    expect(mockCheck).not.toHaveBeenCalled();
+    expect(onHealthIssue).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What & why

Opening `https://gsd.vinny.dev` on a tab left open through a sleep/wake cycle could surface **several identical** "N pending operations are older than 1 hour" toasts stacked on top of each other (user-reported: 3 at once). The *condition* is legitimate — there's genuinely a queued sync op stuck > 1h, and **Sync Now** flushes it — but showing it more than once is a bug.

Two root causes in `components/sync/use-sync-health.ts`:

1. **No stable toast `id`.** `toast()` was called without an `id`, so sonner stacks each call as a new toast instead of replacing the existing one.
2. **Racy cooldown + timer churn.** The notification cooldown lived in React state (`lastNotificationTime`) that was *also* an effect dependency, alongside unstable `onHealthIssue`/`onSync` callbacks. Every 1s/2s/5s status-poll re-render tore down and re-armed the health-check timers, so on wake a burst of backed-up checks could slip past the cooldown before its state settled.

## Changes

- `components/sync/use-sync-health.ts` — each issue gets a stable `id` (`sync-health-<type>`) via a pure `buildNotification` helper; the cooldown and the consumer callbacks move into refs so the timer effect depends only on `isEnabled` (no re-arm churn). Behavior (error vs. stale-queue-warning vs. ignored) is preserved.
- `components/sync/sync-button.tsx` — passes the `id` to `toast({ id })` so sonner replaces a recurring health toast in place.
- `tests/ui/use-sync-health.test.tsx` — **new**, 7 fake-timer tests (TDD: RED confirmed the hook was calling `onHealthIssue` positionally with no `id`).
- Patch bump 9.11.2 → 9.11.3.

## How to test locally

```
bun run test -- tests/ui/use-sync-health.test.tsx --run   # 7 pass
bun run test                                              # full suite
bun typecheck
```

## Verification

- TDD: 3 tests failed first for the right reason (positional `(message, action, duration)`, no `id`), then green.
- `bun run test` → **2013 pass / 1 skip**, no regressions. `bun typecheck` clean. Existing `tests/ui/sync-button.test.tsx` → 5 pass (consumer contract intact).
- **No live browser verification:** `SyncButton` renders identically — there is no visual change. The fix is toast-dedup under a wake-from-sleep timer race that requires sync-enabled + auth + an op stuck > 1h to stage, which is impractical to reproduce live or via Playwright. Deterministic fake-timer unit tests are the correct surface for this timing logic.

## Out of scope

The underlying stuck sync operation itself — the message is accurate; this PR only fixes the duplicate-toast behavior.

https://claude.ai/code/session_01WVSQZozWAUQUmqodSrRQxT
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->