### PR TITLE
chore: fix all coding-standards compliance findings

### DIFF
--- a/app/(archive)/archive/page.tsx
+++ b/app/(archive)/archive/page.tsx
@@ -33,6 +33,38 @@ function sortByArchivedDate(tasks: TaskRecord[]): TaskRecord[] {
   });
 }
 
+interface ArchivedTaskCardProps {
+  task: TaskRecord;
+  allTasks: TaskRecord[];
+  onRestore: (task: TaskRecord) => void;
+  onDelete: (task: TaskRecord) => void;
+}
+
+/** Renders a single archived task card with dimmed opacity and restore/delete hover actions. */
+function ArchivedTaskCard({ task, allTasks, onRestore, onDelete }: ArchivedTaskCardProps): React.ReactElement {
+  return (
+    <div className="relative group">
+      {/* Archived items read dimmed and read-only (reference §07);
+          handlers are no-ops and the card sits at 0.72 opacity. */}
+      <div className="opacity-[0.72]">
+        <TaskCard task={task} allTasks={allTasks} onEdit={() => {}} onDelete={() => {}} onToggleComplete={() => {}} />
+      </div>
+      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-card via-card to-transparent p-3 opacity-0 group-hover:opacity-100 transition-opacity">
+        <div className="flex items-center justify-end gap-2">
+          <Button variant="subtle" onClick={() => onRestore(task)} className="gap-2 text-sm h-auto py-1 px-2">
+            <RefreshCcwIcon className="h-3 w-3" />
+            Restore
+          </Button>
+          <Button variant="destructive" onClick={() => onDelete(task)} className="gap-2 text-sm h-auto py-1 px-2">
+            <Trash2Icon className="h-3 w-3" />
+            Delete
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function ArchivePage() {
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -158,59 +190,25 @@ export default function ArchivePage() {
             >
               {virtualizer.getVirtualItems().map((virtualRow) => {
                 const startIndex = virtualRow.index * columnCount;
-                const rowTasks = archivedTasks.slice(
-                  startIndex,
-                  startIndex + columnCount
-                );
-
+                const rowTasks = archivedTasks.slice(startIndex, startIndex + columnCount);
                 return (
                   <div
                     key={virtualRow.key}
                     style={{
-                      position: "absolute",
-                      top: 0,
-                      left: 0,
-                      width: "100%",
+                      position: "absolute", top: 0, left: 0, width: "100%",
                       height: `${virtualRow.size}px`,
                       transform: `translateY(${virtualRow.start}px)`,
                     }}
                   >
                     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                       {rowTasks.map((task) => (
-                        <div key={task.id} className="relative group">
-                          {/* Archived items read dimmed and read-only (reference §07);
-                              handlers are no-ops and the card sits at 0.72 opacity. */}
-                          <div className="opacity-[0.72]">
-                            <TaskCard
-                              task={task}
-                              allTasks={archivedTasks}
-                              onEdit={() => {}}
-                              onDelete={() => {}}
-                              onToggleComplete={() => {}}
-                            />
-                          </div>
-
-                          <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-card via-card to-transparent p-3 opacity-0 group-hover:opacity-100 transition-opacity">
-                            <div className="flex items-center justify-end gap-2">
-                              <Button
-                                variant="subtle"
-                                onClick={() => handleRestore(task)}
-                                className="gap-2 text-sm h-auto py-1 px-2"
-                              >
-                                <RefreshCcwIcon className="h-3 w-3" />
-                                Restore
-                              </Button>
-                              <Button
-                                variant="destructive"
-                                onClick={() => handleDelete(task)}
-                                className="gap-2 text-sm h-auto py-1 px-2"
-                              >
-                                <Trash2Icon className="h-3 w-3" />
-                                Delete
-                              </Button>
-                            </div>
-                          </div>
-                        </div>
+                        <ArchivedTaskCard
+                          key={task.id}
+                          task={task}
+                          allTasks={archivedTasks}
+                          onRestore={handleRestore}
+                          onDelete={handleDelete}
+                        />
                       ))}
                     </div>
                   </div>

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { Route } from "next";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   CheckCircle2Icon,
@@ -20,15 +20,15 @@ import { TimeAnalytics } from "@/components/dashboard/time-analytics";
 import { useTasks } from "@/lib/use-tasks";
 import { useKeyboardShortcuts } from "@/lib/use-keyboard-shortcuts";
 import { ROUTES } from "@/lib/routes";
-import {
-  calculateMetrics,
-  getCompletionTrend,
-  getStreakData,
-  calculateTimeTrackingSummary,
-  getTimeByQuadrant,
-} from "@/lib/analytics";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { DashboardSkeleton } from "@/components/dashboard/dashboard-skeleton";
+import { useDashboardData } from "./use-dashboard-data";
+
+const TREND_OPTIONS = [
+  { value: "7", label: "7 Days" },
+  { value: "30", label: "30 Days" },
+  { value: "90", label: "90 Days" },
+] as const;
 
 /**
  * Dashboard page showing productivity metrics and analytics.
@@ -38,83 +38,17 @@ import { DashboardSkeleton } from "@/components/dashboard/dashboard-skeleton";
  *   Row 3: Upcoming deadlines + tag analytics
  *   Row 4: Time tracking (full width, conditional)
  */
-export default function DashboardPage() {
+export default function DashboardPage(): React.ReactElement {
   const router = useRouter();
   const { all: tasks, isLoading } = useTasks();
   const [trendPeriod, setTrendPeriod] = useState<7 | 30 | 90>(30);
   const [searchQuery, setSearchQuery] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
-
-  const metrics = useMemo(() => calculateMetrics(tasks), [tasks]);
-  const last7TrendData = useMemo(() => getCompletionTrend(tasks, 7), [tasks]);
-  const trendData = useMemo(
-    () => getCompletionTrend(tasks, trendPeriod),
-    [tasks, trendPeriod],
-  );
-  const streakData = useMemo(() => getStreakData(tasks), [tasks]);
-  const timeTrackingSummary = useMemo(
-    () => calculateTimeTrackingSummary(tasks),
-    [tasks],
-  );
-  const timeByQuadrant = useMemo(() => getTimeByQuadrant(tasks), [tasks]);
-  const completedSeries = useMemo(
-    () => last7TrendData.map((p) => p.completed),
-    [last7TrendData],
-  );
-  const createdSeries = useMemo(
-    () => last7TrendData.map((p) => p.created),
-    [last7TrendData],
-  );
-  const completionRateSeries = useMemo(
-    () =>
-      last7TrendData.map((p) => {
-        const denom = p.created || 1;
-        return Math.round((p.completed / denom) * 100);
-      }),
-    [last7TrendData],
-  );
-  const { completedTrend, previousSixAverage } = useMemo(() => {
-    const todayTrend = last7TrendData.at(-1)?.completed ?? 0;
-    let previousTotal = 0;
-    for (let i = 0; i < last7TrendData.length - 1; i += 1) {
-      previousTotal += last7TrendData[i].completed;
-    }
-    const previousCount = Math.max(0, last7TrendData.length - 1);
-    const nextPreviousSixAverage =
-      previousCount > 0 ? previousTotal / previousCount : 0;
-    const nextCompletedTrend = nextPreviousSixAverage > 0
-      ? Math.round(((todayTrend - nextPreviousSixAverage) / nextPreviousSixAverage) * 100)
-      : todayTrend > 0 ? 100 : 0;
-    return {
-      completedTrend: nextCompletedTrend,
-      previousSixAverage: nextPreviousSixAverage,
-    };
-  }, [last7TrendData]);
-  const completedInsight = metrics.completedToday === 0
-    ? "Ready to start today"
-    : completedTrend > 10
-      ? "Above your recent pace"
-      : completedTrend < -10
-        ? "Below your recent pace"
-        : "Holding steady";
-  const plannedActiveShare = metrics.activeTasks > 0
-    ? Math.round(((metrics.activeTasks - metrics.noDueDateCount) / metrics.activeTasks) * 100)
-    : 0;
-  const activeInsight = metrics.overdueCount > 0
-    ? `${metrics.overdueCount} overdue`
-    : metrics.noDueDateCount > 0
-      ? `${metrics.noDueDateCount} unscheduled`
-      : "Well scoped";
-  const completionInsight = metrics.completionRate >= 80
-    ? "Strong follow-through"
-    : metrics.completionRate >= 60
-      ? "Healthy momentum"
-      : "Room to tighten execution";
+  const data = useDashboardData(tasks, trendPeriod);
 
   const openMatrixAction = useCallback((params?: URLSearchParams) => {
     const query = params?.toString();
-    const href = query ? (`/?${query}` as Route) : ROUTES.HOME;
-    router.push(href);
+    router.push(query ? (`/?${query}` as Route) : ROUTES.HOME);
   }, [router]);
 
   const handleDeadlineTaskClick = useCallback(
@@ -126,15 +60,6 @@ export default function DashboardPage() {
     [openMatrixAction]
   );
 
-  const trendOptions = useMemo(
-    () => [
-      { value: "7", label: "7 Days" },
-      { value: "30", label: "30 Days" },
-      { value: "90", label: "90 Days" },
-    ],
-    []
-  );
-
   useKeyboardShortcuts(
     {
       onNewTask: () => {
@@ -143,9 +68,7 @@ export default function DashboardPage() {
         openMatrixAction(params);
       },
       onSearch: () => searchInputRef.current?.focus(),
-      onHelp: () => {
-        window.dispatchEvent(new CustomEvent("gsd:open-help"));
-      },
+      onHelp: () => { window.dispatchEvent(new CustomEvent("gsd:open-help")); },
     },
     searchInputRef
   );
@@ -158,130 +81,136 @@ export default function DashboardPage() {
       searchInputRef={searchInputRef}
     >
       <div className="space-y-8 pb-10">
-          <div className="border-b border-border/60 bg-gradient-to-b from-background to-background-muted/40 px-4 py-8 sm:px-6 sm:py-10">
-            <div className="mx-auto max-w-7xl">
-              <p className="eyebrow">
-                Workspace Insights
-              </p>
-              <h1 className="rd-serif mt-2 text-3xl tracking-tight text-foreground sm:text-4xl">
-                Dashboard
-              </h1>
-              <p className="mt-3 max-w-2xl text-sm leading-relaxed text-foreground-muted sm:text-base">
-                Track follow-through, spot overdue drag, and keep the matrix balanced before work starts to sprawl.
-              </p>
-            </div>
+        <div className="border-b border-border/60 bg-gradient-to-b from-background to-background-muted/40 px-4 py-8 sm:px-6 sm:py-10">
+          <div className="mx-auto max-w-7xl">
+            <p className="eyebrow">Workspace Insights</p>
+            <h1 className="rd-serif mt-2 text-3xl tracking-tight text-foreground sm:text-4xl">Dashboard</h1>
+            <p className="mt-3 max-w-2xl text-sm leading-relaxed text-foreground-muted sm:text-base">
+              Track follow-through, spot overdue drag, and keep the matrix balanced before work starts to sprawl.
+            </p>
           </div>
+        </div>
 
-          <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 sm:py-8">
-            {isLoading ? (
-              <DashboardSkeleton />
-            ) : tasks.length === 0 ? (
-              <div className="rounded-lg border-hair border-border bg-card p-12 text-center shadow-sm">
-                <ListTodoIcon className="mx-auto h-12 w-12 text-foreground-muted" />
-                <h2 className="mt-4 text-xl font-semibold text-foreground">
-                  No tasks yet
-                </h2>
-                <p className="mt-2 text-sm text-foreground-muted">
-                  Create your first task to start tracking your productivity!
-                </p>
-              </div>
-            ) : (
-              <div className="space-y-6">
-                <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-                  <StatsCard
-                    title="Completed Today"
-                    value={metrics.completedToday}
-                    icon={CheckCircle2Icon}
-                    trend={previousSixAverage > 0 ? { value: completedTrend, isPositive: completedTrend >= 0 } : undefined}
-                    insight={completedInsight}
-                    footerMeta={`${metrics.completedThisWeek} / 7d`}
-                    series={completedSeries}
-                  />
-                  <StatsCard
-                    title="Active Tasks"
-                    value={metrics.activeTasks}
-                    icon={ListTodoIcon}
-                    insight={activeInsight}
-                    footerMeta={`${plannedActiveShare}% scheduled`}
-                    series={createdSeries}
-                  />
-                  <StatsCard
-                    title="Completion Rate"
-                    value={`${metrics.completionRate}%`}
-                    icon={TrendingUpIcon}
-                    insight={completionInsight}
-                    footerMeta={`${metrics.completedTasks} done overall`}
-                    series={completionRateSeries}
-                  />
-                  <StreakIndicator streakData={streakData} />
-                </div>
-
-                {metrics.overdueCount > 0 && (
-                  <div className="alert is-danger items-center rounded-xl px-5 py-3.5">
-                    <AlertTriangleIcon className="h-5 w-5 shrink-0 text-rust" />
-                    <div className="flex-1">
-                      <p className="alert-title text-sm">
-                        {metrics.overdueCount} overdue{" "}
-                        {metrics.overdueCount === 1 ? "task" : "tasks"}
-                        {metrics.dueTodayCount > 0 && (
-                          <span className="alert-body">
-                            {" "}
-                            &middot; {metrics.dueTodayCount} due today
-                          </span>
-                        )}
-                      </p>
-                    </div>
-                  </div>
-                )}
-
-                <div className="grid gap-6 lg:grid-cols-3">
-                  <div className="space-y-4 lg:col-span-2">
-                    <div className="flex items-center">
-                      <SegmentedControl
-                        options={trendOptions}
-                        value={String(trendPeriod) as "7" | "30" | "90"}
-                        onChange={(v) =>
-                          setTrendPeriod(Number(v) as 7 | 30 | 90)
-                        }
-                      />
-                    </div>
-                    <CompletionChart data={trendData} />
-                  </div>
-                  <QuadrantDistribution
-                    distribution={metrics.quadrantDistribution}
-                  />
-                </div>
-
-                <div className="grid gap-6 lg:grid-cols-2">
-                  <UpcomingDeadlines
-                    tasks={tasks}
-                    onTaskClick={handleDeadlineTaskClick}
-                  />
-                  {metrics.tagStats.length > 0 ? (
-                    <TagAnalytics tagStats={metrics.tagStats} maxTags={8} />
-                  ) : (
-                    <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
-                      <h3 className="mb-4 text-lg font-semibold text-foreground">
-                        Top Tags
-                      </h3>
-                      <div className="flex h-[240px] items-center justify-center">
-                        <p className="text-sm text-foreground-muted">
-                          Add tags to your tasks to see analytics here.
-                        </p>
-                      </div>
-                    </div>
-                  )}
-                </div>
-
-                <TimeAnalytics
-                  summary={timeTrackingSummary}
-                  quadrantDistribution={timeByQuadrant}
-                />
-              </div>
-            )}
-          </div>
-
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 sm:py-8">
+          {isLoading ? (
+            <DashboardSkeleton />
+          ) : tasks.length === 0 ? (
+            <DashboardEmpty />
+          ) : (
+            <DashboardContent
+              data={data}
+              tasks={tasks}
+              trendPeriod={trendPeriod}
+              onTrendPeriodChange={setTrendPeriod}
+              onDeadlineTaskClick={handleDeadlineTaskClick}
+            />
+          )}
+        </div>
       </div>
     </AppShell>
+  );
+}
+
+function DashboardEmpty(): React.ReactElement {
+  return (
+    <div className="rounded-lg border-hair border-border bg-card p-12 text-center shadow-sm">
+      <ListTodoIcon className="mx-auto h-12 w-12 text-foreground-muted" />
+      <h2 className="mt-4 text-xl font-semibold text-foreground">No tasks yet</h2>
+      <p className="mt-2 text-sm text-foreground-muted">
+        Create your first task to start tracking your productivity!
+      </p>
+    </div>
+  );
+}
+
+interface DashboardContentProps {
+  data: ReturnType<typeof useDashboardData>;
+  tasks: ReturnType<typeof useTasks>["all"];
+  trendPeriod: 7 | 30 | 90;
+  onTrendPeriodChange: (v: 7 | 30 | 90) => void;
+  onDeadlineTaskClick: (task: { id: string }) => void;
+}
+
+function DashboardContent({ data, tasks, trendPeriod, onTrendPeriodChange, onDeadlineTaskClick }: DashboardContentProps): React.ReactElement {
+  const { metrics, trendData, streakData, timeTrackingSummary, timeByQuadrant,
+    completedSeries, createdSeries, completionRateSeries,
+    completedTrend, previousSixAverage,
+    completedInsight, activeInsight, completionInsight, plannedActiveShare } = data;
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        <StatsCard
+          title="Completed Today"
+          value={metrics.completedToday}
+          icon={CheckCircle2Icon}
+          trend={previousSixAverage > 0 ? { value: completedTrend, isPositive: completedTrend >= 0 } : undefined}
+          insight={completedInsight}
+          footerMeta={`${metrics.completedThisWeek} / 7d`}
+          series={completedSeries}
+        />
+        <StatsCard
+          title="Active Tasks"
+          value={metrics.activeTasks}
+          icon={ListTodoIcon}
+          insight={activeInsight}
+          footerMeta={`${plannedActiveShare}% scheduled`}
+          series={createdSeries}
+        />
+        <StatsCard
+          title="Completion Rate"
+          value={`${metrics.completionRate}%`}
+          icon={TrendingUpIcon}
+          insight={completionInsight}
+          footerMeta={`${metrics.completedTasks} done overall`}
+          series={completionRateSeries}
+        />
+        <StreakIndicator streakData={streakData} />
+      </div>
+
+      {metrics.overdueCount > 0 && (
+        <div className="alert is-danger items-center rounded-xl px-5 py-3.5">
+          <AlertTriangleIcon className="h-5 w-5 shrink-0 text-rust" />
+          <div className="flex-1">
+            <p className="alert-title text-sm">
+              {metrics.overdueCount} overdue {metrics.overdueCount === 1 ? "task" : "tasks"}
+              {metrics.dueTodayCount > 0 && (
+                <span className="alert-body"> &middot; {metrics.dueTodayCount} due today</span>
+              )}
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="space-y-4 lg:col-span-2">
+          <div className="flex items-center">
+            <SegmentedControl
+              options={TREND_OPTIONS}
+              value={String(trendPeriod) as "7" | "30" | "90"}
+              onChange={(v) => onTrendPeriodChange(Number(v) as 7 | 30 | 90)}
+            />
+          </div>
+          <CompletionChart data={trendData} />
+        </div>
+        <QuadrantDistribution distribution={metrics.quadrantDistribution} />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <UpcomingDeadlines tasks={tasks} onTaskClick={onDeadlineTaskClick} />
+        {metrics.tagStats.length > 0 ? (
+          <TagAnalytics tagStats={metrics.tagStats} maxTags={8} />
+        ) : (
+          <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
+            <h3 className="mb-4 text-lg font-semibold text-foreground">Top Tags</h3>
+            <div className="flex h-[240px] items-center justify-center">
+              <p className="text-sm text-foreground-muted">Add tags to your tasks to see analytics here.</p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <TimeAnalytics summary={timeTrackingSummary} quadrantDistribution={timeByQuadrant} />
+    </div>
   );
 }

--- a/app/(dashboard)/dashboard/use-dashboard-data.ts
+++ b/app/(dashboard)/dashboard/use-dashboard-data.ts
@@ -1,0 +1,84 @@
+import { useMemo } from "react";
+import type { TaskRecord } from "@/lib/types";
+import {
+  calculateMetrics,
+  getCompletionTrend,
+  getStreakData,
+  calculateTimeTrackingSummary,
+  getTimeByQuadrant,
+} from "@/lib/analytics";
+
+export interface DashboardData {
+  metrics: ReturnType<typeof calculateMetrics>;
+  trendData: ReturnType<typeof getCompletionTrend>;
+  streakData: ReturnType<typeof getStreakData>;
+  timeTrackingSummary: ReturnType<typeof calculateTimeTrackingSummary>;
+  timeByQuadrant: ReturnType<typeof getTimeByQuadrant>;
+  completedSeries: number[];
+  createdSeries: number[];
+  completionRateSeries: number[];
+  completedTrend: number;
+  previousSixAverage: number;
+  completedInsight: string;
+  activeInsight: string;
+  completionInsight: string;
+  plannedActiveShare: number;
+}
+
+/** Derives all analytics values for the Dashboard page from the raw task list. */
+export function useDashboardData(tasks: TaskRecord[], trendPeriod: 7 | 30 | 90): DashboardData {
+  const metrics = useMemo(() => calculateMetrics(tasks), [tasks]);
+  const last7TrendData = useMemo(() => getCompletionTrend(tasks, 7), [tasks]);
+  const trendData = useMemo(() => getCompletionTrend(tasks, trendPeriod), [tasks, trendPeriod]);
+  const streakData = useMemo(() => getStreakData(tasks), [tasks]);
+  const timeTrackingSummary = useMemo(() => calculateTimeTrackingSummary(tasks), [tasks]);
+  const timeByQuadrant = useMemo(() => getTimeByQuadrant(tasks), [tasks]);
+
+  const completedSeries = useMemo(() => last7TrendData.map((p) => p.completed), [last7TrendData]);
+  const createdSeries = useMemo(() => last7TrendData.map((p) => p.created), [last7TrendData]);
+  const completionRateSeries = useMemo(
+    () => last7TrendData.map((p) => Math.round((p.completed / (p.created || 1)) * 100)),
+    [last7TrendData]
+  );
+
+  const { completedTrend, previousSixAverage } = useMemo(() => {
+    const todayTrend = last7TrendData.at(-1)?.completed ?? 0;
+    let previousTotal = 0;
+    for (let i = 0; i < last7TrendData.length - 1; i += 1) {
+      previousTotal += last7TrendData[i].completed;
+    }
+    const previousCount = Math.max(0, last7TrendData.length - 1);
+    const nextPreviousSixAverage = previousCount > 0 ? previousTotal / previousCount : 0;
+    const nextCompletedTrend = nextPreviousSixAverage > 0
+      ? Math.round(((todayTrend - nextPreviousSixAverage) / nextPreviousSixAverage) * 100)
+      : todayTrend > 0 ? 100 : 0;
+    return { completedTrend: nextCompletedTrend, previousSixAverage: nextPreviousSixAverage };
+  }, [last7TrendData]);
+
+  const completedInsight = metrics.completedToday === 0
+    ? "Ready to start today"
+    : completedTrend > 10 ? "Above your recent pace"
+    : completedTrend < -10 ? "Below your recent pace"
+    : "Holding steady";
+
+  const plannedActiveShare = metrics.activeTasks > 0
+    ? Math.round(((metrics.activeTasks - metrics.noDueDateCount) / metrics.activeTasks) * 100)
+    : 0;
+
+  const activeInsight = metrics.overdueCount > 0
+    ? `${metrics.overdueCount} overdue`
+    : metrics.noDueDateCount > 0 ? `${metrics.noDueDateCount} unscheduled`
+    : "Well scoped";
+
+  const completionInsight = metrics.completionRate >= 80
+    ? "Strong follow-through"
+    : metrics.completionRate >= 60 ? "Healthy momentum"
+    : "Room to tighten execution";
+
+  return {
+    metrics, trendData, streakData, timeTrackingSummary, timeByQuadrant,
+    completedSeries, createdSeries, completionRateSeries,
+    completedTrend, previousSixAverage,
+    completedInsight, activeInsight, completionInsight, plannedActiveShare,
+  };
+}

--- a/app/(sync)/sync-history/page.tsx
+++ b/app/(sync)/sync-history/page.tsx
@@ -11,39 +11,108 @@ import { getRecentHistory, getHistoryStats, clearHistory } from "@/lib/sync-hist
 import type { SyncHistoryRecord } from "@/lib/types";
 import { toast } from "sonner";
 import { formatDistanceToNow } from "date-fns";
+import { TOAST_DURATION } from "@/lib/constants";
 
 const HISTORY_KEY = ["syncHistory"] as const;
 const STATS_KEY = ["syncHistoryStats"] as const;
 const ESTIMATED_ROW_HEIGHT = 120;
 const ROW_GAP = 16;
 
-function getStatusIcon(status: SyncHistoryRecord["status"]) {
-	switch (status) {
-		case "success":
-			return <CheckCircle2Icon className="h-5 w-5 text-green-600" />;
-		case "error":
-			return <XCircleIcon className="h-5 w-5 text-red-600" />;
-		case "conflict":
-			return <AlertTriangleIcon className="h-5 w-5 text-amber-600" />;
-		case "partial":
-			return <AlertTriangleIcon className="h-5 w-5 text-orange-600" />;
-	}
+function getStatusIcon(status: SyncHistoryRecord["status"]): React.ReactElement | null {
+  switch (status) {
+    case "success": return <CheckCircle2Icon className="h-5 w-5 text-green-600" />;
+    case "error": return <XCircleIcon className="h-5 w-5 text-red-600" />;
+    case "conflict": return <AlertTriangleIcon className="h-5 w-5 text-amber-600" />;
+    case "partial": return <AlertTriangleIcon className="h-5 w-5 text-orange-600" />;
+  }
 }
 
 function getStatusColor(status: SyncHistoryRecord["status"]): string {
-	switch (status) {
-		case "success":
-			return "bg-green-50 border-green-200";
-		case "error":
-			return "bg-red-50 border-red-200";
-		case "conflict":
-			return "bg-amber-50 border-amber-200";
-		case "partial":
-			return "bg-orange-50 border-orange-200";
-	}
+  switch (status) {
+    case "success": return "bg-green-50 border-green-200";
+    case "error": return "bg-red-50 border-red-200";
+    case "conflict": return "bg-amber-50 border-amber-200";
+    case "partial": return "bg-orange-50 border-orange-200";
+  }
 }
 
-export default function SyncHistoryPage() {
+interface SyncStatsData {
+  totalSyncs: number;
+  successfulSyncs: number;
+  totalPushed: number;
+  totalPulled: number;
+}
+
+function SyncHistoryStats({ stats }: { stats: SyncStatsData }): React.ReactElement {
+  return (
+    <div className="mb-8 grid gap-4 md:grid-cols-4">
+      <div className="rounded-lg border border-border bg-background-muted p-4">
+        <div className="text-sm text-foreground-muted">Total Syncs</div>
+        <div className="text-2xl font-semibold text-foreground">{stats.totalSyncs}</div>
+      </div>
+      <div className="rounded-lg border border-border bg-background-muted p-4">
+        <div className="text-sm text-foreground-muted">Successful</div>
+        <div className="text-2xl font-semibold text-green-600">{stats.successfulSyncs}</div>
+      </div>
+      <div className="rounded-lg border border-border bg-background-muted p-4">
+        <div className="text-sm text-foreground-muted">Tasks Pushed</div>
+        <div className="text-2xl font-semibold text-foreground">{stats.totalPushed}</div>
+      </div>
+      <div className="rounded-lg border border-border bg-background-muted p-4">
+        <div className="text-sm text-foreground-muted">Tasks Pulled</div>
+        <div className="text-2xl font-semibold text-foreground">{stats.totalPulled}</div>
+      </div>
+    </div>
+  );
+}
+
+function SyncHistoryRow({ record }: { record: SyncHistoryRecord }): React.ReactElement {
+  return (
+    <div className={`rounded-lg border p-4 ${getStatusColor(record.status)}`}>
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          {getStatusIcon(record.status)}
+          <div className="flex-1">
+            <div className="flex items-center gap-2">
+              <h3 className="font-medium text-foreground capitalize">
+                {record.status === "conflict" ? "Sync with Conflicts" : `${record.status} Sync`}
+              </h3>
+              <span className="inline-flex items-center gap-1 text-xs text-foreground-muted">
+                {record.triggeredBy === "user"
+                  ? (<><UserIcon className="h-3 w-3" />Manual</>)
+                  : (<><CloudIcon className="h-3 w-3" />Auto</>)
+                }
+              </span>
+            </div>
+            <div className="mt-1 flex items-center gap-1 text-sm text-foreground-muted">
+              <ClockIcon className="h-3 w-3" />
+              {formatDistanceToNow(new Date(record.timestamp), { addSuffix: true })}
+            </div>
+            <div className="mt-2 flex flex-wrap gap-4 text-sm">
+              {record.pushedCount > 0 && (
+                <span className="text-foreground-muted"><span className="font-medium text-foreground">{record.pushedCount}</span> pushed</span>
+              )}
+              {record.pulledCount > 0 && (
+                <span className="text-foreground-muted"><span className="font-medium text-foreground">{record.pulledCount}</span> pulled</span>
+              )}
+              {record.conflictsResolved > 0 && (
+                <span className="text-foreground-muted"><span className="font-medium text-amber-600">{record.conflictsResolved}</span> conflicts resolved</span>
+              )}
+              {record.duration && (
+                <span className="text-foreground-muted">{record.duration}ms</span>
+              )}
+            </div>
+            {record.errorMessage && (
+              <div className="mt-2 rounded bg-red-100 p-2 text-sm text-red-700">{record.errorMessage}</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function SyncHistoryPage(): React.ReactElement {
 	const router = useRouter();
 	const queryClient = useQueryClient();
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -66,16 +135,16 @@ export default function SyncHistoryPage() {
 			toast.success("Sync history cleared");
 		},
 		onError: (err) => {
-			const errorMsg = err instanceof Error ? err.message : "Failed to clear history";
-			toast.error(errorMsg);
+			toast.error(err instanceof Error ? err.message : "Failed to clear history");
 		},
 	});
 
-	const handleClearHistory = () => {
-		if (!confirm("Clear all sync history? This cannot be undone.")) {
-			return;
-		}
-		clearMutation.mutate();
+	const handleClearHistory = (): void => {
+		// Use a confirmation toast instead of window.confirm to stay non-blocking
+		toast("Clear all sync history? This cannot be undone.", {
+			duration: TOAST_DURATION.LONG,
+			action: { label: "Clear", onClick: () => clearMutation.mutate() },
+		});
 	};
 
 	const virtualizer = useVirtualizer({
@@ -91,37 +160,14 @@ export default function SyncHistoryPage() {
 			caption={`${history.length} sync operation${history.length !== 1 ? "s" : ""}`}
 			topbarRightSlot={
 				history.length > 0 ? (
-					<Button
-						variant="subtle"
-						onClick={handleClearHistory}
-						className="text-sm"
-					>
+					<Button variant="subtle" onClick={handleClearHistory} className="text-sm">
 						Clear History
 					</Button>
 				) : undefined
 			}
 		>
 			<div className="pb-8">
-				{stats && history.length > 0 && (
-					<div className="mb-8 grid gap-4 md:grid-cols-4">
-						<div className="rounded-lg border border-border bg-background-muted p-4">
-							<div className="text-sm text-foreground-muted">Total Syncs</div>
-							<div className="text-2xl font-semibold text-foreground">{stats.totalSyncs}</div>
-						</div>
-						<div className="rounded-lg border border-border bg-background-muted p-4">
-							<div className="text-sm text-foreground-muted">Successful</div>
-							<div className="text-2xl font-semibold text-green-600">{stats.successfulSyncs}</div>
-						</div>
-						<div className="rounded-lg border border-border bg-background-muted p-4">
-							<div className="text-sm text-foreground-muted">Tasks Pushed</div>
-							<div className="text-2xl font-semibold text-foreground">{stats.totalPushed}</div>
-						</div>
-						<div className="rounded-lg border border-border bg-background-muted p-4">
-							<div className="text-sm text-foreground-muted">Tasks Pulled</div>
-							<div className="text-2xl font-semibold text-foreground">{stats.totalPulled}</div>
-						</div>
-					</div>
-				)}
+				{stats && history.length > 0 && <SyncHistoryStats stats={stats} />}
 
 				{isLoading ? (
 					<div className="flex items-center justify-center py-12">
@@ -129,111 +175,29 @@ export default function SyncHistoryPage() {
 					</div>
 				) : history.length === 0 ? (
 					<div className="mx-auto max-w-xl rounded-3xl border border-border bg-background-muted p-8 text-center">
-						<h2 className="text-lg font-semibold text-foreground">
-							No sync history yet
-						</h2>
+						<h2 className="text-lg font-semibold text-foreground">No sync history yet</h2>
 						<p className="mt-2 text-sm text-foreground-muted">
 							Your sync operations will appear here once you enable cloud sync.
 						</p>
-						<Button
-							variant="primary"
-							className="mt-4"
-							onClick={() => router.push("/")}
-						>
+						<Button variant="primary" className="mt-4" onClick={() => router.push("/")}>
 							Back to Tasks
 						</Button>
 					</div>
 				) : (
-					<div
-						ref={scrollContainerRef}
-						className="overflow-auto"
-						style={{ height: "70vh" }}
-					>
-						<div
-							style={{
-								height: `${virtualizer.getTotalSize()}px`,
-								width: "100%",
-								position: "relative",
-							}}
-						>
-							{virtualizer.getVirtualItems().map((virtualRow) => {
-								const record = history[virtualRow.index];
-								return (
-									<div
-										key={virtualRow.key}
-										style={{
-											position: "absolute",
-											top: 0,
-											left: 0,
-											width: "100%",
-											height: `${virtualRow.size}px`,
-											transform: `translateY(${virtualRow.start}px)`,
-										}}
-									>
-										<div className={`rounded-lg border p-4 ${getStatusColor(record.status)}`}>
-											<div className="flex items-start justify-between gap-4">
-												<div className="flex items-start gap-3">
-													{getStatusIcon(record.status)}
-													<div className="flex-1">
-														<div className="flex items-center gap-2">
-															<h3 className="font-medium text-foreground capitalize">
-																{record.status === "conflict" ? "Sync with Conflicts" : `${record.status} Sync`}
-															</h3>
-															<span className="inline-flex items-center gap-1 text-xs text-foreground-muted">
-																{record.triggeredBy === "user" ? (
-																	<>
-																		<UserIcon className="h-3 w-3" />
-																		Manual
-																	</>
-																) : (
-																	<>
-																		<CloudIcon className="h-3 w-3" />
-																		Auto
-																	</>
-																)}
-															</span>
-														</div>
-
-														<div className="mt-1 flex items-center gap-1 text-sm text-foreground-muted">
-															<ClockIcon className="h-3 w-3" />
-															{formatDistanceToNow(new Date(record.timestamp), { addSuffix: true })}
-														</div>
-
-														<div className="mt-2 flex flex-wrap gap-4 text-sm">
-															{record.pushedCount > 0 && (
-																<span className="text-foreground-muted">
-																	<span className="font-medium text-foreground">{record.pushedCount}</span> pushed
-																</span>
-															)}
-															{record.pulledCount > 0 && (
-																<span className="text-foreground-muted">
-																	<span className="font-medium text-foreground">{record.pulledCount}</span> pulled
-																</span>
-															)}
-															{record.conflictsResolved > 0 && (
-																<span className="text-foreground-muted">
-																	<span className="font-medium text-amber-600">{record.conflictsResolved}</span> conflicts resolved
-																</span>
-															)}
-															{record.duration && (
-																<span className="text-foreground-muted">
-																	{record.duration}ms
-																</span>
-															)}
-														</div>
-
-														{record.errorMessage && (
-															<div className="mt-2 rounded bg-red-100 p-2 text-sm text-red-700">
-																{record.errorMessage}
-															</div>
-														)}
-													</div>
-												</div>
-											</div>
-										</div>
-									</div>
-								);
-							})}
+					<div ref={scrollContainerRef} className="overflow-auto" style={{ height: "70vh" }}>
+						<div style={{ height: `${virtualizer.getTotalSize()}px`, width: "100%", position: "relative" }}>
+							{virtualizer.getVirtualItems().map((virtualRow) => (
+								<div
+									key={virtualRow.key}
+									style={{
+										position: "absolute", top: 0, left: 0, width: "100%",
+										height: `${virtualRow.size}px`,
+										transform: `translateY(${virtualRow.start}px)`,
+									}}
+								>
+									<SyncHistoryRow record={history[virtualRow.index]} />
+								</div>
+							))}
 						</div>
 					</div>
 				)}

--- a/components/matrix-simplified/edit-drawer-fields.tsx
+++ b/components/matrix-simplified/edit-drawer-fields.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { CalendarIcon, XIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { quadrants, QUADRANT_ACCENT } from "@/lib/quadrants";
+import { DUE_PRESETS, type DuePreset } from "@/lib/due-date-presets";
+
+// ─── Shared ────────────────────────────────────────────────────────────────
+
+export function Field({ label, children }: { label: string; children: React.ReactNode }): React.ReactElement {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-[11px] font-semibold uppercase tracking-wider text-foreground-muted">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+// ─── QuadrantField ──────────────────────────────────────────────────────────
+
+interface QuadrantFieldProps {
+  urgent: boolean;
+  important: boolean;
+  onChange: (urgent: boolean, important: boolean) => void;
+}
+
+export function QuadrantField({ urgent, important, onChange }: QuadrantFieldProps): React.ReactElement {
+  return (
+    <Field label="Quadrant">
+      <div className="grid grid-cols-2 gap-2">
+        {quadrants.map((q) => {
+          const active = q.urgent === urgent && q.important === important;
+          const a = QUADRANT_ACCENT[q.rdKey];
+          return (
+            <button
+              data-testid={`edit-quadrant-${q.rdKey}`}
+              key={q.id}
+              type="button"
+              aria-label={q.title}
+              onClick={() => onChange(q.urgent, q.important)}
+              className={cn(
+                "rounded-lg border px-3 py-2.5 text-left transition-colors",
+                active ? "border-2" : "border hover:bg-background-muted/30"
+              )}
+              style={
+                active
+                  ? { borderColor: a, backgroundColor: `color-mix(in srgb, ${a} 14%, transparent)`, color: a }
+                  : { borderColor: `color-mix(in srgb, ${a} 35%, transparent)`, color: `color-mix(in srgb, ${a} 78%, var(--ink-3))` }
+              }
+              aria-pressed={active}
+            >
+              <div className="text-[12px] font-bold uppercase tracking-wider">{q.title}</div>
+              <div className="mt-0.5 text-[11.5px] opacity-80">{q.rdTag}</div>
+            </button>
+          );
+        })}
+      </div>
+    </Field>
+  );
+}
+
+// ─── DueDateField ───────────────────────────────────────────────────────────
+
+function formatChipDate(iso: string): string {
+  const date = new Date(`${iso}T00:00:00`);
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}
+
+interface DueDateFieldProps {
+  duePreset: DuePreset;
+  customDate: string | undefined;
+  showCustomDateInput: boolean;
+  onPresetChange: (preset: DuePreset) => void;
+  onCustomDateChange: (date: string | undefined) => void;
+  onToggleCustomInput: (show: boolean) => void;
+}
+
+export function DueDateField({
+  duePreset, customDate, showCustomDateInput,
+  onPresetChange, onCustomDateChange, onToggleCustomInput,
+}: DueDateFieldProps): React.ReactElement {
+  return (
+    <Field label="Due date">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="inline-flex rounded-lg border border-border bg-background-muted p-1">
+          {DUE_PRESETS.map((p) => {
+            const isActive = !customDate && duePreset === p.value;
+            return (
+              <button
+                key={p.value}
+                type="button"
+                onClick={() => { onPresetChange(p.value); onCustomDateChange(undefined); onToggleCustomInput(false); }}
+                className={cn(
+                  // Selected due-date preset reads in tide tint (reference §07);
+                  // unselected presets stay graphite.
+                  "rounded-md px-3 py-1.5 text-[12.5px] font-medium transition-all duration-200",
+                  isActive
+                    ? "bg-accent-tint text-accent font-semibold shadow-sm"
+                    : "text-foreground-muted hover:text-foreground"
+                )}
+                aria-pressed={isActive}
+              >
+                {p.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {customDate ? (
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-foreground-muted/30 bg-background px-2.5 py-1 text-[12px] font-medium text-foreground">
+            <CalendarIcon className="h-3 w-3" aria-hidden />
+            {formatChipDate(customDate)}
+            <button
+              type="button"
+              onClick={() => { onCustomDateChange(undefined); onToggleCustomInput(false); }}
+              aria-label="Clear custom date"
+              className="ml-0.5 text-foreground-muted hover:text-foreground"
+            >
+              <XIcon className="h-3 w-3" />
+            </button>
+          </span>
+        ) : showCustomDateInput ? (
+          <input
+            type="date"
+            autoFocus
+            onChange={(e) => { if (e.target.value) { onCustomDateChange(e.target.value); onToggleCustomInput(false); } }}
+            onBlur={() => onToggleCustomInput(false)}
+            className="rounded-md border border-border bg-background px-2.5 py-1 text-[12.5px] font-medium text-foreground outline-none focus:border-foreground-muted"
+            aria-label="Pick a custom due date"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => onToggleCustomInput(true)}
+            className="inline-flex items-center gap-1 rounded-md border border-dashed border-border px-2.5 py-1 text-[12.5px] font-medium text-foreground-muted transition-colors hover:border-foreground-muted/50 hover:text-foreground"
+          >
+            <CalendarIcon className="h-3 w-3" aria-hidden />
+            Pick a date…
+          </button>
+        )}
+      </div>
+    </Field>
+  );
+}
+
+// ─── TagsField ──────────────────────────────────────────────────────────────
+
+interface TagsFieldProps {
+  tags: string[];
+  tagInput: string;
+  onTagInputChange: (v: string) => void;
+  onAddTag: () => void;
+  onRemoveTag: (tag: string) => void;
+  onTagKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+}
+
+export function TagsField({ tags, tagInput, onTagInputChange, onAddTag, onRemoveTag, onTagKeyDown }: TagsFieldProps): React.ReactElement {
+  return (
+    <Field label="Tags">
+      <div className="flex flex-wrap items-center gap-1.5 rounded-lg border border-border bg-background p-2">
+        {tags.map((t) => (
+          <span
+            key={t}
+            className="inline-flex items-center gap-1 rounded bg-background-muted px-2 py-0.5 text-[11.5px] font-medium text-foreground-muted"
+          >
+            <span className="opacity-60">#</span>
+            {t}
+            <button
+              type="button"
+              onClick={() => onRemoveTag(t)}
+              aria-label={`Remove ${t}`}
+              className="hover:text-foreground"
+            >
+              <XIcon className="h-3 w-3" />
+            </button>
+          </span>
+        ))}
+        <input
+          value={tagInput}
+          onChange={(e) => onTagInputChange(e.target.value)}
+          onKeyDown={onTagKeyDown}
+          onBlur={onAddTag}
+          placeholder={tags.length ? "" : "Add a tag…"}
+          className="min-w-[80px] flex-1 border-0 bg-transparent text-[13px] text-foreground outline-none"
+        />
+      </div>
+    </Field>
+  );
+}

--- a/components/matrix-simplified/edit-drawer.tsx
+++ b/components/matrix-simplified/edit-drawer.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useEffect, useRef, useState, type FormEvent } from "react";
-import { XIcon, CheckIcon, CalendarIcon } from "lucide-react";
+import { useEffect, useRef, type FormEvent } from "react";
+import { XIcon, CheckIcon } from "lucide-react";
 import type { TaskRecord } from "@/lib/types";
 import { quadrants, QUADRANT_ACCENT } from "@/lib/quadrants";
-import { resolveDuePreset, DUE_PRESETS, type DuePreset } from "@/lib/due-date-presets";
 import { cn } from "@/lib/utils";
 import { DrawerHint } from "@/components/ui/drawer-hint";
 import { useDialogFocus } from "./use-dialog-focus";
+import { useEditDraftState } from "./use-edit-draft-state";
+import { Field, QuadrantField, DueDateField, TagsField } from "./edit-drawer-fields";
 
 export interface EditDraft {
   title: string;
@@ -27,128 +28,38 @@ interface EditDrawerProps {
   onSubmit: (draft: EditDraft, taskId?: string) => void | Promise<void>;
 }
 
-function classifyExistingDate(iso: string | undefined): DuePreset {
-  if (!iso) return "none";
-  const todayIso = new Date().toISOString().slice(0, 10);
-  // Support both date-only ("2026-04-27") and full datetime ("2026-04-27T14:00:00Z")
-  const dateOnly = iso.slice(0, 10);
-  if (dateOnly === todayIso) return "today";
-  const target = new Date(`${dateOnly}T00:00:00`);
-  const today = new Date(`${todayIso}T00:00:00`);
-  const diff = (target.getTime() - today.getTime()) / (1000 * 60 * 60 * 24);
-  if (diff > 0 && diff <= 7) return "this-week";
-  if (diff > 7 && diff <= 14) return "next-week";
-  return "none";
-}
-
-/**
- * If an existing iso date doesn't fall into a preset bucket but is set,
- * surface it as a custom date string ("YYYY-MM-DD"). Otherwise undefined.
- */
-function classifyExistingCustomDate(iso: string | undefined): string | undefined {
-  if (!iso) return undefined;
-  const dateOnly = iso.slice(0, 10);
-  if (classifyExistingDate(iso) !== "none") return undefined;
-  return dateOnly;
-}
-
-function formatChipDate(iso: string): string {
-  const date = new Date(`${iso}T00:00:00`);
-  return new Intl.DateTimeFormat(undefined, {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-  }).format(date);
-}
-
-export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: EditDrawerProps) {
+export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: EditDrawerProps): React.ReactElement | null {
   const titleRef = useRef<HTMLInputElement>(null);
   const drawerRef = useRef<HTMLFormElement>(null);
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [urgent, setUrgent] = useState(false);
-  const [important, setImportant] = useState(false);
-  const [duePreset, setDuePreset] = useState<DuePreset>("none");
-  const [customDate, setCustomDate] = useState<string | undefined>(undefined);
-  const [showCustomDateInput, setShowCustomDateInput] = useState(false);
-  const [tags, setTags] = useState<string[]>([]);
-  const [tagInput, setTagInput] = useState("");
+  const draft = useEditDraftState(open, task, initialDraft, titleRef);
   const trapKeyDown = useDialogFocus(open, drawerRef);
 
-  // The drawer owns draft state while open, then rehydrates from the selected task.
-  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (!open) return;
-    if (task) {
-      setTitle(task.title);
-      setDescription(task.description ?? "");
-      setUrgent(task.urgent);
-      setImportant(task.important);
-      setDuePreset(classifyExistingDate(task.dueDate));
-      setCustomDate(classifyExistingCustomDate(task.dueDate));
-      setTags(task.tags ?? []);
-    } else {
-      setTitle(initialDraft?.title ?? "");
-      setDescription(initialDraft?.description ?? "");
-      setUrgent(initialDraft?.urgent ?? false);
-      setImportant(initialDraft?.important ?? false);
-      setDuePreset("none");
-      setCustomDate(undefined);
-      setTags(initialDraft?.tags ?? []);
-    }
-    setShowCustomDateInput(false);
-    setTagInput("");
-    setTimeout(() => titleRef.current?.focus(), 50);
-  }, [open, task, initialDraft]);
-  /* eslint-enable react-hooks/set-state-in-effect */
-
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [open, onClose]);
 
   if (!open) return null;
-  const isCreateMode = !task;
 
-  const activeQuadrant = quadrants.find((q) => q.urgent === urgent && q.important === important);
+  const isCreateMode = !task;
+  const activeQuadrant = quadrants.find((q) => q.urgent === draft.urgent && q.important === draft.important);
   const accent = activeQuadrant ? QUADRANT_ACCENT[activeQuadrant.rdKey] : "var(--rust)";
 
-  const submit = (e?: FormEvent) => {
+  const submit = (e?: FormEvent): void => {
     e?.preventDefault();
-    if (!title.trim()) return;
-    // Custom date wins over preset when set.
-    const rawDate = customDate ?? resolveDuePreset(duePreset);
-    // Convert date-only "YYYY-MM-DD" to full ISO datetime required by taskDraftSchema
-    const dueDate = rawDate ? new Date(`${rawDate}T00:00:00`).toISOString() : undefined;
-    void onSubmit(
-      {
-        title: title.trim(),
-        description: description.trim(),
-        urgent,
-        important,
-        dueDate,
-        tags,
-      },
-      task?.id
-    );
-  };
-
-  const addTag = () => {
-    const v = tagInput.trim().toLowerCase().replace(/^#/, "");
-    if (!v || tags.includes(v)) {
-      setTagInput("");
-      return;
-    }
-    setTags([...tags, v]);
-    setTagInput("");
+    if (!draft.title.trim()) return;
+    void onSubmit(draft.toDraft(), task?.id);
   };
 
   return (
-    <div onClick={onClose} onKeyDown={(e) => { if (e.key === 'Escape') onClose(); }} role="presentation" className="fixed inset-0 z-[60] flex justify-end bg-black/30 animate-drawer-overlay">
+    <div
+      onClick={onClose}
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
+      role="presentation"
+      className="fixed inset-0 z-[60] flex justify-end bg-black/30 animate-drawer-overlay"
+    >
       <form
         data-testid="edit-drawer"
         ref={drawerRef}
@@ -164,10 +75,7 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
           <span aria-hidden className="h-2 w-2 rounded-full" style={{ backgroundColor: accent }} />
           <h2 className="rd-serif text-[22px] text-foreground">{isCreateMode ? "New task" : "Edit task"}</h2>
           {activeQuadrant ? (
-            <span
-              className="ml-1 text-[11px] font-semibold uppercase tracking-wider"
-              style={{ color: accent }}
-            >
+            <span className="ml-1 text-[11px] font-semibold uppercase tracking-wider" style={{ color: accent }}>
               {activeQuadrant.title}
             </span>
           ) : null}
@@ -182,12 +90,11 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
         </header>
 
         <div className="flex flex-1 flex-col gap-5 overflow-auto px-5 py-5">
-          {/* Title — placeholder carries affordance, the uppercase label is dropped */}
           <input
             data-testid="edit-title"
             ref={titleRef}
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
+            value={draft.title}
+            onChange={(e) => draft.setTitle(e.target.value)}
             placeholder="What needs doing?"
             className="w-full rounded-lg border border-border bg-background px-3 py-3 text-[18px] font-medium text-foreground outline-none focus:border-foreground-muted placeholder:font-normal"
             aria-label="Title"
@@ -196,160 +103,42 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
           <Field label="Description">
             <textarea
               data-testid="edit-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
+              value={draft.description}
+              onChange={(e) => draft.setDescription(e.target.value)}
               rows={4}
               placeholder="Optional details, links, context"
               className="w-full resize-y rounded-lg border border-border bg-background px-3 py-2.5 text-[13.5px] leading-relaxed text-foreground outline-none focus:border-foreground-muted"
             />
           </Field>
 
-          <Field label="Quadrant">
-            <div className="grid grid-cols-2 gap-2">
-              {quadrants.map((q) => {
-                const active = q.urgent === urgent && q.important === important;
-                const a = QUADRANT_ACCENT[q.rdKey];
-                return (
-                  <button
-                    data-testid={`edit-quadrant-${q.rdKey}`}
-                    key={q.id}
-                    type="button"
-                    aria-label={q.title}
-                    onClick={() => {
-                      setUrgent(q.urgent);
-                      setImportant(q.important);
-                    }}
-                    className={cn(
-                      "rounded-lg border px-3 py-2.5 text-left transition-colors",
-                      active ? "border-2" : "border hover:bg-background-muted/30"
-                    )}
-                    // The picker mirrors the matrix: the selected cell is solid
-                    // (wash fill + full accent border), the other three carry their
-                    // own pigment at ~0.35 so all four colors read at a glance.
-                    style={
-                      active
-                        ? { borderColor: a, backgroundColor: `color-mix(in srgb, ${a} 14%, transparent)`, color: a }
-                        : { borderColor: `color-mix(in srgb, ${a} 35%, transparent)`, color: `color-mix(in srgb, ${a} 78%, var(--ink-3))` }
-                    }
-                    aria-pressed={active}
-                  >
-                    <div className="text-[12px] font-bold uppercase tracking-wider">{q.title}</div>
-                    <div className="mt-0.5 text-[11.5px] opacity-80">{q.rdTag}</div>
-                  </button>
-                );
-              })}
-            </div>
-          </Field>
+          <QuadrantField
+            urgent={draft.urgent}
+            important={draft.important}
+            onChange={(u, i) => { draft.setUrgent(u); draft.setImportant(i); }}
+          />
 
-          <Field label="Due date">
-            <div className="flex flex-wrap items-center gap-2">
-              <div className="inline-flex rounded-lg border border-border bg-background-muted p-1">
-                {DUE_PRESETS.map((p) => {
-                  const isActive = !customDate && duePreset === p.value;
-                  return (
-                    <button
-                      key={p.value}
-                      type="button"
-                      onClick={() => {
-                        setDuePreset(p.value);
-                        setCustomDate(undefined);
-                        setShowCustomDateInput(false);
-                      }}
-                      className={cn(
-                        // Selected due-date preset reads in tide tint (reference §07);
-                        // unselected presets stay graphite.
-                        "rounded-md px-3 py-1.5 text-[12.5px] font-medium transition-all duration-200",
-                        isActive
-                          ? "bg-accent-tint text-accent font-semibold shadow-sm"
-                          : "text-foreground-muted hover:text-foreground"
-                      )}
-                      aria-pressed={isActive}
-                    >
-                      {p.label}
-                    </button>
-                  );
-                })}
-              </div>
+          <DueDateField
+            duePreset={draft.duePreset}
+            customDate={draft.customDate}
+            showCustomDateInput={draft.showCustomDateInput}
+            onPresetChange={draft.setDuePreset}
+            onCustomDateChange={draft.setCustomDate}
+            onToggleCustomInput={draft.setShowCustomDateInput}
+          />
 
-              {customDate ? (
-                <span className="inline-flex items-center gap-1.5 rounded-full border border-foreground-muted/30 bg-background px-2.5 py-1 text-[12px] font-medium text-foreground">
-                  <CalendarIcon className="h-3 w-3" aria-hidden />
-                  {formatChipDate(customDate)}
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setCustomDate(undefined);
-                      setShowCustomDateInput(false);
-                    }}
-                    aria-label="Clear custom date"
-                    className="ml-0.5 text-foreground-muted hover:text-foreground"
-                  >
-                    <XIcon className="h-3 w-3" />
-                  </button>
-                </span>
-              ) : showCustomDateInput ? (
-                <input
-                  type="date"
-                  autoFocus
-                  onChange={(e) => {
-                    if (e.target.value) {
-                      setCustomDate(e.target.value);
-                      setShowCustomDateInput(false);
-                    }
-                  }}
-                  onBlur={() => setShowCustomDateInput(false)}
-                  className="rounded-md border border-border bg-background px-2.5 py-1 text-[12.5px] font-medium text-foreground outline-none focus:border-foreground-muted"
-                  aria-label="Pick a custom due date"
-                />
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => setShowCustomDateInput(true)}
-                  className="inline-flex items-center gap-1 rounded-md border border-dashed border-border px-2.5 py-1 text-[12.5px] font-medium text-foreground-muted transition-colors hover:border-foreground-muted/50 hover:text-foreground"
-                >
-                  <CalendarIcon className="h-3 w-3" aria-hidden />
-                  Pick a date…
-                </button>
-              )}
-            </div>
-          </Field>
-
-          <Field label="Tags">
-            <div className="flex flex-wrap items-center gap-1.5 rounded-lg border border-border bg-background p-2">
-              {tags.map((t) => (
-                <span
-                  key={t}
-                  className="inline-flex items-center gap-1 rounded bg-background-muted px-2 py-0.5 text-[11.5px] font-medium text-foreground-muted"
-                >
-                  <span className="opacity-60">#</span>
-                  {t}
-                  <button
-                    type="button"
-                    onClick={() => setTags(tags.filter((x) => x !== t))}
-                    aria-label={`Remove ${t}`}
-                    className="hover:text-foreground"
-                  >
-                    <XIcon className="h-3 w-3" />
-                  </button>
-                </span>
-              ))}
-              <input
-                value={tagInput}
-                onChange={(e) => setTagInput(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === ",") {
-                    e.preventDefault();
-                    addTag();
-                  } else if (e.key === "Backspace" && !tagInput && tags.length) {
-                    setTags(tags.slice(0, -1));
-                  }
-                }}
-                onBlur={addTag}
-                placeholder={tags.length ? "" : "Add a tag…"}
-                className="min-w-[80px] flex-1 border-0 bg-transparent text-[13px] text-foreground outline-none"
-              />
-            </div>
-          </Field>
+          <TagsField
+            tags={draft.tags}
+            tagInput={draft.tagInput}
+            onTagInputChange={draft.setTagInput}
+            onAddTag={draft.addTag}
+            onRemoveTag={(t) => draft.setTags(draft.tags.filter((x) => x !== t))}
+            onTagKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === ",") { e.preventDefault(); draft.addTag(); }
+              else if (e.key === "Backspace" && !draft.tagInput && draft.tags.length) {
+                draft.setTags(draft.tags.slice(0, -1));
+              }
+            }}
+          />
         </div>
 
         <footer className="flex items-center gap-2.5 border-t border-border/60 bg-background px-5 py-3.5">
@@ -365,7 +154,7 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
           <button
             data-testid="save-task"
             type="submit"
-            disabled={!title.trim()}
+            disabled={!draft.title.trim()}
             className={cn(
               "inline-flex items-center gap-1.5 rounded-lg bg-foreground px-3.5 py-1.5 text-[13px] font-medium text-background",
               "hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-40"
@@ -377,16 +166,5 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
         </footer>
       </form>
     </div>
-  );
-}
-
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <label className="flex flex-col gap-1.5">
-      <span className="text-[11px] font-semibold uppercase tracking-wider text-foreground-muted">
-        {label}
-      </span>
-      {children}
-    </label>
   );
 }

--- a/components/matrix-simplified/use-edit-draft-state.ts
+++ b/components/matrix-simplified/use-edit-draft-state.ts
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+import type { TaskRecord } from "@/lib/types";
+import { resolveDuePreset, type DuePreset } from "@/lib/due-date-presets";
+import { UI_TIMING } from "@/lib/constants/ui";
+import type { EditDraft } from "./edit-drawer";
+
+function classifyExistingDate(iso: string | undefined): DuePreset {
+  if (!iso) return "none";
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const dateOnly = iso.slice(0, 10);
+  if (dateOnly === todayIso) return "today";
+  const target = new Date(`${dateOnly}T00:00:00`);
+  const today = new Date(`${todayIso}T00:00:00`);
+  const diff = (target.getTime() - today.getTime()) / (1000 * 60 * 60 * 24);
+  if (diff > 0 && diff <= 7) return "this-week";
+  if (diff > 7 && diff <= 14) return "next-week";
+  return "none";
+}
+
+function classifyExistingCustomDate(iso: string | undefined): string | undefined {
+  if (!iso) return undefined;
+  if (classifyExistingDate(iso) !== "none") return undefined;
+  return iso.slice(0, 10);
+}
+
+export interface EditDraftState {
+  title: string;
+  setTitle: (v: string) => void;
+  description: string;
+  setDescription: (v: string) => void;
+  urgent: boolean;
+  setUrgent: (v: boolean) => void;
+  important: boolean;
+  setImportant: (v: boolean) => void;
+  duePreset: DuePreset;
+  setDuePreset: (v: DuePreset) => void;
+  customDate: string | undefined;
+  setCustomDate: (v: string | undefined) => void;
+  showCustomDateInput: boolean;
+  setShowCustomDateInput: (v: boolean) => void;
+  tags: string[];
+  setTags: (v: string[]) => void;
+  tagInput: string;
+  setTagInput: (v: string) => void;
+  addTag: () => void;
+  toDraft: () => EditDraft;
+}
+
+/**
+ * Owns all form-field state for EditDrawer and rehydrates when the drawer
+ * opens or the selected task changes.
+ */
+export function useEditDraftState(
+  open: boolean,
+  task: TaskRecord | null | undefined,
+  initialDraft: Partial<EditDraft> | undefined,
+  titleRef: RefObject<HTMLInputElement | null>
+): EditDraftState {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [urgent, setUrgent] = useState(false);
+  const [important, setImportant] = useState(false);
+  const [duePreset, setDuePreset] = useState<DuePreset>("none");
+  const [customDate, setCustomDate] = useState<string | undefined>(undefined);
+  const [showCustomDateInput, setShowCustomDateInput] = useState(false);
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState("");
+
+  // Rehydrate all draft fields whenever the drawer opens or the selected task changes.
+  // Calling multiple setters inside a useEffect is intentional here — each setter maps
+  // directly to one form field, and batching them into a reducer would add indirection
+  // without improving clarity. React 18 batches these updates automatically.
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    if (!open) return;
+    if (task) {
+      setTitle(task.title);
+      setDescription(task.description ?? "");
+      setUrgent(task.urgent);
+      setImportant(task.important);
+      setDuePreset(classifyExistingDate(task.dueDate));
+      setCustomDate(classifyExistingCustomDate(task.dueDate));
+      setTags(task.tags ?? []);
+    } else {
+      setTitle(initialDraft?.title ?? "");
+      setDescription(initialDraft?.description ?? "");
+      setUrgent(initialDraft?.urgent ?? false);
+      setImportant(initialDraft?.important ?? false);
+      setDuePreset("none");
+      setCustomDate(undefined);
+      setTags(initialDraft?.tags ?? []);
+    }
+    setShowCustomDateInput(false);
+    setTagInput("");
+    setTimeout(() => titleRef.current?.focus(), UI_TIMING.FOCUS_DELAY_MS);
+  }, [open, task, initialDraft, titleRef]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  const addTag = (): void => {
+    const v = tagInput.trim().toLowerCase().replace(/^#/, "");
+    if (!v || tags.includes(v)) {
+      setTagInput("");
+      return;
+    }
+    setTags([...tags, v]);
+    setTagInput("");
+  };
+
+  const toDraft = (): EditDraft => {
+    const rawDate = customDate ?? resolveDuePreset(duePreset);
+    const dueDate = rawDate ? new Date(`${rawDate}T00:00:00`).toISOString() : undefined;
+    return {
+      title: title.trim(),
+      description: description.trim(),
+      urgent,
+      important,
+      dueDate,
+      tags,
+    };
+  };
+
+  return {
+    title, setTitle,
+    description, setDescription,
+    urgent, setUrgent,
+    important, setImportant,
+    duePreset, setDuePreset,
+    customDate, setCustomDate,
+    showCustomDateInput, setShowCustomDateInput,
+    tags, setTags,
+    tagInput, setTagInput,
+    addTag,
+    toDraft,
+  };
+}

--- a/components/matrix-simplified/use-matrix-window-events.ts
+++ b/components/matrix-simplified/use-matrix-window-events.ts
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import { createTask } from "@/lib/tasks";
 import { parseShareCaptureParams } from "@/lib/share-capture";
 import { TOAST_DURATION } from "@/lib/constants";
+import { UI_TIMING } from "@/lib/constants/ui";
 import {
   APPLY_SMART_VIEW_EVENT,
   HIGHLIGHT_TASK_EVENT,
@@ -47,7 +48,7 @@ export function useMatrixWindowEvents({
     if (!action) return;
 
     if (action === "new-task") {
-      setTimeout(() => captureInputRef.current?.focus(), 50);
+      setTimeout(() => captureInputRef.current?.focus(), UI_TIMING.FOCUS_DELAY_MS);
     } else if (action === "capture") {
       const draft = parseShareCaptureParams(params);
       if (draft) {

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -110,7 +110,6 @@ export async function restoreTask(taskId: string): Promise<void> {
   }
 
   // Remove archivedAt timestamp
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { archivedAt: _archivedAt, ...taskWithoutArchive } = archivedTask;
 
   // Move back to main tasks table

--- a/lib/constants/ui.ts
+++ b/lib/constants/ui.ts
@@ -42,6 +42,9 @@ export const UI_TIMING = {
 
   /** Auto-refresh interval for sync debug panel (2 seconds) */
   DEBUG_PANEL_REFRESH_MS: 2000,
+
+  /** Delay before focusing a newly-opened input field (50ms) */
+  FOCUS_DELAY_MS: 50,
 } as const;
 
 /**

--- a/lib/sync/pb-auth.ts
+++ b/lib/sync/pb-auth.ts
@@ -76,7 +76,8 @@ function closeOAuthPopup(popupWindow?: Window | null): void {
   try {
     popupWindow?.close?.();
   } catch {
-    // Some mobile browsers do not allow closing OAuth browser contexts.
+    // Some mobile browsers do not allow closing OAuth browser contexts — expected, not an error.
+    logger.debug("Could not close OAuth popup window — expected on some mobile browsers");
   }
 }
 

--- a/lib/tasks/import-export.ts
+++ b/lib/tasks/import-export.ts
@@ -3,6 +3,7 @@ import { generateId } from "@/lib/id-generator";
 import { createLogger } from "@/lib/logger";
 import { importPayloadSchema, taskRecordSchema } from "@/lib/schema";
 import type { ImportPayload, TaskRecord } from "@/lib/types";
+import type { SyncQueue } from "@/lib/sync/queue";
 import { isoNow } from "@/lib/utils";
 
 /** Maximum number of tasks allowed in a single import to prevent storage DoS */
@@ -127,7 +128,7 @@ function remapTaskReferences(
 }
 
 /** Resolve sync modules outside transaction to avoid detaching Dexie context */
-async function resolveSyncDeps() {
+async function resolveSyncDeps(): Promise<{ syncEnabled: boolean; queue: SyncQueue; scheduleSyncAfterChange: () => void }> {
   const { getSyncConfig } = await import("@/lib/sync/config");
   const { getSyncQueue } = await import("@/lib/sync/queue");
   const { scheduleSyncAfterChange } = await import("@/lib/tasks/crud/helpers");

--- a/lib/use-error-handler.ts
+++ b/lib/use-error-handler.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback } from "react";
-import { useToast } from "@/components/ui/toast";
+import { toast } from "sonner";
 import { logError, getUserErrorMessage } from "@/lib/error-logger";
 import type { ErrorContext } from "@/lib/error-logger";
 import { TOAST_DURATION } from "@/lib/constants";
@@ -24,20 +24,12 @@ import { TOAST_DURATION } from "@/lib/constants";
  * }
  * ```
  */
-export function useErrorHandler() {
-  const { showToast } = useToast();
-
-  return useCallback(
-    (error: unknown, context: ErrorContext) => {
-      // Log the error with full context
-      logError(error, context);
-
-      // Show user-friendly error message
-      const userMessage = getUserErrorMessage(error, context.userMessage);
-      showToast(userMessage, undefined, TOAST_DURATION.LONG);
-    },
-    [showToast]
-  );
+export function useErrorHandler(): (error: unknown, context: ErrorContext) => void {
+  return useCallback((error: unknown, context: ErrorContext) => {
+    logError(error, context);
+    const userMessage = getUserErrorMessage(error, context.userMessage);
+    toast.error(userMessage, { duration: TOAST_DURATION.LONG });
+  }, []);
 }
 
 /**
@@ -57,23 +49,21 @@ export function useErrorHandler() {
  * }
  * ```
  */
-export function useErrorHandlerWithUndo() {
-  const { showToast } = useToast();
-
-  const handleError = useCallback(
-    (error: unknown, context: ErrorContext) => {
-      logError(error, context);
-      const userMessage = getUserErrorMessage(error, context.userMessage);
-      showToast(userMessage, undefined, TOAST_DURATION.LONG);
-    },
-    [showToast]
-  );
+export function useErrorHandlerWithUndo(): {
+  handleError: (error: unknown, context: ErrorContext) => void;
+  handleSuccess: (message: string, undoAction: () => Promise<void>, duration?: number) => void;
+} {
+  const handleError = useCallback((error: unknown, context: ErrorContext) => {
+    logError(error, context);
+    const userMessage = getUserErrorMessage(error, context.userMessage);
+    toast.error(userMessage, { duration: TOAST_DURATION.LONG });
+  }, []);
 
   const handleSuccess = useCallback(
     (message: string, undoAction: () => Promise<void>, duration = TOAST_DURATION.LONG) => {
-      showToast(
-        message,
-        {
+      toast(message, {
+        duration,
+        action: {
           label: "Undo",
           onClick: async () => {
             try {
@@ -84,14 +74,13 @@ export function useErrorHandlerWithUndo() {
                 userMessage: 'Failed to undo operation',
                 timestamp: new Date().toISOString()
               });
-              showToast('Failed to undo operation', undefined, TOAST_DURATION.SHORT);
+              toast.error('Failed to undo operation', { duration: TOAST_DURATION.SHORT });
             }
-          }
+          },
         },
-        duration
-      );
+      });
     },
-    [showToast]
+    []
   );
 
   return { handleError, handleSuccess };

--- a/scripts/test-coverage.sh
+++ b/scripts/test-coverage.sh
@@ -13,7 +13,7 @@ echo ""
 
 # Run tests with coverage
 echo "Running tests with coverage..."
-bun test -- --coverage --no-coverage.thresholds 2>&1
+bun run test -- --coverage --no-coverage.thresholds 2>&1
 TEST_EXIT_CODE=$?
 
 echo ""
@@ -37,7 +37,7 @@ if [ ! -d "coverage" ]; then
   echo ""
   echo "To fix this:"
   echo ""
-  echo "  1. Run 'bun test' to see detailed test failures"
+  echo "  1. Run 'bun run test' to see detailed test failures"
   echo "  2. Fix tests that have unhandled promises or cleanup issues"
   echo "  3. Look for errors about 'test environment torn down'"
   echo "  4. Ensure all tests properly clean up timers/promises"

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,6 +2,35 @@
 
 ---
 
+## Resuming From Here — 2026-06-23
+
+**Active branch:** `chore/coding-standards-compliance`
+
+**What was done in this session:** Full codebase compliance audit against `coding-standards.md`. Fixed all findings:
+- Migrated `lib/use-error-handler.ts` off legacy `useToast()` to `sonner` directly (🔴 blocking)
+- Fixed `scripts/test-coverage.sh` to use `bun run test` not `bun test` (🔴 blocking)
+- Fixed `localStorage.clear()` → `removeItem()` in `tests/data/reset-everything.test.ts` (🔴 blocking)
+- Added `FOCUS_DELAY_MS` constant to `lib/constants/ui.ts`; replaced two inline `50` literals
+- Removed dead `eslint-disable-next-line no-unused-vars` in `lib/archive.ts` (rule is off globally)
+- Added debug log to silent `catch {}` in `lib/sync/pb-auth.ts`
+- Improved eslint-disable comment in `edit-drawer.tsx` with justification
+- Added explicit return type to `resolveSyncDeps()` in `lib/tasks/import-export.ts`
+- Extracted `useEditDraftState` hook + `edit-drawer-fields.tsx` sub-components; `EditDrawer` function now ~40 lines
+- Extracted `useDashboardData` hook; `DashboardPage` now uses `DashboardContent` / `DashboardEmpty` sub-components
+- Extracted `SyncHistoryRow` + `SyncHistoryStats` sub-components; replaced `window.confirm` with sonner confirmation toast
+- Extracted `ArchivedTaskCard` sub-component from `ArchivePage`
+- Cleaned up `tasks/todo.md` handoff state
+
+**Next steps:** Run `bun typecheck` + `bun run test` on the branch, then open PR.
+
+**Branches pending merge (pre-existing, from prior sessions):**
+- `fix/sync-health-toast-dedup` — complete per 2026-06-20 entry below; awaiting commit/PR
+- `chore/refactor-review-refine` — complete per 2026-06-19 entry below; "awaiting user go-ahead"
+- `feat/design-reference-compliance` — complete per 2026-06-14 entry below; "ready to push + PR"
+- `fix/security-medium-findings` — complete per 2026-06-10 entry below
+
+---
+
 ## In progress — 2026-06-20: Fix stacked sync-health toasts (TDD)
 
 **Branch:** `fix/sync-health-toast-dedup` · **Tier:** Standard (one hook + its single consumer; internal callback contract change; TDD).

--- a/tests/data/reset-everything.test.ts
+++ b/tests/data/reset-everything.test.ts
@@ -64,7 +64,10 @@ describe('reset-everything', () => {
     vi.clearAllMocks();
     mockGetSyncConfig.mockResolvedValue(null);
     mockToArray.mockResolvedValue([]);
-    localStorage.clear();
+    // localStorage.clear() does not work in jsdom-under-Bun — remove keys individually
+    localStorage.removeItem('pocketbase_auth');
+    localStorage.removeItem('gsd-pwa-dismissed');
+    localStorage.removeItem('theme');
   });
 
   describe('resetEverything', () => {


### PR DESCRIPTION
## Summary

Full codebase audit against `coding-standards.md` v16.1. Fixes all 11 findings across three severity levels.

---

## 🔴 Blocking

| File | Issue | Fix |
|---|---|---|
| `lib/use-error-handler.ts` | Used deprecated `useToast()` from `components/ui/toast.tsx` | Migrated to `toast.error()`/`toast()` from `sonner` directly; hook is now stable (no deps) |
| `scripts/test-coverage.sh` | `bun test` invokes Bun's built-in runner, not Vitest | Changed to `bun run test` in both the run command and the error message |
| `tests/data/reset-everything.test.ts` | `localStorage.clear()` doesn't work in jsdom-under-Bun | Replaced with 3× `removeItem()` for each key the tests depend on |

## 🟠 Important

| File | Issue | Fix |
|---|---|---|
| `edit-drawer.tsx` | `EditDrawer` function was ~317 lines (limit 40) — deferred S1 | Extracted `useEditDraftState` hook + `edit-drawer-fields.tsx` (QuadrantField, DueDateField, TagsField); orchestrator is now 170 lines with the function body ~40 lines |
| `dashboard/page.tsx` | `DashboardPage` ~246 lines | Extracted `useDashboardData` hook + `DashboardContent`/`DashboardEmpty` sub-components |
| `sync-history/page.tsx` | `SyncHistoryPage` ~197 lines; `window.confirm()` usage | Extracted `SyncHistoryRow`/`SyncHistoryStats`; replaced `window.confirm` with non-blocking sonner confirmation toast |
| `archive/page.tsx` | Inline archived-task-with-actions render ~55 lines | Extracted `ArchivedTaskCard` sub-component |
| `lib/tasks/import-export.ts` | `resolveSyncDeps()` missing explicit return type | Added `Promise<{ syncEnabled, queue, scheduleSyncAfterChange }>` |
| `lib/constants/ui.ts` | Two inline `50` ms literals in `edit-drawer` and `use-matrix-window-events` | Added `FOCUS_DELAY_MS = 50`; both sites use the constant |

## 🟡 Nits

- `lib/archive.ts`: removed dead `eslint-disable-next-line no-unused-vars` (rule is globally off in `eslint.config.mjs`)
- `lib/sync/pb-auth.ts`: added `logger.debug()` to previously silent `catch {}` for popup-close failure
- `edit-drawer.tsx`: improved eslint-disable block comment with justification for why multiple setters in one effect is intentional
- `tasks/todo.md`: added "Resuming From Here" handoff block per Session Handoff Protocol

## How to test locally

```bash
git checkout chore/coding-standards-compliance
bun install
bun typecheck
bun run test
```

Key behavioral tests to watch: `tests/ui/edit-drawer.test.tsx`, `tests/data/reset-everything.test.ts`, `tests/ui/matrix-simplified.test.tsx`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->