### PR TITLE
fix(privacy): redact task content from logs and align Sentry allowlist

### DIFF
--- a/lib/error-logger.ts
+++ b/lib/error-logger.ts
@@ -8,6 +8,7 @@
  */
 
 import { captureException } from '@/lib/sentry';
+import { filterSentryMetadata } from '@/lib/logger';
 
 export interface ErrorContext {
   action: string;
@@ -56,7 +57,14 @@ export function logError(error: unknown, context: ErrorContext): LoggedError {
     });
   }
 
-  captureException(error, { ...loggedError });
+  // Apply the same allowlist as lib/logger.ts so only safe diagnostic keys
+  // reach Sentry. Flatten `metadata` first so allowlisted keys inside it
+  // (operation, correlationId) survive while task content / raw input are
+  // stripped.
+  captureException(
+    error,
+    filterSentryMetadata({ ...loggedError, ...loggedError.metadata })
+  );
 
   return loggedError;
 }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -211,9 +211,26 @@ function maskError(error: Error): Error {
  */
 const SENTRY_SAFE_METADATA_KEYS: ReadonlySet<string> = new Set([
   'correlationId', 'userId', 'taskId', 'deviceId', 'phase', 'operation',
-  'trigger', 'triggeredBy', 'validationErrors', 'componentStack', 'count',
-  'attempt', 'status', 'statusCode', 'type', 'url', 'timestamp',
+  'action', 'trigger', 'triggeredBy', 'validationErrors', 'componentStack',
+  'count', 'attempt', 'status', 'statusCode', 'type', 'url', 'timestamp',
 ]);
+
+/**
+ * Keep only allowlisted, secret-masked diagnostic metadata. This is the single
+ * gate that decides what leaves the device for Sentry; anything not listed —
+ * task `input`, PocketBase `record`, etc. — is dropped. Exported so other Sentry
+ * entry points (e.g. error-logger.ts) reuse this allowlist rather than
+ * duplicating the key set.
+ */
+export function filterSentryMetadata(metadata?: LogMetadata): LogMetadata {
+  const allowed: LogMetadata = {};
+  for (const key of Object.keys(metadata ?? {})) {
+    if (SENTRY_SAFE_METADATA_KEYS.has(key)) {
+      allowed[key] = metadata![key];
+    }
+  }
+  return sanitizeMetadata(allowed) ?? {};
+}
 
 /**
  * Build the Sentry context: the logger context name plus only the allowlisted,
@@ -223,13 +240,7 @@ function buildSentryContext(
   context: LogContext,
   metadata?: LogMetadata
 ): Record<string, unknown> {
-  const allowed: LogMetadata = {};
-  for (const key of Object.keys(metadata ?? {})) {
-    if (SENTRY_SAFE_METADATA_KEYS.has(key)) {
-      allowed[key] = metadata![key];
-    }
-  }
-  return { context, ...(sanitizeMetadata(allowed) ?? {}) };
+  return { context, ...filterSentryMetadata(metadata) };
 }
 
 /**

--- a/lib/tasks/crud/create.ts
+++ b/lib/tasks/crud/create.ts
@@ -28,9 +28,14 @@ export async function createTask(input: TaskDraft): Promise<TaskRecord> {
 
   const result = taskDraftSchema.safeParse(normalized);
   if (!result.success) {
-    const msg = result.error.issues.map(i => i.message).join(", ");
-    logger.error("Task validation failed", undefined, { input, validationErrors: msg });
-    throw new Error(`Task validation failed: ${msg}`);
+    // Summarize failures as field + Zod error code only. Never log the raw
+    // input — it holds the task title/description and would leak free-text
+    // content to the browser console.
+    const fieldErrors = result.error.issues
+      .map(issue => `${issue.path.join(".") || "(root)"} (${issue.code})`)
+      .join(", ");
+    logger.error("Task validation failed", undefined, { validationErrors: fieldErrors });
+    throw new Error(`Task validation failed: ${fieldErrors}`);
   }
 
   try {

--- a/lib/tasks/crud/create.ts
+++ b/lib/tasks/crud/create.ts
@@ -56,8 +56,10 @@ export async function createTask(input: TaskDraft): Promise<TaskRecord> {
 
     return record;
   } catch (error) {
+    // Log only the operation, never the raw input — it holds the task
+    // title/description and these error logs fire in the production console.
     logger.error("Failed to create task", error instanceof Error ? error : undefined, {
-      input,
+      operation: "create",
     });
     throw new Error(`Failed to create task: ${formatErrorMessage(error)}`);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.12.2",
+	"version": "9.12.3",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/data/error-logger.test.ts
+++ b/tests/data/error-logger.test.ts
@@ -206,6 +206,34 @@ describe("Error Logger module", () => {
 			);
 		});
 
+		it("should send only allowlisted metadata to Sentry, stripping task content", async () => {
+			const { captureException: mockCapture } = vi.mocked(
+				await import("@/lib/sentry")
+			);
+			mockCapture.mockClear();
+
+			const error = new Error("boom");
+			const context: ErrorContext = {
+				action: ErrorActions.CREATE_TASK,
+				userId: "user-1",
+				timestamp: "2025-01-15T12:00:00Z",
+				userMessage: "Failed to create task",
+				metadata: { title: "secret task content", operation: "createTask" },
+			};
+
+			logError(error, context);
+
+			const sentryContext = mockCapture.mock.calls[0][1] as Record<
+				string,
+				unknown
+			>;
+			// Non-allowlisted content must never reach Sentry, even nested.
+			expect(JSON.stringify(sentryContext)).not.toContain("secret task content");
+			// Allowlisted diagnostic keys still pass through.
+			expect(sentryContext.userId).toBe("user-1");
+			expect(sentryContext.operation).toBe("createTask");
+		});
+
 		it("should return complete LoggedError object", () => {
 			const error = new Error("Test error");
 			const context: ErrorContext = {

--- a/tests/data/tasks/create-validation-redaction.test.ts
+++ b/tests/data/tasks/create-validation-redaction.test.ts
@@ -1,13 +1,35 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { createTask } from "@/lib/tasks/crud/create";
 import type { TaskDraft } from "@/lib/types";
 
+const { mockAdd, mockGetSyncContext, mockEnqueue } = vi.hoisted(() => ({
+  mockAdd: vi.fn(),
+  mockGetSyncContext: vi.fn(),
+  mockEnqueue: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getDb: () => ({ tasks: { add: mockAdd } }),
+}));
+
+vi.mock("@/lib/tasks/crud/helpers", () => ({
+  getSyncContext: mockGetSyncContext,
+  enqueueSyncOperation: mockEnqueue,
+}));
+
 /**
- * Regression for #400: a validation failure must never write raw task content
- * (title/description) to the browser console. Only field names + Zod error
- * codes are safe to log.
+ * Regression for #400: task content (title/description) must never be written
+ * to the browser console on a failed create — neither on a Zod validation
+ * failure nor on a database-write failure. Only field names, Zod error codes,
+ * and the operation name are safe to log.
  */
-describe("createTask validation logging redaction", () => {
+describe("createTask logging redaction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSyncContext.mockResolvedValue({ syncConfig: { enabled: false } });
+    mockEnqueue.mockResolvedValue(undefined);
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -36,5 +58,34 @@ describe("createTask validation logging redaction", () => {
     expect(logged).not.toContain(secretDescription);
     // Field names remain useful and are safe to log.
     expect(logged).toContain("title");
+  });
+
+  it("should not log task title or description content on database-write failure", async () => {
+    mockAdd.mockRejectedValue(new Error("DB write failed"));
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const secretTitle = "SECRET_DB_TITLE_NO_LEAK";
+    const secretDescription = "SECRET_DB_DESC_NO_LEAK";
+    const validDraft = {
+      title: secretTitle,
+      description: secretDescription,
+      urgent: true,
+      important: false,
+    } as TaskDraft;
+
+    await expect(createTask(validDraft)).rejects.toThrow(
+      /Failed to create task/
+    );
+
+    const logged = consoleErrorSpy.mock.calls
+      .map((call) => JSON.stringify(call))
+      .join("|");
+
+    expect(logged).not.toContain(secretTitle);
+    expect(logged).not.toContain(secretDescription);
+    // Operation context is non-content and safe to log.
+    expect(logged).toContain("create");
   });
 });

--- a/tests/data/tasks/create-validation-redaction.test.ts
+++ b/tests/data/tasks/create-validation-redaction.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createTask } from "@/lib/tasks/crud/create";
+import type { TaskDraft } from "@/lib/types";
+
+/**
+ * Regression for #400: a validation failure must never write raw task content
+ * (title/description) to the browser console. Only field names + Zod error
+ * codes are safe to log.
+ */
+describe("createTask validation logging redaction", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should not log task description content on validation failure", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const secretDescription = "DIAGNOSIS_RESULTS_DO_NOT_LEAK";
+    const invalidDraft = {
+      title: "", // empty title fails z.string().min(1)
+      description: secretDescription,
+      urgent: true,
+      important: false,
+    } as TaskDraft;
+
+    await expect(createTask(invalidDraft)).rejects.toThrow(
+      /Task validation failed/
+    );
+
+    const logged = consoleErrorSpy.mock.calls
+      .map((call) => JSON.stringify(call))
+      .join("|");
+
+    expect(logged).not.toContain(secretDescription);
+    // Field names remain useful and are safe to log.
+    expect(logged).toContain("title");
+  });
+});


