### PR TITLE
fix(security): resolve security-review findings 1, 2, 5 (MCP CLI URL, @claude workflow, Caddy admin API)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,12 +11,21 @@ on:
     types: [submitted]
 
 jobs:
+  # Only trusted actors may invoke the OAuth-backed agent. Each event branch
+  # also requires author_association in the allowlist so an arbitrary public
+  # commenter who types "@claude" cannot trigger a secret-bearing run.
+  # OWNER/MEMBER/COLLABORATOR are the associations with write-level trust;
+  # CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, NONE, etc. are intentionally excluded.
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -47,14 +47,30 @@
 	}
 
 	# ---- PocketBase reverse proxy ----
-	# API endpoints
+	# Block administrative PocketBase API routes at the public origin. Superuser
+	# auth lives under /api/collections/_superusers/* (PB v0.23+); /api/admins/*
+	# is the legacy path. The browser app never needs either — it authenticates
+	# via OAuth against the users collection — so keeping admin auth off the
+	# public origin matches the "admin is not exposed" boundary that the /_/*
+	# rule already enforces. handle blocks match most-specific-first, so these
+	# deny rules take precedence over the broad /api/* proxy below.
+	handle /api/collections/_superusers/* {
+		respond "PocketBase admin API is not exposed through this origin." 404
+	}
+	handle /api/admins/* {
+		respond "PocketBase admin API is not exposed through this origin." 404
+	}
+
+	# App-facing API endpoints
 	handle /api/* {
 		reverse_proxy localhost:8090
 	}
 
-	# PocketBase admin is intentionally not exposed on the public app origin.
-	# For setup, either use scripts/setup-pocketbase-collections.sh through
-	# /api/* or publish 127.0.0.1:8090 from docker-compose temporarily.
+	# PocketBase admin UI is intentionally not exposed on the public app origin.
+	# Run admin/setup scripts (scripts/setup-pocketbase-collections.sh) against
+	# the PocketBase port directly — set PB_URL=http://127.0.0.1:8090 on the host,
+	# or publish 127.0.0.1:8090 from docker-compose temporarily. Superuser auth is
+	# no longer reachable through /api/* on this origin (see the deny rules above).
 	handle /_/* {
 		respond "PocketBase admin is not exposed through this origin." 404
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "10.0.0",
+	"version": "10.0.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the GSD MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2026-06-30 🔒
+
+Security hardening. Closes a gap left by 1.1.4: the exact-match `pocketBaseUrl`
+policy lived only in `configSchema`, but the setup wizard and validator built
+configs straight from prompts/env and reached token-bearing PocketBase calls
+without applying it.
+
+### Security
+- **Setup wizard and `--validate` now gate the PocketBase URL through the shared
+  HTTPS-or-loopback policy before any network request.** `isSafePocketBaseUrl`
+  is exported from `server/config` and both CLIs reject an unsafe
+  `GSD_POCKETBASE_URL` (plain HTTP to a non-loopback host, `localhost`-subdomain
+  and userinfo bypasses, unparseable input) and exit before `GSD_AUTH_TOKEN`
+  can be attached to a connectivity probe or sync-status check.
+
 ## [1.1.4] - 2026-05-12 🔒
 
 Security hardening release. Addresses the MCP server findings from the May 2026

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-mcp-server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "MCP server for GSD Task Manager — 20 tools for task CRUD, analytics, and diagnostics over PocketBase. Validated inputs, dry-run support, JWT-aware token health, and dependency-safe deletes.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/src/__tests__/cli/url-safety.test.ts
+++ b/packages/mcp-server/src/__tests__/cli/url-safety.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The CLI guards reuse the same URL policy as the server config. tools.js is
+// mocked so the wizard/validator cannot perform real PocketBase calls if the
+// guard ever regresses — the assertions below would catch the leak.
+vi.mock('../../tools.js', () => ({
+  getSyncStatus: vi.fn(),
+  listDevices: vi.fn(),
+  listTasks: vi.fn(),
+}));
+
+vi.mock('../../cli/index.js', () => ({
+  prompt: vi.fn(() => Promise.resolve('http://api.attacker.example')),
+  promptPassword: vi.fn(() => Promise.resolve('paste-token')),
+  getClaudeConfigPath: vi.fn(() => '/tmp/claude_desktop_config.json'),
+}));
+
+vi.mock('../../cli/setup-artifact.js', () => ({
+  getSetupArtifactPath: vi.fn(() => '/tmp/.gsd-mcp-setup.json'),
+  removeSetupArtifact: vi.fn(),
+}));
+
+import { isSafePocketBaseUrl } from '../../server/config.js';
+import { getSyncStatus } from '../../tools.js';
+import { runValidation } from '../../cli/validation.js';
+import { runSetupWizard } from '../../cli/setup-wizard.js';
+
+describe('isSafePocketBaseUrl', () => {
+  it('accepts https URLs', () => {
+    expect(isSafePocketBaseUrl('https://api.example.com')).toBe(true);
+  });
+
+  it('accepts http loopback URLs', () => {
+    expect(isSafePocketBaseUrl('http://127.0.0.1:8090')).toBe(true);
+  });
+
+  it('rejects plain http to a non-loopback host', () => {
+    expect(isSafePocketBaseUrl('http://api.example.com')).toBe(false);
+  });
+
+  it('rejects the localhost-subdomain bypass', () => {
+    expect(isSafePocketBaseUrl('http://localhost.attacker.com')).toBe(false);
+  });
+
+  it('rejects the userinfo bypass', () => {
+    expect(isSafePocketBaseUrl('http://localhost@attacker.com')).toBe(false);
+  });
+
+  it('rejects unparseable input', () => {
+    expect(isSafePocketBaseUrl('not a url')).toBe(false);
+  });
+});
+
+describe('CLI URL safety guards', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchSpy = vi.fn(() => Promise.resolve({ ok: true, status: 200 } as Response));
+    vi.stubGlobal('fetch', fetchSpy);
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    delete process.env.GSD_POCKETBASE_URL;
+    delete process.env.GSD_AUTH_TOKEN;
+  });
+
+  it('runValidation exits before any network I/O when the env URL is unsafe', async () => {
+    process.env.GSD_POCKETBASE_URL = 'http://api.attacker.example';
+    process.env.GSD_AUTH_TOKEN = 'secret-token';
+
+    await expect(runValidation()).rejects.toThrow('process.exit:1');
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(getSyncStatus).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('runSetupWizard exits before token-bearing calls when the prompted URL is unsafe', async () => {
+    // prompt() is mocked to return an unsafe http://api.attacker.example URL.
+    await expect(runSetupWizard()).rejects.toThrow('process.exit:1');
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(getSyncStatus).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/mcp-server/src/cli/setup-wizard.ts
+++ b/packages/mcp-server/src/cli/setup-wizard.ts
@@ -6,6 +6,7 @@
 import { writeFileSync, chmodSync } from 'node:fs';
 import type { GsdConfig } from '../tools.js';
 import { getSyncStatus, listTasks } from '../tools.js';
+import { isSafePocketBaseUrl, UNSAFE_POCKETBASE_URL_MESSAGE } from '../server/config.js';
 import { prompt, promptPassword, getClaudeConfigPath } from './index.js';
 import { getSetupArtifactPath, removeSetupArtifact } from './setup-artifact.js';
 
@@ -189,6 +190,13 @@ Welcome! This wizard will help you configure the MCP server for Claude Desktop.
     // Step 1: PocketBase URL
     console.log('Step 1/4: PocketBase URL');
     const pbUrl = await prompt('Enter your PocketBase URL', DEFAULT_POCKETBASE_URL);
+    // Gate the destination through the shared policy BEFORE any request — the
+    // connectivity probe and (later) the token-bearing sync check must never
+    // reach an unvalidated host.
+    if (!isSafePocketBaseUrl(pbUrl)) {
+      console.log(`✗ ${UNSAFE_POCKETBASE_URL_MESSAGE}`);
+      process.exit(1);
+    }
     await validateConnectivity(pbUrl);
     console.log();
 

--- a/packages/mcp-server/src/cli/validation.ts
+++ b/packages/mcp-server/src/cli/validation.ts
@@ -5,6 +5,7 @@
 
 import type { GsdConfig, SyncStatus } from '../tools.js';
 import { getSyncStatus, listDevices, listTasks } from '../tools.js';
+import { isSafePocketBaseUrl, UNSAFE_POCKETBASE_URL_MESSAGE } from '../server/config.js';
 
 /**
  * Validation check result
@@ -188,6 +189,15 @@ export async function runValidation(): Promise<void> {
 
   // Step 1: Environment variables
   const { pbUrl, authToken } = validateEnvironmentVariables();
+
+  // Gate the destination through the shared policy before any request so a
+  // misconfigured GSD_POCKETBASE_URL can never receive the auth token.
+  if (!isSafePocketBaseUrl(pbUrl)) {
+    console.log('✗ Configuration Error\n');
+    console.log(UNSAFE_POCKETBASE_URL_MESSAGE);
+    console.log(`\nGSD_POCKETBASE_URL is currently: ${pbUrl}`);
+    process.exit(1);
+  }
 
   checks.push({
     name: 'Environment Variables',

--- a/packages/mcp-server/src/server/config.ts
+++ b/packages/mcp-server/src/server/config.ts
@@ -7,12 +7,24 @@ const logger = createMcpLogger('CONFIG');
 const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
 
 /**
+ * Human-readable explanation of the PocketBase URL policy, shared by the zod
+ * schema and the setup/validation CLIs so every entry point reports the same
+ * rule.
+ */
+export const UNSAFE_POCKETBASE_URL_MESSAGE =
+  'PocketBase URL must use HTTPS (or http://localhost / http://127.0.0.1 / http://[::1] for local development)';
+
+/**
  * Validate that a URL either uses HTTPS, or uses HTTP only when targeting a
  * loopback hostname. Uses exact hostname matching after parsing so that
  * `http://localhost.attacker.com` and `http://localhost@attacker.com` are
  * correctly rejected (a `startsWith` check is bypassable).
+ *
+ * Exported so the CLIs (setup wizard, validator) gate the same way before
+ * attaching `GSD_AUTH_TOKEN` to any request — they build configs from raw
+ * prompts/env and never reach `configSchema.parse`.
  */
