### PR TITLE
ci(openwiki): export OPENROUTER_API_KEY required by the CLI

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -13,9 +13,9 @@ name: OpenWiki Update
 # push -> CI -> push loop on a protected branch.
 #
 # ─── Required repository configuration ──────────────────────────────────────────
-#   Secret:  OPENWIKI_API_KEY   -> model API key used by the OpenWiki CLI
-#                                  (set this to your Anthropic/OpenAI key, whichever
-#                                   your OpenWiki install expects).
+#   Secret:  OPENWIKI_API_KEY   -> OpenRouter API key (sk-or-...). The CLI only
+#                                  reads OPENROUTER_API_KEY in non-interactive
+#                                  runs, so the secret is exported under that name.
 #   Setting: Allow GitHub Actions to create and approve pull requests
 #            (Settings -> Actions -> General -> Workflow permissions).
 # ────────────────────────────────────────────────────────────────────────────────
@@ -83,10 +83,9 @@ jobs:
 
       - name: Run OpenWiki update
         env:
-          # OpenWiki reads whichever of these your install expects; we export the
-          # single configured secret under the common names so it "just works".
-          OPENWIKI_API_KEY: ${{ secrets.OPENWIKI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.OPENWIKI_API_KEY }}
+          # The CLI hard-requires OPENROUTER_API_KEY when running non-interactively;
+          # OPENWIKI_API_KEY / ANTHROPIC_API_KEY are never read in CI.
+          OPENROUTER_API_KEY: ${{ secrets.OPENWIKI_API_KEY }}
           # Non-interactive so the CLI never blocks waiting for input in CI.
           CI: "true"
         run: |


### PR DESCRIPTION
## What

Fixes the OpenWiki Update workflow, which has failed on every run (2× push, 1× schedule, 1× post-merge) with:

```
OPENROUTER_API_KEY is required for non-interactive runs. Run openwiki in an interactive terminal to save credentials.
```

Two stacked causes, both now resolved:

1. The `OPENWIKI_API_KEY` repo secret didn't exist (env rendered blank in run logs) — **now added** (set to an OpenRouter `sk-or-...` key).
2. The workflow exported the secret as `OPENWIKI_API_KEY`/`ANTHROPIC_API_KEY`, but the CLI only reads `OPENROUTER_API_KEY` in non-interactive mode (locally it works because interactive runs save credentials to the home dir). This PR maps the secret to the env var the CLI actually reads and fixes the misleading setup comment.

## How to test

Merging this does **not** trigger the workflow (`.github/**` isn't in its path filter). After merge:

```
gh workflow run openwiki-update.yml
gh run watch
```

## Remaining known blocker

The repo setting **"Allow GitHub Actions to create and approve pull requests"** is still disabled (`can_approve_pull_request_reviews: false`), so the final `create-pull-request` step will fail until it's enabled: Settings → Actions → General → Workflow permissions.

https://claude.ai/code/session_01LmqQpyAED661HMZ565yqfQ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->