### PR TITLE
fix(sync): resilience — token refresh, Retry-After, sanitized failure reasons

### DIFF
--- a/lib/constants/sync.ts
+++ b/lib/constants/sync.ts
@@ -41,6 +41,12 @@ export const SYNC_CONFIG = {
 
   /** Exponential backoff delays for sync retries: 5s, 10s, 30s, 60s, 300s */
   RETRY_DELAYS: [5000, 10000, 30000, 60000, 300000] as readonly number[],
+
+  /**
+   * Ceiling applied to a server-provided Retry-After before honoring it (5 min).
+   * Bounds the wait so a bogus or hostile header can't freeze sync indefinitely.
+   */
+  MAX_RETRY_AFTER_MS: 5 * 60 * 1000,
 } as const;
 
 /**

--- a/lib/sync/error-categorizer.ts
+++ b/lib/sync/error-categorizer.ts
@@ -210,3 +210,23 @@ export function parseRetryAfterMs(value: string | null | undefined): number | nu
   if (Number.isNaN(timestamp)) return null;
   return Math.max(0, timestamp - Date.now());
 }
+
+/**
+ * Read a previously-captured Retry-After delay (in ms) off a thrown sync error.
+ *
+ * PocketBase's ClientResponseError forwards only `status` and the parsed body —
+ * never response headers. `pocketbase-client`'s afterSend hook folds the parsed
+ * `Retry-After` value into that body as `retryAfterMs`, so the 429 backoff path
+ * can read it back here without reaching into the SDK's internals. Returns
+ * `null` when no usable hint is present.
+ */
+export function extractRetryAfterMs(error: unknown): number | null {
+  if (!error || typeof error !== 'object') return null;
+
+  const response = (error as { response?: unknown }).response;
+  if (!response || typeof response !== 'object') return null;
+
+  const ms = (response as { retryAfterMs?: unknown }).retryAfterMs;
+  if (typeof ms === 'number' && Number.isFinite(ms) && ms >= 0) return ms;
+  return null;
+}

--- a/lib/sync/health-monitor.ts
+++ b/lib/sync/health-monitor.ts
@@ -6,6 +6,7 @@
 
 import { getSyncQueue } from './queue';
 import { getPocketBase, isAuthenticated } from './pocketbase-client';
+import { ensureValidAuth } from './pb-auth';
 import { getDb } from '@/lib/db';
 import { createLogger } from '@/lib/logger';
 import { SYNC_CONFIG } from '@/lib/constants/sync';
@@ -77,7 +78,7 @@ export class HealthMonitor {
       const failedIssue = await this.checkFailedItems();
       if (failedIssue) issues.push(failedIssue);
 
-      const authIssue = this.checkAuth();
+      const authIssue = await this.checkAuth();
       if (authIssue) issues.push(authIssue);
 
       const connectivityIssue = await this.checkServerConnectivity();
@@ -131,16 +132,19 @@ export class HealthMonitor {
     };
   }
 