### PR DESCRIPTION
## What & why

Three privacy/observability fixes that stop free-text task content (titles, descriptions, raw input) from leaking off the local-first device.

### #400 — Redact task content from create failure logs
`createTask` leaked raw task content to the **browser console** on failure in two places:
1. **Validation failure:** logged the full `{ input, validationErrors }` object. Now logs only the failing field paths + Zod error codes, e.g. `"Task validation failed: title (too_small)"`. No values logged. Mirrors the already-safe pattern in `update.ts`.
2. **Database-write failure (catch block):** logged the full `{ input }` (task title + description). Since this is an error-level log it is not environment-gated and fires in the production console. Now logs only `{ operation: "create" }` — no task content. The success `logger.info("Task created", { ..., title })` log is intentionally left untouched (info logs are environment-gated).

### #394 — Align error-logger Sentry path with the primary logger allowlist
`error-logger.logError()` did `captureException(error, { ...loggedError })`, spreading the nested `metadata` object (which can hold task content / raw input) straight to Sentry — bypassing the `SENTRY_SAFE_METADATA_KEYS` allowlist that `lib/logger.ts` already enforces.

Fix: export a reusable `filterSentryMetadata(metadata)` helper from `lib/logger.ts` (refactored out of the existing `buildSentryContext`, no key-list duplication) and apply it in `error-logger.ts`. The `metadata` object is flattened first so allowlisted keys inside it (`operation`, `correlationId`) survive while content keys are dropped. Added `action` to the shared allowlist since it is a fixed `ErrorActions` enum (no user content) and is error-logger's primary diagnostic key.

## How to test
- `bun run test` — full suite green (2055 passed / 1 skipped)
- `bun typecheck` — clean
- `bun lint` — 0 errors (pre-existing warnings only)
- Targeted: `bun run test -- create-validation-redaction error-logger logger.test`

## Per-issue verification notes
- **#400 (validation path)**: `tests/data/tasks/create-validation-redaction.test.ts` spies on `console.error`, triggers a validation failure with a secret description, and asserts the secret never appears in any log call while the field name does. RED before, GREEN after.
- **#400 (DB-write path)**: same test file forces the catch block by mocking `getDb().tasks.add` to reject with a valid draft containing a secret title + description, and asserts neither secret appears in any `console.error` call (only the operation name does). RED before, GREEN after.
- **#394**: new test in `tests/data/error-logger.test.ts` asserts a non-allowlisted nested key (`metadata.title = "secret task content"`) is stripped before `captureException`, while allowlisted keys (`userId`, `operation`) pass through. RED before, GREEN after.

Closes #400
Closes #394