### PR TITLE
feat(social): Phase 1 X publishing for GitHub Releases (approval-gated)

### DIFF
--- a/.github/workflows/post-gsd-release-to-x.yml
+++ b/.github/workflows/post-gsd-release-to-x.yml
@@ -1,0 +1,128 @@
+name: Post GSD Release to X
+
+# Composes a draft X post from a published GitHub Release (or a manual dispatch),
+# previews it in the job summary, and publishes to @GSDTaskManager ONLY after the
+# `social-gsd-x` environment is approved. See docs/social-publishing.md.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Compose and preview only; do not publish"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      post_text:
+        description: "Optional exact post text. If supplied, use this instead of generated release text."
+        required: false
+        type: string
+      release_url:
+        description: "Optional release URL to include when using manual post text."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  compose:
+    # Never run on forks; release/dispatch on the canonical repo only.
+    if: github.repository == 'vscarpenter/gsd-task-manager'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/social-publisher
+    outputs:
+      length: ${{ steps.compose.outputs.length }}
+      dry_run: ${{ steps.compose.outputs.dry_run }}
+      publishable: ${{ steps.compose.outputs.publishable }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install (isolated package)
+        run: npm ci --ignore-scripts
+
+      - name: Compose draft post
+        id: compose
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          APP_NAME: GSD Task Manager
+          X_ACCOUNT_HANDLE: GSDTaskManager
+          MAX_POST_CHARS: "280"
+        run: node src/compose-post.mjs --out post.txt
+
+      - name: Upload draft post
+        uses: actions/upload-artifact@v4
+        with:
+          name: gsd-draft-post
+          path: tools/social-publisher/post.txt
+          retention-days: 7
+
+  publish:
+    needs: compose
+    # Publish only for a release, or a manual dispatch with dry_run=false, and
+    # only when compose produced a real (non-sample) post. The environment adds
+    # the human approval gate; nothing posts until it is approved.
+    if: >
+      github.repository == 'vscarpenter/gsd-task-manager' &&
+      needs.compose.outputs.publishable == 'true' &&
+      ( github.event_name == 'release' ||
+        (github.event_name == 'workflow_dispatch' && inputs.dry_run == 'false') )
+    runs-on: ubuntu-latest
+    environment:
+      name: social-gsd-x
+    defaults:
+      run:
+        working-directory: tools/social-publisher
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install (isolated package)
+        run: npm ci --ignore-scripts
+
+      - name: Download draft post
+        uses: actions/download-artifact@v4
+        with:
+          name: gsd-draft-post
+          path: tools/social-publisher
+
+      - name: Publish to X
+        id: publish
+        env:
+          DRY_RUN: "false"
+          X_ACCOUNT_HANDLE: GSDTaskManager
+          MAX_POST_CHARS: "280"
+          X_API_KEY: ${{ secrets.X_API_KEY }}
+          X_API_SECRET: ${{ secrets.X_API_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+        run: |
+          RESULT=$(node src/post-to-x.mjs --post-file post.txt)
+          echo "$RESULT"
+          POST_URL=$(node -e "process.stdout.write((JSON.parse(process.argv[1]).post_url)||'')" "$RESULT")
+          {
+            echo "## Published to @GSDTaskManager"
+            echo ""
+            echo "- Post URL: ${POST_URL}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/social-publishing.md
+++ b/docs/social-publishing.md
@@ -1,0 +1,158 @@
+# Social Publishing (Phase 1 — X / @GSDTaskManager)
+
+Automated, approval-gated X posting for GSD Task Manager releases.
+
+## What it does
+
+When a GitHub **Release** is published, the
+[`Post GSD Release to X`](../.github/workflows/post-gsd-release-to-x.yml) workflow:
+
+1. **Composes** a draft post from the release (version, up to 3 highlights, release URL).
+2. **Previews** it in the GitHub Actions job summary and uploads it as an artifact.
+3. **Publishes** to [@GSDTaskManager](https://x.com/GSDTaskManager) — but only after the
+   **`social-gsd-x`** GitHub Environment is approved by a required reviewer.
+
+It also supports manual runs via **workflow_dispatch** for dry-run previews and for
+publishing exact, hand-written text. Nothing is ever posted on commits, PRs, or from forks.
+
+The publisher is an isolated npm package at [`tools/social-publisher/`](../tools/social-publisher)
+— it is **not** part of the app's bun workspace and shares none of its dependencies.
+
+### How highlights are chosen
+
+The repo's releases use GitHub's auto-generated "What's Changed" PR list. The composer:
+
+- keeps `feat`/`fix`/`perf` PRs, drops `test`/`chore`/`docs`/`ci`/`build`/`refactor`/`style` and `*(deps)`;
+- strips the `type(scope):` prefix, the `by @user in <url>` suffix, markdown links, and PR numbers;
+- caps at 3 highlights;
+- for hand-written `### Added`/`### Fixed` release notes, uses those section bullets instead;
+- falls back to the release title's subtitle (`v10.0.0 — Security & Sync` → "This release focuses on Security & Sync."), then to a generic line.
+
+Because PR order is not importance order, **always review the draft in the job summary**
+before approving. For any release where the auto-text is weak, re-run via
+workflow_dispatch with exact `post_text`.
+
+## One-time setup
+
+### 1. X developer app
+
+1. Create (or confirm) an X developer app for `@GSDTaskManager`.
+2. Ensure the app has **Read and Write** permissions.
+3. Generate **user-context** OAuth 1.0a tokens for the account:
+   `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET`.
+
+### 2. GitHub Environment `social-gsd-x`
+
+Create the environment so publishing is gated behind human approval:
+
+1. Repo → **Settings → Environments → New environment** → name it `social-gsd-x`.
+2. Under **Deployment protection rules**, enable **Required reviewers** and add yourself.
+3. Under **Environment secrets** (NOT repository secrets), add the four secrets:
+
+   ```
+   X_API_KEY
+   X_API_SECRET
+   X_ACCESS_TOKEN
+   X_ACCESS_TOKEN_SECRET
+   ```
+
+Storing them as environment secrets means the publish job can only read them after the
+environment is approved. The compose job never sees them.
+
+## Running it
+
+### Dry run (no credentials needed)
+
+Actions → **Post GSD Release to X** → **Run workflow** → `dry_run: true`. The `compose`
+job builds and previews a post in the summary; the `publish` job is skipped, so no
+credentials or approval are involved.
+
+To preview exact text, also fill `post_text` (and optionally `release_url`).
+
+### Manual publish
+
+Run the workflow with `dry_run: false` **and** a non-empty `post_text`. The `publish` job
+then waits for `social-gsd-x` approval. (A `dry_run: false` run with no `post_text` only
+produces a sample and will **not** publish.)
+
+### Publish from a GitHub Release
+
+Publish a Release as usual. The workflow composes the post and the `publish` job pauses
+for `social-gsd-x` approval. Review the draft in the run summary, then approve to post.
+The summary then shows the resulting post URL.
+
+## Operations
+
+### Rotate X credentials
+
+1. In the X developer portal, regenerate the access token/secret (and API key/secret if needed).
+2. Update the four secrets under **Settings → Environments → `social-gsd-x`**.
+3. Revoke the old tokens in the X portal.
+
+No code change or redeploy is required.
+
+### Disable quickly
+
+Any one of these stops all posting immediately:
+
+- Actions → **Post GSD Release to X** → **⋯ → Disable workflow**.
+- Remove the required-reviewer approval (or yourself as reviewer) on `social-gsd-x` — approvals can no longer be granted.
+- Delete the four environment secrets — the publish job fails closed (`Missing required secrets`) without posting.
+
+## Quality bar
+
+```bash
+cd tools/social-publisher
+npm ci
+npm test
+```
+
+## Setup Checklist
+
+- [ ] Create or confirm the X developer app.
+- [ ] Ensure the X app has write permissions.
+- [ ] Generate user-context tokens for `@GSDTaskManager`.
+- [ ] Create GitHub Environment `social-gsd-x`.
+- [ ] Add required reviewers to `social-gsd-x`.
+- [ ] Add X secrets to `social-gsd-x`.
+- [ ] Run the workflow manually with `dry_run=true`.
+- [ ] Confirm the preview post looks right.
+- [ ] Run the workflow manually with `dry_run=false` and `post_text`.
+- [ ] Confirm the post appears on `@GSDTaskManager`.
+- [ ] Publish the next GitHub Release and confirm the release workflow works.
+
+## Sample release note → expected post
+
+Release body:
+
+```markdown
+## What's Changed
+
+### Added
+- Added faster quick capture from the menu bar.
+- Added better grouping for completed tasks.
+
+### Fixed
+- Fixed a bug where completed tasks could briefly reappear after sync.
+```
+
+Composed post:
+
+```text
+GSD Task Manager v1.2.3 is out.
+
+New in this release:
+• Added faster quick capture from the menu bar
+• Added better grouping for completed tasks
+• Fixed a bug where completed tasks could briefly reappear after sync
+
+Release notes:
+https://github.com/vscarpenter/gsd-task-manager/releases/tag/v1.2.3
+```
+
+## Security
+
+- Credentials live only in the `social-gsd-x` environment; the compose job runs without them.
+- Secrets are never logged; the publisher prints only the SDK message/code on failure.
+- The dry-run path never imports the X SDK and never calls the API.
+- Workflow permissions are `contents: read`; no forks, no PRs, one publish per run.

--- a/docs/superpowers/plans/2026-06-30-social-publishing-phase-1.md
+++ b/docs/superpowers/plans/2026-06-30-social-publishing-phase-1.md
@@ -1,0 +1,181 @@
+# Social Publishing Phase 1 (X) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a GitHub Release is published, compose a draft X post from the release, preview it in the Actions summary, and publish to `@GSDTaskManager` only after approval through the `social-gsd-x` GitHub Environment.
+
+**Architecture:** An isolated npm package at `tools/social-publisher/` (outside the `packages/*` bun workspace) holds three small ESM CLIs over a pure-function core (`post-utils.mjs`). A two-job workflow composes (no secrets) then publishes (environment-gated). `twitter-api-v2` is lazy-imported only on the real publish path so unit tests and dry-runs need no network or SDK.
+
+**Tech Stack:** Node 24 (CI) / 22 (local), npm + `package-lock.json`, `node --test`, `twitter-api-v2` (OAuth 1.0a user-context), GitHub Actions.
+
+## Global Constraints
+
+- App name: `GSD Task Manager`; X handle: `GSDTaskManager`; endpoint `POST https://api.x.com/2/tweets` body `{"text": "..."}`.
+- `MAX_POST_CHARS` default `280`. Tone: direct, practical, no hype, no emojis-by-default, no excess hashtags.
+- Required secrets (env-scoped to `social-gsd-x`): `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET`.
+- Optional env: `X_ACCOUNT_HANDLE=GSDTaskManager`, `APP_NAME=GSD Task Manager`, `MAX_POST_CHARS=280`, `DRY_RUN=true|false`.
+- NEVER log/print secrets or token prefixes; never write credentials to disk; never put real creds in fixtures.
+- Dry-run path must NOT call the X API. Publish only behind the `social-gsd-x` environment. Workflow permissions: `contents: read`. Never publish from forks; never publish twice per run.
+- Isolated from the app: `tools/social-publisher` is NOT a `packages/*` workspace member; bun/vitest/main-CI never touch it.
+- Highlight sourcing (decided): filter GitHub "What's Changed" PR lists to `feat`/`fix`/`perf`, drop `test`/`chore`/`docs`/`ci`/`build`/`refactor`/`style`/`*(deps)`; fall back to the release-title subtitle, then a generic line.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `tools/social-publisher/package.json` | npm package metadata, scripts, `twitter-api-v2` dep |
+| `tools/social-publisher/package-lock.json` | pinned lockfile for `npm ci` |
+| `tools/social-publisher/src/post-utils.mjs` | pure functions: extract/normalize highlights, compose, validate |
+| `tools/social-publisher/src/compose-post.mjs` | CLI: GitHub event JSON / dispatch inputs → post text → file + stdout + summary |
+| `tools/social-publisher/src/post-to-x.mjs` | CLI: post text → X API (lazy `twitter-api-v2`), dry-run aware |
+| `tools/social-publisher/test/post-utils.test.mjs` | `node --test` unit tests (pure, no deps) |
+| `.github/workflows/post-gsd-release-to-x.yml` | compose + publish jobs, env gate, triggers |
+| `docs/social-publishing.md` | setup, environment, secrets, dry-run, publish, rotate, disable |
+
+### Public interfaces (`post-utils.mjs`)
+
+```js
+// Strip conventional-commit prefix (`type(scope): `), GitHub "by @user in <url>"
+// suffix, trailing "(#123)"/"#123", markdown links ([t](u) -> t); collapse
+// whitespace; trim; capitalize first letter. Returns "" if nothing remains.
+normalizeHighlight(text: string): string
+
+// Parse release body. Returns up to 3 USER-FACING highlights only.
+// Keeps feat/fix/perf and prefix-less human bullets; drops test/chore/docs/ci/
+// build/refactor/style and *(deps). Handles both Keep-a-Changelog sections and
+// GitHub auto "## What's Changed" PR lists. Empty array when nothing user-facing.
+extractHighlights(releaseBody: string): string[]
+
+// Return curated subtitle from a release title like "v10.0.0 — Foo & Bar"
+// (text after an em-dash or " - " separator), else null.
+parseReleaseSubtitle(releaseName: string): string | null
+
+// Build the final post. Body precedence: user-facing highlights -> subtitle
+// summary -> generic line. Shrinks (drop bullets) to fit maxChars; throws if
+// still over after dropping all bullets.
+composeReleasePost({ appName, version, releaseName, releaseBody, releaseUrl, maxChars }): string
+
+// Throw on empty/whitespace text or text.length > maxChars. Returns void.
+validatePostText(text: string, maxChars: number): void
+```
+
+---
+
+## Task 1: Scaffold the isolated package
+
+**Files:** Create `tools/social-publisher/package.json`, `.gitignore`; generate `package-lock.json`.
+
+- [ ] **Step 1:** Write `package.json`:
+
+```json
+{
+  "name": "gsd-social-publisher",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Phase 1 X publishing for GSD Task Manager (isolated, not a workspace member).",
+  "type": "module",
+  "engines": { "node": ">=22" },
+  "scripts": {
+    "test": "node --test",
+    "compose:dry-run": "node src/compose-post.mjs"
+  },
+  "dependencies": { "twitter-api-v2": "1.27.0" }
+}
+```
+
+- [ ] **Step 2:** Write `tools/social-publisher/.gitignore` with `node_modules/`.
+- [ ] **Step 3:** Generate the lockfile. Try in place first: `cd tools/social-publisher && npm install --package-lock-only`. If it errors with `EOVERRIDE` (root overrides bleed in — the Remotion precedent), generate in the scratchpad and copy `package-lock.json` back: run `npm install --package-lock-only` in a temp copy of the package.json outside the repo, then move the lockfile in.
+- [ ] **Step 4:** Commit: `git add tools/social-publisher/package.json tools/social-publisher/package-lock.json tools/social-publisher/.gitignore && git commit -m "build(social): scaffold isolated social-publisher package"`
+
+## Task 2: `post-utils.mjs` — pure core (TDD)
+
+**Files:** Create `tools/social-publisher/src/post-utils.mjs`; Test `tools/social-publisher/test/post-utils.test.mjs`.
+
+**Test list (the 10 spec cases + 2 for the real format):**
+1. extracts feat/fix bullets from a "What's Changed" PR list
+2. extracts bullets from hand-written `### Added`/`### Fixed` sections
+3. drops `test`/`chore`/`docs`/`ci`/`refactor` PRs (real-format noise filter)
+4. ignores empty/whitespace release bodies → `[]`
+5. `normalizeHighlight` strips `type(scope):`, `by @user in <url>`, `(#123)`, markdown links
+6. limits highlights to 3
+7. `composeReleasePost` uses generic fallback when no highlights and no subtitle
+8. `composeReleasePost` uses subtitle fallback when no user-facing highlights but title has subtitle
+9. `validatePostText` throws on empty text
+10. `validatePostText` throws on over-length text
+11. long release notes shrink (drop bullets) rather than blindly exceeding maxChars
+12. dependency-only PRs deprioritized when user-facing changes exist
+
+- [ ] **Step 1:** Write all tests above (real assertions, fixtures inline). Use a v10.0.0-style "What's Changed" fixture.
+- [ ] **Step 2:** Run `cd tools/social-publisher && node --test` → expect FAIL (module missing).
+- [ ] **Step 3:** Implement `post-utils.mjs` with the five exported functions per the interface block. Constants: `USER_FACING_TYPES = new Set(['feat','fix','perf'])`, `KAC_HEADINGS = /added|changed|improved|fixed|what changed|changes/i`.
+- [ ] **Step 4:** Run `node --test` → expect PASS.
+- [ ] **Step 5:** Commit: `feat(social): post composition + validation utilities with tests`
+
+## Task 3: `compose-post.mjs` — event → post CLI
+
+**Files:** Create `tools/social-publisher/src/compose-post.mjs`. (Covered by Task 2 utils + a smoke run.)
+
+Behavior:
+- Read `GITHUB_EVENT_NAME`, `GITHUB_EVENT_PATH` (JSON), `APP_NAME`, `MAX_POST_CHARS`, `X_ACCOUNT_HANDLE`.
+- `release`: `composeReleasePost({appName, version: release.tag_name, releaseName: release.name, releaseBody: release.body, releaseUrl: release.html_url, maxChars})`.
+- `workflow_dispatch`: if `inputs.post_text` non-empty → trim, optionally append `inputs.release_url` if absent and length allows, `validatePostText`. If no `post_text` → emit a harmless sample post and mark dry-run (publish job will be skipped anyway).
+- Output: write post to `--out <file>` (and echo to stdout). Append a markdown preview block + `Length: N / MAX` + `Dry run: <bool>` to `$GITHUB_STEP_SUMMARY` when set.
+- Empty/over-length → print a clean error, exit non-zero (no mangled publish).
+
+- [ ] **Step 1:** Implement `compose-post.mjs`.
+- [ ] **Step 2:** Smoke test with a fixture event file: `GITHUB_EVENT_NAME=release GITHUB_EVENT_PATH=/tmp/ev.json node src/compose-post.mjs --out /tmp/post.txt` → prints the v10.0.0 post; exit 0.
+- [ ] **Step 3:** Commit: `feat(social): compose-post CLI for release and manual events`
+
+## Task 4: `post-to-x.mjs` — publish CLI (lazy SDK)
+
+**Files:** Create `tools/social-publisher/src/post-to-x.mjs`.
+
+Behavior:
+- Post text from `POST_TEXT` env or `--post-file <path>`.
+- Require all four `X_*` secrets present (presence only; never print values). Missing → error, exit non-zero.
+- `validatePostText(text, MAX_POST_CHARS)`.
+- `DRY_RUN=true` → print `{"ok":true,"dry_run":true}` and exit 0 WITHOUT importing/calling the SDK.
+- `DRY_RUN=false` → `const { TwitterApi } = await import('twitter-api-v2')`; OAuth1.0a client; `client.v2.tweet(text)`; one short retry on 429/5xx (single, bounded). Success → print `{"ok":true,"post_id","post_url":"https://x.com/<handle>/status/<id>"}`. Failure → useful error w/o secrets, exit non-zero.
+
+- [ ] **Step 1:** Implement `post-to-x.mjs`.
+- [ ] **Step 2:** Dry-run smoke (no creds, no network): `DRY_RUN=true POST_TEXT="hello" X_API_KEY=x X_API_SECRET=x X_ACCESS_TOKEN=x X_ACCESS_TOKEN_SECRET=x node src/post-to-x.mjs` → prints dry-run JSON, exit 0, never imports SDK.
+- [ ] **Step 3:** Missing-secret smoke: unset one `X_*`, `DRY_RUN=false` → clean error, exit non-zero, no secret echoed.
+- [ ] **Step 4:** Commit: `feat(social): post-to-x publisher with dry-run and lazy SDK import`
+
+## Task 5: GitHub Actions workflow
+
+**Files:** Create `.github/workflows/post-gsd-release-to-x.yml`.
+
+- `on`: `release: [published]`; `workflow_dispatch` with inputs `dry_run` (choice true/false, default true), `post_text` (string, optional), `release_url` (string, optional).
+- `permissions: contents: read`.
+- Job `compose`: runs on the main repo only (`if: github.repository == 'vscarpenter/gsd-task-manager'`); checkout; `actions/setup-node@v4` node 24; `cd tools/social-publisher && npm ci`; run compose-post writing `post.txt`; `actions/upload-artifact` the post; outputs `length`. No secrets.
+- Job `publish`: `needs: compose`; `if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == 'false')`; `environment: social-gsd-x`; download artifact; `npm ci`; `DRY_RUN=false node src/post-to-x.mjs --post-file post.txt` with the four `X_*` env from `secrets`; print result to `$GITHUB_STEP_SUMMARY`.
+
+- [ ] **Step 1:** Write the workflow.
+- [ ] **Step 2:** Validate YAML parses (ruby `YAML.load_file`) and `if`/inputs intact.
+- [ ] **Step 3:** Commit: `ci(social): release-triggered X publish workflow with environment gate`
+
+## Task 6: Documentation
+
+**Files:** Create `docs/social-publishing.md`.
+
+Cover: what it does; create `social-gsd-x` Environment with required reviewers; add the four env secrets; run a dry-run dispatch; manual publish; release publish; rotate X credentials; disable quickly (delete/disable workflow or remove env approval); the Setup Checklist; the sample release note + expected post.
+
+- [ ] **Step 1:** Write `docs/social-publishing.md`.
+- [ ] **Step 2:** Commit: `docs(social): setup and operations guide for X publishing`
+
+## Task 7: Verify & PR
+
+- [ ] **Step 1:** `cd tools/social-publisher && npm ci && npm test` → all green.
+- [ ] **Step 2:** Re-validate workflow YAML.
+- [ ] **Step 3:** Move the original root spec into `docs/` (or leave); decide with repo owner.
+- [ ] **Step 4:** Push branch; open PR using the spec's PR Summary Template (with the Required Manual Setup section).
+
+---
+
+## Risks / Notes
+- **Lockfile isolation:** if `npm install` under the repo hits `EOVERRIDE` from root `overrides`, generate the lockfile outside the repo and copy it in; in CI, `npm ci` runs with `working-directory: tools/social-publisher` and the committed lockfile — confirm it resolves without the root overrides (add `--no-workspaces` if needed).
+- **Manual prerequisites (owner):** X developer app with write perms, user-context tokens for `@GSDTaskManager`, the `social-gsd-x` Environment + reviewers + secrets. Nothing posts until these exist and an approval is granted.
+- **Node 24** in CI per spec; local dev on 22 is fine (`node --test`, no SDK needed for tests).

--- a/tools/social-publisher/.gitignore
+++ b/tools/social-publisher/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tools/social-publisher/package-lock.json
+++ b/tools/social-publisher/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "gsd-social-publisher",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gsd-social-publisher",
+      "version": "0.1.0",
+      "dependencies": {
+        "twitter-api-v2": "^1.29.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/twitter-api-v2": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/twitter-api-v2/-/twitter-api-v2-1.29.0.tgz",
+      "integrity": "sha512-v473q5bwme4N+DWSg6qY+JCvfg1nSJRWwui3HUALafxfqCvVkKiYmS/5x/pVeJwTmyeBxexMbzHwnzrH4h6oYQ==",
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/tools/social-publisher/package.json
+++ b/tools/social-publisher/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "gsd-social-publisher",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Phase 1 X publishing for GSD Task Manager (isolated, not a workspace member).",
+  "type": "module",
+  "engines": { "node": ">=22" },
+  "scripts": {
+    "test": "node --test",
+    "compose:dry-run": "node src/compose-post.mjs"
+  },
+  "dependencies": {
+    "twitter-api-v2": "^1.29.0"
+  }
+}

--- a/tools/social-publisher/src/compose-post.mjs
+++ b/tools/social-publisher/src/compose-post.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * Compose the draft X post for a release or a manual dispatch, then write it to
+ * a file (for the publish job), echo it to stdout, and render a preview into
+ * the GitHub Actions step summary.
+ *
+ * Never calls the X API. Reads the GitHub event JSON from GITHUB_EVENT_PATH.
+ *
+ * Env:
+ *   GITHUB_EVENT_NAME    'release' | 'workflow_dispatch'
+ *   GITHUB_EVENT_PATH    path to the event payload JSON
+ *   APP_NAME             default 'GSD Task Manager'
+ *   MAX_POST_CHARS       default 280
+ *   GITHUB_STEP_SUMMARY  (optional) summary file to append a preview to
+ *   GITHUB_OUTPUT        (optional) outputs file (writes length, dry_run, publishable)
+ * Args:
+ *   --out <file>         write the composed post text to <file>
+ */
+
+import { readFileSync, writeFileSync, appendFileSync } from 'node:fs';
+import { composeReleasePost, validatePostText } from './post-utils.mjs';
+
+function getArg(name) {
+  const i = process.argv.indexOf(name);
+  return i !== -1 && i + 1 < process.argv.length ? process.argv[i + 1] : undefined;
+}
+
+function readEvent() {
+  const path = process.env.GITHUB_EVENT_PATH;
+  if (!path) throw new Error('GITHUB_EVENT_PATH is not set.');
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+/** Build the post for a release event. */
+function composeForRelease(event, appName, maxChars) {
+  const release = event.release || {};
+  return composeReleasePost({
+    appName,
+    version: release.tag_name || release.name || '',
+    releaseName: release.name || release.tag_name || '',
+    releaseBody: release.body || '',
+    releaseUrl: release.html_url || '',
+    maxChars,
+  });
+}
+
+/** Build the post for a manual dispatch. Returns { text, publishable }. */
+function composeForDispatch(event, appName, maxChars) {
+  const inputs = event.inputs || {};
+  const manual = (inputs.post_text || '').trim();
+
+  if (!manual) {
+    // No text supplied: a harmless sample that must never be published.
+    const text = `${appName} — social publishing dry run. No manual post_text was supplied, so nothing will be published.`;
+    return { text, publishable: false };
+  }
+
+  let text = manual;
+  const releaseUrl = (inputs.release_url || '').trim();
+  if (releaseUrl && !text.includes(releaseUrl)) {
+    const withUrl = `${text}\n\n${releaseUrl}`;
+    if (withUrl.length <= maxChars) text = withUrl;
+  }
+  validatePostText(text, maxChars);
+  return { text, publishable: true };
+}
+
+function writeOutputs({ length, dryRun, publishable }) {
+  const out = process.env.GITHUB_OUTPUT;
+  if (!out) return;
+  appendFileSync(out, `length=${length}\ndry_run=${dryRun}\npublishable=${publishable}\n`);
+}
+
+function writeSummary({ text, length, maxChars, dryRun }) {
+  const summary = process.env.GITHUB_STEP_SUMMARY;
+  if (!summary) return;
+  const handle = process.env.X_ACCOUNT_HANDLE || 'GSDTaskManager';
+  const block = [
+    `## Draft X Post for @${handle}`,
+    '',
+    '```text',
+    text,
+    '```',
+    '',
+    `Length: ${length} / ${maxChars} characters`,
+    `Dry run: ${dryRun}`,
+    '',
+  ].join('\n');
+  appendFileSync(summary, block);
+}
+
+function main() {
+  const appName = process.env.APP_NAME || 'GSD Task Manager';
+  const maxChars = Number(process.env.MAX_POST_CHARS || '280');
+  const eventName = process.env.GITHUB_EVENT_NAME || '';
+  const event = readEvent();
+
+  let text;
+  let publishable;
+  let dryRun;
+
+  if (eventName === 'release' || event.release) {
+    text = composeForRelease(event, appName, maxChars);
+    publishable = true;
+    dryRun = false;
+  } else if (eventName === 'workflow_dispatch' || event.inputs) {
+    const result = composeForDispatch(event, appName, maxChars);
+    text = result.text;
+    publishable = result.publishable;
+    const requested = (event.inputs || {}).dry_run;
+    dryRun = requested !== 'false' || !publishable;
+  } else {
+    throw new Error(`Unsupported event: ${eventName || '(unknown)'}`);
+  }
+
+  validatePostText(text, maxChars);
+
+  const outFile = getArg('--out');
+  if (outFile) writeFileSync(outFile, text);
+  process.stdout.write(`${text}\n`);
+
+  writeSummary({ text, length: text.length, maxChars, dryRun });
+  writeOutputs({ length: text.length, dryRun, publishable });
+}
+
+try {
+  main();
+} catch (err) {
+  process.stderr.write(`compose-post failed: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+}

--- a/tools/social-publisher/src/post-to-x.mjs
+++ b/tools/social-publisher/src/post-to-x.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Publish a post to X (@GSDTaskManager) using OAuth 1.0a user-context creds.
+ *
+ * Reads post text from POST_TEXT or `--post-file <path>`. In dry-run mode it
+ * never imports the SDK, never needs credentials, and never calls X. On a real
+ * publish it posts to https://api.x.com/2/tweets via twitter-api-v2.
+ *
+ * Env:
+ *   X_API_KEY, X_API_SECRET, X_ACCESS_TOKEN, X_ACCESS_TOKEN_SECRET  (required to publish)
+ *   X_ACCOUNT_HANDLE   default 'GSDTaskManager' (for the result URL only)
+ *   MAX_POST_CHARS     default 280
+ *   DRY_RUN            publish only when exactly 'false'; anything else is a dry run
+ * Args:
+ *   --post-file <path> read the post text from a file
+ *
+ * Secrets are never logged. Error output is the SDK message/code only — never
+ * credentials or token prefixes.
+ */
+
+import { readFileSync } from 'node:fs';
+import { validatePostText } from './post-utils.mjs';
+
+const REQUIRED_SECRETS = ['X_API_KEY', 'X_API_SECRET', 'X_ACCESS_TOKEN', 'X_ACCESS_TOKEN_SECRET'];
+
+function getArg(name) {
+  const i = process.argv.indexOf(name);
+  return i !== -1 && i + 1 < process.argv.length ? process.argv[i + 1] : undefined;
+}
+
+function readPostText() {
+  const file = getArg('--post-file');
+  if (file) return readFileSync(file, 'utf8').replace(/\n+$/, '');
+  if (process.env.POST_TEXT != null) return process.env.POST_TEXT;
+  throw new Error('No post text: set POST_TEXT or pass --post-file <path>.');
+}
+
+function requireSecrets() {
+  const missing = REQUIRED_SECRETS.filter((k) => !process.env[k]);
+  if (missing.length) {
+    // Names only — never values.
+    throw new Error(`Missing required secrets: ${missing.join(', ')}`);
+  }
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function isTransient(err) {
+  const code = err?.code ?? err?.status ?? err?.rateLimitError;
+  return code === 429 || (typeof code === 'number' && code >= 500 && code < 600) || err?.rateLimitError === true;
+}
+
+/** Post the tweet with one short retry for transient 429/5xx responses. */
+async function publishWithRetry(client, text) {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      return await client.v2.tweet(text);
+    } catch (err) {
+      if (attempt === 0 && isTransient(err)) {
+        await sleep(2000);
+        continue;
+      }
+      throw err;
+    }
+  }
+  // Unreachable: the loop either returns or throws.
+  throw new Error('publish failed');
+}
+
+async function main() {
+  const maxChars = Number(process.env.MAX_POST_CHARS || '280');
+  const handle = process.env.X_ACCOUNT_HANDLE || 'GSDTaskManager';
+  const text = readPostText();
+
+  validatePostText(text, maxChars);
+
+  // Dry run short-circuits before requiring any credentials or importing the SDK.
+  if (process.env.DRY_RUN !== 'false') {
+    process.stdout.write(`${JSON.stringify({ ok: true, dry_run: true, length: text.length })}\n`);
+    return;
+  }
+
+  requireSecrets();
+
+  const { TwitterApi } = await import('twitter-api-v2');
+  const client = new TwitterApi({
+    appKey: process.env.X_API_KEY,
+    appSecret: process.env.X_API_SECRET,
+    accessToken: process.env.X_ACCESS_TOKEN,
+    accessSecret: process.env.X_ACCESS_TOKEN_SECRET,
+  });
+
+  const res = await publishWithRetry(client, text);
+  const postId = res?.data?.id;
+  if (!postId) throw new Error('X API returned no post id.');
+
+  process.stdout.write(
+    `${JSON.stringify({
+      ok: true,
+      post_id: postId,
+      post_url: `https://x.com/${handle}/status/${postId}`,
+    })}\n`
+  );
+}
+
+main().catch((err) => {
+  // Print the message/code only — never secrets.
+  const code = err?.code ?? err?.status;
+  const detail = code ? ` (code ${code})` : '';
+  process.stderr.write(`post-to-x failed: ${err instanceof Error ? err.message : String(err)}${detail}\n`);
+  process.exit(1);
+});

--- a/tools/social-publisher/src/post-utils.mjs
+++ b/tools/social-publisher/src/post-utils.mjs
@@ -1,0 +1,158 @@
+/**
+ * Pure helpers for composing GSD Task Manager X posts from GitHub Release data.
+ *
+ * No I/O, no network, no secrets — every function here is deterministic and
+ * unit-tested. The CLIs (compose-post, post-to-x) wrap these with environment
+ * reading and the X API call.
+ */
+
+/** Conventional-commit types we treat as user-facing. */
+const USER_FACING_TYPES = new Set(['feat', 'fix', 'perf']);
+
+/** Sections (in hand-written Keep-a-Changelog bodies) whose bullets are highlights. */
+const KAC_SECTION = /^#{2,3}\s+(added|changed|improved|fixed|what changed|changes)\s*$/i;
+
+const MAX_HIGHLIGHTS = 3;
+
+const GENERIC_BODY =
+  'This release includes small improvements and fixes to make the task flow smoother.';
+
+/** Match a leading conventional-commit prefix: `type(scope)!: `. */
+const CONVENTIONAL_PREFIX = /^(\w+)(?:\(([^)]*)\))?!?:\s+/;
+
+/**
+ * Clean a raw bullet/PR title into a short, human highlight: drop the
+ * GitHub "by @user in <url>" suffix, the conventional-commit prefix, markdown
+ * links, trailing PR numbers, and a single trailing period; capitalize.
+ */
+export function normalizeHighlight(text) {
+  let out = String(text ?? '').trim();
+  // GitHub auto-format suffix: " by @user[bot] in https://…"
+  out = out.replace(/\s+by\s+@[\w-]+(?:\[bot\])?\s+in\s+https?:\/\/\S+\s*$/i, '');
+  // Conventional-commit prefix.
+  out = out.replace(CONVENTIONAL_PREFIX, '');
+  // Markdown links: [text](url) -> text
+  out = out.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1');
+  // Trailing PR/issue number: " (#123)" or " #123"
+  out = out.replace(/\s*\(#\d+\)\s*$/, '').replace(/\s+#\d+\s*$/, '');
+  // Collapse whitespace, trim, drop one trailing period.
+  out = out.replace(/\s+/g, ' ').trim().replace(/\.$/, '');
+  if (!out) return '';
+  return out.charAt(0).toUpperCase() + out.slice(1);
+}
+
+/** Classify a raw bullet's conventional type as user-facing, or null to drop. */
+function isUserFacingPrTitle(raw) {
+  const stripped = raw.replace(/\s+by\s+@[\w-]+(?:\[bot\])?\s+in\s+https?:\/\/\S+\s*$/i, '');
+  const m = stripped.match(CONVENTIONAL_PREFIX);
+  if (!m) return false; // GitHub-list bullets without a known type are dropped as noise.
+  const type = m[1].toLowerCase();
+  const scope = (m[2] || '').toLowerCase();
+  if (scope.includes('deps')) return false;
+  return USER_FACING_TYPES.has(type);
+}
+
+/** Collect raw bullet contents from lines like "- x" / "* x". */
+function bulletLines(lines) {
+  const out = [];
+  for (const line of lines) {
+    const m = line.match(/^\s*[-*]\s+(.+?)\s*$/);
+    if (m) out.push(m[1]);
+  }
+  return out;
+}
+
+/** Collect bullets that sit under a Keep-a-Changelog highlight section. */
+function kacSectionBullets(lines) {
+  const out = [];
+  let inSection = false;
+  for (const line of lines) {
+    if (/^#{1,6}\s+/.test(line)) {
+      inSection = KAC_SECTION.test(line);
+      continue;
+    }
+    if (inSection) {
+      const m = line.match(/^\s*[-*]\s+(.+?)\s*$/);
+      if (m) out.push(m[1]);
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract up to 3 user-facing highlights from a release body. Handles both
+ * GitHub auto-generated "What's Changed" PR lists (keep feat/fix/perf, drop the
+ * rest) and hand-written `### Added`/`### Fixed` sections (keep their bullets).
+ */
+export function extractHighlights(releaseBody) {
+  const body = String(releaseBody ?? '');
+  if (!body.trim()) return [];
+  const lines = body.split(/\r?\n/);
+
+  const hasKac = lines.some((l) => KAC_SECTION.test(l));
+  const raw = hasKac ? kacSectionBullets(lines) : bulletLines(lines).filter(isUserFacingPrTitle);
+
+  const seen = new Set();
+  const highlights = [];
+  for (const item of raw) {
+    const h = normalizeHighlight(item);
+    if (!h || seen.has(h.toLowerCase())) continue;
+    seen.add(h.toLowerCase());
+    highlights.push(h);
+    if (highlights.length >= MAX_HIGHLIGHTS) break;
+  }
+  return highlights;
+}
+
+/** Return the curated subtitle after an em-dash / " - " in a release title, else null. */
+export function parseReleaseSubtitle(releaseName) {
+  const name = String(releaseName ?? '');
+  const m = name.match(/\s+(?:—|–|-)\s+(.+)$/);
+  return m ? m[1].trim() : null;
+}
+
+function buildPost(appName, version, bodyBlock, releaseUrl) {
+  return `${appName} ${version} is out.\n\n${bodyBlock}\n\nRelease notes:\n${releaseUrl}`;
+}
+
+function bulletBlock(highlights) {
+  return ['New in this release:', ...highlights.map((h) => `• ${h}`)].join('\n');
+}
+
+/**
+ * Compose the release post. Body precedence: user-facing highlights → release
+ * subtitle → generic line. Shrinks by dropping trailing bullets to fit
+ * maxChars; throws if even the minimal form is too long (caller should then
+ * require a manual post_text override).
+ */
+export function composeReleasePost({ appName, version, releaseName, releaseBody, releaseUrl, maxChars }) {
+  const highlights = extractHighlights(releaseBody || '');
+  const subtitle = parseReleaseSubtitle(releaseName || '');
+
+  for (let n = highlights.length; n >= 1; n -= 1) {
+    const post = buildPost(appName, version, bulletBlock(highlights.slice(0, n)), releaseUrl);
+    if (post.length <= maxChars) return post;
+  }
+
+  if (subtitle) {
+    const post = buildPost(appName, version, `This release focuses on ${subtitle}.`, releaseUrl);
+    if (post.length <= maxChars) return post;
+  }
+
+  const generic = buildPost(appName, version, GENERIC_BODY, releaseUrl);
+  if (generic.length <= maxChars) return generic;
+
+  throw new Error(
+    `Composed post exceeds ${maxChars} characters even at minimal form; supply a manual post_text override.`
+  );
+}
+
+/** Throw if the post text is empty/whitespace or longer than maxChars. */
+export function validatePostText(text, maxChars) {
+  if (!text || !String(text).trim()) {
+    throw new Error('Post text is empty.');
+  }
+  if (String(text).length > maxChars) {
+    throw new Error(`Post text exceeds ${maxChars} characters (${String(text).length}).`);
+  }
+}

--- a/tools/social-publisher/test/post-utils.test.mjs
+++ b/tools/social-publisher/test/post-utils.test.mjs
@@ -1,0 +1,140 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  extractHighlights,
+  normalizeHighlight,
+  parseReleaseSubtitle,
+  composeReleasePost,
+  validatePostText,
+} from '../src/post-utils.mjs';
+
+const APP = 'GSD Task Manager';
+
+// GitHub auto-generated "What's Changed" body (the repo's real format).
+const GITHUB_BODY = `## What's Changed
+* test(pb): cover encryption adapters by @cursor[bot] in https://github.com/o/r/pull/375
+* feat(capture): faster quick capture from the menu bar by @vscarpenter in https://github.com/o/r/pull/384
+* chore(deps): bump dependencies by @vscarpenter in https://github.com/o/r/pull/381
+* fix(sync): completed tasks could reappear after sync by @vscarpenter in https://github.com/o/r/pull/403
+* docs: update readme by @vscarpenter in https://github.com/o/r/pull/379
+* perf(matrix): virtualize long task lists by @vscarpenter in https://github.com/o/r/pull/390
+
+**Full Changelog**: https://github.com/o/r/compare/v1...v2`;
+
+// Hand-written Keep-a-Changelog body.
+const KAC_BODY = `## What's Changed
+
+### Added
+- Added faster quick capture from the menu bar.
+- Added better grouping for completed tasks.
+
+### Fixed
+- Fixed a bug where completed tasks could briefly reappear after sync.`;
+
+test('1: extracts feat/fix/perf highlights from a GitHub What\'s Changed PR list', () => {
+  assert.deepEqual(extractHighlights(GITHUB_BODY), [
+    'Faster quick capture from the menu bar',
+    'Completed tasks could reappear after sync',
+    'Virtualize long task lists',
+  ]);
+});
+
+test('2: extracts bullets from hand-written Added/Fixed sections', () => {
+  assert.deepEqual(extractHighlights(KAC_BODY), [
+    'Added faster quick capture from the menu bar',
+    'Added better grouping for completed tasks',
+    'Fixed a bug where completed tasks could briefly reappear after sync',
+  ]);
+});
+
+test('3: drops test/chore/docs/deps PRs from the GitHub list', () => {
+  const out = extractHighlights(GITHUB_BODY);
+  assert.ok(!out.some((h) => /cover encryption|bump dependencies|update readme/i.test(h)));
+});
+
+test('4: returns [] for empty or whitespace bodies', () => {
+  assert.deepEqual(extractHighlights(''), []);
+  assert.deepEqual(extractHighlights('   \n  '), []);
+});
+
+test('5: normalizeHighlight strips prefix, by-line, markdown links, PR numbers', () => {
+  const raw =
+    'feat(seo): add [sitemap](https://x.com) for pages (#384) by @vscarpenter in https://github.com/o/r/pull/384';
+  assert.equal(normalizeHighlight(raw), 'Add sitemap for pages');
+});
+
+test('6: limits highlights to 3', () => {
+  const body = `## What's Changed
+* feat: one by @u in https://github.com/o/r/pull/1
+* feat: two by @u in https://github.com/o/r/pull/2
+* feat: three by @u in https://github.com/o/r/pull/3
+* feat: four by @u in https://github.com/o/r/pull/4`;
+  assert.equal(extractHighlights(body).length, 3);
+});
+
+test('7: composeReleasePost uses generic fallback with no highlights and no subtitle', () => {
+  const post = composeReleasePost({
+    appName: APP,
+    version: 'v1.0.0',
+    releaseName: 'v1.0.0',
+    releaseBody: '## What\'s Changed\n* chore: internal by @u in https://github.com/o/r/pull/1',
+    releaseUrl: 'https://example.com/r',
+    maxChars: 280,
+  });
+  assert.match(post, /small improvements and fixes/);
+  assert.match(post, /^GSD Task Manager v1\.0\.0 is out\./);
+  assert.match(post, /Release notes:\nhttps:\/\/example\.com\/r$/);
+});
+
+test('8: composeReleasePost uses subtitle fallback when title has a subtitle', () => {
+  const post = composeReleasePost({
+    appName: APP,
+    version: 'v1.0.0',
+    releaseName: 'v1.0.0 — Big Internal Refactor',
+    releaseBody: '## What\'s Changed\n* chore: internal by @u in https://github.com/o/r/pull/1',
+    releaseUrl: 'https://example.com/r',
+    maxChars: 280,
+  });
+  assert.match(post, /This release focuses on Big Internal Refactor\./);
+});
+
+test('9: validatePostText throws on empty text', () => {
+  assert.throws(() => validatePostText('', 280), /empty/i);
+  assert.throws(() => validatePostText('   ', 280), /empty/i);
+});
+
+test('10: validatePostText throws on over-length text', () => {
+  assert.throws(() => validatePostText('a'.repeat(281), 280), /exceed/i);
+  assert.doesNotThrow(() => validatePostText('a'.repeat(280), 280));
+});
+
+test('11: long release notes shrink (drop bullets) instead of exceeding max', () => {
+  // Three distinct 30-char highlights. Full 3-bullet post is ~190 chars; a
+  // 2-bullet post is ~157. maxChars=170 forces a drop without throwing.
+  const mk = (c, n) => `* feat: ${c}${'a'.repeat(29)} by @u in https://github.com/o/r/pull/${n}`;
+  const body = `## What's Changed\n${mk('a', 1)}\n${mk('b', 2)}\n${mk('c', 3)}`;
+  const maxChars = 170;
+  const post = composeReleasePost({
+    appName: APP,
+    version: 'v2.0.0',
+    releaseName: 'v2.0.0',
+    releaseBody: body,
+    releaseUrl: 'https://example.com/r',
+    maxChars,
+  });
+  assert.ok(post.length <= maxChars, `expected <= ${maxChars}, got ${post.length}`);
+  const bullets = (post.match(/•/g) || []).length;
+  assert.ok(bullets >= 1 && bullets <= 2, `expected shrink to 1-2 bullets, got ${bullets}`);
+});
+
+test('12: dependency-only changes are deprioritized when user-facing changes exist', () => {
+  const out = extractHighlights(GITHUB_BODY);
+  assert.ok(out.length >= 1);
+  assert.ok(!out.some((h) => /bump dependencies/i.test(h)));
+});
+
+test('parseReleaseSubtitle: returns text after em-dash, else null', () => {
+  assert.equal(parseReleaseSubtitle('v10.0.0 — Security & Sync'), 'Security & Sync');
+  assert.equal(parseReleaseSubtitle('v10.0.0 - Hyphen Sub'), 'Hyphen Sub');
+  assert.equal(parseReleaseSubtitle('v10.0.0'), null);
+});


### PR DESCRIPTION
## Summary

Adds Phase 1 social publishing automation for GSD Task Manager. On a published GitHub Release, a workflow composes an X post from the release metadata, previews it in the Actions summary, and publishes to `@GSDTaskManager` **only after approval** through the `social-gsd-x` GitHub Environment. Manual dry-run and manual-publish are supported via `workflow_dispatch`.

## Added
- Release-triggered workflow `.github/workflows/post-gsd-release-to-x.yml` (compose + publish jobs, `contents: read` only)
- Isolated `tools/social-publisher` package (npm, `node --test`, `twitter-api-v2`) — outside the bun workspace
- `post-utils.mjs` pure core + 13 tests, `compose-post.mjs`, `post-to-x.mjs`
- `docs/social-publishing.md` (setup, dry-run, manual/release publish, rotate, disable, checklist)
- Implementation plan: `docs/superpowers/plans/2026-06-30-social-publishing-phase-1.md`

## Repo-specific decisions (from brainstorming)
- **Highlights tuned to your real release format.** Your Releases are GitHub's auto-generated "What's Changed" PR lists, not hand-written Added/Fixed sections. The composer keeps `feat`/`fix`/`perf` PRs, drops `test`/`chore`/`docs`/`ci`/`build`/`refactor`/`*(deps)`, strips the `type(scope):` prefix + `by @user in <url>` + PR numbers, caps 3, then falls back to the release-title subtitle and a generic line. (The spec's literal section-parser would have surfaced test/chore noise.)
- **Isolated, not a workspace member.** Sits outside `workspaces: ["packages/*"]`, so the root `overrides` never touch it (the EOVERRIDE trap the Remotion subproject hit). bun/vitest/main-CI never see it.
- **Dry-run is credential-free and SDK-free.** `post-to-x.mjs` lazy-imports `twitter-api-v2` only on the real publish path; previews and unit tests need no network, SDK, or secrets.
- **Samples can't publish.** A `dry_run=false` dispatch with no `post_text` yields a non-publishable sample; the publish job gates on `publishable == 'true'`.

## Required Manual Setup (before publishing works)
Create the `social-gsd-x` GitHub Environment with **required reviewers**, and add these as **environment** secrets (not repo secrets):

- `X_API_KEY`
- `X_API_SECRET`
- `X_ACCESS_TOKEN`
- `X_ACCESS_TOKEN_SECRET`

Plus an X developer app with write perms and user-context tokens for `@GSDTaskManager`. Full steps in `docs/social-publishing.md`. Nothing posts until the environment exists and an approval is granted.

## Validation
- `cd tools/social-publisher && npm ci && npm test` → **13/13** (clean-room from lockfile, 0 vulnerabilities)
- compose-post smoke: release / manual-with-text / sample-no-text paths all correct (real v10.0.0-style body)
- post-to-x smoke: credential-free dry-run, missing-secret fail (names only), empty-text fail
- workflow YAML parses; jobs/permissions/env/outputs verified

## Notes
- Node 24 in CI (per spec); local dev/tests run on Node 22 with no SDK needed.
- The original Codex spec (`gsd-social-publishing-phase-1-spec.md`) is left untracked at repo root — tell me if you want it moved into `docs/` or removed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->