### PR TITLE
docs(testing): list tests/pb in test layout

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -19,6 +19,7 @@ paths:
 
 - `tests/ui/` — UI/component tests (React Testing Library)
 - `tests/data/` — data logic, schemas, mappers
+- `tests/pb/` — PocketBase at-rest encryption (core crypto, adapters, backfill migration)
 - `tests/e2e/` — Playwright (auto-starts dev server via `playwright.config.ts`)
 - `packages/mcp-server/src/__tests__/` — MCP server tests
 


### PR DESCRIPTION
## What & why
`.claude/rules/testing.md` documents the test directory layout (`tests/ui/`, `tests/data/`, `tests/e2e/`, `packages/mcp-server/src/__tests__/`) but omitted `tests/pb/`, which holds the PocketBase at-rest encryption tests (`encryption-core`, `encryption-pocketbase-adapter`, `encryption-migration`). This adds the missing entry.

Flagged by Devin review on #375.

## Scope
Documentation-only. No code, no behavior change. The `paths:` frontmatter already globs `tests/**`, so the rule was auto-loading correctly for `tests/pb/` edits — only the human-readable layout list was stale.

## How to test
N/A — single-line doc edit. Verify the line renders in the Test Layout section.

https://claude.ai/code/session_01SbXrUzWvwNKyQwxn5Z4Yoy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->