### PR TITLE
fix(security): frame-ancestors meta CSP + share email validation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -64,6 +64,11 @@ const contentSecurityPolicy = [
   "default-src 'self'",
   "base-uri 'none'",
   "object-src 'none'",
+  // Browsers IGNORE frame-ancestors when it's delivered via a <meta> tag — it is
+  // only enforced from an HTTP response header (set at the CloudFront/Caddy edge).
+  // It's declared here for defense-in-depth parity and to document clickjacking
+  // intent for tooling that parses the meta CSP; the meta tag does not enforce it.
+  "frame-ancestors 'none'",
   "form-action 'self'",
   "img-src 'self' data: blob:",
   "font-src 'self' data:",

--- a/components/share-task-dialog/format-task-details.ts
+++ b/components/share-task-dialog/format-task-details.ts
@@ -5,6 +5,15 @@ export function canUseWebShare(): boolean {
   return typeof navigator !== "undefined" && typeof navigator.share === "function";
 }
 
+// Deliberately a loose format check, NOT full RFC 5322 validation. It only needs
+// to catch obvious typos before building a mailto: link; the recipient is also
+// percent-encoded at the call site to guard against header injection.
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function isValidEmail(email: string): boolean {
+  return EMAIL_PATTERN.test(email);
+}
+
 export function formatTaskHeader(task: TaskRecord): string[] {
   return [`Task: ${task.title}`, ""];
 }

--- a/components/share-task-dialog/index.tsx
+++ b/components/share-task-dialog/index.tsx
@@ -17,6 +17,7 @@ import { createLogger } from "@/lib/logger";
 import {
   canUseWebShare,
   formatTaskDetails,
+  isValidEmail,
 } from "@/components/share-task-dialog/format-task-details";
 import {
   ShareTabButtons,
@@ -37,6 +38,7 @@ export function ShareTaskDialog({ task, open, onOpenChange }: ShareTaskDialogPro
     canUseWebShare() ? "native" : "email"
   );
   const [recipientEmail, setRecipientEmail] = useState("");
+  const [emailError, setEmailError] = useState<string | null>(null);
 
   if (!task) return null;
 
@@ -44,10 +46,22 @@ export function ShareTaskDialog({ task, open, onOpenChange }: ShareTaskDialogPro
   const emailSubject = `Task: ${task.title}`;
   const emailBody = encodeURIComponent(taskDetails);
 
+  const handleRecipientEmailChange = (email: string) => {
+    setRecipientEmail(email);
+    setEmailError(null);
+  };
+
   const handleOpenEmailClient = () => {
-    const mailto = recipientEmail
-      ? `mailto:${recipientEmail}?subject=${encodeURIComponent(emailSubject)}&body=${emailBody}`
-      : `mailto:?subject=${encodeURIComponent(emailSubject)}&body=${emailBody}`;
+    const trimmedEmail = recipientEmail.trim();
+    if (trimmedEmail && !isValidEmail(trimmedEmail)) {
+      setEmailError("Enter a valid email address, or leave it blank to pick a recipient in your mail app.");
+      return;
+    }
+
+    // Percent-encode the recipient so a value like "a?cc=x@b.com" can't smuggle
+    // extra mailto headers; a validated address still round-trips correctly.
+    const recipient = trimmedEmail ? encodeURIComponent(trimmedEmail) : "";
+    const mailto = `mailto:${recipient}?subject=${encodeURIComponent(emailSubject)}&body=${emailBody}`;
 
     const anchor = document.createElement("a");
     anchor.href = mailto;
@@ -111,7 +125,8 @@ export function ShareTaskDialog({ task, open, onOpenChange }: ShareTaskDialogPro
             activeTab={activeTab}
             taskDetails={taskDetails}
             recipientEmail={recipientEmail}
-            onRecipientEmailChange={setRecipientEmail}
+            onRecipientEmailChange={handleRecipientEmailChange}
+            emailError={emailError}
           />
 
           <div className="flex items-center justify-end gap-2 pt-2">

--- a/components/share-task-dialog/share-tab-content.tsx
+++ b/components/share-task-dialog/share-tab-content.tsx
@@ -80,6 +80,7 @@ interface ShareTabContentProps {
   taskDetails: string;
   recipientEmail: string;
   onRecipientEmailChange: (email: string) => void;
+  emailError?: string | null;
 }
 
 export function ShareTabContent({
@@ -87,6 +88,7 @@ export function ShareTabContent({
   taskDetails,
   recipientEmail,
   onRecipientEmailChange,
+  emailError,
 }: ShareTabContentProps) {
   if (activeTab === "native") {
     return (
@@ -112,7 +114,14 @@ export function ShareTabContent({
             placeholder="Enter email address…"
             value={recipientEmail}
             onChange={(e) => onRecipientEmailChange(e.target.value)}
+            aria-invalid={emailError ? true : undefined}
+            aria-describedby={emailError ? "recipient-email-error" : undefined}
           />
+          {emailError && (
+            <p id="recipient-email-error" role="alert" className="text-xs text-red-600">
+              {emailError}
+            </p>
+          )}
         </div>
         <TaskDetailsPreview label="Email Preview" taskDetails={taskDetails} />
       </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.12.2",
+	"version": "9.12.5",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/data/format-task-details.test.ts
+++ b/tests/data/format-task-details.test.ts
@@ -6,6 +6,7 @@ import {
   formatTaskHeader,
   formatTaskMetadata,
   formatTaskSubtasks,
+  isValidEmail,
 } from "@/components/share-task-dialog/format-task-details";
 import { createMockTask } from "@/tests/fixtures";
 
@@ -119,5 +120,18 @@ describe("format-task-details", () => {
       });
       expect(canUseWebShare()).toBe(true);
     });
+  });
+
+  describe("isValidEmail", () => {
+    it("accepts a well-formed address", () => {
+      expect(isValidEmail("alice@example.com")).toBe(true);
+    });
+
+    it.each(["", "no-at-sign", "missing@domain", "missing.tld@", "a b@c.com"])(
+      "rejects the malformed value %j",
+      (value) => {
+        expect(isValidEmail(value)).toBe(false);
+      }
+    );
   });
 });

--- a/tests/e2e/share-task-dialog.spec.ts
+++ b/tests/e2e/share-task-dialog.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "./fixtures/test-fixtures";
+import { MatrixPage } from "./pages/matrix-page";
+import type { Page, Locator } from "@playwright/test";
+
+type MailtoWindow = Window & { __mailtoHrefs: string[] };
+
+/**
+ * Live-engine verification for the share-dialog recipient-email validation (#399).
+ * Intercepts mailto: anchor clicks so a valid submit can't launch a real mail
+ * client during the run, and so we can assert the generated link is percent-encoded.
+ */
+async function openEmailTab(page: Page): Promise<Locator> {
+  await page.addInitScript(() => {
+    const w = window as unknown as MailtoWindow;
+    w.__mailtoHrefs = [];
+    const proto = HTMLAnchorElement.prototype;
+    const originalClick = proto.click;
+    proto.click = function (this: HTMLAnchorElement) {
+      if (typeof this.href === "string" && this.href.startsWith("mailto:")) {
+        w.__mailtoHrefs.push(this.href);
+        return;
+      }
+      originalClick.call(this);
+    };
+  });
+
+  const matrix = new MatrixPage(page);
+  await matrix.goto();
+  await matrix.createTask("Verify share email validation");
+
+  const card = page.locator("[data-testid='task-card']").first();
+  await card.hover();
+  await card.getByRole("button", { name: "Share task" }).click();
+
+  const dialog = page.locator("[data-testid='share-task-dialog']");
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("tab", { name: "Email" }).click();
+  return dialog;
+}
+
+test.describe("Share task dialog · recipient email validation (#399)", () => {
+  test("invalid email shows an inline error and does not open a mail client", async ({
+    page,
+    clearIndexedDB,
+  }) => {
+    const dialog = await openEmailTab(page);
+    await dialog.locator("#recipient-email").fill("not-an-email");
+    await dialog.getByRole("button", { name: "Open Email Client" }).click();
+
+    await expect(dialog.getByRole("alert")).toBeVisible();
+    await expect(dialog).toBeVisible(); // guard returns early; dialog stays open
+    const mailtoCount = await page.evaluate(
+      () => (window as unknown as MailtoWindow).__mailtoHrefs.length
+    );
+    expect(mailtoCount).toBe(0);
+  });
+
+  test("editing the recipient clears the error", async ({ page, clearIndexedDB }) => {
+    const dialog = await openEmailTab(page);
+    await dialog.locator("#recipient-email").fill("bad");
+    await dialog.getByRole("button", { name: "Open Email Client" }).click();
+    await expect(dialog.getByRole("alert")).toBeVisible();
+
+    await dialog.locator("#recipient-email").fill("bad@example.com");
+    await expect(dialog.getByRole("alert")).toHaveCount(0);
+  });
+
+  test("valid email builds a percent-encoded mailto and closes the dialog", async ({
+    page,
+    clearIndexedDB,
+  }) => {
+    const dialog = await openEmailTab(page);
+    await dialog.locator("#recipient-email").fill("test@example.com");
+    await dialog.getByRole("button", { name: "Open Email Client" }).click();
+
+    await expect(dialog).toBeHidden();
+    const hrefs = await page.evaluate(
+      () => (window as unknown as MailtoWindow).__mailtoHrefs
+    );
+    expect(hrefs).toHaveLength(1);
+    expect(hrefs[0]).toContain("mailto:test%40example.com");
+  });
+});

--- a/tests/ui/app-pages.test.tsx
+++ b/tests/ui/app-pages.test.tsx
@@ -166,6 +166,21 @@ describe('RootLayout', () => {
     expect(cspContent).not.toContain("connect-src 'self' https: wss:");
     expect(cspContent).toContain('https://api.vinny.io');
   });
+
+  it('declares frame-ancestors in the meta CSP for header parity', () => {
+    // Note: browsers ignore frame-ancestors when delivered via <meta> (only
+    // honored from an HTTP header). The directive is still present here for
+    // defense-in-depth parity with the CloudFront/Caddy headers and to document
+    // clickjacking intent for tooling that parses the meta tag. See issue #398.
+    render(
+      <RootLayout>
+        <p>content</p>
+      </RootLayout>
+    );
+
+    const csp = document.querySelector('meta[http-equiv="Content-Security-Policy"]');
+    expect(csp).toHaveAttribute('content', expect.stringContaining("frame-ancestors 'none'"));
+  });
 });
 
 describe('AboutPage', () => {

--- a/tests/ui/share-task-dialog.test.tsx
+++ b/tests/ui/share-task-dialog.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Tests for the share-task email flow (issue #399):
+ * recipient email is validated and encoded before building the mailto: link.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ShareTaskDialog } from "@/components/share-task-dialog";
+import { createMockTask } from "@/tests/fixtures";
+
+// jsdom has no navigator.share, so the dialog defaults to the Email tab and the
+// recipient input is visible without any extra interaction.
+
+describe("ShareTaskDialog email flow", () => {
+  let capturedHref: string | null;
+  let clickSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    capturedHref = null;
+    // Capture the mailto target without navigating: the handler builds an
+    // anchor, clicks it, then removes it from the DOM.
+    clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        capturedHref = this.getAttribute("href");
+      });
+  });
+
+  afterEach(() => {
+    clickSpy.mockRestore();
+  });
+
+  it("builds an encoded mailto link for a valid recipient and closes", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <ShareTaskDialog task={createMockTask()} open onOpenChange={onOpenChange} />
+    );
+
+    await user.type(screen.getByLabelText(/recipient email/i), "alice@example.com");
+    await user.click(screen.getByRole("button", { name: /open email client/i }));
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(capturedHref).toMatch(/^mailto:alice%40example\.com\?subject=/);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("shows an inline error and does not open the link for an invalid email", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <ShareTaskDialog task={createMockTask()} open onOpenChange={onOpenChange} />
+    );
+
+    await user.type(screen.getByLabelText(/recipient email/i), "not-an-email");
+    await user.click(screen.getByRole("button", { name: /open email client/i }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/valid email/i);
+    expect(clickSpy).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("preserves the recipient-less link when the email is left blank", async () => {
+    const user = userEvent.setup();
+    render(<ShareTaskDialog task={createMockTask()} open onOpenChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: /open email client/i }));
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(capturedHref).toMatch(/^mailto:\?subject=/);
+  });
+
+  it("clears the error once the user edits the email again", async () => {
+    const user = userEvent.setup();
+    render(<ShareTaskDialog task={createMockTask()} open onOpenChange={vi.fn()} />);
+
+    const input = screen.getByLabelText(/recipient email/i);
+    await user.type(input, "bad");
+    await user.click(screen.getByRole("button", { name: /open email client/i }));
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    await user.type(input, "x");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What & why

Two small, independent security hardening fixes verified against the live code.

### #398 — `frame-ancestors 'none'` in the meta CSP (REAL)
`app/layout.tsx` builds the `<meta http-equiv="Content-Security-Policy">` content from an array that omitted `frame-ancestors`. Added `frame-ancestors 'none'` for defense-in-depth parity with the HTTP CSP set at the CloudFront/Caddy edge.

> **Honest caveat (important):** Per the CSP spec, `frame-ancestors` is **ignored by browsers when delivered via a `<meta>` tag** — it is only enforced from an HTTP response header. The real clickjacking protection still comes from the edge header. This directive is here for parity, to document intent, and for tooling that parses the meta CSP. A code comment in `app/layout.tsx` states this so future readers don't mistake the meta tag for enforcement.

### #399 — Validate + encode recipient email in the share dialog (REAL)
`components/share-task-dialog/index.tsx` interpolated `recipientEmail` directly into the `mailto:` URL with no validation or encoding (subject/body were already encoded; the recipient was not). A value like `a?cc=x@b.com` would smuggle extra mailto headers.

- Loose format check (`/^[^\s@]+@[^\s@]+\.[^\s@]+$/`, not full RFC 5322) via `isValidEmail`.
- Invalid input shows an inline `role="alert"` error (with `aria-invalid`/`aria-describedby`); the link is **not** opened.
- Valid recipient is `encodeURIComponent`-encoded before building the link (header-injection guard).
- Blank email preserves the existing recipient-less `mailto:?subject=…` behavior.

## How to test locally
- `bun run test` — full suite green (2063 passing).
- CSP: `tests/ui/app-pages.test.tsx` asserts the rendered meta CSP contains `frame-ancestors 'none'`.
- Share email: `tests/ui/share-task-dialog.test.tsx` (valid → encoded mailto + closes; invalid → inline error + link not opened; blank → recipient-less link; error clears on edit) and `tests/data/format-task-details.test.ts` (`isValidEmail` unit cases).
- Manual: open a task's Share dialog → Email tab. Try `not-an-email` (inline error, nothing opens), `alice@example.com` (opens mail client), blank (opens with no recipient).

## Verification
- `bun run test`: pass (2063 passed, 1 skipped)
- `bun typecheck`: clean
- `bun lint`: 0 errors (21 pre-existing warnings, none in changed files)

## Notes
- TDD: failing tests written first (CSP directive + 3 email behaviors), then implementation.
- These `.tsx` edits would normally get browser verification, but this was done in a headless worktree — covered by render + interaction unit tests instead. A maintainer may want to spot-check the Share dialog email tab in the running app.

Closes #398
Closes #399
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

## Live verification (added)

Added a Chromium Playwright spec (`tests/e2e/share-task-dialog.spec.ts`) that exercises the #399 email-validation flow in a real browser: invalid email shows an inline error and opens no mail client, editing the recipient clears the error, and a valid email builds a percent-encoded `mailto:` (header-injection guard) before closing the dialog. The spec intercepts `mailto:` anchor clicks so the run never launches a real mail client. Verified: `bun run test:e2e -- --project=chromium tests/e2e/share-task-dialog.spec.ts` → 3 passed.