-  private checkAuth(): HealthIssue | null {
-    if (!isAuthenticated()) {
-      return {
-        type: 'token_expired',
-        severity: 'error',
-        message: 'Authentication token has expired',
-        suggestedAction: 'Sign in again to continue syncing',
-      };
-    }
-    return null;
+  private async checkAuth(): Promise<HealthIssue | null> {
+    if (isAuthenticated()) return null;
+
+    // The JWT has lapsed, but the server session may still be valid — try a
+    // silent refresh before surfacing a "sign in again" error to the user.
+    if (await ensureValidAuth()) return null;
+
+    return {
+      type: 'token_expired',
+      severity: 'error',
+      message: 'Authentication token has expired',
+      suggestedAction: 'Sign in again to continue syncing',
+    };
   }
 
   private async checkServerConnectivity(): Promise<HealthIssue | null> {

--- a/lib/sync/pb-auth.ts
+++ b/lib/sync/pb-auth.ts
@@ -215,3 +215,22 @@ export async function refreshAuth(): Promise<boolean> {
     return false;
   }
 }
+
+/**
+ * Ensure there's a usable auth session for a background operation.
+ *
+ * Background sync, the health monitor, and fullSync historically only checked
+ * `authStore.isValid`, which flips false the instant the JWT's exp passes —
+ * even though PocketBase can still mint a fresh token from the server session.
+ * This attempts that silent refresh so a merely-expired token doesn't surface
+ * as "not authenticated" until the user manually re-auths.
+ *
+ * Checks `isValid` first so a healthy session never triggers a redundant
+ * network refresh. Returns true when the session is (or becomes) valid.
+ */
+export async function ensureValidAuth(): Promise<boolean> {
+  const pb = getPocketBase();
+  if (pb.authStore.isValid) return true;
+  if (!pb.authStore.token) return false;
+  return refreshAuth();
+}

--- a/lib/sync/pb-push.ts
+++ b/lib/sync/pb-push.ts
@@ -10,7 +10,7 @@ import { getSyncQueue } from './queue';
 import { taskRecordToPocketBase } from './task-mapper';
 import { createLogger } from '@/lib/logger';
 import { THROTTLE_MS, delay, getDeviceId, getCurrentUserId, fetchRemoteTaskIndex } from './pb-sync-helpers';
-import { sanitizeSyncError, isTransientSyncFailure } from './error-categorizer';
+import { sanitizeSyncError, isTransientSyncFailure, extractRetryAfterMs } from './error-categorizer';
 import type { SyncQueueItem, RemoteTaskIndexEntry } from './types';
 
 const logger = createLogger('SYNC_ENGINE');
@@ -41,6 +41,8 @@ export interface PushResult {
   failedCount: number;
   lastError: string | null;
   authenticated: boolean;
+  /** Server-requested backoff (ms) parsed from a 429 Retry-After, if any. */
+  retryAfterMs?: number | null;
 }
 
 /**
@@ -195,6 +197,7 @@ export async function pushLocalChanges(): Promise<PushResult> {
   let failedCount = 0;
   let skippedCount = 0;
   let lastError: string | null = null;
+  let retryAfterMs: number | null = null;
 
   for (const item of pending) {
     try {
@@ -237,10 +240,13 @@ export async function pushLocalChanges(): Promise<PushResult> {
       // we don't hammer it through the remaining queue items at 100ms
       // throttle and amplify the rate-limit response.
       if (isRateLimitError(error)) {
+        // Honor the server's Retry-After (if it sent one) for the next backoff.
+        retryAfterMs = extractRetryAfterMs(error);
         logger.warn('Aborting push loop due to rate limit (429)', {
           pushedCount,
           failedCount,
           skippedCount,
+          retryAfterMs,
           remaining: pending.length - (pushedCount + failedCount + skippedCount),
         });
         break;
@@ -249,5 +255,5 @@ export async function pushLocalChanges(): Promise<PushResult> {
   }
 
   logger.debug('Push completed', { pushedCount, failedCount, skippedCount, total: pending.length });
-  return { pushedCount, failedCount, lastError, authenticated: true };
+  return { pushedCount, failedCount, lastError, authenticated: true, retryAfterMs };
 }

--- a/lib/sync/pb-sync-engine.ts
+++ b/lib/sync/pb-sync-engine.ts
@@ -11,7 +11,8 @@ import { createLogger } from '@/lib/logger';
 import { getRetryManager } from './retry-manager';
 import { recordSyncSuccess, recordSyncError, recordSyncPartial } from '@/lib/sync-history';
 import { notifySyncSuccess, notifySyncError } from './notifications';
-import { isTransientSyncFailure, sanitizeSyncError } from './error-categorizer';
+import { isTransientSyncFailure, sanitizeSyncError, extractRetryAfterMs } from './error-categorizer';
+import { ensureValidAuth } from './pb-auth';
 import { getDeviceId } from './pb-sync-helpers';
 import { pushLocalChanges } from './pb-push';
 import { pullRemoteChanges } from './pb-pull';
@@ -111,6 +112,11 @@ export async function fullSync(triggeredBy: 'user' | 'auto' = 'auto'): Promise<P
     const db = getDb();
     const config = await db.syncMetadata.get('sync_config') as PBSyncConfig | undefined;
 
+    // A merely-expired JWT can still be refreshed from the server session.
+    // Attempt that silently here; if it fails, push/pull report the auth
+    // failure cleanly via the unauthenticated path below.
+    await ensureValidAuth();
+
     const pushResult = await pushLocalChanges();
     const pullResult = await pullRemoteChanges(resolveServerCursor(config));
 
@@ -165,7 +171,7 @@ async function updateSyncCursor(config: PBSyncConfig | undefined, maxTimestamp: 
 }
 
 async function reportPartialFailure(
-  pushResult: { pushedCount: number; failedCount: number; lastError: string | null },
+  pushResult: { pushedCount: number; failedCount: number; lastError: string | null; retryAfterMs?: number | null },
   pullResult: { pulledCount: number },
   retryManager: ReturnType<typeof getRetryManager>,
   deviceId: string,
@@ -173,7 +179,7 @@ async function reportPartialFailure(
   duration: number,
 ): Promise<PBSyncResult> {
   const errorMsg = `${pushResult.failedCount} item(s) failed to sync: ${pushResult.lastError}`;
-  await retryManager.recordFailure(new Error(errorMsg));
+  await retryManager.recordFailure(new Error(errorMsg), { retryAfterMs: pushResult.retryAfterMs ?? null });
   await recordSyncPartial({
     pushedCount: pushResult.pushedCount,
     pulledCount: pullResult.pulledCount,
@@ -204,7 +210,8 @@ async function reportSyncError(
   // PB 4xx bodies can echo submitted field values (task titles), so persist
   // and surface only the stable code; keep the raw Error for diagnostics.
   const errorCode = sanitizeSyncError(errorObj);
-  await retryManager.recordFailure(errorObj);
+  // A directly-thrown 429 (e.g. from pull) may carry a Retry-After hint.
+  await retryManager.recordFailure(errorObj, { retryAfterMs: extractRetryAfterMs(errorObj) });
   await recordSyncError(errorCode, deviceId, triggeredBy, Date.now() - startTime);
   notifySyncError(errorCode, false);
   if (isTransientSyncFailure(errorObj)) {

--- a/lib/sync/pocketbase-client.ts
+++ b/lib/sync/pocketbase-client.ts
@@ -8,6 +8,7 @@
 
 import PocketBase from 'pocketbase';
 import { ENV_CONFIG } from '@/lib/env-config';
+import { parseRetryAfterMs } from './error-categorizer';
 
 let pbInstance: PocketBase | null = null;
 
@@ -20,6 +21,19 @@ export function getPocketBase(): PocketBase {
     pbInstance = new PocketBase(ENV_CONFIG.pocketBaseUrl);
     // Disable auto-cancellation so concurrent requests don't cancel each other
     pbInstance.autoCancellation(false);
+    // The SDK throws ClientResponseError after afterSend but forwards only
+    // status + parsed body — never response headers. afterSend is the one place
+    // with header access, so capture the server's Retry-After on a 429 and fold
+    // it into the body the error will carry (read back via extractRetryAfterMs).
+    pbInstance.afterSend = (response, data) => {
+      if (response.status === 429 && data && typeof data === 'object') {
+        const retryAfterMs = parseRetryAfterMs(response.headers.get('Retry-After'));
+        if (retryAfterMs !== null) {
+          (data as Record<string, unknown>).retryAfterMs = retryAfterMs;
+        }
+      }
+      return data;
+    };
   }
   return pbInstance;
 }

--- a/lib/sync/retry-manager.ts
+++ b/lib/sync/retry-manager.ts
@@ -6,16 +6,23 @@
 import { getSyncConfig, updateSyncConfig } from './config';
 import { createLogger } from '@/lib/logger';
 import { SYNC_CONFIG } from '@/lib/constants/sync';
+import { sanitizeSyncError } from './error-categorizer';
 
 const logger = createLogger('SYNC_RETRY');
 
-const { MAX_RETRIES, RETRY_DELAYS } = SYNC_CONFIG;
+const { MAX_RETRIES, RETRY_DELAYS, MAX_RETRY_AFTER_MS } = SYNC_CONFIG;
+
+/** Optional hints a caller can attach to a recorded failure. */
+export interface RecordFailureOptions {
+  /** Server-provided Retry-After delay (ms); overrides exponential backoff. */
+  retryAfterMs?: number | null;
+}
 
 export class RetryManager {
   /**
    * Record a sync failure and update retry metadata
    */
-  async recordFailure(error: Error): Promise<void> {
+  async recordFailure(error: Error, options?: RecordFailureOptions): Promise<void> {
     const config = await getSyncConfig();
     if (!config) {
       logger.error('Cannot record failure: sync config not found');
@@ -23,22 +30,40 @@ export class RetryManager {
     }
 
     const consecutiveFailures = config.consecutiveFailures + 1;
-    const nextRetryDelay = this.getNextRetryDelay(consecutiveFailures);
+    const retryAfterMs = options?.retryAfterMs ?? null;
+    const nextRetryDelay = this.resolveRetryDelay(consecutiveFailures, retryAfterMs);
     const nextRetryAt = Date.now() + nextRetryDelay;
+    // PocketBase 4xx bodies can echo submitted field values (task titles), so
+    // persist only a stable code — the raw message stays in the diagnostic log.
+    const failureReason = sanitizeSyncError(error);
 
     logger.info('Recording sync failure', {
       consecutiveFailures,
+      failureReason,
       errorMessage: error.message,
       nextRetryDelay: `${nextRetryDelay / 1000}s`,
+      honoredRetryAfter: retryAfterMs !== null,
       nextRetryAt: new Date(nextRetryAt).toISOString(),
     });
 
     await updateSyncConfig({
       consecutiveFailures,
       lastFailureAt: Date.now(),
-      lastFailureReason: error.message,
+      lastFailureReason: failureReason,
       nextRetryAt,
     });
+  }
+
+  /**
+   * Pick the backoff delay. A server-provided Retry-After wins over the
+   * exponential schedule (honor the backend's explicit pacing), but is clamped
+   * to MAX_RETRY_AFTER_MS so a bogus/hostile header can't freeze sync.
+   */
+  private resolveRetryDelay(consecutiveFailures: number, retryAfterMs: number | null): number {
+    if (retryAfterMs !== null && retryAfterMs >= 0) {
+      return Math.min(retryAfterMs, MAX_RETRY_AFTER_MS);
+    }
+    return this.getNextRetryDelay(consecutiveFailures);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "9.12.2",
+	"version": "9.12.6",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/data/additional-branches.test.ts
+++ b/tests/data/additional-branches.test.ts
@@ -58,7 +58,8 @@ describe("RetryManager", () => {
       expect(mockUpdateSyncConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           consecutiveFailures: 3,
-          lastFailureReason: "network fail",
+          // Persisted reason is a sanitized stable code, not the raw message.
+          lastFailureReason: "network_error",
         })
       );
     });

--- a/tests/data/sync/error-categorizer.test.ts
+++ b/tests/data/sync/error-categorizer.test.ts
@@ -7,6 +7,7 @@ import {
   isPermanentError,
   sanitizeSyncError,
   parseRetryAfterMs,
+  extractRetryAfterMs,
 } from '@/lib/sync/error-categorizer';
 
 describe('error-categorizer', () => {
@@ -260,6 +261,36 @@ describe('error-categorizer', () => {
 
     it('clamps negative numeric values to 0', () => {
       expect(parseRetryAfterMs('-5')).toBe(0);
+    });
+  });
+
+  describe('extractRetryAfterMs', () => {
+    it('reads a pre-parsed retryAfterMs folded into the error response body', () => {
+      const error = Object.assign(new Error('429 too many requests'), {
+        status: 429,
+        response: { retryAfterMs: 45_000 },
+      });
+      expect(extractRetryAfterMs(error)).toBe(45_000);
+    });
+
+    it('accepts a zero-delay hint', () => {
+      const error = { status: 429, response: { retryAfterMs: 0 } };
+      expect(extractRetryAfterMs(error)).toBe(0);
+    });
+
+    it('returns null when no retryAfterMs is present', () => {
+      const error = Object.assign(new Error('429 too many requests'), {
+        status: 429,
+        response: { message: 'rate limited' },
+      });
+      expect(extractRetryAfterMs(error)).toBeNull();
+    });
+
+    it('returns null for non-object / missing / non-numeric values', () => {
+      expect(extractRetryAfterMs(null)).toBeNull();
+      expect(extractRetryAfterMs('429')).toBeNull();
+      expect(extractRetryAfterMs({ response: { retryAfterMs: 'soon' } })).toBeNull();
+      expect(extractRetryAfterMs({ response: { retryAfterMs: NaN } })).toBeNull();
     });
   });
 });

--- a/tests/data/sync/health-monitor.test.ts
+++ b/tests/data/sync/health-monitor.test.ts
@@ -30,6 +30,13 @@ vi.mock('@/lib/sync/pocketbase-client', () => ({
   isAuthenticated: () => mockIsAuthenticated(),
 }));
 
+// Silent token refresh — defaults to "could not refresh" so existing
+// token_expired assertions hold; tests opt in to a successful refresh.
+const mockEnsureValidAuth = vi.fn().mockResolvedValue(false);
+vi.mock('@/lib/sync/pb-auth', () => ({
+  ensureValidAuth: () => mockEnsureValidAuth(),
+}));
+
 // Mock database
 const mockDb = {
   syncMetadata: {
@@ -51,6 +58,7 @@ describe('HealthMonitor', () => {
     mockQueue.getPending.mockResolvedValue([]);
     mockQueue.getFailed.mockResolvedValue([]);
     mockPb.health.check.mockResolvedValue({ code: 200 });
+    mockEnsureValidAuth.mockResolvedValue(false);
   });
 
   describe('start/stop', () => {
@@ -124,6 +132,24 @@ describe('HealthMonitor', () => {
       const authIssue = report.issues.find(i => i.type === 'token_expired');
       expect(authIssue).toBeDefined();
       expect(authIssue!.severity).toBe('error');
+    });
+
+    it('does not flag token_expired when a silent refresh succeeds', async () => {
+      // Token's JWT has lapsed (isAuthenticated false), but the server session
+      // is still good, so ensureValidAuth refreshes it. No scary issue surfaces.
+      mockIsAuthenticated.mockReturnValue(false);
+      mockEnsureValidAuth.mockResolvedValue(true);
+
+      const report = await monitor.check();
+      const authIssue = report.issues.find(i => i.type === 'token_expired');
+      expect(authIssue).toBeUndefined();
+    });
+
+    it('does not attempt a refresh when the token is already valid', async () => {
+      mockIsAuthenticated.mockReturnValue(true);
+
+      await monitor.check();
+      expect(mockEnsureValidAuth).not.toHaveBeenCalled();
     });
 
     it('should detect unreachable server', async () => {

--- a/tests/data/sync/pb-auth.test.ts
+++ b/tests/data/sync/pb-auth.test.ts
@@ -37,12 +37,14 @@ import {
   getOAuthErrorMessage,
   openOAuthPopup,
   refreshAuth,
+  ensureValidAuth,
 } from '@/lib/sync/pb-auth';
 
 describe('PocketBase Auth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPb.authStore.token = 'test-token';
+    mockPb.authStore.isValid = true;
   });
 
   describe('loginWithProvider', () => {
@@ -204,6 +206,48 @@ describe('PocketBase Auth', () => {
       mockPb.authStore.token = '';
 
       const result = await refreshAuth();
+
+      expect(mockAuthRefresh).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('ensureValidAuth', () => {
+    it('returns true without refreshing when the token is still valid', async () => {
+      mockPb.authStore.isValid = true;
+
+      const result = await ensureValidAuth();
+
+      expect(result).toBe(true);
+      expect(mockAuthRefresh).not.toHaveBeenCalled();
+    });
+
+    it('attempts a silent refresh when the token is expired but present', async () => {
+      mockPb.authStore.isValid = false;
+      mockPb.authStore.token = 'expired-but-present';
+      mockAuthRefresh.mockResolvedValue({});
+
+      const result = await ensureValidAuth();
+
+      expect(mockAuthRefresh).toHaveBeenCalledTimes(1);
+      expect(result).toBe(true);
+    });
+
+    it('reports failure cleanly when the silent refresh fails', async () => {
+      mockPb.authStore.isValid = false;
+      mockPb.authStore.token = 'expired-but-present';
+      mockAuthRefresh.mockRejectedValue(new Error('refresh rejected'));
+
+      const result = await ensureValidAuth();
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false without refreshing when there is no token at all', async () => {
+      mockPb.authStore.isValid = false;
+      mockPb.authStore.token = '';
+
+      const result = await ensureValidAuth();
 
       expect(mockAuthRefresh).not.toHaveBeenCalled();
       expect(result).toBe(false);

--- a/tests/data/sync/pb-push.test.ts
+++ b/tests/data/sync/pb-push.test.ts
@@ -343,4 +343,63 @@ describe('pushLocalChanges LWW guard', () => {
     expect(result.pushedCount).toBe(1);
     expect(await getSyncQueue().getPendingCount()).toBe(0);
   });
+
+  it('surfaces the server Retry-After (ms) from a 429 so the caller can back off', async () => {
+    const payload = makeTask('t1', '2026-05-18T12:00:00.000Z');
+    await getSyncQueue().enqueue('update', 't1', payload);
+
+    fetchRemoteTaskIndexMock.mockResolvedValue({
+      index: new Map([
+        ['t1', { pbRecordId: 'rec-1', clientUpdatedAt: '2026-05-18T11:00:00.000Z' }],
+      ]),
+      fetchSucceeded: true,
+    });
+
+    // pocketbase-client's afterSend hook folds the parsed Retry-After header
+    // into error.response.retryAfterMs; the push path reads it back here.
+    const rateLimited = Object.assign(new Error('429 too many requests'), {
+      status: 429,
+      response: { retryAfterMs: 30_000 },
+    });
+    const updateSpy = vi.fn(async () => {
+      throw rateLimited;
+    });
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({ create: vi.fn(), update: updateSpy, delete: vi.fn() }),
+    });
+
+    const result = await pushLocalChanges();
+
+    expect(result.failedCount).toBe(1);
+    expect(result.lastError).toBe('rate_limited');
+    expect(result.retryAfterMs).toBe(30_000);
+    // Item stays queued for the (delayed) retry.
+    expect(await getSyncQueue().getPendingCount()).toBe(1);
+  });
+
+  it('reports a null Retry-After when a 429 carries no header', async () => {
+    const payload = makeTask('t1', '2026-05-18T12:00:00.000Z');
+    await getSyncQueue().enqueue('update', 't1', payload);
+
+    fetchRemoteTaskIndexMock.mockResolvedValue({
+      index: new Map([
+        ['t1', { pbRecordId: 'rec-1', clientUpdatedAt: '2026-05-18T11:00:00.000Z' }],
+      ]),
+      fetchSucceeded: true,
+    });
+
+    const rateLimited = Object.assign(new Error('429 too many requests'), { status: 429 });
+    const updateSpy = vi.fn(async () => {
+      throw rateLimited;
+    });
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({ create: vi.fn(), update: updateSpy, delete: vi.fn() }),
+    });
+
+    const result = await pushLocalChanges();
+
+    expect(result.failedCount).toBe(1);
+    expect(result.lastError).toBe('rate_limited');
+    expect(result.retryAfterMs).toBeNull();
+  });
 });

--- a/tests/data/sync/pb-sync-engine.test.ts
+++ b/tests/data/sync/pb-sync-engine.test.ts
@@ -108,10 +108,17 @@ vi.mock('@/lib/sync/pb-sync-helpers', () => ({
   getDeviceId: vi.fn().mockResolvedValue('device-123'),
 }));
 
+// Mock auth — fullSync attempts a silent token refresh before push/pull.
+const mockEnsureValidAuth = vi.fn().mockResolvedValue(true);
+vi.mock('@/lib/sync/pb-auth', () => ({
+  ensureValidAuth: () => mockEnsureValidAuth(),
+}));
+
 describe('pb-sync-engine', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockTasks.clear();
+    mockEnsureValidAuth.mockResolvedValue(true);
   });
 
   describe('applyRemoteChange', () => {
@@ -322,6 +329,48 @@ describe('pb-sync-engine', () => {
       expect(vi.mocked(notifySyncError).mock.calls[0][0]).toBe('validation_failed');
       expect(JSON.stringify(vi.mocked(recordSyncError).mock.calls)).not.toContain(secretTitle);
       expect(JSON.stringify(vi.mocked(notifySyncError).mock.calls)).not.toContain(secretTitle);
+    });
+
+    it('attempts a silent token refresh before pushing', async () => {
+      await fullSync('auto');
+
+      expect(mockEnsureValidAuth).toHaveBeenCalledTimes(1);
+    });
+
+    it('threads a push Retry-After hint into the retry manager on partial failure', async () => {
+      const { pushLocalChanges } = await import('@/lib/sync/pb-push');
+      vi.mocked(pushLocalChanges).mockResolvedValueOnce({
+        pushedCount: 0,
+        failedCount: 1,
+        lastError: 'rate_limited',
+        authenticated: true,
+        retryAfterMs: 30_000,
+      });
+
+      await fullSync('auto');
+
+      expect(mockRetryManager.recordFailure).toHaveBeenCalledWith(
+        expect.any(Error),
+        { retryAfterMs: 30_000 },
+      );
+    });
+
+    it('honors a Retry-After carried on a thrown 429 error', async () => {
+      const { pushLocalChanges } = await import('@/lib/sync/pb-push');
+      const rateLimited = Object.assign(new Error('429 too many requests'), {
+        status: 429,
+        response: { retryAfterMs: 12_000 },
+      });
+      vi.mocked(pushLocalChanges).mockRejectedValueOnce(rateLimited);
+
+      const result = await fullSync('auto');
+
+      expect(result.status).toBe('error');
+      expect(result.error).toBe('rate_limited');
+      expect(mockRetryManager.recordFailure).toHaveBeenCalledWith(
+        rateLimited,
+        { retryAfterMs: 12_000 },
+      );
     });
   });
 });

--- a/tests/data/sync/pocketbase-client.test.ts
+++ b/tests/data/sync/pocketbase-client.test.ts
@@ -9,6 +9,8 @@ const mockPb = {
   autoCancellation: vi.fn(),
   authStore: mockAuthStore,
   collection: vi.fn(),
+  // Assigned by getPocketBase(); the SDK invokes it after every response.
+  afterSend: undefined as ((response: Response, data: unknown) => unknown) | undefined,
 };
 
 // vi.fn() with a function body that returns mockPb acts as a constructor
@@ -90,5 +92,30 @@ describe('PocketBase Client', () => {
     mockAuthStore.record = { id: 'user-abc-123' };
 
     expect(getCurrentUserId()).toBe('user-abc-123');
+  });
+
+  it('captures a 429 Retry-After header into the response body via afterSend', async () => {
+    const { getPocketBase } = await import('@/lib/sync/pocketbase-client');
+    getPocketBase();
+
+    expect(typeof mockPb.afterSend).toBe('function');
+    const response = {
+      status: 429,
+      headers: { get: (h: string) => (h.toLowerCase() === 'retry-after' ? '30' : null) },
+    } as unknown as Response;
+
+    const result = mockPb.afterSend!(response, { code: 429, message: 'rate limited' }) as {
+      retryAfterMs?: number;
+    };
+    expect(result.retryAfterMs).toBe(30_000);
+  });
+
+  it('leaves the body unchanged for non-429 responses', async () => {
+    const { getPocketBase } = await import('@/lib/sync/pocketbase-client');
+    getPocketBase();
+
+    const response = { status: 200, headers: { get: () => null } } as unknown as Response;
+    const result = mockPb.afterSend!(response, { ok: true });
+    expect(result).toEqual({ ok: true });
   });
 });

--- a/tests/data/sync/retry-manager.test.ts
+++ b/tests/data/sync/retry-manager.test.ts
@@ -74,9 +74,25 @@ describe('RetryManager', () => {
       expect(updateSyncConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           consecutiveFailures: 1,
-          lastFailureReason: 'Network error',
+          // Persisted reason is a stable code, not the raw message.
+          lastFailureReason: 'network_error',
         }),
       );
+    });
+
+    it('persists a sanitized error code, never raw PB validation content', async () => {
+      // PocketBase 4xx bodies can echo submitted field values (task titles).
+      // recordFailure must reduce the error to a stable code before it lands
+      // in IndexedDB sync metadata, so task content never leaks.
+      const { updateSyncConfig } = await import('@/lib/sync/config');
+      const leakedTitle = 'Confidential: acquire MegaCorp';
+      await manager.recordFailure(
+        new Error(`422 Unprocessable: title "${leakedTitle}" failed to validate`),
+      );
+
+      const call = vi.mocked(updateSyncConfig).mock.lastCall![0] as { lastFailureReason: string };
+      expect(call.lastFailureReason).toBe('validation_failed');
+      expect(JSON.stringify(call)).not.toContain(leakedTitle);
     });
 
     it('should set nextRetryAt with exponential backoff', async () => {
@@ -86,6 +102,37 @@ describe('RetryManager', () => {
 
       const call = vi.mocked(updateSyncConfig).mock.lastCall![0] as { nextRetryAt: number };
       expect(call.nextRetryAt).toBeGreaterThanOrEqual(before + 5000);
+    });
+
+    it('honors a server Retry-After hint over the exponential schedule', async () => {
+      // First failure would normally back off 5s; a 45s Retry-After must win.
+      const { updateSyncConfig } = await import('@/lib/sync/config');
+      const before = Date.now();
+      await manager.recordFailure(new Error('429 too many requests'), { retryAfterMs: 45_000 });
+
+      const call = vi.mocked(updateSyncConfig).mock.lastCall![0] as { nextRetryAt: number };
+      expect(call.nextRetryAt).toBeGreaterThanOrEqual(before + 45_000);
+      expect(call.nextRetryAt).toBeLessThan(before + 60_000);
+    });
+
+    it('clamps an excessive Retry-After hint to the max backoff', async () => {
+      // A hostile/bogus header must not freeze sync for hours.
+      const { updateSyncConfig } = await import('@/lib/sync/config');
+      const before = Date.now();
+      await manager.recordFailure(new Error('429'), { retryAfterMs: 9_999_999_999 });
+
+      const call = vi.mocked(updateSyncConfig).mock.lastCall![0] as { nextRetryAt: number };
+      expect(call.nextRetryAt).toBeLessThanOrEqual(before + 5 * 60 * 1000 + 50);
+    });
+
+    it('falls back to exponential backoff when no Retry-After hint is given', async () => {
+      const { updateSyncConfig } = await import('@/lib/sync/config');
+      const before = Date.now();
+      await manager.recordFailure(new Error('500 server error'), { retryAfterMs: null });
+
+      const call = vi.mocked(updateSyncConfig).mock.lastCall![0] as { nextRetryAt: number };
+      expect(call.nextRetryAt).toBeGreaterThanOrEqual(before + 5000);
+      expect(call.nextRetryAt).toBeLessThan(before + 10_000);
     });
   });
 

--- a/tests/sync/health-monitor.test.ts
+++ b/tests/sync/health-monitor.test.ts
@@ -31,6 +31,12 @@ vi.mock('@/lib/sync/pocketbase-client', () => ({
   isAuthenticated: vi.fn(() => mockIsAuthenticated),
 }));
 
+// checkAuth attempts a silent refresh before flagging token_expired. Default
+// to "could not refresh" so existing expired-token assertions still hold.
+vi.mock('@/lib/sync/pb-auth', () => ({
+  ensureValidAuth: vi.fn(async () => mockEnsureValidAuth),
+}));
+
 // Import the mocked function so we can change its return value per-test
 import { isAuthenticated } from '@/lib/sync/pocketbase-client';
 
@@ -42,6 +48,8 @@ const mockQueue = {
 
 // Default: user is authenticated
 let mockIsAuthenticated = true;
+// Default: a lapsed token cannot be silently refreshed.
+let mockEnsureValidAuth = false;
 
 describe('HealthMonitor', () => {
   let monitor: HealthMonitor;
@@ -65,6 +73,7 @@ describe('HealthMonitor', () => {
     mockQueue.getFailed.mockResolvedValue([]);
     mockHealthCheck.mockResolvedValue({});
     mockIsAuthenticated = true;
+    mockEnsureValidAuth = false;
     // Re-set the mock return value after clearAllMocks
     vi.mocked(isAuthenticated).mockImplementation(() => mockIsAuthenticated);
   });

--- a/tests/sync/pb-sync-engine.test.ts
+++ b/tests/sync/pb-sync-engine.test.ts
@@ -69,6 +69,12 @@ vi.mock('@/lib/sync/retry-manager', () => ({
   getRetryManager: vi.fn(() => mockRetryManager),
 }));
 
+// fullSync attempts a silent token refresh before push/pull; keep it a no-op
+// here so these engine tests don't exercise the real auth path.
+vi.mock('@/lib/sync/pb-auth', () => ({
+  ensureValidAuth: vi.fn().mockResolvedValue(true),
+}));
+
 vi.mock('@/lib/sync-history', () => ({
   recordSyncSuccess: vi.fn(),
   recordSyncError: vi.fn(),


### PR DESCRIPTION
## What & why

Three confirmed sync-reliability gaps in the PocketBase sync subsystem. All were verified against current code before implementing (none were already handled).

### #392 — Sanitize persisted retry failure reason
`RetryManager.recordFailure()` stored the raw `error.message` in `lastFailureReason`, which lands in IndexedDB sync metadata. PocketBase 4xx validation bodies echo submitted field values (e.g. task titles), so this leaked task content into local sync metadata. Now it persists `sanitizeSyncError(error)` — a stable code (`validation_failed`, `rate_limited`, etc.). The raw message is still kept in the diagnostic `info` log (not persisted, not sent to Sentry). `lastFailureReason` has no UI/display consumer, so no surface regresses.

### #396 — Honor PocketBase `Retry-After` on 429
`parseRetryAfterMs()` existed but was never called (dead code). PocketBase's `ClientResponseError` forwards only `status` + parsed body, never headers — so the header is captured in the `pocketbase-client` `afterSend` hook (the one place with `Response.headers` access) and folded into the error body as `retryAfterMs`. `extractRetryAfterMs()` reads it back; `RetryManager` honors it over the exponential schedule, clamped to `MAX_RETRY_AFTER_MS` (5 min) so a bogus/hostile header can't freeze sync. Threaded through both the push-partial path (`pushLocalChanges` returns `retryAfterMs`) and the directly-thrown-error path in `fullSync`. Applies to manual and auto sync (both flow through `fullSync` → `recordFailure` → `nextRetryAt`).

### #389 — Proactive token refresh in background sync
`refreshAuth()` was only invoked from the auth dialog and account deletion. Background sync / health monitor only checked `isValid`, which flips false the instant the JWT expires — even though PocketBase can mint a fresh token from the still-valid server session. New `ensureValidAuth()` checks `isValid` first (no redundant refresh on a healthy session), then attempts a silent `authRefresh()` when a token is present but expired. Wired into `fullSync()` (before push/pull) and the health monitor (before it reports `token_expired`). A refresh failure still reports the auth error cleanly via the existing unauthenticated path.

**Note on the sync coordinator:** issue #389 also mentions the coordinator, but it delegates exclusively to `fullSync()` (`executeSync` → `fullSync`), which now refreshes — so every background/manual sync is already covered. A separate coordinator-level check would be redundant, so it was intentionally centralized in `fullSync`.

## How to test locally

- `bun run test -- tests/data/sync tests/sync` — all sync suites green
- `bun run test` — full suite (2073 passed, 1 skipped)
- `bun typecheck` — clean
- `bun lint` — 0 errors (21 pre-existing warnings)

New/updated tests cover: sanitized persisted reason (no task content), `extractRetryAfterMs`, the `afterSend` header capture, push-path `retryAfterMs` surfacing, `recordFailure` honoring/clamping the hint, `ensureValidAuth` (valid → no refresh, expired+token → refresh, no token → false), and `fullSync`/health-monitor integration.

Closes #389
Closes #392
Closes #396
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->