-function isSafePocketBaseUrl(url: string): boolean {
+export function isSafePocketBaseUrl(url: string): boolean {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -36,8 +48,7 @@ function isSafePocketBaseUrl(url: string): boolean {
  */
 export const configSchema = z.object({
   pocketBaseUrl: z.url().refine(isSafePocketBaseUrl, {
-    message:
-      'PocketBase URL must use HTTPS (or http://localhost / http://127.0.0.1 / http://[::1] for local development)',
+    message: UNSAFE_POCKETBASE_URL_MESSAGE,
   }),
   authToken: z.string().min(1),
 });


### PR DESCRIPTION
## What & why

Resolves three findings from the repository security review. All three were verified still present at HEAD before fixing; none had been resolved already.

### Finding 1 — MCP CLI sends bearer token to unvalidated URLs (medium)
`isSafePocketBaseUrl` lived only in `configSchema`, but the setup wizard and `--validate` built configs straight from prompts/env and reached token-bearing PocketBase calls without it. Both CLIs now gate the URL through the shared policy (exported predicate + shared message constant) **before any request** — an unsafe `GSD_POCKETBASE_URL` is rejected before `GSD_AUTH_TOKEN` is attached to a connectivity probe or sync-status check.

### Finding 2 — `@claude` workflow runs for any commenter (medium)
`.github/workflows/claude.yml` only checked for the `@claude` string. Added an `author_association` allowlist (`OWNER`/`MEMBER`/`COLLABORATOR`) to every event branch so an arbitrary public commenter cannot trigger the OAuth-backed run. (Job permissions were already read-only.)

### Finding 5 — Caddy exposes PocketBase superuser API (low)
`/api/*` proxied everything, including `/api/collections/_superusers/*`. Added deny rules (404) for `_superusers` and the legacy `/api/admins/*` ahead of the broad proxy. Updated the setup comment: admin/setup scripts must target the direct PB port (`PB_URL=http://127.0.0.1:8090`), since superuser auth is no longer reachable through `/api/*` on the public origin.

## Test plan
- `cd packages/mcp-server && npx vitest run` → **153/153** (8 new url-safety tests, written RED→GREEN)
- `npx tsc --noEmit` (mcp) → clean
- `npx eslint` on changed TS → clean
- `caddy validate --config docker/Caddyfile` → **Valid configuration**
- `claude.yml` parses; `if` expression intact

## Notes
- For Finding 1 to reach end users, `gsd-mcp-server` must be republished (bumped to 1.2.2 here; not published).
- `scripts/setup-pocketbase-collections.sh` was intentionally **not** edited — a repo `PreToolUse` hook blocks edits to it; the direct-port instruction lives in the Caddyfile comment instead.
- Out of scope per triage: findings 3/4/6/9 (vendored `impeccable` dev tooling — report upstream, don't fork) and 7/8/10 (low/accepted product or deferred-feature items).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->