### PR TITLE
fix(validation): defense-in-depth schema validation on read/write/sync paths

### DIFF
--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -64,8 +64,13 @@ export const taskRecordSchema = taskDraftSchema
 	})
 	.strict();
 
-/** Lenient task schema for importing legacy exports (strips unknown fields like vectorClock) */
-const taskRecordImportSchema = taskDraftSchema
+/**
+ * Lenient task-record schema that strips unknown fields (e.g. vectorClock from the
+ * old Cloudflare sync system) instead of rejecting them. Used both for importing
+ * legacy exports and for validating records read back from IndexedDB, so a record
+ * carrying a harmless extra field is kept rather than quarantined as corrupt.
+ */
+export const storedTaskRecordSchema = taskDraftSchema
 	.extend({
 		id: z.string().min(SCHEMA_LIMITS.ID_MIN_LENGTH),
 		quadrant: quadrantIdSchema,
@@ -83,7 +88,7 @@ const taskRecordImportSchema = taskDraftSchema
 	.strip();
 
 export const importPayloadSchema = z.object({
-	tasks: z.array(taskRecordImportSchema),
+	tasks: z.array(storedTaskRecordSchema),
 	exportedAt: z.string().datetime({ offset: true }),
 	version: z.string(),
 });

--- a/lib/sync/task-mapper.ts
+++ b/lib/sync/task-mapper.ts
@@ -10,6 +10,7 @@ import type { TaskRecord, Subtask, TimeEntry } from '@/lib/types';
 import type { RecordModel } from 'pocketbase';
 import { z } from 'zod';
 import { quadrantIdSchema, recurrenceTypeSchema, subtaskSchema, timeEntrySchema } from '@/lib/schema';
+import { SCHEMA_LIMITS } from '@/lib/constants/schema';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('SYNC_PULL');
@@ -83,11 +84,14 @@ export function taskRecordToPocketBase(
 /**
  * Zod schema for validating PocketBase task records at the sync boundary.
  * Uses .strip() to discard unknown fields from the remote response.
+ *
+ * Length and count limits mirror SCHEMA_LIMITS so oversized remote data is
+ * rejected at the pull boundary instead of being persisted to IndexedDB.
  */
 const pbTaskRecordSchema = z.object({
   task_id: z.string().min(1),
-  title: z.string().min(1),
-  description: z.string().default(''),
+  title: z.string().min(1).max(SCHEMA_LIMITS.TASK_TITLE_MAX_LENGTH),
+  description: z.string().max(SCHEMA_LIMITS.TASK_DESCRIPTION_MAX_LENGTH).default(''),
   urgent: z.boolean(),
   important: z.boolean(),
   quadrant: quadrantIdSchema,
@@ -97,16 +101,16 @@ const pbTaskRecordSchema = z.object({
   client_created_at: z.string(),
   client_updated_at: z.string(),
   recurrence: recurrenceTypeSchema.default('none'),
-  tags: z.array(z.string()).default([]),
-  subtasks: z.array(subtaskSchema).default([]),
-  dependencies: z.array(z.string()).default([]),
+  tags: z.array(z.string().max(SCHEMA_LIMITS.TAG_MAX_LENGTH)).max(SCHEMA_LIMITS.MAX_TAGS).default([]),
+  subtasks: z.array(subtaskSchema).max(SCHEMA_LIMITS.MAX_SUBTASKS).default([]),
+  dependencies: z.array(z.string()).max(SCHEMA_LIMITS.MAX_DEPENDENCIES).default([]),
   notification_enabled: z.boolean().default(true),
   notification_sent: z.boolean().default(false),
   notify_before: z.number().int().min(0).nullable().default(null),
   last_notification_at: z.string().default(''),
   estimated_minutes: z.number().int().min(0).nullable().default(null),
   time_spent: z.number().int().min(0).default(0),
-  time_entries: z.array(timeEntrySchema).default([]),
+  time_entries: z.array(timeEntrySchema).max(SCHEMA_LIMITS.MAX_TIME_ENTRIES).default([]),
   snoozed_until: z.string().default(''),
 }).strip();
 

--- a/lib/tasks/crud/time-tracking.ts
+++ b/lib/tasks/crud/time-tracking.ts
@@ -1,6 +1,7 @@
 import { nanoid } from "nanoid";
 import { getDb } from "@/lib/db";
 import { createLogger } from "@/lib/logger";
+import { timeEntrySchema } from "@/lib/schema";
 import type { TaskRecord, TimeEntry } from "@/lib/types";
 import { isoNow } from "@/lib/utils";
 import { enqueueSyncOperation, getSyncContext } from "./helpers";
@@ -100,6 +101,11 @@ export async function stopTimeTracking(
   if (runningEntryIndex === undefined || runningEntryIndex === -1) {
     logger.warn("No running timer to stop", { taskId });
     throw new Error("No running timer found for this task");
+  }
+
+  const notesValidation = timeEntrySchema.shape.notes.safeParse(notes);
+  if (!notesValidation.success) {
+    throw new Error(`Invalid time entry notes: ${notesValidation.error.issues.map((i) => i.message).join(", ")}`);
   }
 
   const { syncConfig } = await getSyncContext();

--- a/lib/tasks/crud/update.ts
+++ b/lib/tasks/crud/update.ts
@@ -1,3 +1,4 @@
+import { buildDescription, extractUrlsFromTitle } from "@/lib/capture-parser";
 import { getDb } from "@/lib/db";
 import { createLogger } from "@/lib/logger";
 import { resolveQuadrantId } from "@/lib/quadrants";
@@ -25,6 +26,12 @@ export async function updateTask(
     }
 
     const nextDraft = mergeTaskUpdates(existing, updates);
+    // Extract URLs from the title into the description, mirroring createTask so
+    // edits and creates handle links identically (idempotent on already-clean titles).
+    const { cleanTitle, urls } = extractUrlsFromTitle(nextDraft.title);
+    nextDraft.title = cleanTitle;
+    nextDraft.description = buildDescription(nextDraft.description, urls);
+
     const result = taskDraftSchema.safeParse(nextDraft);
     if (!result.success) {
       const fields = result.error.issues.map((i) => i.path.join('.')).join(', ');

--- a/lib/tasks/subtasks.ts
+++ b/lib/tasks/subtasks.ts
@@ -1,5 +1,7 @@
 import { getDb } from "@/lib/db";
 import { generateId } from "@/lib/id-generator";
+import { subtaskSchema } from "@/lib/schema";
+import { SCHEMA_LIMITS } from "@/lib/constants/schema";
 import type { TaskRecord } from "@/lib/types";
 import { isoNow } from "@/lib/utils";
 import { getSyncQueue } from "@/lib/sync/queue";
@@ -46,15 +48,22 @@ export async function addSubtask(taskId: string, title: string): Promise<TaskRec
     throw new Error(`Task ${taskId} not found`);
   }
 
-  const newSubtask = {
+  if (existing.subtasks.length >= SCHEMA_LIMITS.MAX_SUBTASKS) {
+    throw new Error(`Cannot add subtask: maximum of ${SCHEMA_LIMITS.MAX_SUBTASKS} subtasks reached`);
+  }
+
+  const validation = subtaskSchema.safeParse({
     id: generateId(),
     title,
-    completed: false
-  };
+    completed: false,
+  });
+  if (!validation.success) {
+    throw new Error(`Invalid subtask: ${validation.error.issues.map((i) => i.message).join(", ")}`);
+  }
 
   const nextRecord: TaskRecord = {
     ...existing,
-    subtasks: [...existing.subtasks, newSubtask],
+    subtasks: [...existing.subtasks, validation.data],
     updatedAt: isoNow(),
   };
 

--- a/lib/use-tasks.ts
+++ b/lib/use-tasks.ts
@@ -1,12 +1,36 @@
 import { useLiveQuery } from "dexie-react-hooks";
 import { getDb } from "@/lib/db";
+import { storedTaskRecordSchema } from "@/lib/schema";
+import { createLogger } from "@/lib/logger";
 import type { TaskRecord } from "@/lib/types";
 import { quadrantOrder } from "@/lib/quadrants";
+
+const logger = createLogger("DB");
 
 export interface TaskBuckets {
   all: TaskRecord[];
   byQuadrant: Record<string, TaskRecord[]>;
   isLoading: boolean;
+}
+
+/**
+ * Validate records read back from IndexedDB and drop any that are corrupt so
+ * malformed data never reaches the UI. Uses the lenient (strip) record schema,
+ * which keeps records carrying harmless legacy fields and only quarantines
+ * genuinely invalid ones (wrong types, missing fields, bad enums).
+ */
+export function keepValidTaskRecords(rows: TaskRecord[]): TaskRecord[] {
+  return rows.filter((task) => {
+    const parsed = storedTaskRecordSchema.safeParse(task);
+    if (parsed.success) {
+      return true;
+    }
+    logger.warn("Quarantined corrupt task record", {
+      taskId: task?.id,
+      errors: parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "),
+    });
+    return false;
+  });
 }
 
 export function useTasks(): TaskBuckets {
@@ -16,7 +40,8 @@ export function useTasks(): TaskBuckets {
     }
     const db = getDb();
     const rows = await db.tasks.toArray();
-    return rows.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    const valid = keepValidTaskRecords(rows);
+    return valid.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
   }, [], []);
 
   const isLoading = result === undefined;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.12.2",
+	"version": "9.12.4",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/data/sync/task-mapper.test.ts
+++ b/tests/data/sync/task-mapper.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { taskRecordToPocketBase, pocketBaseToTaskRecord } from '@/lib/sync/task-mapper';
+import { SCHEMA_LIMITS } from '@/lib/constants/schema';
 import type { TaskRecord } from '@/lib/types';
 
 // Mock logger to avoid side effects
@@ -216,6 +217,62 @@ describe('task-mapper', () => {
       const result = pocketBaseToTaskRecord(pb);
       expect(result).not.toBeNull();
       expect(result!.id).toBe('task-123');
+    });
+
+    describe('length and count constraints (defense-in-depth)', () => {
+      it('should skip a record whose title exceeds TASK_TITLE_MAX_LENGTH', () => {
+        const pb = buildPBRecord({ title: 'a'.repeat(SCHEMA_LIMITS.TASK_TITLE_MAX_LENGTH + 1) });
+        expect(pocketBaseToTaskRecord(pb)).toBeNull();
+      });
+
+      it('should skip a record whose description exceeds TASK_DESCRIPTION_MAX_LENGTH', () => {
+        const pb = buildPBRecord({ description: 'a'.repeat(SCHEMA_LIMITS.TASK_DESCRIPTION_MAX_LENGTH + 1) });
+        expect(pocketBaseToTaskRecord(pb)).toBeNull();
+      });
+
+      it('should skip a record with more than MAX_TAGS tags', () => {
+        const pb = buildPBRecord({
+          tags: Array.from({ length: SCHEMA_LIMITS.MAX_TAGS + 1 }, (_, i) => `tag${i}`),
+        });
+        expect(pocketBaseToTaskRecord(pb)).toBeNull();
+      });
+
+      it('should skip a record with a single tag longer than TAG_MAX_LENGTH', () => {
+        const pb = buildPBRecord({ tags: ['a'.repeat(SCHEMA_LIMITS.TAG_MAX_LENGTH + 1)] });
+        expect(pocketBaseToTaskRecord(pb)).toBeNull();
+      });
+
+      it('should skip a record with more than MAX_SUBTASKS subtasks', () => {
+        const pb = buildPBRecord({
+          subtasks: Array.from({ length: SCHEMA_LIMITS.MAX_SUBTASKS + 1 }, (_, i) => ({
+            id: `sub-${i}`,
+            title: `Subtask ${i}`,
+            completed: false,
+          })),
+        });
+        expect(pocketBaseToTaskRecord(pb)).toBeNull();
+      });
+
+      it('should skip a record with a subtask title longer than SUBTASK_TITLE_MAX_LENGTH', () => {
+        const pb = buildPBRecord({
+          subtasks: [{ id: 'sub-1', title: 'a'.repeat(SCHEMA_LIMITS.SUBTASK_TITLE_MAX_LENGTH + 1), completed: false }],
+        });
+        expect(pocketBaseToTaskRecord(pb)).toBeNull();
+      });
+
+      it('should accept a record sized exactly at the limits', () => {
+        const pb = buildPBRecord({
+          title: 'a'.repeat(SCHEMA_LIMITS.TASK_TITLE_MAX_LENGTH),
+          description: 'a'.repeat(SCHEMA_LIMITS.TASK_DESCRIPTION_MAX_LENGTH),
+          tags: Array.from({ length: SCHEMA_LIMITS.MAX_TAGS }, (_, i) => `tag${i}`),
+          subtasks: Array.from({ length: SCHEMA_LIMITS.MAX_SUBTASKS }, (_, i) => ({
+            id: `sub-${i}`,
+            title: 'Subtask',
+            completed: false,
+          })),
+        });
+        expect(pocketBaseToTaskRecord(pb)).not.toBeNull();
+      });
     });
 
     it('should apply defaults for missing optional fields', () => {

--- a/tests/data/tasks/crud.test.ts
+++ b/tests/data/tasks/crud.test.ts
@@ -354,6 +354,49 @@ describe('Task CRUD Operations', () => {
 
       await expect(updateTask('task-1', { title: 'Updated' })).rejects.toThrow('Failed to update task');
     });
+
+    it.each([
+      {
+        scenario: 'extracts a URL from an updated title into the description',
+        initialDescription: 'Existing notes',
+        newTitle: 'Watch https://example.com/video',
+        expectedTitle: 'Watch',
+        expectedDescription: 'Existing notes\nhttps://example.com/video',
+      },
+      {
+        scenario: 'falls back to placeholder when the updated title is URL-only',
+        initialDescription: '',
+        newTitle: 'https://example.com',
+        expectedTitle: 'Review link below',
+        expectedDescription: 'https://example.com/',
+      },
+      {
+        scenario: 'leaves the title unchanged when the updated title has no URL',
+        initialDescription: 'Plain description',
+        newTitle: 'Plain updated title',
+        expectedTitle: 'Plain updated title',
+        expectedDescription: 'Plain description',
+      },
+    ])('$scenario', async ({ initialDescription, newTitle, expectedTitle, expectedDescription }) => {
+      const existing: TaskRecord = {
+        ...baseDraft,
+        id: 'task-1',
+        description: initialDescription,
+        quadrant: 'urgent-important',
+        completed: false,
+        createdAt: '2025-01-15T10:00:00Z',
+        updatedAt: '2025-01-15T10:00:00Z',
+        notificationSent: false,
+      };
+
+      mockDb.tasks.get.mockResolvedValue(existing);
+      mockDb.tasks.put.mockResolvedValue(undefined);
+
+      const result = await updateTask('task-1', { title: newTitle });
+
+      expect(result.title).toBe(expectedTitle);
+      expect(result.description).toBe(expectedDescription);
+    });
   });
 
   describe('toggleCompleted', () => {

--- a/tests/data/tasks/subtasks.test.ts
+++ b/tests/data/tasks/subtasks.test.ts
@@ -7,6 +7,7 @@ import {
 import { getDb } from '@/lib/db';
 import { getSyncConfig } from '@/lib/sync/config';
 import { getSyncQueue } from '@/lib/sync/queue';
+import { SCHEMA_LIMITS } from '@/lib/constants/schema';
 import type { TaskRecord } from '@/lib/types';
 
 // Mock dependencies
@@ -256,6 +257,39 @@ describe('Task Subtask Operations', () => {
 
       expect(result.subtasks).toHaveLength(1);
       expect(result.subtasks[0].title).toBe('First Subtask');
+    });
+
+    it('should reject a title longer than SUBTASK_TITLE_MAX_LENGTH without persisting', async () => {
+      mockDb.tasks.get.mockResolvedValue(baseTask);
+
+      await expect(
+        addSubtask('task-1', 'a'.repeat(SCHEMA_LIMITS.SUBTASK_TITLE_MAX_LENGTH + 1))
+      ).rejects.toThrow(/subtask/i);
+      expect(mockDb.tasks.put).not.toHaveBeenCalled();
+    });
+
+    it('should reject an empty title without persisting', async () => {
+      mockDb.tasks.get.mockResolvedValue(baseTask);
+
+      await expect(addSubtask('task-1', '')).rejects.toThrow(/subtask/i);
+      expect(mockDb.tasks.put).not.toHaveBeenCalled();
+    });
+
+    it('should reject adding a subtask beyond MAX_SUBTASKS without persisting', async () => {
+      const fullTask = {
+        ...baseTask,
+        subtasks: Array.from({ length: SCHEMA_LIMITS.MAX_SUBTASKS }, (_, i) => ({
+          id: `sub-${i}`,
+          title: `Subtask ${i}`,
+          completed: false,
+        })),
+      };
+      mockDb.tasks.get.mockResolvedValue(fullTask);
+
+      await expect(addSubtask('task-1', 'One too many')).rejects.toThrow(
+        new RegExp(`${SCHEMA_LIMITS.MAX_SUBTASKS}`)
+      );
+      expect(mockDb.tasks.put).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/data/time-tracking.test.ts
+++ b/tests/data/time-tracking.test.ts
@@ -237,6 +237,22 @@ describe('stopTimeTracking', () => {
     );
   });
 
+  it('rejects notes longer than TIME_ENTRY_NOTES_MAX_LENGTH without persisting', async () => {
+    const { stopTimeTracking } = await import('@/lib/tasks/crud/time-tracking');
+    const { SCHEMA_LIMITS } = await import('@/lib/constants/schema');
+
+    const task = createBaseTask({
+      timeEntries: [{ id: 'entry-1', startedAt: '2025-06-01T12:00:00.000Z' }],
+    });
+    mockGet.mockResolvedValue(task);
+    mockPut.mockResolvedValue(undefined);
+
+    await expect(
+      stopTimeTracking('task-1', 'a'.repeat(SCHEMA_LIMITS.TIME_ENTRY_NOTES_MAX_LENGTH + 1))
+    ).rejects.toThrow(/notes/i);
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
   it('throws when task not found', async () => {
     const { stopTimeTracking } = await import('@/lib/tasks/crud/time-tracking');
 

--- a/tests/data/use-tasks.test.ts
+++ b/tests/data/use-tasks.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import { keepValidTaskRecords } from '@/lib/use-tasks';
+import type { TaskRecord } from '@/lib/types';
+
+// Mock logger so quarantine warnings don't produce side effects during tests.
+const mockWarn = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: mockWarn,
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+function buildTask(overrides?: Partial<TaskRecord>): TaskRecord {
+  return {
+    id: 'task-1',
+    title: 'Valid Task',
+    description: '',
+    urgent: true,
+    important: false,
+    quadrant: 'urgent-not-important',
+    completed: false,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+    recurrence: 'none',
+    tags: [],
+    subtasks: [],
+    dependencies: [],
+    notificationEnabled: true,
+    notificationSent: false,
+    ...overrides,
+  };
+}
+
+describe('keepValidTaskRecords', () => {
+  it('passes valid records through unchanged', () => {
+    const tasks = [buildTask({ id: 'task-a' }), buildTask({ id: 'task-b' })];
+    expect(keepValidTaskRecords(tasks)).toEqual(tasks);
+  });
+
+  it('excludes a record with an invalid quadrant', () => {
+    const corrupt = buildTask({ id: 'task-bad', quadrant: 'not-a-quadrant' as TaskRecord['quadrant'] });
+    const valid = buildTask({ id: 'task-good' });
+
+    const result = keepValidTaskRecords([corrupt, valid]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('task-good');
+  });
+
+  it('excludes a record missing a required field', () => {
+    const corrupt = { ...buildTask({ id: 'task-bad' }), title: undefined } as unknown as TaskRecord;
+    const valid = buildTask({ id: 'task-good' });
+
+    const result = keepValidTaskRecords([corrupt, valid]);
+
+    expect(result.map((t) => t.id)).toEqual(['task-good']);
+  });
+
+  it('logs a warning when a record is quarantined', () => {
+    mockWarn.mockClear();
+    const corrupt = buildTask({ id: 'task-bad', quadrant: 'nope' as TaskRecord['quadrant'] });
+
+    keepValidTaskRecords([corrupt]);
+
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it('keeps a record carrying a harmless legacy field (does not over-quarantine)', () => {
+    const legacy = { ...buildTask({ id: 'task-legacy' }), vectorClock: { device: 3 } } as unknown as TaskRecord;
+
+    const result = keepValidTaskRecords([legacy]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('task-legacy');
+  });
+});


### PR DESCRIPTION
## What & why

Several write/read/sync paths persisted or surfaced task data without enforcing the limits in `lib/constants/schema.ts` (`SCHEMA_LIMITS`). This PR closes those gaps so oversized or corrupt data can't silently enter IndexedDB or reach the UI. All four issues were verified against current code before implementing — all confirmed real.

### Closes #391 — Align PocketBase pull schema with local SCHEMA_LIMITS
`pbTaskRecordSchema` validated structure but had no length/count limits, so oversized remote records could be written to IndexedDB. Added `.max()` to title, description, tags (per-tag + array count), subtasks count, dependencies count, and time-entries count. The pull path (`pb-pull.ts` / `pb-sync-engine.ts`) already skips records when `pocketBaseToTaskRecord` returns `null` and logs via `lib/logger`, so oversized records are now skipped + logged, not persisted and not crashing the pull.

### Closes #393 — Validate subtask and time-tracking writes
`addSubtask()` and `stopTimeTracking()` called `db.tasks.put()` directly with no validation.
- `addSubtask`: enforces `MAX_SUBTASKS` (clear "maximum reached" error) and validates the new subtask through `subtaskSchema` (`SUBTASK_TITLE_MAX_LENGTH`, non-empty).
- `stopTimeTracking`: validates `notes` through `timeEntrySchema.shape.notes` (`TIME_ENTRY_NOTES_MAX_LENGTH`).
- Both throw before persisting. (Subtask toggle/delete were assessed: they only flip a boolean / remove an item and cannot introduce oversized content, so no length validation was added there.)

### Closes #397 — Extract URLs in update path to match create path
`createTask()` runs `extractUrlsFromTitle()` + `buildDescription()`; the update path did not, so editing a title to add a URL behaved differently from creating one. `updateTask()` now runs the same helpers (DRY — reuses `lib/capture-parser`, which already sanitizes via the http/https-only `sanitizeTitleUrl`). The edit-drawer save path calls `updateTask()`, so it inherits the fix with no component change.

### Closes #395 — Read-time validation in `useTasks()`
Reads loaded straight from Dexie with no validation. `useTasks()` now filters each record through a lenient stored-record schema inside the `useLiveQuery` callback (runs on data change, not per render) and quarantines corrupt rows with a logged warning. **Design note:** validation uses the lenient (`.strip()`) `storedTaskRecordSchema`, not the strict `taskRecordSchema`, so records carrying harmless legacy fields (e.g. `vectorClock` from the retired Cloudflare sync) are kept rather than made to vanish from the UI; only genuinely invalid records (wrong types, missing fields, bad enums) are quarantined. `storedTaskRecordSchema` is the existing import schema, now exported and reused (also used by `importPayloadSchema`).

## How to test
- `bun run test` — full suite green (2071 passed, 1 skipped)
- `bun typecheck` — clean
- `bun lint` — 0 errors (pre-existing warnings only)

Targeted: `bun run test -- tests/data/use-tasks tests/data/sync/task-mapper tests/data/sync/pb-pull tests/data/tasks/subtasks tests/data/time-tracking tests/data/tasks/crud`

## Per-issue verification notes
- **#391**: new task-mapper tests assert oversized title/description/tags(count+length)/subtasks(count) records return `null` (skipped) and a record sized exactly at the limits passes.
- **#393**: new subtasks tests reject over-long/empty titles and adding beyond `MAX_SUBTASKS` without calling `db.put`; new time-tracking test rejects over-long notes without persisting.
- **#397**: new `updateTask` parametrized tests mirror the create-path URL tests (extract into description, URL-only fallback title, no-op when no URL).
- **#395**: new `keepValidTaskRecords` tests confirm valid pass-through, quarantine of invalid quadrant / missing field (with logged warning), and that a harmless legacy field is kept.

TDD: failing tests were written and confirmed red before each implementation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->