### PR TITLE
ci: add Docker image publish workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,155 @@
+name: Publish Docker Image
+
+# Builds the self-hosted image (docker/Dockerfile: Caddy + PocketBase + static site)
+# and publishes it to GHCR and Docker Hub.
+#
+#   push to main      -> :edge and :sha-<short>   (moving + immutable "latest commit")
+#   push tag vX.Y.Z   -> :X.Y.Z, :X.Y, :latest    (release)
+#   workflow_dispatch -> build only by default (dry_run), or push when dry_run=false
+#
+# GHCR auth uses the built-in GITHUB_TOKEN. Docker Hub is published only when the
+# DOCKERHUB_USERNAME / DOCKERHUB_TOKEN repo secrets are configured, so the workflow
+# stays correct even if those secrets are absent.
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (build only, do not push)'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-docker-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure build
+        id: cfg
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          # Registries: GHCR always; Docker Hub only when its secret is configured.
+          IMAGES="ghcr.io/${REPO}"
+          if [ -n "$DOCKERHUB_USERNAME" ]; then
+            IMAGES="${IMAGES}"$'\n'"docker.io/${DOCKERHUB_USERNAME}/gsd-task-manager"
+            echo "dockerhub_enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dockerhub_enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Push on every trigger except an explicit dry-run dispatch.
+          if [ "$EVENT" = "workflow_dispatch" ] && [ "$DRY_RUN" = "true" ]; then
+            echo "push_enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "push_enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          {
+            echo "images<<EOF"
+            echo "$IMAGES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Verify release tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          TAG_REF: ${{ github.ref_name }}
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+
+          TAG_VERSION="${TAG_REF#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+          RELEASE_COMMIT=$(git rev-parse "${GITHUB_SHA}^{commit}")
+          if ! git merge-base --is-ancestor "$RELEASE_COMMIT" origin/main; then
+            echo "::error::Release commit $RELEASE_COMMIT is not reachable from origin/main"
+            exit 1
+          fi
+          echo "Publishing release $PKG_VERSION"
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.cfg.outputs.images }}
+          flavor: |
+            latest=false
+          tags: |
+            type=edge,branch=main
+            type=sha,prefix=sha-,format=short,enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: steps.cfg.outputs.push_enabled == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: steps.cfg.outputs.push_enabled == 'true' && steps.cfg.outputs.dockerhub_enabled == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ steps.cfg.outputs.push_enabled == 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+
+      - name: Summary
+        run: |
+          {
+            echo "### Docker image"
+            if [ "${{ steps.cfg.outputs.push_enabled }}" = "true" ]; then
+              echo "Pushed the following tags:"
+            else
+              echo "Dry run — built but did not push. Tags that would have been pushed:"
+            fi
+            echo '```'
+            echo "${{ steps.meta.outputs.tags }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What & why

Adds `.github/workflows/publish-docker.yml` so the self-hosted image (`docker/Dockerfile`: Caddy + PocketBase + Next.js static export) is built and published automatically. Today the image only exists as a local `docker-compose build` — there's no prebuilt image for users to pull. This fills that gap.

Publishes to **both** GHCR and Docker Hub, multi-arch (`linux/amd64` + `linux/arm64`).

### Triggers & tags

| Trigger | `push_enabled` | Tags |
|---|---|---|
| Push to `main` (any commit) | yes | `:edge`, `:sha-<short>` |
| Push tag `vX.Y.Z` | yes (after guards) | `:X.Y.Z`, `:X.Y`, `:latest` |
| `workflow_dispatch` (default `dry_run=true`) | no | builds, pushes nothing |
| `workflow_dispatch` (`dry_run=false`) | yes | tags for the current ref |

`:edge` is a moving pointer to the newest main build; `:sha-<short>` is the immutable pin for rollbacks.

### Design notes
- **GHCR** auth uses the built-in `GITHUB_TOKEN` (zero setup). **Docker Hub** is gated on `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` repo secrets (already configured) — if absent, the workflow still runs correctly and just skips Docker Hub.
- Reuses the `publish-mcp-server.yml` safety guards on tag pushes: tag version must match `package.json`, and the tagged commit must be reachable from `origin/main`.
- GHA layer cache (`type=gha`) to cut rebuild time; `provenance: false` to avoid multi-registry attestation manifest quirks.
- `concurrency` cancels superseded **main** builds only — never an in-flight release.

## How to test

- **Actions → Publish Docker Image → Run workflow**, leave `dry_run` checked. Builds both arches and pushes nothing — the safe end-to-end check (~15-25 min; arm64 runs under QEMU emulation).
- Or merge and push a `vX.Y.Z` tag to exercise the release path.

## Notes
- First GHCR push creates the package as **private** — flip to public in package settings for anonymous `docker pull`. Docker Hub auto-creates the repo public.
- CI-only change: no `package.json` version bump, no app/runtime code touched.

https://claude.ai/code/session_01XgGmUZtvspfDFDJp9ehAV8
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->