### PR TITLE
feat(seo): add sitemap.xml for public pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.12.1",
+	"version": "9.12.2",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  GSD Task Manager sitemap. Referenced from /robots.txt.
+
+  Hand-maintained because the site is a Next.js static export. Lists only the
+  public, indexable pages. The application routes (/, /dashboard, /archive,
+  /sync-history, /settings) are deliberately omitted: task data lives in the
+  visitor's IndexedDB, so those routes render as empty shells to a crawler and
+  carry no indexable content. URLs use the no-trailing-slash form to match the
+  canonical convention in app/about/page.tsx and .well-known/oauth-protected-resource.
+-->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://gsd.vinny.dev/about</loc>
+    <lastmod>2026-06-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://gsd.vinny.dev/install</loc>
+    <lastmod>2026-06-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '9.12.1';
+const CACHE_VERSION = '9.12.2';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 


### PR DESCRIPTION
## What & why

`public/robots.txt` already advertised `Sitemap: https://gsd.vinny.dev/sitemap.xml`, but no sitemap existed — so the reference 404'd. Cloudflare's "Is your site agent ready" scan flagged the gap. This adds a hand-maintained `public/sitemap.xml` that completes the reference.

### Scope
- Lists only **public, indexable** pages:
  - `/about` — canonical landing page (priority 1.0)
  - `/install` — PWA install page (priority 0.8)
- **Excludes** the application routes (`/`, `/dashboard`, `/archive`, `/sync-history`, `/settings`): task data lives in the visitor's IndexedDB, so those routes render as empty shells to a crawler and carry no indexable content.
- Static file (not Next's `app/sitemap.ts`) to fit the static-export + `trailingSlash` setup and match the existing hand-authored `public/.well-known/*` convention. URLs use the no-trailing-slash form to match the canonical convention in `app/about/page.tsx` and `.well-known/oauth-protected-resource`.

### Deliberately not in scope
- **DNS-AID records** (the scan's other recommendation) — skipped: early IETF individual draft with no adoption, no network-discoverable agent endpoint (the MCP server is stdio/local), and DNSSEC carries real availability risk for negligible current payoff. The existing `.well-known/*` HTTP discovery already covers the same ground.

## How to test
- `xmllint --noout public/sitemap.xml` → well-formed (verified locally).
- After deploy + CloudFront invalidation, `curl -i https://gsd.vinny.dev/sitemap.xml` → 200. Existing edge caches hold a 404 until invalidated; `deploy-cloudfront-function.sh` already invalidates `/*`.

https://claude.ai/code/session_01Puyh8tfprXvTy2HjFCUUBN
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->