### PR TITLE
fix(types): restore green typecheck and sync-history test on main

### DIFF
--- a/components/ui/segmented-control.tsx
+++ b/components/ui/segmented-control.tsx
@@ -3,7 +3,7 @@
 import { cn } from "@/lib/utils";
 
 interface SegmentedControlProps<T extends string> {
-  options: { value: T; label: string }[];
+  options: readonly { value: T; label: string }[];
   value: T;
   onChange: (value: T) => void;
   className?: string;

--- a/lib/use-error-handler.ts
+++ b/lib/use-error-handler.ts
@@ -60,7 +60,7 @@ export function useErrorHandlerWithUndo(): {
   }, []);
 
   const handleSuccess = useCallback(
-    (message: string, undoAction: () => Promise<void>, duration = TOAST_DURATION.LONG) => {
+    (message: string, undoAction: () => Promise<void>, duration: number = TOAST_DURATION.LONG) => {
       toast(message, {
         duration,
         action: {

--- a/tests/ui/sync-history-page.test.tsx
+++ b/tests/ui/sync-history-page.test.tsx
@@ -56,12 +56,15 @@ vi.mock("@/lib/sync-history", () => ({
   clearHistory: () => mockClearHistory(),
 }));
 
-// Mock sonner toast
+// Mock sonner toast. The real export is a callable function with methods
+// attached; the page calls toast(message, { action }) for confirmations.
+const mockToast = Object.assign(vi.fn(), {
+  success: vi.fn(),
+  error: vi.fn(),
+});
+
 vi.mock("sonner", () => ({
-  toast: {
-    success: vi.fn(),
-    error: vi.fn(),
-  },
+  toast: mockToast,
 }));
 
 // Mock date-fns to avoid timezone issues
@@ -198,12 +201,10 @@ describe("SyncHistoryPage with TanStack Query + Virtual", () => {
     });
   });
 
-  it("clears history via useMutation with confirmation", async () => {
+  it("clears history when the confirmation toast action is invoked", async () => {
     const user = userEvent.setup();
     const records = [createMockHistoryRecord()];
     mockGetRecentHistory.mockResolvedValue(records);
-
-    vi.spyOn(window, "confirm").mockReturnValue(true);
 
     render(<SyncHistoryPage />, { wrapper: createQueryWrapper() });
 
@@ -214,18 +215,28 @@ describe("SyncHistoryPage with TanStack Query + Virtual", () => {
     });
 
     await user.click(screen.getByRole("button", { name: /clear history/i }));
+
+    // Clicking only surfaces a non-blocking confirmation toast — nothing cleared yet.
+    expect(mockToast).toHaveBeenCalledWith(
+      "Clear all sync history? This cannot be undone.",
+      expect.objectContaining({
+        action: expect.objectContaining({ label: "Clear" }),
+      })
+    );
+    expect(mockClearHistory).not.toHaveBeenCalled();
+
+    // Invoking the toast's "Clear" action triggers the mutation.
+    mockToast.mock.calls[0][1].action.onClick();
 
     await waitFor(() => {
       expect(mockClearHistory).toHaveBeenCalledTimes(1);
     });
   });
 
-  it("does not clear history when confirmation cancelled", async () => {
+  it("does not clear history until the confirmation toast action is invoked", async () => {
     const user = userEvent.setup();
     const records = [createMockHistoryRecord()];
     mockGetRecentHistory.mockResolvedValue(records);
-
-    vi.spyOn(window, "confirm").mockReturnValue(false);
 
     render(<SyncHistoryPage />, { wrapper: createQueryWrapper() });
 
@@ -237,6 +248,8 @@ describe("SyncHistoryPage with TanStack Query + Virtual", () => {
 
     await user.click(screen.getByRole("button", { name: /clear history/i }));
 
+    // The confirmation toast appears, but without invoking its action nothing clears.
+    expect(mockToast).toHaveBeenCalledTimes(1);
     expect(mockClearHistory).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## What & why
#377 was merged with red CI, leaving `main` broken: `bun typecheck` fails with two errors and one UI test fails. This restores both.

### Type regressions (from #377's `as const` additions)
- **`components/ui/segmented-control.tsx`** — `options` now accepts a `readonly` array. `TREND_OPTIONS` was made `as const` (a readonly tuple) in #377, which was no longer assignable to the mutable prop type (TS4104). The component only `.map`s over `options`, so widening to `readonly` is safe and strictly more permissive — no existing caller breaks.
- **`lib/use-error-handler.ts`** — `handleSuccess` annotates `duration: number`. With `TOAST_DURATION` now `as const`, the `duration = TOAST_DURATION.LONG` default was inferred as the literal `5000`, which didn't match the hook's declared `duration?: number` return type (TS2322).

### Test break (from #377's UX change)
- **`tests/ui/sync-history-page.test.tsx`** — #377 replaced blocking `window.confirm` with a non-blocking confirmation **toast** (`toast(msg, { action: { label: "Clear", onClick } })`). The two confirmation tests still mocked `window.confirm` and the `toast` mock wasn't callable, so clicking "Clear History" threw instead of clearing. The mock is now a callable `vi.fn()` with `.success`/`.error` attached, and the tests drive the toast's "Clear" action to assert the mutation fires (and that nothing clears until it does).

## Verification
- `bun typecheck` → 0 errors
- `bun run test` → **2042 passed**, 1 skipped, 0 failed (was 1 failed)

## Scope / notes
- Three files only. Does **not** touch the unrelated dependency-bump changes currently in the working tree (`package.json`/`bun.lock`/`public/sw.js`), and intentionally does **not** bump the version, since `package.json` already carries that separate in-progress work.

https://claude.ai/code/session_01SbXrUzWvwNKyQwxn5Z4Yoy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->