### PR TITLE
chore(styles): remove unused --chart-series-2 CSS token

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -142,7 +142,6 @@
   --gradient-schedule:  var(--q2);
   --gradient-delegate:  var(--q3);
   --gradient-eliminate: var(--q4);
-  --chart-series-2:     var(--sky);
 
   /* Task-status palette — derived from Inkwell semantic tokens. */
   --status-overdue:        var(--rust);


### PR DESCRIPTION
## What & why

Removes the orphaned `--chart-series-2` CSS custom property from `app/globals.css`. It was the only `--chart-series-*` token and had **zero `var()` consumers** anywhere in the codebase — it was left behind when the dashboard completion chart was rewritten to use semantic tokens (`var(--accent)`, `var(--status-success)`).

This is the sole concrete, actionable finding from the post-v9 UI/UX audit tracked in #260. The rest of #260 is a passing health-status baseline (regression patterns, typecheck/lint/test all green), so no further code change is warranted from it.

## How to test

- `rg "chart-series"` returns no matches after this change.
- `bun run build` / dashboard render unaffected — the token was never referenced, so removing it is a no-op at runtime (pure dead-token cleanup).

## Notes

- Pure CSS dead-token removal, no behavioral change → Trivial tier, no test added per the project's "pure CSS/styling changes with no behavioral difference" TDD exception.
- Addresses the one concrete item in #260; recommend closing #260 (audit baseline complete) — see issue comment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->