### PR TITLE
feat(matrix): restore dependency linking (Depends on field) in v9 edit drawer

### DIFF
--- a/coding-standards.md
+++ b/coding-standards.md
@@ -1,491 +1,229 @@
-# Code Standards & Agentic Guidance v16.4
+# Code Standards & Agentic Guidance v17.1
 
 **Purpose.** Directives governing how LLMs approach complex, multi-step development tasks. Optimized for the Claude Code harness. Every directive applies to every coding session.
 
-**How to use this file.** This is the full reference. Load only what's needed at runtime. Enforce mechanical rules with hooks, not prose. 
+**How to use this file.** This is the full reference. Load only what's needed at runtime. Enforce mechanical rules with hooks, not prose.
 
-**Portability (Claude Code and Codex).** Parts 1 through 8 and Part 10 belong in both `CLAUDE.md` and a Codex `AGENTS.md`. Harness mechanics are Claude Code specific and are tagged where they appear. When generating an `AGENTS.md` for Codex, omit Part 9, the environment-specific verification surfaces in Part 1, and the hook examples. Canonical prompt text lives in `.claude/commands/`; port those files to Codex's custom prompt mechanism rather than inlining them. Codex does not share the remaining primitives, and carrying them over is dead weight at best and misleading at worst.
-
----
-
-## Part 1: Agentic Behavior
-
-### Task Tiers (scale ceremony to the task)
-
-Match process weight to task size. Full spec, test-first, and ADR machinery on a one-line fix is its own kind of overengineering.
-
-| Tier | Definition | Process |
-|---|---|---|
-| Trivial | One file, under ~20 lines, no interface change. Typo, copy edit, config tweak, obvious one-liner. | Skip the spec and the approval gate. Make the change, verify it, commit. |
-| Standard | A few files, bounded scope, no new public contract. | Lightweight plan in `tasks/todo.md`. Test-first for any real logic. No formal spec required. |
-| Non-trivial | Coordinated changes across more than one file, more than ~50 lines, a changed public interface, or any edit to shared code or infrastructure. | Full process: `tasks/spec.md`, approval before coding, red/green/refactor, ADR if an architectural decision is made. |
-
-When a task sits on a boundary, state which tier you picked and why before proceeding.
-
-### Scope Discipline
-
-Models overengineer when unconstrained. Counter it with explicit minimalism.
-
-- **Scope:** Do not add features, refactor, or improve beyond what was asked. A bug fix does not need surrounding code cleaned up.
-- **Documentation:** Do not add docstrings, comments, or type annotations to code you did not change.
-- **Defensive coding:** Do not add error handling for scenarios that cannot happen. Trust internal code and framework guarantees. Validate at system boundaries only.
-- **Abstractions:** Do not create helpers for one-time operations. YAGNI (Part 2) applies with extra force here.
-
-### Codebase Orientation (REQUIRED before first write)
-
-1. Read README, CLAUDE.md, and CONTRIBUTING docs first.
-2. Explore the directory structure. Understand the project layout.
-3. Identify existing patterns: naming, module organization, error handling, test structure.
-4. Check for existing utilities before creating new ones.
-5. Match existing code style exactly, even if it differs from these standards.
-
-**Investigate before answering.** Never speculate about code you have not opened. If the user references a specific file, read it before answering. Make no claims about a codebase before investigating.
-
-**Resumed sessions:** Read CLAUDE.md, then `tasks/lessons.md`, then `tasks/todo.md`, then check git log (last 3 to 5 commits). Do not ask the user to re-explain context captured in these files.
-
-**Rule:** The existing codebase is the primary style guide. These standards apply to greenfield code or explicit refactoring.
-
-### Spec-Driven Development (REQUIRED for non-trivial tasks; see Task Tiers)
-
-1. Write the spec first. Create `tasks/spec.md` before any implementation begins.
-2. Define the contract: inputs, outputs, constraints, edge cases, and what success looks like.
-3. State anti-goals explicitly. What this does NOT do. Prevents scope creep.
-4. Get approval. Do not start coding until the spec is reviewed and confirmed.
-5. Treat drift as a failure. Update the spec first and get re-confirmation before continuing.
-
-**Spec template fields:**
-
-| Field | Content |
-|---|---|
-| Goal | One sentence: what this does and why. |
-| Inputs / Outputs | What goes in, what comes out, what format. |
-| Constraints | Performance, security, compatibility, size requirements. |
-| Edge Cases | Empty inputs, nulls, concurrent calls, failure modes. |
-| Out of Scope | Explicit list of what this version does not handle. |
-| Acceptance Criteria | Checkable statements that prove correctness. |
-| Test Stubs | Draft test function names (empty bodies) mapping to each criterion. Shipped with the spec. |
-
-**Rule:** Code without a spec is a guess. A spec written after the code is a rationalization. Write it first.
-
-### Handling Ambiguity
-
-- **Ask before assuming.** If a requirement has multiple valid interpretations, ask which is intended.
-- **State your assumptions.** If proceeding without clarification, list every assumption explicitly.
-- **Prefer reversible choices.** When guessing, choose the option easiest to change later.
-- **Flag scope questions early.** Confirm scope before modifying shared code, external APIs, or infrastructure.
-
-### Stop Conditions
-
-Halt and re-establish context when any of these are true:
-
-- A plan breaks. Do not push through ambiguity by guessing forward.
-- Context budget hits 80% with major uncommitted work. Commit, then continue.
-- You cannot write a failing test first (Part 3).
-- Verification surfaces a result you cannot explain. Diagnose root cause before patching.
-- A required clarification is missing. Ask before building on a guess.
-
-### Tool Efficiency
-
-Claude executes tool calls in parallel by default. Reserve sequential execution for true dependencies (output of A feeds input of B). For everything else, fire concurrently. Never use placeholders or guess missing parameters.
-
-- Use `grep` or `ripgrep` to search across files instead of reading them individually.
-- Use `git log`, `git diff`, and `git status` directly rather than asking Claude to summarize manually.
-- For bulk refactors, use `sed` or `awk` on multiple files in one pass.
-- Set explicit timeouts upfront for long-running bash operations.
-- **Clean up temporary files.** If you create scratchpads, helper scripts, or iteration files, remove them before declaring the task complete.
-
-### Hard-to-Reverse Action Safety
-
-Local, reversible actions are encouraged without confirmation: editing files, running tests, creating branches, local commits.
-
-**Confirm before proceeding** on actions that are hard to reverse, affect shared systems, or are destructive:
-
-- **Destructive:** `rm -rf`, dropping tables, deleting branches, force-deleting files.
-- **Hard to reverse:** `git push --force`, `git reset --hard`, amending published commits.
-- **Externally visible:** pushing code, commenting on PRs or issues, sending messages, modifying shared infrastructure.
-
-**Never bypass safety checks** with shortcuts like `--no-verify`. Do not discard unfamiliar files. They may be in-progress work.
-
-### Context Management & Sustained Work
-
-1. Outline the implementation plan with milestones and acceptance criteria for each.
-2. Work through each milestone, committing every functional change or logical unit of work.
-3. Monitor context usage. Prioritize committing working code before context exhaustion.
-4. Never leave significant work uncommitted.
-
-**Prefer fresh context over compaction.** State lives in `tasks/`. Resume by reading those files, not by summarizing chat history. Current models are effective at discovering state from the local filesystem. Lean on that.
-
-**Outcomes, not process.** Every multi-step task must have a stated "done" condition the model can recognize autonomously.
-
-- Process-defined (avoid): "Keep checking the logs until you find the error."
-- Outcome-defined (prefer): "Check the last 100 lines of logs. If you find an error, explain root cause and propose one fix. If none found, say so and stop."
-
-### Session Handoff Protocol (REQUIRED before ending)
-
-1. Commit all working code.
-2. Update `tasks/todo.md` with "Resuming From Here": completed work, next steps, blockers, and assumptions future work depends on.
-3. Run the test suite. Do not end with failing tests.
-
-**Rule:** A clean handoff is as important as clean code. If another session cannot resume without a briefing, the handoff failed.
-
-### Self-Improvement Loop
-
-After any correction from the user, capture the pattern in `tasks/lessons.md` immediately. End every correction session with: *"Update CLAUDE.md so this mistake does not recur."*
-
-| File | Purpose |
-|---|---|
-| `tasks/lessons.md` | Project-specific learnings: patterns, gotchas, context that matters for this codebase. |
-| `CLAUDE.md` | Persistent behavioral rules that apply across sessions and projects. |
-
-**Rule:** Corrections are learning contracts. Every mistake that recurs after being corrected once is a process failure, not a knowledge gap.
-
-### Verification
-
-Verification has two phases. Define the method before writing code. Run the checks before declaring complete.
-
-**Before implementation:**
-
-1. Define the verification method and match it to the domain.
-2. Backend: test suite. API: curl or integration tests. Frontend: browser, screenshot, accessibility. Data: row-count diffs. Infra: terraform plan, smoke tests.
-3. Confirm the loop is fast and runnable autonomously. Building a fast feedback loop is higher priority than the feature.
-
-**Verification surfaces in this environment** *(Claude Code specific; adjust or omit for Codex)*: Playwright MCP for UI, GitHub MCP for repo state, aws-core MCP for cloud, Biome for format and lint, project test runner for behavior.
-
-**Before presenting code or marking complete:**
-
-1. Re-read every changed file. Check for typos, leftover debug statements, TODO comments.
-2. Verify all imports are used and no dead code remains.
-3. Confirm naming is consistent across the changeset.
-4. Check that error paths are handled, not just the happy path.
-5. Ensure the code compiles, runs, and tests pass.
-6. Run the elegance check below.
-7. Ask: "Would a staff engineer approve this?" If uncertain, keep improving.
-
-**Elegance check (required for non-trivial changes).** Verify all four:
-
-- Fewer branches than the previous implementation, or branches justified by edge cases.
-- New dependencies clear the stdlib bar in Part 2: the dep must cut more than 2x the code.
-- Diff is the smallest set of changes that implements the spec.
-- A junior engineer can read it without flipping to another file.
-
-**Rule:** Never present code you have not re-read. A 30-second review catches the majority of avoidable mistakes.
-
-### Incremental Progress
-
-- Get a minimal working version first, then extend.
-- Avoid writing large amounts of code before testing any of it.
-- Run the affected tests after each change. Run the full suite at logical checkpoints and before commit. The Stop hook (Part 9) owns the final gate.
-- Do not assume code is correct without execution.
-- Each increment is one red/green/refactor cycle (see Part 3). No second function before the first has a passing test.
+**Portability (Claude Code and Codex).** Parts 1 through 4 and Part 6 belong in both `CLAUDE.md` and a Codex `AGENTS.md`. Harness mechanics are Claude Code specific and are tagged. When generating an `AGENTS.md` for Codex, omit Part 5 and hook examples. Canonical prompt text lives in `.claude/commands/`; port those files to Codex's custom prompt mechanism rather than inlining them.
 
 ---
 
-## Part 2: Code Quality Standards
+## Part 1: The Agentic Lifecycle
 
-### Core Principles
+### Phase 1: Pre-computation & Discovery
 
-1. **Simplicity over cleverness.** Prefer clarity to novelty.
-2. **Build small, iterate fast.** Deliver working code before optimizing.
-3. **Code for humans.** Readable by a junior engineer (enforced by the elegance check in Part 1).
-4. **Prefer boring tech.** Stability over hype.
-5. **Automate consistency.** Enforce formatting, linting, and tests in CI.
-6. **Standard lib over external.** Use stdlib unless an external dep cuts more than 2x the code.
-7. **Solve generally, not for tests.** Implement the actual logic. Do not hard-code values or write code that only passes the test cases. Tests verify correctness; they do not define the solution.
+**1. Codebase Orientation (REQUIRED before first write)**
+* Read `README.md`, `CLAUDE.md`, and `CONTRIBUTING.md`. Explore directory structure.
+* Identify existing patterns: naming, module organization, error handling, test structure, and verification commands.
+* Check for existing utilities before creating new helpers.
+* **Investigate before answering:** Never speculate about code you have not opened. If the user references a specific file, read it before answering.
+* **Resumed sessions:** Read `CLAUDE.md` → `tasks/lessons.md` → `tasks/todo.md` → `tasks/implementation-notes.md` → `git log`. Do not ask for re-explanation of captured state.
+* Match existing style exactly. The codebase is the primary style guide.
 
-### Naming & Clarity
+**2. Task Tiers**
+* **Trivial:** One file, <20 lines, no interface change (typo, config). *Skip spec/approval. Fix, verify, commit.*
+* **Standard:** Few files, bounded scope, no new public contract. *Lightweight plan in `tasks/todo.md`. Test-first for real logic.*
+* **Non-trivial:** Coordinated changes, >50 lines, public interface changes, shared code, or infrastructure. *Full process: `tasks/spec.md`, approval, red/green/refactor, ADR if architecture changes.*
+* **Boundary rule:** When a task sits on a tier boundary, state which tier you picked and why before proceeding.
 
-- Descriptive names. Avoid `data`, `temp`, single letters.
-- Functions ≤ 40 lines with single responsibility.
-- Maximum 3 levels of nesting. Use early returns.
-- Comments explain WHY, not WHAT.
-- Document public APIs with usage examples.
-- Limit code files to approximately 400 lines. Split by responsibility.
+**3. Handling Ambiguity**
+* Ask before assuming. If assuming, list every assumption explicitly.
+* Prefer reversible choices when proceeding under an explicit assumption.
+* **Unknowns Interview (Non-trivial):** Before requesting spec approval, ask one question at a time. Prioritize blast-radius (data models, architecture, public interfaces). Fold answers into `tasks/spec.md`.
 
-### Type Safety & Static Analysis
+**4. Tool Efficiency**
+* Use `rg`, `git status`, `git diff`, and `git log` directly for discovery and verification.
+* Use parallel tool calls when tasks are independent. Reserve sequential execution for true dependencies.
+* Set explicit timeouts for long-running operations.
+* Clean up temporary files, helper scripts, scratchpads, and iteration artifacts before declaring the task complete.
+* Never use placeholders or guess missing parameters.
 
-- Type annotations on ALL function signatures (parameters and return types).
-- Strict compiler settings (TypeScript `strict`, Python `mypy strict`).
-- Typed data structures (interfaces, typed dicts) over untyped maps.
-- Run static analysis and type checking as part of the verification workflow.
-- Never use `any`, `object`, or escape hatches without a justification comment.
+### Phase 2: Implementation Execution
 
-### Structure & Abstraction
+**1. Spec-Driven Development (REQUIRED for non-trivial tasks)**
+* Write `tasks/spec.md` before coding. Include: Goal, Inputs/Outputs, Constraints, Edge Cases, Out of Scope, Acceptance Criteria, Test Stubs.
+* Do not start coding until the user approves the spec.
+* Treat contract drift as a failure. If inputs, outputs, constraints, scope, or acceptance criteria change, STOP, update the spec, and get re-approval.
 
-- Apply DRY at the third occurrence (rule of three). Two instances can stay duplicated.
-- YAGNI: do not build for hypothetical futures.
-- Composition over inheritance.
-- Duplicate if it is clearer than abstracting.
-- No magic numbers. Use named constants.
-- Inject dependencies (I/O, time, randomness).
+**2. Scope Discipline & Incremental Progress**
+* **Scope:** Do NOT add features, refactor, or improve beyond what was asked. No YAGNI.
+* Do not add docstrings, comments, type annotations, abstractions, or cleanup outside the touched scope.
+* **Defensive coding:** Validate at system boundaries only. Trust internal guarantees.
+* **Execution:** One red/green/refactor cycle at a time. Do not assume correctness without execution.
+* For long-running work, commit each functional change or logical unit before continuing.
+
+**3. Verification Plan**
+* Define the verification method before coding.
+* Match verification to the domain: backend tests, API integration checks, frontend browser/screenshot/accessibility checks, data row-count diffs, infrastructure plans, smoke tests, or project-specific runners.
+* Confirm the loop is fast and runnable autonomously before investing heavily in implementation.
+
+**4. Deviations Ledger & Stop Conditions**
+* **Halt & Re-plan if:** A plan breaks, context budget hits 80%, a test cannot be written first, verification surfaces unexplainable results, or required clarification is missing.
+* **Log deviations:** Record tactical deviations in `tasks/implementation-notes.md`. If the contract drifts (inputs/outputs change), STOP and update the spec for re-approval.
+* Diagnose root cause before patching when verification fails. Avoid trial-and-error fixes.
+
+**5. Hard-to-Reverse Action Safety**
+* **Confirm before proceeding on:** `rm -rf`, dropping tables, deleting branches, force-deleting files, `git push --force`, `git reset --hard`, amending published commits, modifying shared infra, pushing code, commenting on PRs/issues, or sending external messages.
+* Local reversible actions require no confirmation.
+* Never bypass safety checks with shortcuts like `--no-verify`. Do not discard unfamiliar files.
+
+### Phase 3: Handoff & Delivery
+
+**1. Git Workflow**
+* Commit format: `<type>(<scope>): <description>`. Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`, `ci`, `build`.
+* Imperative mood, lowercase, no period, max 72 chars.
+* Branch format: `<type>/<short-description>` when creating a branch.
+* PRs should cover one logical concern. Split large PRs unless the split makes review less clear.
+* PR descriptions should include what changed, why it changed, how to test locally, screenshots for UI changes, and known deferred follow-ups.
+
+**2. Session Handoff Protocol (REQUIRED before ending)**
+* Commit all working code. Never leave significant work uncommitted.
+* Update `tasks/todo.md` with "Resuming From Here": completed work, next steps, blockers, and assumptions.
+* Run the test suite. Do not end with failing tests.
+* **Self-Improvement Loop:** Distill `tasks/implementation-notes.md` into `tasks/lessons.md` (project learnings) or `CLAUDE.md` (behavioral rules), then delete the ledger.
+
+**3. Comprehension Gate (Non-trivial tier)**
+* Before PR, generate a change report (context, intent, what changed, why it changed, and existing code paths affected) and a 5-10 question quiz testing edge cases and blast radius.
+* The user must pass before merging. A miss means re-reading the report, not retaking until lucky.
+* Never merge code you cannot explain.
+
+---
+
+## Part 2: Non-Negotiable Invariants
+
+*Note: Linting, formatting (Biome), and dependency audits are enforced via background hooks where available. Fix any hook failures autonomously and immediately.*
+
+### Code Quality & Structure
+* **Simplicity:** Simplicity over cleverness. Build small, iterate fast.
+* **Human readability:** A junior engineer should understand the change without flipping across many files.
+* **Dependencies:** Standard lib > external. Only add a dep if it cuts >2x the code.
+* **Types:** Type annotations required on ALL function signatures. Strict compiler settings enabled. Never use `any` or `object` without a justification comment.
+* **Constraints:** Functions ≤ 40 lines. Max 3 levels of nesting. No magic numbers. Limit files to ~400 lines.
+* **Comments:** Explain WHY, not WHAT.
+* **Abstraction:** Apply DRY at the third occurrence. Duplicate twice if clearer than abstracting. Do not create helpers for one-time operations.
+* **Design:** Prefer composition over inheritance. Inject I/O, time, randomness, and external services instead of hard-coding them.
+* **Tests:** Solve generally, not just for the current test cases.
 
 ### Dependency Management
+* Pin production dependency versions in lockfiles. Avoid floating ranges.
+* Review maintenance health, license, security posture, bundle/runtime impact, and transitive dependency risk before adding a dependency.
+* Remove unused dependencies promptly.
+* New dependencies must be justified, reviewed, audited, and locked before completion.
 
-- Pin versions in lockfiles. No floating ranges in production.
-- Run `npm audit` or `pip-audit` every CI build, and in a PostToolUse hook so agentic installs are caught too. Fail on high-severity findings.
-- Add new dependencies deliberately. Evaluate maintenance, license, bundle size.
-- Remove unused dependencies promptly. Document why non-obvious ones exist.
+### Security & Error Handling
+* **Security:** Validate/sanitize all user inputs. Parameterized queries only. Least-privilege. No committed secrets.
+* **Errors:** Fail fast with clear messages. Typed/custom errors for domain-specific failures.
+* **Exceptions:** Re-raise or handle. NEVER swallow exceptions.
+* **Logging:** Log with useful context and no secrets.
+* **Retries:** Retry transient failures deliberately with bounded exponential backoff when appropriate.
 
-**Rule:** Claude Code installs packages autonomously, and every package it adds is your team's responsibility. Review first, accept second, and scrutinize agentic installs like any other code change.
-
----
-
-## Part 3: Testing & Error Handling
-
-### Red/Green/Refactor (canonical home, NOT OPTIONAL for Standard and Non-trivial tiers)
-
-| Step | Action |
-|---|---|
-| 1. RED | Write a test that describes the desired behavior. Run it. Confirm it fails for the right reason, not a syntax error or missing import. |
-| 2. GREEN | Write the minimal implementation that makes the test pass. No more, no less. |
-| 3. REFACTOR | Extract duplication, improve naming, simplify logic without breaking the test. |
-| 4. REPEAT | Each new behavior gets its own cycle before moving on. |
-
-**Rule:** If you cannot write a failing test first, you do not yet understand the requirement well enough to implement it. Stop and clarify.
-
-### Test Quality
-
-- Coverage target: roughly 80% line coverage as a floor. **100% coverage of all acceptance criteria from the spec.**
-- Test naming: behavior-based. `should_return_404_when_user_not_found`, not `test_get_user`.
-- Arrange-Act-Assert. One assertion concept per test. Include positive AND negative cases.
-- Independent tests. No shared mutable state. Mock external deps at the boundary.
-- Unit tests under 100ms each. Move slow tests to integration suites.
-- Test behavior, not implementation. Tests should survive internal refactors.
-
-### Error Handling
-
-- Fail fast with clear messages.
-- Never swallow exceptions.
-- Typed or custom errors for domain-specific failures (not-found ≠ unauthorized ≠ validation-failed).
-- Log with context, no secrets.
-- Retry transient failures with exponential backoff. Circuit breakers for dependencies.
-- Return meaningful error responses: status code, error type, human-readable message.
+### Testing (Red/Green/Refactor)
+* **Metrics:** Target 80% coverage floor. **100% coverage of spec acceptance criteria.**
+* **Structure:** Arrange-Act-Assert. One assertion concept per test. Include positive and negative cases. Unit tests <100ms.
+* **Rule:** If you cannot write a failing test first, you do not understand the requirement.
+* Confirm the red test fails for the right reason before writing implementation.
+* Refactor only after green, and only to simplify, remove duplication, or improve naming without changing behavior.
 
 ---
 
-## Part 4: Security
+## Part 3: Architecture & Decisions
 
-- Validate and sanitize all user inputs.
-- Use parameterized queries. No SQL concatenation.
-- Apply least-privilege principles.
-- Never commit secrets. Rotate regularly.
-- Keep dependencies patched and scanned. See Dependency Management in Part 2.
-
----
-
-## Part 5: Git Workflow
-
-### Commit Standards
-
-```
-<type>(<scope>): <description>
-
-[optional body, what and why, not how]
-
-[optional footer, BREAKING CHANGE: / Closes #42]
-```
-
-**Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `perf`, `ci`, `build`
-
-Subject line: imperative mood, lowercase, no period, max 72 characters. Standard workflow: **commit, push, create PR.**
-
-Branch naming: `<type>/<short-description>`, for example `feat/oauth-login` or `fix/null-payment-response`.
-
-### Code Review Standards
-
-**PR size:** ≤ 400 lines of non-generated code, single logical concern. Split larger PRs.
-
-**PR description must include:** what and why, how to test locally, screenshots for UI changes, deferred follow-up linked to ticket.
-
-**Reviewer checks:** spec match, edge cases and error paths, security or perf or observability regressions, readability, meaningful tests, tests written before implementation (check commit order), dependencies justified.
-
-Respond to review requests within one business day. Use `nit:` or `suggestion:` prefix for non-blocking comments. Approve only when you would be comfortable owning this code if the author left tomorrow.
-
----
-
-## Part 6: Architecture & Decisions
-
-### Architecture Decision Records (ADRs)
-
-Required when a decision is hard to reverse, affects multiple teams or services, or future engineers will wonder why it was made.
-
-**Location:** `docs/adr/NNNN-short-title.md`
+**Architecture Decision Records (ADRs)**
+Required when a decision is hard to reverse, affects multiple systems or teams, or future engineers will wonder why it was made. Location: `docs/adr/NNNN-short-title.md`.
 
 | Field | Content |
 |---|---|
-| Date | YYYY-MM-DD |
-| Status | Proposed \| Accepted \| Deprecated \| Superseded by [NNNN] |
-| Deciders | Names or team |
-| Context | What situation or problem prompted this decision? |
-| Decision | What was decided? State it directly. |
-| Consequences | What becomes easier? Harder? Out of scope? |
-| Alternatives | What else was evaluated and why was it rejected? |
+| Date / Status / Deciders | YYYY-MM-DD \| Proposed/Accepted/Deprecated/Superseded \| Names |
+| Context / Decision | Problem prompting the decision \| What was decided |
+| Consequences / Alternatives | What is easier/harder/out of scope \| Rejected options and why |
 
-**Rule:** If you are explaining an architectural choice in a Slack thread or PR comment, that explanation belongs in an ADR instead.
+**Rule:** If an architectural choice needs a Slack thread or PR comment to explain it, it probably belongs in an ADR.
 
 ---
 
-## Part 7: Task Management
+## Part 4: Prompt Engineering Standards
 
-### Workflow
+**Prompt Structure:** Role/Context → Task → Constraints → Anti-goals → Output Format.
 
-1. **Plan first.** Write your plan to `tasks/todo.md` with checkable items before touching any code. For non-trivial work, write `tasks/spec.md` first (see Part 1).
-2. **Verify plan.** Check in with the user before implementation on Standard and Non-trivial tiers. Spec approval (Part 1) covers this for Non-trivial work.
-3. **Track progress.** Mark items complete as you go. Never batch-mark at the end.
-4. **Explain changes.** High-level summary at each significant step.
-5. **Document results.** Add a review section to `tasks/todo.md` when the task is complete.
-6. **Capture lessons.** Follow the Self-Improvement Loop (Part 1).
+**Prompt Sources:** Canonical prompt text lives in `.claude/commands/` (`qspec.md`, `tdd.md`, `qcheck.md`, and successors). The executable prompt file is the source of truth. Edit wording there, not in scattered docs or ad hoc chat prompts.
 
-### Definition of Done (ALL must be true)
-
-**Correctness & Quality**
-
-- [ ] Implementation matches the spec or ticket acceptance criteria.
-- [ ] Verification method was defined before coding and passes autonomously.
-- [ ] Tests were written BEFORE implementation (red confirmed before green).
-- [ ] Each acceptance criterion has at least one corresponding passing test.
-- [ ] Refactor step was completed after green (no dead code, no over-fit logic).
-- [ ] All new and existing tests pass before commit.
-- [ ] Linting, formatting, and type checking pass with no suppressions.
-
-**Documentation & Process**
-
-- [ ] PR description is complete and reviewable without a verbal walkthrough.
-- [ ] New environment variables or config are documented.
-- [ ] ADR written if an architectural decision was made.
-- [ ] New dependencies audited and locked in the lockfile.
-- [ ] Feature flags named, owned, and have a removal date.
-- [ ] Accessibility baseline met (if frontend work).
-
-**Rule:** "It works on my machine" is not done. This checklist is done.
-
-> Self-review items (debug statements, dead code, naming, error handling, staff engineer approval) are enforced in Part 1's Verification section. They are not duplicated here.
+**Prompt Anti-Patterns (DO NOT USE):**
+* Vague goals ("make this better") or conversational framing.
+* Missing constraints or anti-goals (invites scope creep).
+* Stacked goals (asking for spec, code, and docs simultaneously).
+* Implicit context, scope, or ambition. Say exactly what should be included.
+* Severity self-censorship ("only flag high-severity").
+* No exit conditions ("keep checking until..."). Use outcome-defined conditions instead.
+* Skipping TDD in the prompt for Standard or Non-trivial implementation work.
 
 ---
 
-## Part 8: Prompt Engineering Standards
+## Part 5: Claude Code Primitives
 
-### Prompt Structure
+*Claude Code specific. Omit from Codex `AGENTS.md`.*
 
-| Element | Purpose |
+* **Routing:** Commands initiate, subagents verify, hooks gate.
+* **Slash Commands (`.claude/commands/`):** Short, repeatable actions. Canonical text of prompts lives here (e.g., `/qspec`, `/tdd`, `/qcheck`).
+* **Skills (`.claude/skills/`):** Complex multi-step workflows. Write descriptions as triggers ("when should I fire?"). Provide goals, constraints, and a "Gotchas" section.
+* **Subagents (`.claude/agents/`):** Spawn for fanning out or parallel reads. Skip for <3 tool calls. Read-only agents use `haiku`; write agents use `sonnet`/`opus` with `isolation: worktree`.
+* **Agent teams vs subagents:** Use subagents for scoped delegation inside one workstream. Use teams when work should split across longer-lived sessions that coordinate.
+* **Hooks:** Enforce standards mechanically (e.g., `PostToolUse`, `Stop`). Hook types: shell commands, prompt hooks, MCP tool hooks.
+* Hooks receive event data as JSON on stdin. Read fields with `jq`, for example `.tool_input.file_path`; do not rely on `$CLAUDE_FILE_PATH` style variables unless explicitly configured.
+
+---
+
+## Part 6: Exit & Validation Matrix
+
+**ALL items must be TRUE before declaring a task "Done" or ending a session.**
+
+**Code & Execution**
+- [ ] No speculation occurred; relevant codebase files were read first.
+- [ ] Existing utilities and patterns were checked before new helpers were created.
+- [ ] Correct task tier was selected; boundary cases were explained.
+- [ ] Spec-driven development used for non-trivial work.
+- [ ] Code is minimalist; no out-of-scope refactoring, documentation, type churn, or YAGNI features.
+- [ ] Implementation was written strictly AFTER tests (Red/Green/Refactor).
+- [ ] Red tests failed for the right reason before implementation.
+- [ ] All acceptance criteria have corresponding passing tests.
+- [ ] Verification method was defined before coding and matched to the domain.
+- [ ] Relevant tests, type checks, linting, formatting, and security checks pass.
+- [ ] Every changed file was re-read for typos, debug code, TODOs, dead imports, unused code, naming drift, and untested error paths.
+- [ ] No hard-to-reverse actions were executed without explicit user confirmation.
+- [ ] Elegance Check passed (junior engineer readable, minimal diff, justified branches).
+- [ ] Temporary files, helper scripts, and scratchpads were removed.
+
+**Process & Handoff**
+- [ ] Task plan (`tasks/todo.md`) updated with progress and "Resuming From Here".
+- [ ] `tasks/lessons.md` updated with any required corrections from this session.
+- [ ] New dependencies justified, reviewed, audited, and locked in the lockfile.
+- [ ] ADR written for architectural changes.
+- [ ] PR covers one logical concern and includes what changed, why, and how to test.
+- [ ] Comprehension quiz passed by user (Non-trivial tier only).
+- [ ] All code committed and tests pass.
+
+---
+
+## Part 7: Red Flags Index
+
+Use this as a fast drift check when behavior feels off.
+
+| Red flag | Corrective action |
 |---|---|
-| Role / Context | Tell the model who it is and what it knows. |
-| Task | State the goal clearly. One prompt, one goal. |
-| Constraints | What must be true about the output? |
-| Anti-goals | What should the output NOT do or include? |
-| Output Format | Specify the expected shape of the response. |
-
-### Prompt Sources
-
-Canonical prompt text lives in `.claude/commands/` (`qspec.md`, `tdd.md`, `qcheck.md`). The executable file is the source of truth. Edit wording there, not here. This document defines the structure every command prompt follows and the anti-patterns none of them may contain.
-
-### Prompt Anti-Patterns
-
-- **Vague goals:** "Make this better" without specifying what better means.
-- **Missing constraints:** Prompts with no constraints invite over-engineering.
-- **No anti-goals:** Without them, the model expands scope by default.
-- **Stacked goals:** One prompt asking for spec, implementation, tests, and docs simultaneously.
-- **Implicit context:** Assuming the model knows your project structure or prior decisions.
-- **Implicit scope or ambition:** The model does exactly what was asked, no more. "Apply this to every section" beats "Apply this." If you want above-and-beyond, say so.
-- **Conversational framing on operational tasks:** "Could you please help me understand..." Write direct commands instead.
-- **No exit conditions:** "Keep checking until you find the issue" loops indefinitely. Define outcome-based done conditions (Part 1).
-- **Severity self-censorship in reviews:** "Be conservative" or "only flag high-severity" causes the model to investigate fully but report less. Ask for all findings, tagged by severity.
-- **Skipping TDD in the prompt:** Not specifying red/green/refactor invites code-first, tests-after.
-
-**Rule:** A prompt is a spec for the model. Apply the same rigor you would to a spec for code.
-
----
-
-## Part 9: Claude Code Primitives
-
-*Claude Code specific. Omit from a Codex `AGENTS.md`.*
-
-Reusable building blocks: slash commands, skills, subagents, and hooks. If you do something more than once a day, it should be one of these, not a prompt you retype.
-
-**Routing between primitives.** Commands initiate, subagents verify, hooks gate. `/tdd` starts the red/green/refactor cycle; `tdd-enforcer` audits that it happened; the Stop hook blocks completion if tests fail. When two primitives overlap, that division is the tiebreaker.
-
-### Slash Commands (`.claude/commands/`)
-
-Short, repeatable actions checked into git. Executable with a single invocation. Can inline Bash for pre-computed context. Each command file is the canonical text of its prompt; Part 8 defines the structure and anti-patterns it must follow.
-
-Current commands: `/qspec` (generate a spec), `/tdd` (start a red/green/refactor cycle), `/qcheck` (skeptical staff engineer review). The directory is the living index. Other candidates: commit-push-PR, run tests, format code, generate changelog.
-
-### Skills (`.claude/skills/`)
-
-Complex multi-step workflows with domain knowledge or conditional logic. SKILL.md describes when to fire and what to do. Progressive disclosure: skills are folders with `references/`, `scripts/`, `examples/` subdirectories.
-
-*Examples:* analytics queries, incident response, migration playbooks.
-
-**Skill design rules:**
-
-- Skill description is a trigger, not a summary. Write it for the model: "when should I fire?"
-- Don't state the obvious. Focus on what pushes Claude out of default behavior.
-- Don't railroad with prescriptive step-by-step instructions. Give goals and constraints.
-- Include scripts and libraries so Claude composes rather than reconstructs boilerplate.
-- Build a Gotchas section in every skill. Add Claude's failure points over time.
-
-### Subagents (`.claude/agents/`)
-
-Steer subagent use explicitly:
-
-- **Spawn** when fanning out across items or reading multiple files in parallel.
-- **Do not spawn** for work completable in a single response, such as refactoring a function already in view.
-- **Skip subagents** for tasks under 3 tool calls. Overhead exceeds benefit.
-
-When you do spawn, constrain behavior:
-
-- Subagents return concise summaries, not raw output.
-- Read-only tools for research subagents. Write access only for implementation subagents.
-- Set `isolation: worktree` on any agent that modifies files, so edits land in a separate git worktree rather than your checkout.
-- Use `model: haiku` for read-only analysis. `sonnet` or `opus` for architecture reasoning. Aliases or a full model ID both work.
-
-**Standard agent files:** `build-validator`, `code-simplifier`, `security-reviewer`, `tdd-enforcer`, `verify-app`.
-
-**Fork mode.** A fork reuses the parent's prompt cache, which makes it cheaper than spawning a fresh subagent for work that needs the same context. Enable with `CLAUDE_CODE_FORK_SUBAGENT=1`. The `isolation: worktree` setting above applies to forks as well. A fork cannot spawn further forks.
-
-**Agent Teams vs subagents.** Subagents are scoped workers inside one session that return a single result and cannot talk to each other. Agent Teams coordinate multiple longer-lived sessions that message each other and share task lists. Use subagents for delegation inside one workstream. Use teams when the work itself should split across sessions.
-
-### Hooks
-
-Hooks enforce mechanically what prose enforces by hope. Every rule moved to a hook is one fewer instruction competing for attention in the context window.
-
-Hooks receive event data as JSON on stdin, not as environment variables. Read fields with `jq`, for example `.tool_input.file_path`. `$CLAUDE_FILE_PATH` style variables are not set by current Claude Code.
-
-```
-PostToolUse (auto-format):  jq -r '.tool_input.file_path' | xargs -r npx biome check --write
-PostToolUse (audit deps):   npm audit --audit-level=high || exit 1
-PostCompact (re-inject):    cat tasks/todo.md tasks/lessons.md
-Stop (verification gate):   npm test && npx tsc --noEmit || exit 1
-```
-
-Use `biome format --write` instead of `biome check --write` if you want formatting only, without lint and import organization.
-
-**Hook types.** Beyond shell `command` hooks, Claude Code supports `prompt` hooks (an LLM evaluates a completion check, useful on Stop and SubagentStop) and `mcp_tool` hooks (invoke a configured MCP tool directly).
-
-**Rule:** If a standard can be enforced by a hook, it should be. Human discipline is a backup, not the primary mechanism.
-
----
-
-## Part 10: Red Flags Index
-
-A runtime checklist of behavioral drift, the failures a model backslides into rather than the mechanical ones that lint, types, and hooks already catch. Each item points to the section where the rule is defined.
-
-| Red flag | Reference |
-|---|---|
-| Speculating about code without opening it | Part 1: Codebase Orientation |
-| Writing code before reading existing patterns | Part 1: Codebase Orientation |
-| Implementing without a spec on non-trivial work | Part 1: Spec-Driven Development |
-| Applying full spec and TDD ceremony to a trivial change | Part 1: Task Tiers |
-| Implementation written before tests | Part 3: Red/Green/Refactor |
-| Refactor step skipped after reaching green | Part 3: Red/Green/Refactor |
-| Trial-and-error fixes without root cause analysis | Part 1: Stop Conditions |
-| Pushing through a broken plan instead of re-planning | Part 1: Stop Conditions |
-| Modifying files outside the task's scope | Part 1: Scope Discipline |
-| Hard-to-reverse actions without confirmation | Part 1: Hard-to-Reverse Action Safety |
-| Ending a session with failing tests or uncommitted changes | Part 1: Session Handoff |
-| Over-engineering beyond what was asked | Part 1: Scope Discipline |
+| Speculating about code without opening files | Stop and inspect the relevant files. |
+| Writing code before reading existing patterns | Return to Codebase Orientation. |
+| Applying full ceremony to a trivial fix | Re-tier the task and simplify. |
+| Implementing without a spec on non-trivial work | Stop, write the spec, and get approval. |
+| Coding before tests | Re-enter red/green/refactor. |
+| Pushing through a broken plan | Re-plan before continuing. |
+| Trial-and-error fixes | Diagnose root cause before patching. |
+| Silent deviation from plan | Log the deviation or update the spec. |
+| Scope creep outside the request | Revert or isolate out-of-scope changes. |
+| Ending with failing tests or uncommitted work | Fix, commit, or clearly hand off blockers. |
+| Hard-to-reverse action without confirmation | Stop and ask for explicit approval. |
+| Non-trivial work done without report and quiz | Run the comprehension gate. |
 
 ---
 
 > "Code should be safe to modify, easy to reason about, and boring to maintain. When in doubt, simplify."
 >
-> Vinny Carpenter, Document Version 16.4
+> Vinny Carpenter, Document Version 17.1

--- a/components/matrix-simplified/edit-drawer-dependencies.tsx
+++ b/components/matrix-simplified/edit-drawer-dependencies.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState } from "react";
+import { XIcon } from "lucide-react";
+import type { TaskRecord } from "@/lib/types";
+import { wouldCreateCircularDependency } from "@/lib/dependencies";
+import { SCHEMA_LIMITS } from "@/lib/constants/schema";
+import { Field } from "./edit-drawer-fields";
+
+const MAX_SUGGESTIONS = 8;
+
+/**
+ * Save-time cycle guard for the edit drawer. Unlike lib's validateDependencies,
+ * IDs that don't resolve locally are skipped rather than rejected — they may
+ * reference tasks that haven't synced to this device yet and must be preserved.
+ */
+export function findDependencyCycleError(
+  taskId: string,
+  dependencies: string[],
+  allTasks: TaskRecord[]
+): string | null {
+  const byId = new Map(allTasks.map((t) => [t.id, t]));
+  for (const depId of dependencies) {
+    const dep = byId.get(depId);
+    if (!dep) continue;
+    if (wouldCreateCircularDependency(taskId, depId, allTasks)) {
+      return `Circular dependency: "${dep.title}" already depends on this task.`;
+    }
+  }
+  return null;
+}
+
+interface DependenciesFieldProps {
+  /** Undefined in create mode — cycle filtering is skipped (nothing can depend on an unsaved task). */
+  taskId?: string;
+  dependencies: string[];
+  allTasks: TaskRecord[];
+  onChange: (ids: string[]) => void;
+  error?: string | null;
+}
+
+export function DependenciesField({
+  taskId,
+  dependencies,
+  allTasks,
+  onChange,
+  error,
+}: DependenciesFieldProps): React.ReactElement {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+
+  // Ghost IDs (no local record) render no chip but stay in `dependencies`.
+  const chips = dependencies
+    .map((id) => allTasks.find((t) => t.id === id))
+    .filter((t): t is TaskRecord => t !== undefined);
+  const atLimit = dependencies.length >= SCHEMA_LIMITS.MAX_DEPENDENCIES;
+
+  return (
+    <Field label="Depends on">
+      <div
+        className="relative"
+        onBlur={(e) => {
+          if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setOpen(false);
+        }}
+      >
+        <div className="flex flex-wrap items-center gap-1.5 rounded-lg border border-border bg-background p-2">
+          {chips.map((t) => (
+            <span
+              key={t.id}
+              data-testid="dep-chip"
+              className="inline-flex items-center gap-1 rounded bg-background-muted px-2 py-0.5 text-[11.5px] font-medium text-foreground-muted"
+            >
+              {t.title}
+              <button
+                type="button"
+                onClick={() => onChange(dependencies.filter((id) => id !== t.id))}
+                aria-label={`Remove dependency ${t.title}`}
+                className="hover:text-foreground"
+              >
+                <XIcon className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+          <input
+            value={query}
+            disabled={atLimit}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setOpen(true);
+            }}
+            onFocus={() => setOpen(true)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") e.preventDefault();
+            }}
+            placeholder={chips.length ? "" : "Search tasks this one depends on…"}
+            aria-label="Search tasks to add as a dependency"
+            className="min-w-[80px] flex-1 border-0 bg-transparent text-[13px] text-foreground outline-none disabled:cursor-not-allowed"
+          />
+        </div>
+        <Suggestions
+          open={open}
+          query={query}
+          taskId={taskId}
+          dependencies={dependencies}
+          allTasks={allTasks}
+          onPick={(id) => {
+            onChange([...dependencies, id]);
+            setQuery("");
+            setOpen(false);
+          }}
+        />
+      </div>
+      {atLimit ? (
+        <p className="text-[11.5px] text-foreground-muted">
+          Dependency limit reached ({SCHEMA_LIMITS.MAX_DEPENDENCIES}).
+        </p>
+      ) : null}
+      {error ? (
+        <p role="alert" className="text-xs text-red-400">
+          {error}
+        </p>
+      ) : null}
+    </Field>
+  );
+}
+
+function isCandidate(
+  candidate: TaskRecord,
+  taskId: string | undefined,
+  dependencies: string[],
+  allTasks: TaskRecord[]
+): boolean {
+  if (candidate.id === taskId) return false;
+  if (dependencies.includes(candidate.id)) return false;
+  if (candidate.completed) return false;
+  if (taskId && wouldCreateCircularDependency(taskId, candidate.id, allTasks)) return false;
+  return true;
+}
+
+function Suggestions({
+  open,
+  query,
+  taskId,
+  dependencies,
+  allTasks,
+  onPick,
+}: {
+  open: boolean;
+  query: string;
+  taskId?: string;
+  dependencies: string[];
+  allTasks: TaskRecord[];
+  onPick: (id: string) => void;
+}): React.ReactElement | null {
+  const trimmed = query.trim().toLowerCase();
+  if (!open || !trimmed) return null;
+
+  const matches = allTasks
+    .filter((t) => isCandidate(t, taskId, dependencies, allTasks))
+    .filter((t) => t.title.toLowerCase().includes(trimmed))
+    .slice(0, MAX_SUGGESTIONS);
+
+  return (
+    <div className="absolute z-10 mt-1 w-full overflow-hidden rounded-lg border border-border bg-card shadow-lg">
+      {matches.length > 0 ? (
+        matches.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            data-testid="dep-suggestion"
+            onClick={() => onPick(t.id)}
+            className="block w-full truncate px-3 py-2 text-left text-[13px] text-foreground hover:bg-background-muted"
+          >
+            {t.title}
+          </button>
+        ))
+      ) : (
+        <p className="px-3 py-2 text-[12.5px] text-foreground-muted">No matching tasks.</p>
+      )}
+    </div>
+  );
+}

--- a/components/matrix-simplified/edit-drawer-dependencies.tsx
+++ b/components/matrix-simplified/edit-drawer-dependencies.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useRef, useState } from "react";
 import { XIcon } from "lucide-react";
 import type { TaskRecord } from "@/lib/types";
 import { wouldCreateCircularDependency } from "@/lib/dependencies";
@@ -48,12 +48,18 @@ export function DependenciesField({
 }: DependenciesFieldProps): React.ReactElement {
   const [query, setQuery] = useState("");
   const [open, setOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const limitNoteId = useId();
+  const errorId = useId();
 
   // Ghost IDs (no local record) render no chip but stay in `dependencies`.
   const chips = dependencies
     .map((id) => allTasks.find((t) => t.id === id))
     .filter((t): t is TaskRecord => t !== undefined);
   const atLimit = dependencies.length >= SCHEMA_LIMITS.MAX_DEPENDENCIES;
+  const suggestionsVisible = open && query.trim().length > 0;
+  const describedBy =
+    [atLimit ? limitNoteId : null, error ? errorId : null].filter(Boolean).join(" ") || undefined;
 
   return (
     <Field label="Depends on">
@@ -82,6 +88,7 @@ export function DependenciesField({
             </span>
           ))}
           <input
+            ref={inputRef}
             value={query}
             disabled={atLimit}
             onChange={(e) => {
@@ -91,9 +98,17 @@ export function DependenciesField({
             onFocus={() => setOpen(true)}
             onKeyDown={(e) => {
               if (e.key === "Enter") e.preventDefault();
+              // Escape dismisses the suggestion popup only; a second Escape
+              // (popup closed) bubbles to the drawer's window listener as usual.
+              if (e.key === "Escape" && suggestionsVisible) {
+                e.stopPropagation();
+                setOpen(false);
+              }
             }}
             placeholder={chips.length ? "" : "Search tasks this one depends on…"}
             aria-label="Search tasks to add as a dependency"
+            aria-invalid={error ? true : undefined}
+            aria-describedby={describedBy}
             className="min-w-[80px] flex-1 border-0 bg-transparent text-[13px] text-foreground outline-none disabled:cursor-not-allowed"
           />
         </div>
@@ -107,16 +122,19 @@ export function DependenciesField({
             onChange([...dependencies, id]);
             setQuery("");
             setOpen(false);
+            // Picking removes the focused suggestion button from the DOM;
+            // return focus to the input so keyboard users keep their place.
+            inputRef.current?.focus();
           }}
         />
       </div>
       {atLimit ? (
-        <p className="text-[11.5px] text-foreground-muted">
+        <p id={limitNoteId} className="text-[11.5px] text-foreground-muted">
           Dependency limit reached ({SCHEMA_LIMITS.MAX_DEPENDENCIES}).
         </p>
       ) : null}
       {error ? (
-        <p role="alert" className="text-xs text-red-400">
+        <p id={errorId} role="alert" className="text-xs text-rust">
           {error}
         </p>
       ) : null}

--- a/components/matrix-simplified/edit-drawer-dependencies.tsx
+++ b/components/matrix-simplified/edit-drawer-dependencies.tsx
@@ -88,6 +88,7 @@ export function DependenciesField({
             </span>
           ))}
           <input
+            data-testid="dep-search"
             ref={inputRef}
             value={query}
             disabled={atLimit}

--- a/components/matrix-simplified/edit-drawer.tsx
+++ b/components/matrix-simplified/edit-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useEffectEvent, useRef, type FormEvent } from "react";
+import { useEffect, useEffectEvent, useRef, useState, type FormEvent } from "react";
 import { XIcon, CheckIcon } from "lucide-react";
 import type { TaskRecord } from "@/lib/types";
 import { quadrants, QUADRANT_ACCENT } from "@/lib/quadrants";
@@ -9,6 +9,7 @@ import { DrawerHint } from "@/components/ui/drawer-hint";
 import { useDialogFocus } from "./use-dialog-focus";
 import { useEditDraftState } from "./use-edit-draft-state";
 import { Field, QuadrantField, DueDateField, TagsField } from "./edit-drawer-fields";
+import { DependenciesField, findDependencyCycleError } from "./edit-drawer-dependencies";
 
 export interface EditDraft {
   title: string;
@@ -17,6 +18,7 @@ export interface EditDraft {
   important: boolean;
   dueDate?: string;
   tags: string[];
+  dependencies: string[];
 }
 
 interface EditDrawerProps {
@@ -24,13 +26,15 @@ interface EditDrawerProps {
   task?: TaskRecord | null;
   /** Pre-fill fields when opening in create mode (task is null/absent). */
   initialDraft?: Partial<EditDraft>;
+  /** Full live task list — candidate pool for the dependency picker. */
+  allTasks?: TaskRecord[];
   onClose: () => void;
   onSubmit: (draft: EditDraft, taskId?: string) => void | Promise<void>;
 }
 
 type EditDrawerFormProps = Omit<EditDrawerProps, "open">;
 
-export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: EditDrawerProps): React.ReactElement | null {
+export function EditDrawer({ open, task, initialDraft, allTasks, onClose, onSubmit }: EditDrawerProps): React.ReactElement | null {
   if (!open) return null;
   // Remount the form when the selected task changes so its field state is
   // seeded fresh from props — no effect-based rehydration needed.
@@ -39,17 +43,24 @@ export function EditDrawer({ open, task, initialDraft, onClose, onSubmit }: Edit
       key={task?.id ?? "__create__"}
       task={task}
       initialDraft={initialDraft}
+      allTasks={allTasks}
       onClose={onClose}
       onSubmit={onSubmit}
     />
   );
 }
 
-function EditDrawerForm({ task, initialDraft, onClose, onSubmit }: EditDrawerFormProps): React.ReactElement {
+function EditDrawerForm({ task, initialDraft, allTasks = [], onClose, onSubmit }: EditDrawerFormProps): React.ReactElement {
   const titleRef = useRef<HTMLInputElement>(null);
   const drawerRef = useRef<HTMLFormElement>(null);
   const draft = useEditDraftState(task, initialDraft, titleRef);
   const trapKeyDown = useDialogFocus(true, drawerRef);
+  const [dependencyError, setDependencyError] = useState<string | null>(null);
+
+  const handleDependenciesChange = (ids: string[]): void => {
+    setDependencyError(null);
+    draft.setDependencies(ids);
+  };
 
   // `onClose` may change identity between renders; useEffectEvent keeps the
   // keydown listener subscribed once while always calling the latest handler.
@@ -67,6 +78,13 @@ function EditDrawerForm({ task, initialDraft, onClose, onSubmit }: EditDrawerFor
   const submit = (e?: FormEvent): void => {
     e?.preventDefault();
     if (!draft.title.trim()) return;
+    const cycleError = task
+      ? findDependencyCycleError(task.id, draft.dependencies, allTasks)
+      : null;
+    if (cycleError) {
+      setDependencyError(cycleError);
+      return;
+    }
     void onSubmit(draft.toDraft(), task?.id);
   };
 
@@ -155,6 +173,14 @@ function EditDrawerForm({ task, initialDraft, onClose, onSubmit }: EditDrawerFor
                 draft.setTags(draft.tags.slice(0, -1));
               }
             }}
+          />
+
+          <DependenciesField
+            taskId={task?.id}
+            dependencies={draft.dependencies}
+            allTasks={allTasks}
+            onChange={handleDependenciesChange}
+            error={dependencyError}
           />
         </div>
 

--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -230,6 +230,7 @@ export function MatrixSimplified() {
           important: draft.important,
           dueDate: draft.dueDate,
           tags: draft.tags.length > 0 ? draft.tags : undefined,
+          dependencies: draft.dependencies.length > 0 ? draft.dependencies : undefined,
         });
         toast.success("Task added", { duration: TOAST_DURATION.SHORT });
         dispatchOverlay({ type: "closeCreate" });
@@ -304,6 +305,7 @@ export function MatrixSimplified() {
       <EditDrawer
         open={Boolean(editingTask)}
         task={editingTask}
+        allTasks={all}
         onClose={handleEditClose}
         onSubmit={handleEditSubmit}
       />
@@ -311,6 +313,7 @@ export function MatrixSimplified() {
         open={createDrawerOpen}
         task={null}
         initialDraft={createInitial}
+        allTasks={all}
         onClose={handleCreateClose}
         onSubmit={handleEditSubmit}
       />

--- a/components/matrix-simplified/use-edit-draft-state.ts
+++ b/components/matrix-simplified/use-edit-draft-state.ts
@@ -46,6 +46,8 @@ export interface EditDraftState {
   tagInput: string;
   setTagInput: (v: string) => void;
   addTag: () => void;
+  dependencies: string[];
+  setDependencies: (v: string[]) => void;
   toDraft: () => EditDraft;
 }
 
@@ -77,6 +79,9 @@ export function useEditDraftState(
   const [showCustomDateInput, setShowCustomDateInput] = useState(false);
   const [tags, setTags] = useState<string[]>(() => (task ? task.tags ?? [] : initialDraft?.tags ?? []));
   const [tagInput, setTagInput] = useState("");
+  const [dependencies, setDependencies] = useState<string[]>(() =>
+    task ? task.dependencies ?? [] : initialDraft?.dependencies ?? []
+  );
 
   // Move focus to the title field shortly after the drawer mounts.
   useEffect(() => {
@@ -104,6 +109,7 @@ export function useEditDraftState(
       important,
       dueDate,
       tags,
+      dependencies,
     };
   };
 
@@ -118,6 +124,7 @@ export function useEditDraftState(
     tags, setTags,
     tagInput, setTagInput,
     addTag,
+    dependencies, setDependencies,
     toDraft,
   };
 }

--- a/docs/adr/0011-v9-single-matrix-refactor.md
+++ b/docs/adr/0011-v9-single-matrix-refactor.md
@@ -61,3 +61,16 @@ Adopt v9 as the single supported UI. Delete the v8 surface that was definitively
 1. **Feature-flag both surfaces.** Rejected — the v9 work has been live since `cc5c85e` and no rollback path is needed. A flag would add maintenance cost without value.
 2. **Keep v8 code "for reference."** Rejected — that's what git history is for. Dead code in `main` invites accidental re-use, accumulates lint/audit noise, and inflates bundle size.
 3. **Delete the command palette too.** Rejected for now — the `⌘K` shortcut is a frequently-cited feature in user-facing docs and the source is tested; preserving it cheaply keeps the resurrection option open.
+
+## Addendum (2026-07-05): dependency editing restored
+
+The v8 removal (PR #238) dropped `task-form-dependencies.tsx` with the rest of
+the modular task form, leaving the dependency system write-only via MCP/import
+while task cards still displayed Blocked by/Blocking badges. A "Depends on"
+field was restored inside the v9 edit drawer
+(`components/matrix-simplified/edit-drawer-dependencies.tsx`), reusing the
+`lib/dependencies.ts` cycle detection plus a save-time cycle guard that
+preserves dependency IDs not resolvable locally (not-yet-synced tasks).
+Subtask editing remains drawer-less; `restoreTask` still does not restore
+inbound dependency edges; full WAI-ARIA combobox semantics for the picker are
+a tracked follow-up (see tasks/todo.md).

--- a/docs/superpowers/plans/2026-07-05-edit-drawer-dependencies.md
+++ b/docs/superpowers/plans/2026-07-05-edit-drawer-dependencies.md
@@ -1,0 +1,815 @@
+# Edit-Drawer Dependencies ("Depends on") Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `tasks/spec.md` § "Restore dependency-linking ('Depends on') UI in the v9 edit drawer" (2026-07-05). Read it first — acceptance criteria AC1–AC9 referenced below are defined there.
+
+**Goal:** Add a "Depends on" field to the v9 edit drawer so users can link tasks again (lost with the v8 task form in PR #238), reusing the existing `lib/dependencies.ts` graph logic and the already-working `dependencies` persistence in `createTask`/`updateTask`.
+
+**Architecture:** One new pure component (`DependenciesField`) receives the live task list via props (no Dexie access inside — unit-testable without fakes). Draft state extends the existing `useEditDraftState` hook. The drawer gains an `allTasks` prop and a save-time cycle guard. The shell (`index.tsx`) passes `all` from its existing `useTasks()` call and forwards `dependencies` on the create path. **No schema, Dexie, sync, or MCP changes.**
+
+**Tech Stack:** Next.js 16 App Router, React (compiler ON — no manual memoization), TypeScript strict, Tailwind (Inkwell tokens), Vitest + @testing-library/react (`bun run test`, NOT `bun test`), lucide-react icons.
+
+## Global Constraints
+
+- TDD: every behavior change starts with a failing test; confirm red fails for the right reason before green.
+- Files ≤350 lines; keep functions small; nesting ≤3; no magic numbers (name them).
+- No new dependencies. Imports use the `@/` alias.
+- Never commit on `main` — a PreToolUse hook blocks it. All work on branch `feat/edit-drawer-dependencies`.
+- Commit format `<type>(<scope>): <description>` (imperative, lowercase, ≤72 chars); end commit messages with the Claude-Session trailer per repo convention.
+- Run tests with `bun run test -- <file>` (delegates to vitest). `bun test` invokes bun's own runner and will fail — never use it.
+- Coverage for changed files ≥80% (statements/lines/functions).
+- Design: calm Inkwell idiom — reuse the drawer's `Field` label primitive and the tags-field chip styling; error text uses the existing `text-xs text-red-400` idiom; no new colors.
+- Never silently drop dependency IDs that don't resolve to a local task (they may reference tasks not yet synced from another device).
+- `SCHEMA_LIMITS.MAX_DEPENDENCIES` = 50 (`lib/constants/schema.ts:38`) — always reference the constant, never the literal.
+
+---
+
+### Task 1: `DependenciesField` component
+
+**Files:**
+- Create: `components/matrix-simplified/edit-drawer-dependencies.tsx`
+- Create: `tests/ui/edit-drawer-dependencies.test.tsx`
+
+**Interfaces:**
+- Consumes: `wouldCreateCircularDependency(taskId, depId, allTasks)` from `@/lib/dependencies`; `SCHEMA_LIMITS` from `@/lib/constants/schema`; `Field` from `./edit-drawer-fields`; `TaskRecord` from `@/lib/types`.
+- Produces (Task 2 relies on these exact signatures):
+  - `DependenciesField(props: { taskId?: string; dependencies: string[]; allTasks: TaskRecord[]; onChange: (ids: string[]) => void; error?: string | null }): React.ReactElement`
+  - `findDependencyCycleError(taskId: string, dependencies: string[], allTasks: TaskRecord[]): string | null`
+  - Test hooks: `data-testid="dep-chip"` on chips, `data-testid="dep-suggestion"` on suggestion buttons; search input `aria-label="Search tasks to add as a dependency"`; remove buttons `aria-label="Remove dependency {title}"`.
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+git checkout -b feat/edit-drawer-dependencies
+```
+
+- [ ] **Step 2: Write failing tests — rendering (AC1) + cycle-guard helper (AC7)**
+
+Create `tests/ui/edit-drawer-dependencies.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  DependenciesField,
+  findDependencyCycleError,
+} from "@/components/matrix-simplified/edit-drawer-dependencies";
+import type { TaskRecord } from "@/lib/types";
+
+function makeTask(overrides: Partial<TaskRecord> & { id: string }): TaskRecord {
+  return {
+    title: overrides.id,
+    description: "",
+    urgent: true,
+    important: true,
+    quadrant: "urgent-important",
+    completed: false,
+    tags: [],
+    subtasks: [],
+    dependencies: [],
+    recurrence: "none",
+    notificationEnabled: false,
+    notificationSent: false,
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  } as TaskRecord;
+}
+
+describe("<DependenciesField>", () => {
+  it("should_render_chip_with_task_title_for_each_resolvable_dependency", () => {
+    const tasks = [
+      makeTask({ id: "a", title: "Write spec" }),
+      makeTask({ id: "b", title: "Review spec" }),
+      makeTask({ id: "z", title: "Ship it" }),
+    ];
+    render(
+      <DependenciesField taskId="z" dependencies={["a", "b"]} allTasks={tasks} onChange={vi.fn()} />
+    );
+    expect(screen.getAllByTestId("dep-chip")).toHaveLength(2);
+    expect(screen.getByText("Write spec")).toBeInTheDocument();
+    expect(screen.getByText("Review spec")).toBeInTheDocument();
+  });
+
+  it("should_not_render_chip_for_ghost_dependency_id", () => {
+    render(
+      <DependenciesField
+        taskId="z"
+        dependencies={["ghost-1"]}
+        allTasks={[makeTask({ id: "z", title: "Ship it" })]}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.queryAllByTestId("dep-chip")).toHaveLength(0);
+    expect(screen.getByLabelText(/search tasks/i)).toBeInTheDocument();
+  });
+
+  it("should_render_chip_for_completed_dependency_so_it_can_be_removed", () => {
+    const tasks = [
+      makeTask({ id: "a", title: "Done thing", completed: true }),
+      makeTask({ id: "z", title: "Ship it" }),
+    ];
+    render(<DependenciesField taskId="z" dependencies={["a"]} allTasks={tasks} onChange={vi.fn()} />);
+    expect(screen.getByText("Done thing")).toBeInTheDocument();
+  });
+});
+
+describe("findDependencyCycleError", () => {
+  it("should_return_message_naming_the_blocking_task_when_cycle_found", () => {
+    // "Alpha" depends on "Beta"; making Beta depend on Alpha closes the loop.
+    const tasks = [
+      makeTask({ id: "a", title: "Alpha", dependencies: ["b"] }),
+      makeTask({ id: "b", title: "Beta" }),
+    ];
+    expect(findDependencyCycleError("b", ["a"], tasks)).toMatch(/Alpha/);
+  });
+
+  it("should_return_null_for_ghost_ids_and_acyclic_dependencies", () => {
+    const tasks = [makeTask({ id: "a", title: "Alpha" }), makeTask({ id: "b", title: "Beta" })];
+    expect(findDependencyCycleError("b", ["a", "ghost-1"], tasks)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3: Run tests — verify they fail for the right reason**
+
+Run: `bun run test -- tests/ui/edit-drawer-dependencies.test.tsx`
+Expected: FAIL — cannot resolve `@/components/matrix-simplified/edit-drawer-dependencies` (module doesn't exist yet).
+
+- [ ] **Step 4: Implement rendering + cycle helper (minimal green)**
+
+Create `components/matrix-simplified/edit-drawer-dependencies.tsx`:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { XIcon } from "lucide-react";
+import type { TaskRecord } from "@/lib/types";
+import { wouldCreateCircularDependency } from "@/lib/dependencies";
+import { SCHEMA_LIMITS } from "@/lib/constants/schema";
+import { Field } from "./edit-drawer-fields";
+
+const MAX_SUGGESTIONS = 8;
+
+/**
+ * Save-time cycle guard for the edit drawer. Unlike lib's validateDependencies,
+ * IDs that don't resolve locally are skipped rather than rejected — they may
+ * reference tasks that haven't synced to this device yet and must be preserved.
+ */
+export function findDependencyCycleError(
+  taskId: string,
+  dependencies: string[],
+  allTasks: TaskRecord[]
+): string | null {
+  const byId = new Map(allTasks.map((t) => [t.id, t]));
+  for (const depId of dependencies) {
+    const dep = byId.get(depId);
+    if (!dep) continue;
+    if (wouldCreateCircularDependency(taskId, depId, allTasks)) {
+      return `Circular dependency: "${dep.title}" already depends on this task.`;
+    }
+  }
+  return null;
+}
+
+interface DependenciesFieldProps {
+  /** Undefined in create mode — cycle filtering is skipped (nothing can depend on an unsaved task). */
+  taskId?: string;
+  dependencies: string[];
+  allTasks: TaskRecord[];
+  onChange: (ids: string[]) => void;
+  error?: string | null;
+}
+
+export function DependenciesField({
+  taskId,
+  dependencies,
+  allTasks,
+  onChange,
+  error,
+}: DependenciesFieldProps): React.ReactElement {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+
+  // Ghost IDs (no local record) render no chip but stay in `dependencies`.
+  const chips = dependencies
+    .map((id) => allTasks.find((t) => t.id === id))
+    .filter((t): t is TaskRecord => t !== undefined);
+  const atLimit = dependencies.length >= SCHEMA_LIMITS.MAX_DEPENDENCIES;
+
+  return (
+    <Field label="Depends on">
+      <div
+        className="relative"
+        onBlur={(e) => {
+          if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setOpen(false);
+        }}
+      >
+        <div className="flex flex-wrap items-center gap-1.5 rounded-lg border border-border bg-background p-2">
+          {chips.map((t) => (
+            <span
+              key={t.id}
+              data-testid="dep-chip"
+              className="inline-flex items-center gap-1 rounded bg-background-muted px-2 py-0.5 text-[11.5px] font-medium text-foreground-muted"
+            >
+              {t.title}
+              <button
+                type="button"
+                onClick={() => onChange(dependencies.filter((id) => id !== t.id))}
+                aria-label={`Remove dependency ${t.title}`}
+                className="hover:text-foreground"
+              >
+                <XIcon className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+          <input
+            value={query}
+            disabled={atLimit}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setOpen(true);
+            }}
+            onFocus={() => setOpen(true)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") e.preventDefault();
+            }}
+            placeholder={chips.length ? "" : "Search tasks this one depends on…"}
+            aria-label="Search tasks to add as a dependency"
+            className="min-w-[80px] flex-1 border-0 bg-transparent text-[13px] text-foreground outline-none disabled:cursor-not-allowed"
+          />
+        </div>
+        <Suggestions
+          open={open}
+          query={query}
+          taskId={taskId}
+          dependencies={dependencies}
+          allTasks={allTasks}
+          onPick={(id) => {
+            onChange([...dependencies, id]);
+            setQuery("");
+            setOpen(false);
+          }}
+        />
+      </div>
+      {atLimit ? (
+        <p className="text-[11.5px] text-foreground-muted">
+          Dependency limit reached ({SCHEMA_LIMITS.MAX_DEPENDENCIES}).
+        </p>
+      ) : null}
+      {error ? (
+        <p role="alert" className="text-xs text-red-400">
+          {error}
+        </p>
+      ) : null}
+    </Field>
+  );
+}
+
+function isCandidate(
+  candidate: TaskRecord,
+  taskId: string | undefined,
+  dependencies: string[],
+  allTasks: TaskRecord[]
+): boolean {
+  if (candidate.id === taskId) return false;
+  if (dependencies.includes(candidate.id)) return false;
+  if (candidate.completed) return false;
+  if (taskId && wouldCreateCircularDependency(taskId, candidate.id, allTasks)) return false;
+  return true;
+}
+
+function Suggestions({
+  open,
+  query,
+  taskId,
+  dependencies,
+  allTasks,
+  onPick,
+}: {
+  open: boolean;
+  query: string;
+  taskId?: string;
+  dependencies: string[];
+  allTasks: TaskRecord[];
+  onPick: (id: string) => void;
+}): React.ReactElement | null {
+  const trimmed = query.trim().toLowerCase();
+  if (!open || !trimmed) return null;
+
+  const matches = allTasks
+    .filter((t) => isCandidate(t, taskId, dependencies, allTasks))
+    .filter((t) => t.title.toLowerCase().includes(trimmed))
+    .slice(0, MAX_SUGGESTIONS);
+
+  return (
+    <div className="absolute z-10 mt-1 w-full overflow-hidden rounded-lg border border-border bg-card shadow-lg">
+      {matches.length > 0 ? (
+        matches.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            data-testid="dep-suggestion"
+            onClick={() => onPick(t.id)}
+            className="block w-full truncate px-3 py-2 text-left text-[13px] text-foreground hover:bg-background-muted"
+          >
+            {t.title}
+          </button>
+        ))
+      ) : (
+        <p className="px-3 py-2 text-[12.5px] text-foreground-muted">No matching tasks.</p>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run tests — verify green**
+
+Run: `bun run test -- tests/ui/edit-drawer-dependencies.test.tsx`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/matrix-simplified/edit-drawer-dependencies.tsx tests/ui/edit-drawer-dependencies.test.tsx
+git commit -m "feat(matrix): add DependenciesField chips + cycle guard helper"
+```
+
+- [ ] **Step 7: Write failing tests — search, add, exclusions (AC2, AC3)**
+
+Append to the `describe("<DependenciesField>")` block:
+
+```tsx
+  it("should_list_matching_candidates_when_typing_and_cap_at_eight", async () => {
+    const user = userEvent.setup();
+    const tasks = [
+      ...Array.from({ length: 12 }, (_, i) => makeTask({ id: `t${i}`, title: `Report ${i}` })),
+      makeTask({ id: "z", title: "Ship it" }),
+    ];
+    render(<DependenciesField taskId="z" dependencies={[]} allTasks={tasks} onChange={vi.fn()} />);
+    await user.type(screen.getByLabelText(/search tasks/i), "report");
+    expect(screen.getAllByTestId("dep-suggestion")).toHaveLength(8);
+  });
+
+  it("should_add_id_and_clear_query_when_suggestion_clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const tasks = [makeTask({ id: "a", title: "Draft report" }), makeTask({ id: "z", title: "Ship it" })];
+    render(<DependenciesField taskId="z" dependencies={[]} allTasks={tasks} onChange={onChange} />);
+    const input = screen.getByLabelText(/search tasks/i) as HTMLInputElement;
+    await user.type(input, "draft");
+    await user.click(screen.getByTestId("dep-suggestion"));
+    expect(onChange).toHaveBeenCalledWith(["a"]);
+    expect(input.value).toBe("");
+  });
+
+  it("should_exclude_self_selected_completed_and_circular_candidates", async () => {
+    const user = userEvent.setup();
+    const tasks = [
+      makeTask({ id: "self", title: "Self task" }),
+      makeTask({ id: "picked", title: "Picked task" }),
+      makeTask({ id: "done", title: "Done task", completed: true }),
+      makeTask({ id: "cyc", title: "Cycle task", dependencies: ["self"] }),
+      makeTask({ id: "ok", title: "Ok task" }),
+    ];
+    render(
+      <DependenciesField taskId="self" dependencies={["picked"]} allTasks={tasks} onChange={vi.fn()} />
+    );
+    await user.type(screen.getByLabelText(/search tasks/i), "task");
+    const suggestions = screen.getAllByTestId("dep-suggestion").map((b) => b.textContent);
+    expect(suggestions).toEqual(["Ok task"]);
+  });
+
+  it("should_exclude_transitively_circular_candidate", async () => {
+    const user = userEvent.setup();
+    // Alpha → Beta → Gamma; editing Gamma, adding Alpha would close the loop.
+    const tasks = [
+      makeTask({ id: "a", title: "Alpha", dependencies: ["b"] }),
+      makeTask({ id: "b", title: "Beta", dependencies: ["c"] }),
+      makeTask({ id: "c", title: "Gamma" }),
+    ];
+    render(<DependenciesField taskId="c" dependencies={[]} allTasks={tasks} onChange={vi.fn()} />);
+    await user.type(screen.getByLabelText(/search tasks/i), "alpha");
+    expect(screen.queryAllByTestId("dep-suggestion")).toHaveLength(0);
+    expect(screen.getByText(/no matching tasks/i)).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 8: Run tests**
+
+Run: `bun run test -- tests/ui/edit-drawer-dependencies.test.tsx`
+Expected: PASS — the Step 4 implementation already covers search/exclusions. If any of these four fail, fix the implementation (not the test) until green. Either way this step ends green; the red/green value here is confirming the exclusion matrix is actually exercised.
+
+- [ ] **Step 9: Write failing tests — remove/ghost-preserve, Enter guard, limit, empty states (AC4, AC5, AC6, AC8, AC9)**
+
+Append to the `describe("<DependenciesField>")` block:
+
+```tsx
+  it("should_remove_only_targeted_id_and_preserve_ghost_ids_on_remove", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const tasks = [makeTask({ id: "a", title: "Alpha" }), makeTask({ id: "z", title: "Ship it" })];
+    render(
+      <DependenciesField taskId="z" dependencies={["ghost-1", "a"]} allTasks={tasks} onChange={onChange} />
+    );
+    await user.click(screen.getByRole("button", { name: "Remove dependency Alpha" }));
+    expect(onChange).toHaveBeenCalledWith(["ghost-1"]);
+  });
+
+  it("should_not_submit_enclosing_form_when_enter_pressed_in_search", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn((e: React.FormEvent) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <DependenciesField
+          dependencies={[]}
+          allTasks={[makeTask({ id: "a", title: "Alpha" })]}
+          onChange={vi.fn()}
+        />
+      </form>
+    );
+    await user.type(screen.getByLabelText(/search tasks/i), "alp{Enter}");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("should_allow_adding_candidates_in_create_mode_without_task_id", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <DependenciesField
+        dependencies={[]}
+        allTasks={[makeTask({ id: "a", title: "Alpha" })]}
+        onChange={onChange}
+      />
+    );
+    await user.type(screen.getByLabelText(/search tasks/i), "alp");
+    await user.click(screen.getByTestId("dep-suggestion"));
+    expect(onChange).toHaveBeenCalledWith(["a"]);
+  });
+
+  it("should_disable_search_input_with_caption_at_max_dependencies", () => {
+    const deps = Array.from({ length: 50 }, (_, i) => `d${i}`);
+    render(<DependenciesField taskId="z" dependencies={deps} allTasks={[]} onChange={vi.fn()} />);
+    expect(screen.getByLabelText(/search tasks/i)).toBeDisabled();
+    expect(screen.getByText(/dependency limit/i)).toBeInTheDocument();
+  });
+
+  it("should_show_no_matching_tasks_message_when_query_has_no_candidates", async () => {
+    const user = userEvent.setup();
+    render(
+      <DependenciesField
+        taskId="z"
+        dependencies={[]}
+        allTasks={[makeTask({ id: "z", title: "Ship it" })]}
+        onChange={vi.fn()}
+      />
+    );
+    await user.type(screen.getByLabelText(/search tasks/i), "anything");
+    expect(screen.getByText(/no matching tasks/i)).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 10: Run full field test file — verify all green**
+
+Run: `bun run test -- tests/ui/edit-drawer-dependencies.test.tsx`
+Expected: PASS (11 tests). Fix implementation if any behavior gap surfaces.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add tests/ui/edit-drawer-dependencies.test.tsx components/matrix-simplified/edit-drawer-dependencies.tsx
+git commit -m "test(matrix): cover DependenciesField search, exclusions, limits"
+```
+
+---
+
+### Task 2: Wire the field into the edit drawer
+
+**Files:**
+- Modify: `components/matrix-simplified/edit-drawer.tsx` (EditDraft type ~line 13-20; props ~line 22-29; form body after `TagsField` ~line 158; `submit` ~line 67)
+- Modify: `components/matrix-simplified/use-edit-draft-state.ts` (interface ~line 29-50; hook body ~line 63-79; `toDraft` ~line 97-108)
+- Test: `tests/ui/edit-drawer.test.tsx` (append a new `describe` block)
+
+**Interfaces:**
+- Consumes: `DependenciesField`, `findDependencyCycleError` from `./edit-drawer-dependencies` (Task 1 signatures).
+- Produces (Task 3 relies on these):
+  - `EditDraft` gains `dependencies: string[]` (always present in `toDraft()` output).
+  - `EditDrawerProps` gains `allTasks?: TaskRecord[]` (defaults to `[]`; existing call sites and tests stay valid).
+  - `EditDraftState` gains `dependencies: string[]` and `setDependencies: (v: string[]) => void`.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/ui/edit-drawer.test.tsx` (inside the top-level `describe("<EditDrawer>")`, after the existing a11y block; `mockTask` with `id: "t1"` already exists at the top of the file):
+
+```tsx
+  describe("dependencies field", () => {
+    const otherTask: TaskRecord = { ...mockTask, id: "t2", title: "Other task", dependencies: [] };
+
+    it("should_include_added_dependency_id_in_submitted_draft", async () => {
+      const onSubmit = vi.fn();
+      render(
+        <EditDrawer open task={mockTask} allTasks={[mockTask, otherTask]} onClose={vi.fn()} onSubmit={onSubmit} />
+      );
+      await user.type(screen.getByLabelText(/search tasks/i), "other");
+      await user.click(screen.getByTestId("dep-suggestion"));
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ dependencies: ["t2"] }),
+        "t1"
+      );
+    });
+
+    it("should_exclude_removed_dependency_id_from_submitted_draft", async () => {
+      const onSubmit = vi.fn();
+      const taskWithDep: TaskRecord = { ...mockTask, dependencies: ["t2"] };
+      render(
+        <EditDrawer open task={taskWithDep} allTasks={[taskWithDep, otherTask]} onClose={vi.fn()} onSubmit={onSubmit} />
+      );
+      await user.click(screen.getByRole("button", { name: "Remove dependency Other task" }));
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ dependencies: [] }),
+        "t1"
+      );
+    });
+
+    it("should_block_submit_and_show_inline_error_when_dependencies_would_cycle_at_save", async () => {
+      // Simulates a cycle that arrived via realtime sync after the drawer opened:
+      // t1 → t2 (this draft) while t2 → t1 (already in the store).
+      const onSubmit = vi.fn();
+      const blocker: TaskRecord = { ...otherTask, dependencies: ["t1"] };
+      const taskWithCycle: TaskRecord = { ...mockTask, dependencies: ["t2"] };
+      render(
+        <EditDrawer open task={taskWithCycle} allTasks={[taskWithCycle, blocker]} onClose={vi.fn()} onSubmit={onSubmit} />
+      );
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(screen.getByRole("alert")).toHaveTextContent(/circular dependency/i);
+    });
+
+    it("should_submit_dependencies_without_task_id_in_create_mode", async () => {
+      const onSubmit = vi.fn();
+      render(<EditDrawer open task={null} allTasks={[otherTask]} onClose={vi.fn()} onSubmit={onSubmit} />);
+      await user.type(screen.getByLabelText(/title/i), "Brand new task");
+      await user.type(screen.getByLabelText(/search tasks/i), "other");
+      await user.click(screen.getByTestId("dep-suggestion"));
+      await user.click(screen.getByRole("button", { name: /create task/i }));
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ dependencies: ["t2"] }),
+        undefined
+      );
+    });
+
+    it("should_render_without_all_tasks_prop_and_keep_existing_fields_working", () => {
+      render(<EditDrawer open task={mockTask} onClose={vi.fn()} onSubmit={vi.fn()} />);
+      expect(screen.getByLabelText(/search tasks/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests — verify they fail for the right reason**
+
+Run: `bun run test -- tests/ui/edit-drawer.test.tsx`
+Expected: the 5 new tests FAIL (no `allTasks` prop, no dependencies field rendered — `getByLabelText(/search tasks/i)` throws). The pre-existing tests must still PASS.
+
+- [ ] **Step 3: Extend `useEditDraftState`**
+
+In `components/matrix-simplified/use-edit-draft-state.ts`:
+
+Add to the `EditDraftState` interface (after `tags`/`setTags`):
+
+```ts
+  dependencies: string[];
+  setDependencies: (v: string[]) => void;
+```
+
+Add state in the hook body (after the `tags` useState):
+
+```ts
+  const [dependencies, setDependencies] = useState<string[]>(() =>
+    task ? task.dependencies ?? [] : initialDraft?.dependencies ?? []
+  );
+```
+
+Add `dependencies,` to the object returned by `toDraft()` and `dependencies, setDependencies,` to the hook's return object.
+
+- [ ] **Step 4: Extend the drawer**
+
+In `components/matrix-simplified/edit-drawer.tsx`:
+
+1. Add `dependencies: string[];` to the `EditDraft` interface.
+2. Add to `EditDrawerProps`:
+
+```ts
+  /** Full live task list — candidate pool for the dependency picker. */
+  allTasks?: TaskRecord[];
+```
+
+3. Thread `allTasks` through `EditDrawer` → `EditDrawerForm` (add to both destructures and the JSX pass-through, defaulting at the form: `allTasks = []`).
+4. Import `useState` (extend the existing react import) and the new module:
+
+```ts
+import { DependenciesField, findDependencyCycleError } from "./edit-drawer-dependencies";
+```
+
+5. In `EditDrawerForm`, add error state and a change handler that clears it:
+
+```tsx
+  const [dependencyError, setDependencyError] = useState<string | null>(null);
+
+  const handleDependenciesChange = (ids: string[]): void => {
+    setDependencyError(null);
+    draft.setDependencies(ids);
+  };
+```
+
+6. Replace the `submit` function with:
+
+```tsx
+  const submit = (e?: FormEvent): void => {
+    e?.preventDefault();
+    if (!draft.title.trim()) return;
+    const cycleError = task
+      ? findDependencyCycleError(task.id, draft.dependencies, allTasks)
+      : null;
+    if (cycleError) {
+      setDependencyError(cycleError);
+      return;
+    }
+    void onSubmit(draft.toDraft(), task?.id);
+  };
+```
+
+7. Render the field after `<TagsField … />`:
+
+```tsx
+          <DependenciesField
+            taskId={task?.id}
+            dependencies={draft.dependencies}
+            allTasks={allTasks}
+            onChange={handleDependenciesChange}
+            error={dependencyError}
+          />
+```
+
+- [ ] **Step 5: Run tests — verify green (new AND pre-existing)**
+
+Run: `bun run test -- tests/ui/edit-drawer.test.tsx tests/ui/edit-drawer-dependencies.test.tsx`
+Expected: PASS, zero regressions in the existing drawer tests.
+
+- [ ] **Step 6: Check file sizes stay under the cap**
+
+Run: `wc -l components/matrix-simplified/edit-drawer.tsx components/matrix-simplified/use-edit-draft-state.ts components/matrix-simplified/edit-drawer-dependencies.tsx`
+Expected: every file ≤350 lines (drawer lands ~215, hook ~135, field ~190). If any exceeds, split before committing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add components/matrix-simplified/edit-drawer.tsx components/matrix-simplified/use-edit-draft-state.ts tests/ui/edit-drawer.test.tsx
+git commit -m "feat(matrix): wire Depends on field into v9 edit drawer"
+```
+
+---
+
+### Task 3: Shell wiring — pass task list, forward dependencies on create
+
+**Files:**
+- Modify: `components/matrix-simplified/index.tsx` (`handleEditSubmit` ~line 218-240; both `<EditDrawer …>` instances ~lines 304-315)
+- Test: `tests/ui/matrix-simplified.test.tsx` (append one test inside `describe("<MatrixSimplified>")`)
+
+**Interfaces:**
+- Consumes: `EditDrawer` `allTasks` prop and `EditDraft.dependencies` (Task 2); `all` from the existing `const { all } = useTasks()` at `index.tsx:132`; mocked `createTask` from the test file's existing `vi.mock("@/lib/tasks", …)`.
+- Produces: create path forwards `dependencies: draft.dependencies.length > 0 ? draft.dependencies : undefined` to `createTask` (mirrors the existing `tags` handling). Edit path needs no change — `updateTask(taskId, draft)` already passes the whole draft and `lib/tasks/crud/update.ts:82` merges `dependencies`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/ui/matrix-simplified.test.tsx` (model: the existing "opens the create drawer when the shell new-task event fires" test at ~line 201; `tasksFixture`, `makeTask`, and the `@/lib/tasks` mock already exist in this file):
+
+```tsx
+  it("passes drawer-selected dependencies to createTask on the create path", async () => {
+    const user = userEvent.setup();
+    tasksFixture.current = [makeTask({ id: "dep-1", title: "Prepare deck" })];
+    render(<MatrixSimplified />);
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("gsd:new-task"));
+    });
+    await screen.findByRole("heading", { name: /new task/i });
+
+    await user.type(screen.getByLabelText(/title/i), "Present deck");
+    await user.type(screen.getByLabelText(/search tasks/i), "prepare");
+    await user.click(screen.getByTestId("dep-suggestion"));
+    await user.click(screen.getByRole("button", { name: /create task/i }));
+
+    await waitFor(() =>
+      expect(createTask).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Present deck", dependencies: ["dep-1"] })
+      )
+    );
+  });
+```
+
+- [ ] **Step 2: Run test — verify it fails for the right reason**
+
+Run: `bun run test -- tests/ui/matrix-simplified.test.tsx`
+Expected: the new test FAILS at `getByLabelText(/search tasks/i)`-then-suggestion or on the `createTask` payload (no `dependencies` key), because the shell doesn't pass `allTasks` yet. Pre-existing tests still PASS.
+
+- [ ] **Step 3: Implement the wiring**
+
+In `components/matrix-simplified/index.tsx`:
+
+1. Add `allTasks={all}` to **both** `<EditDrawer …>` instances (create-mode and edit-mode, ~lines 304-315). `all` is already in scope from line 132.
+2. In `handleEditSubmit`'s create branch, add one line to the `createTask({...})` argument, after `tags`:
+
+```ts
+          dependencies: draft.dependencies.length > 0 ? draft.dependencies : undefined,
+```
+
+- [ ] **Step 4: Run test — verify green**
+
+Run: `bun run test -- tests/ui/matrix-simplified.test.tsx`
+Expected: PASS, zero regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/matrix-simplified/index.tsx tests/ui/matrix-simplified.test.tsx
+git commit -m "feat(matrix): pass live task list and create-path dependencies through shell"
+```
+
+---
+
+### Task 4: Full verification, live-app check, docs, release prep
+
+**Files:**
+- Modify: `docs/adr/0011-v9-single-matrix-refactor.md` (append addendum)
+- Modify: `package.json` (version bump)
+- Modify: `tasks/todo.md` (Resuming From Here)
+
+- [ ] **Step 1: Full test suite + coverage**
+
+Run: `bun run test -- --coverage`
+Expected: all tests pass; changed files (`edit-drawer-dependencies.tsx`, `edit-drawer.tsx`, `use-edit-draft-state.ts`, `index.tsx`) each ≥80% statements/lines/functions. Add targeted tests if any changed file falls short.
+
+- [ ] **Step 2: Typecheck + lint**
+
+Run: `bun typecheck && bun lint`
+Expected: zero errors (lint may show the pre-existing ~21 warnings on untouched files; no NEW warnings in touched files).
+
+- [ ] **Step 3: Verify in the running app**
+
+Invoke the **`/verify-frontend-change`** skill (mandatory for edited `components/**` files — the service worker serves stale chunks and data surfaces render empty on fresh load, so a naive screenshot lies). Verify at minimum:
+1. Seed ≥3 tasks; open one; "Depends on" field renders below Tags.
+2. Search, add a dependency, save; reopen → chip persists; the depending task's card shows the "Blocked by 1" badge.
+3. Remove the chip, save; badge clears.
+4. Create mode (n key → drawer via "More options"): add a dependency during creation; verify persisted.
+Let the skill decide whether to codify a Playwright spec for the add→save→badge flow (recommended).
+
+- [ ] **Step 4: a11y + sync review agents**
+
+Dispatch the repo's read-only reviewers on the diff: `a11y-reviewer` (new interactive field) and `pb-sync-reviewer` (ghost-ID preservation touches sync-adjacent write paths). Address any blocking findings before proceeding.
+
+- [ ] **Step 5: ADR addendum**
+
+Append to `docs/adr/0011-v9-single-matrix-refactor.md`:
+
+```markdown
+## Addendum (2026-07-05): dependency editing restored
+
+The v8 removal (PR #238) dropped `task-form-dependencies.tsx` with the rest of
+the modular task form, leaving the dependency system write-only via MCP/import
+while cards still displayed Blocked by/Blocking badges. A "Depends on" field
+was restored inside the v9 edit drawer (`edit-drawer-dependencies.tsx`),
+reusing `lib/dependencies.ts` cycle detection. Subtask editing remains
+drawer-less; `restoreTask` still does not restore inbound dependency edges
+(tracked in tasks/todo.md).
+```
+
+- [ ] **Step 6: Version bump**
+
+In `package.json`, bump the minor version (feature): current `9.x.y` → `9.(x+1).0`.
+
+- [ ] **Step 7: Update tasks/todo.md**
+
+Append a "Resuming From Here" entry: feature complete, spec/plan references, deferred follow-ups (subtask editing restoration; `restoreTask` inbound-edge fix).
+
+- [ ] **Step 8: Commit, push, PR**
+
+Invoke the **`commit-commands:commit-push-pr`** skill for the final commit + push + PR (repo convention). PR body: what changed (restored dependency-linking UI in v9 drawer), why (feature lost in #238; data layer was intact), how to test (steps from Step 3), out-of-scope follow-ups, and the spec/plan file paths.
+
+- [ ] **Step 9: Comprehension gate (Non-trivial tier)**
+
+Generate the change report + 5–10 question quiz per coding-standards Part 1 Phase 3 before merge.
+
+---
+
+## Self-Review (completed at authoring time)
+
+- **Spec coverage:** AC1→T1S2, AC2→T1S7+T2S1, AC3→T1S7, AC4→T1S9+T2S1, AC5→T1S9, AC6→T1S9+T2S1+T3S1, AC7→T1S2+T2S1, AC8→T1S9, AC9→T1S9+T2S1. Edge cases 1–9 covered by the same tests; edge case 10 (no migration) is a non-action.
+- **Placeholder scan:** none — all steps carry full code/commands.
+- **Type consistency:** `DependenciesField` prop names (`taskId`, `dependencies`, `allTasks`, `onChange`, `error`) and `findDependencyCycleError(taskId, dependencies, allTasks)` are identical across Tasks 1, 2; `EditDraft.dependencies: string[]` and `allTasks?: TaskRecord[]` identical across Tasks 2, 3.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "10.1.2",
+	"version": "10.2.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -69,3 +69,14 @@ UI padding files (different from data files — these were the *sole* tests for 
 - Pinned `canvas-confetti` from `^1.9.4` to exact `1.9.4`.
 - Migrated `.parse()` to `.safeParse()` in user-input paths (import, create).
 - Refactored `clearIndexedDB()` and `checkAndNotify()` for function length compliance.
+
+## 2026-07-05 — Edit-drawer autofocus is a test trap (unit AND e2e)
+
+`EditDrawerForm` moves focus to the title input ~100ms after mount
+(`UI_TIMING.FOCUS_DELAY_MS`). Any test (jsdom or Playwright) that interacts
+with a *later* drawer field immediately after opening loses focus mid-action —
+which also closes the dependency-suggestion popup via its container onBlur.
+Fix pattern: wait for the title to be focused before touching other fields
+(unit: `waitFor(() => expect(title).toHaveFocus())`; e2e:
+`locator("[data-testid='edit-title']:focus").waitFor()` — now baked into
+`MatrixPage.openEditDrawer`). Same root cause bit both layers in one session.

--- a/tasks/spec.md
+++ b/tasks/spec.md
@@ -76,3 +76,190 @@ a coverage-instrumentation gap, not missing tests:
 
 Measured new-code coverage after the fix: ~87% (conservative estimate ~86.7% with
 no-lcov residuals counted as uncovered), clearing the 80% gate.
+
+---
+
+# Spec: Restore dependency-linking ("Depends on") UI in the v9 edit drawer
+
+**Date:** 2026-07-05 · **Status:** Awaiting approval · **Tier:** Non-trivial (new UI surface, multi-file, behavioral)
+
+## Goal
+
+Restore the ability to link tasks together in the web app — removed with the v8 task
+form in PR #238 — by adding a "Depends on" field to the v9 edit drawer, so users can
+declare which tasks must finish first and the existing "Blocked by / Blocking" card
+badges and "Ready to work" smart view become reachable again without Claude Desktop
+or JSON import.
+
+## Inputs / Outputs
+
+**Data model (unchanged — no schema or migration work):**
+- `TaskRecord.dependencies: string[]` (`lib/types.ts:36`) — IDs of tasks that must
+  complete first. Validated by `taskDraftSchema` (`lib/schema.ts:40`): array of
+  nanoid strings, max `SCHEMA_LIMITS.MAX_DEPENDENCIES` (50), default `[]`.
+- Persistence already flows: `updateTask` merges `updates.dependencies`
+  (`lib/tasks/crud/update.ts:82`); `createTask` defaults to `[]`
+  (`lib/tasks/crud/create.ts:84`); both enqueue sync ops. PocketBase `task-mapper`
+  already round-trips the field.
+
+**UI contract changes:**
+- `EditDraft` (components/matrix-simplified/edit-drawer.tsx) gains
+  `dependencies: string[]`.
+- `EditDrawer` gains prop `allTasks?: TaskRecord[]` (default `[]`) — candidate pool
+  for the picker. `components/matrix-simplified/index.tsx` already holds this via
+  `const { all } = useTasks()` (line 132) and passes it to both drawer instances.
+  Prop injection (not `useTasks()` inside the field) keeps the component pure and
+  unit-testable without Dexie.
+- New file `components/matrix-simplified/edit-drawer-dependencies.tsx` exporting
+  `DependenciesField` — controlled component:
+  `{ taskId?: string; dependencies: string[]; allTasks: TaskRecord[]; onChange: (ids: string[]) => void }`.
+- `useEditDraftState` gains `dependencies` / `setDependencies`, seeded from
+  `task.dependencies ?? []` (edit) or `initialDraft?.dependencies ?? []` (create),
+  emitted by `toDraft()`.
+- Create path: `handleEditSubmit` in `index.tsx` passes
+  `dependencies: draft.dependencies.length > 0 ? draft.dependencies : undefined`
+  to `createTask` (mirrors existing `tags` handling).
+
+**Behavior (reuses `lib/dependencies.ts` — no new graph logic):**
+- Field label "Depends on" using the existing `Field` primitive; selected
+  dependencies render as chips (task title + labeled remove button), matching the
+  tags-field chip idiom.
+- Search input filters candidates by case-insensitive title substring; shows at
+  most 8 suggestions; selecting one appends its ID and clears the query.
+- Candidates exclude: the task being edited, already-selected IDs, completed
+  tasks, and (edit mode) any task failing `wouldCreateCircularDependency`.
+- Submit guard: on save (edit mode), run a cycle-only check against the live task
+  list (`findDependencyCycleError`, wrapping `wouldCreateCircularDependency`); if a
+  cycle is found (e.g. realtime sync changed the graph after selection), block
+  submit and show an inline error instead of calling `onSubmit`. The guard must
+  NOT reuse lib's `validateDependencies` wholesale: its "all tasks must exist"
+  clause would reject ghost IDs that edge case 4 requires preserving.
+
+## Constraints
+
+- **Local-first / privacy:** all reads from the in-memory `allTasks` prop (live
+  Dexie data); no network calls; no task content in logs.
+- **Sync compatibility:** field-level only — the record-level `updateTask` +
+  `enqueueSyncOperation` path is untouched, so PocketBase sync behavior is
+  unchanged. Never silently drop dependency IDs that don't resolve locally
+  (they may reference tasks not yet synced to this device).
+- **File/function limits:** new field component in its own file (edit-drawer-fields.tsx
+  is at 225 lines; adding ~150 would crowd the 350 cap). All files stay ≤350 lines,
+  functions ≤30 lines, nesting ≤3.
+- **Bundle:** zero new dependencies; icons from `lucide-react` already in use.
+- **Design (PRODUCT.md / Inkwell):** calm and low-noise — same `Field` label
+  treatment, chip styling consistent with tags, no new colors; circular-dependency
+  message uses existing muted/error text idiom, not an alert box.
+- **React Compiler is ON:** no manual memoization; follow existing drawer patterns
+  (lazy `useState` seeding, remount-by-key).
+- **A11y (WCAG-AA):** search input labeled; suggestions are real buttons (tabbable,
+  Enter-activatable); remove buttons labeled "Remove dependency {title}"; Enter in
+  the search input must NOT submit the surrounding form.
+- **TDD:** red/green/refactor per AC; coverage for changed files ≥80%.
+
+## Edge Cases
+
+1. **No other tasks exist** (or all filtered out): typing shows a "No matching
+   tasks" empty state, not a broken dropdown.
+2. **Create mode:** no `taskId`, so no cycle risk — cycle filtering and submit
+   guard are skipped; picker otherwise fully functional.
+3. **Circular graphs:** direct (A→B, B→A) and transitive (A→B→C, C→A) cycles are
+   excluded from candidates; a cycle that appears between selection and save (e.g.
+   via realtime sync) is caught by the submit guard.
+4. **Ghost dependencies:** IDs referencing tasks absent locally (deleted, or not
+   yet synced from another device) render no chip but survive the edit round-trip
+   unchanged — removing chip X must not drop ghost ID Y.
+5. **Dependency on a completed task:** allowed to remain (it no longer blocks);
+   completed tasks just can't be newly added. Chips for completed dependencies
+   still render (with their title) so they can be removed.
+6. **50-dependency limit:** at `MAX_DEPENDENCIES`, the search input is disabled
+   with a short caption; schema validation can then never reject on count.
+7. **Offline:** identical behavior — everything is IndexedDB-local; sync queue
+   picks up the change when connectivity returns (existing behavior).
+8. **Concurrent multi-device edits:** last-writer-wins at the record level (existing
+   sync semantics); a cycle formed by merging two devices' edits is tolerated by
+   display logic (BFS visited-set in `wouldCreateCircularDependency` prevents
+   infinite loops) and can be broken by removing a chip.
+9. **Escape key:** existing drawer behavior (Escape closes the drawer) is
+   unchanged; suggestion list closes on blur/selection.
+10. **Schema migration:** none — `dependencies` has existed since the field was
+    introduced; Dexie stays at v14.
+
+## Out of Scope
+
+- Restoring **subtask editing** in the v9 drawer (also lost in #238) — separate task.
+- Fixing `restoreTask` not re-creating inbound dependency edges after delete/undo
+  (known deferred item in tasks/todo.md) — separate task.
+- Editing the **reverse** direction ("Blocking") from the drawer; card badges
+  already display it.
+- Dependency syntax in the capture bar (e.g. "after:task").
+- MCP server, schema, Dexie, or PocketBase changes of any kind.
+- Command-palette integration (palette is not wired into v9).
+- Redesign of the "Blocked by / Blocking" card badges.
+
+## Acceptance Criteria
+
+- **AC1** — Edit drawer for a task with dependencies shows a "Depends on" field
+  with one chip per resolvable dependency, labeled with that task's title.
+- **AC2** — Typing in the search input lists matching candidates (≤8,
+  case-insensitive title match); clicking a suggestion adds a chip, clears the
+  query, and the submitted draft includes the new ID.
+- **AC3** — Suggestions never include: the task being edited, already-selected
+  dependencies, completed tasks, or tasks that would create a circular dependency
+  (direct or transitive).
+- **AC4** — Each chip has a remove button with accessible name
+  "Remove dependency {title}"; after removal the submitted draft excludes that ID
+  while keeping all others (including unresolvable ghost IDs).
+- **AC5** — Pressing Enter in the dependency search input does not submit the form
+  and does not close the drawer.
+- **AC6** — In create mode the field works without a `taskId`, and
+  `handleEditSubmit` passes the selected IDs to `createTask` (`undefined` when
+  empty, mirroring tags).
+- **AC7** — If the draft's dependencies would create a cycle at submit time (edit
+  mode), `onSubmit` is not called and an inline error message is shown; ghost IDs
+  never trigger the guard.
+- **AC8** — With 50 dependencies selected, the search input is disabled and a
+  caption explains the limit.
+- **AC9** — A task list where no candidates match shows a "No matching tasks"
+  message; when `allTasks` is empty/absent the field still renders (empty state,
+  no crash) — existing `EditDrawer` tests stay green without passing the new prop.
+
+## Test Stubs
+
+`tests/ui/edit-drawer-dependencies.test.tsx` (new — field component, prop-driven, no Dexie):
+
+```ts
+describe("<DependenciesField>", () => {
+  it("should_render_chip_with_task_title_for_each_resolvable_dependency", () => {});      // AC1
+  it("should_not_render_chip_for_ghost_dependency_id", () => {});                          // AC1, AC4
+  it("should_list_matching_candidates_when_typing_and_cap_at_eight", () => {});            // AC2
+  it("should_add_chip_and_clear_query_when_suggestion_clicked", () => {});                 // AC2
+  it("should_exclude_self_selected_completed_and_circular_candidates", () => {});          // AC3
+  it("should_exclude_transitively_circular_candidate", () => {});                          // AC3
+  it("should_remove_only_targeted_id_and_preserve_ghost_ids_on_remove", () => {});         // AC4
+  it("should_not_submit_enclosing_form_when_enter_pressed_in_search", () => {});           // AC5
+  it("should_allow_adding_candidates_in_create_mode_without_task_id", () => {});           // AC6
+  it("should_disable_search_input_with_caption_at_max_dependencies", () => {});            // AC8
+  it("should_show_no_matching_tasks_message_when_query_has_no_candidates", () => {});      // AC9
+});
+```
+
+`tests/ui/edit-drawer.test.tsx` (additions — drawer integration):
+
+```ts
+describe("<EditDrawer> dependencies", () => {
+  it("should_include_added_dependency_id_in_submitted_draft", () => {});                   // AC2
+  it("should_exclude_removed_dependency_id_from_submitted_draft", () => {});               // AC4
+  it("should_block_submit_and_show_inline_error_when_dependencies_invalid_at_save", () => {}); // AC7
+  it("should_submit_dependencies_without_task_id_in_create_mode", () => {});               // AC6
+  it("should_render_without_all_tasks_prop_and_keep_existing_fields_working", () => {});   // AC9
+});
+```
+
+`tests/ui/matrix-simplified-shell.test.tsx` or existing shell test home (addition — create wiring):
+
+```ts
+describe("handleEditSubmit create path", () => {
+  it("should_pass_dependencies_to_create_task_when_present_and_undefined_when_empty", () => {}); // AC6
+});
+```

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -528,3 +528,25 @@ None currently.
 - [ ] Pre-existing `findPBRecordId` in `helpers.ts` has the same silent-error-swallowing flaw fixed in PR5 for `fetchSinglePBTaskFresh`. Apply the same `status === 404` discrimination there.
 - [ ] Add lessons.md entry: MCP write-path test fixtures didn't catch the original stale-spread bug because mocks never went stale between calls. Future tests should exercise the read→write timeline, not just data shapes.
 
+
+---
+
+## 2026-07-05 — Depends on field restored in v9 edit drawer (v10.2.0)
+
+Spec: tasks/spec.md § 2026-07-05 · Plan: docs/superpowers/plans/2026-07-05-edit-drawer-dependencies.md
+Branch: feat/edit-drawer-dependencies
+
+- [x] DependenciesField component (chips, search ≤8 suggestions, self/selected/completed/cycle exclusions, 50-cap, ghost-ID preservation)
+- [x] Drawer wiring (EditDraft.dependencies, allTasks prop, save-time cycle guard + inline error)
+- [x] Shell wiring (allTasks to both drawers, create-path dependencies passthrough)
+- [x] a11y hardening per a11y-reviewer (focus return after pick, Escape closes popup before drawer, text-rust contrast, aria-describedby/invalid)
+- [x] pb-sync-reviewer: 0 blocking (ghost round-trip + cycle guard verified; diff UI-only for sync)
+- [x] Live-verified in Chrome (SW-busted, seeded): link → Blocked by 1/Blocking 1 badges → IndexedDB round-trip → unlink; create-mode linking; console clean
+- [x] e2e: tests/e2e/task-dependencies.spec.ts (chromium green; openEditDrawer now waits for title autofocus to settle)
+
+**Resuming From Here / deferred follow-ups:**
+- Full WAI-ARIA combobox semantics for the dependency picker (role/aria-expanded/aria-activedescendant + arrow keys) — a11y-reviewer finding #1; partial roles are worse than the current labeled tabbable buttons.
+- Systemic danger-color token: text-red-400-on-white fails AA in sync-button.tsx:148 and sync-auth-dialog-sections.tsx:212 too — a shared token fix covers all.
+- restoreTask does not re-create inbound dependency edges after delete/undo (pre-existing, noted above).
+- Subtask editing still drawer-less (also lost in #238).
+- Pre-existing on main: scripts/build-openwiki-site.cjs has 2 ESLint errors (no-require-imports) from the OpenWiki commit 907360d — repo-wide `bun lint` exits 1 through no fault of this branch.

--- a/tests/e2e/pages/matrix-page.ts
+++ b/tests/e2e/pages/matrix-page.ts
@@ -85,6 +85,12 @@ export class MatrixPage {
     await taskCard.hover();
     await taskCard.locator("[data-testid='edit-task']").first().click();
     await this.page.locator("[data-testid='edit-drawer']").waitFor({ state: "visible" });
+    // The drawer autofocuses the title ~100ms after mount. Interacting with a
+    // later field before that fires loses focus mid-action (it also dismisses
+    // the dependency-suggestion popup), so wait for the autofocus to land.
+    await this.page
+      .locator("[data-testid='edit-title']:focus")
+      .waitFor({ state: "visible" });
   }
 
   /**
@@ -108,6 +114,35 @@ export class MatrixPage {
     }
     await drawer.locator("[data-testid='save-task']").click();
     await drawer.waitFor({ state: "hidden" });
+  }
+
+  /**
+   * In the open edit drawer, searches the "Depends on" field and picks the
+   * suggestion whose title matches. Requires the drawer to be open.
+   */
+  async addDependencyInDrawer(query: string, suggestionTitle: string): Promise<void> {
+    const drawer = this.page.locator("[data-testid='edit-drawer']");
+    await drawer.locator("[data-testid='dep-search']").fill(query);
+    await drawer
+      .locator("[data-testid='dep-suggestion']")
+      .filter({ hasText: suggestionTitle })
+      .click();
+    await drawer
+      .locator("[data-testid='dep-chip']")
+      .filter({ hasText: suggestionTitle })
+      .waitFor({ state: "visible" });
+  }
+
+  /**
+   * In the open edit drawer, removes the dependency chip for the given title.
+   */
+  async removeDependencyInDrawer(title: string): Promise<void> {
+    const drawer = this.page.locator("[data-testid='edit-drawer']");
+    await drawer.locator(`button[aria-label='Remove dependency ${title}']`).click();
+    await drawer
+      .locator("[data-testid='dep-chip']")
+      .filter({ hasText: title })
+      .waitFor({ state: "hidden" });
   }
 
   async search(query: string): Promise<void> {

--- a/tests/e2e/task-dependencies.spec.ts
+++ b/tests/e2e/task-dependencies.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "./fixtures/test-fixtures";
+import { MatrixPage } from "./pages/matrix-page";
+import { waitForAppLoad } from "./helpers/test-helpers";
+
+// Dependency linking lived in the v8 task form and was silently lost in the v9
+// refactor (#238). This spec defends the restored drawer flow end-to-end:
+// link → badges → unlink.
+test.describe("Task dependencies (Depends on field)", () => {
+  let matrixPage: MatrixPage;
+
+  test.beforeEach(async ({ page, clearIndexedDB }) => {
+    matrixPage = new MatrixPage(page);
+    await matrixPage.goto();
+    await waitForAppLoad(page);
+  });
+
+  test("should link tasks in the edit drawer and surface blocked/blocking badges", async ({
+    page,
+  }) => {
+    await matrixPage.createTask("Write report !!");
+    await matrixPage.createTask("Gather data *");
+
+    await matrixPage.openEditDrawer("Write report");
+    await matrixPage.addDependencyInDrawer("gather", "Gather data");
+    await matrixPage.saveEditDrawer({});
+
+    const blockedCard = page
+      .locator("[data-testid='task-card']")
+      .filter({ hasText: "Write report" });
+    const blockingCard = page
+      .locator("[data-testid='task-card']")
+      .filter({ hasText: "Gather data" });
+    await expect(blockedCard.getByText(/blocked by 1/i)).toBeVisible();
+    await expect(blockingCard.getByText(/blocking 1/i)).toBeVisible();
+
+    // Unlink: chip is re-hydrated from the persisted record, then removed.
+    await matrixPage.openEditDrawer("Write report");
+    await matrixPage.removeDependencyInDrawer("Gather data");
+    await matrixPage.saveEditDrawer({});
+
+    await expect(blockedCard.getByText(/blocked by 1/i)).toBeHidden();
+    await expect(blockingCard.getByText(/blocking 1/i)).toBeHidden();
+  });
+});

--- a/tests/ui/edit-drawer-dependencies.test.tsx
+++ b/tests/ui/edit-drawer-dependencies.test.tsx
@@ -63,6 +63,123 @@ describe("<DependenciesField>", () => {
     render(<DependenciesField taskId="z" dependencies={["a"]} allTasks={tasks} onChange={vi.fn()} />);
     expect(screen.getByText("Done thing")).toBeInTheDocument();
   });
+
+  it("should_list_matching_candidates_when_typing_and_cap_at_eight", async () => {
+    const user = userEvent.setup();
+    const tasks = [
+      ...Array.from({ length: 12 }, (_, i) => makeTask({ id: `t${i}`, title: `Report ${i}` })),
+      makeTask({ id: "z", title: "Ship it" }),
+    ];
+    render(<DependenciesField taskId="z" dependencies={[]} allTasks={tasks} onChange={vi.fn()} />);
+    await user.type(screen.getByLabelText(/search tasks/i), "report");
+    expect(screen.getAllByTestId("dep-suggestion")).toHaveLength(8);
+  });
+
+  it("should_add_id_and_clear_query_when_suggestion_clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const tasks = [makeTask({ id: "a", title: "Draft report" }), makeTask({ id: "z", title: "Ship it" })];
+    render(<DependenciesField taskId="z" dependencies={[]} allTasks={tasks} onChange={onChange} />);
+    const input = screen.getByLabelText(/search tasks/i) as HTMLInputElement;
+    await user.type(input, "draft");
+    await user.click(screen.getByTestId("dep-suggestion"));
+    expect(onChange).toHaveBeenCalledWith(["a"]);
+    expect(input.value).toBe("");
+  });
+
+  it("should_exclude_self_selected_completed_and_circular_candidates", async () => {
+    const user = userEvent.setup();
+    const tasks = [
+      makeTask({ id: "self", title: "Self task" }),
+      makeTask({ id: "picked", title: "Picked task" }),
+      makeTask({ id: "done", title: "Done task", completed: true }),
+      makeTask({ id: "cyc", title: "Cycle task", dependencies: ["self"] }),
+      makeTask({ id: "ok", title: "Ok task" }),
+    ];
+    render(
+      <DependenciesField taskId="self" dependencies={["picked"]} allTasks={tasks} onChange={vi.fn()} />
+    );
+    await user.type(screen.getByLabelText(/search tasks/i), "task");
+    const suggestions = screen.getAllByTestId("dep-suggestion").map((b) => b.textContent);
+    expect(suggestions).toEqual(["Ok task"]);
+  });
+
+  it("should_exclude_transitively_circular_candidate", async () => {
+    const user = userEvent.setup();
+    // Alpha → Beta → Gamma; editing Gamma, adding Alpha would close the loop.
+    const tasks = [
+      makeTask({ id: "a", title: "Alpha", dependencies: ["b"] }),
+      makeTask({ id: "b", title: "Beta", dependencies: ["c"] }),
+      makeTask({ id: "c", title: "Gamma" }),
+    ];
+    render(<DependenciesField taskId="c" dependencies={[]} allTasks={tasks} onChange={vi.fn()} />);
+    await user.type(screen.getByLabelText(/search tasks/i), "alpha");
+    expect(screen.queryAllByTestId("dep-suggestion")).toHaveLength(0);
+    expect(screen.getByText(/no matching tasks/i)).toBeInTheDocument();
+  });
+
+  it("should_remove_only_targeted_id_and_preserve_ghost_ids_on_remove", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const tasks = [makeTask({ id: "a", title: "Alpha" }), makeTask({ id: "z", title: "Ship it" })];
+    render(
+      <DependenciesField taskId="z" dependencies={["ghost-1", "a"]} allTasks={tasks} onChange={onChange} />
+    );
+    await user.click(screen.getByRole("button", { name: "Remove dependency Alpha" }));
+    expect(onChange).toHaveBeenCalledWith(["ghost-1"]);
+  });
+
+  it("should_not_submit_enclosing_form_when_enter_pressed_in_search", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn((e: React.FormEvent) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <DependenciesField
+          dependencies={[]}
+          allTasks={[makeTask({ id: "a", title: "Alpha" })]}
+          onChange={vi.fn()}
+        />
+      </form>
+    );
+    await user.type(screen.getByLabelText(/search tasks/i), "alp{Enter}");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("should_allow_adding_candidates_in_create_mode_without_task_id", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <DependenciesField
+        dependencies={[]}
+        allTasks={[makeTask({ id: "a", title: "Alpha" })]}
+        onChange={onChange}
+      />
+    );
+    await user.type(screen.getByLabelText(/search tasks/i), "alp");
+    await user.click(screen.getByTestId("dep-suggestion"));
+    expect(onChange).toHaveBeenCalledWith(["a"]);
+  });
+
+  it("should_disable_search_input_with_caption_at_max_dependencies", () => {
+    const deps = Array.from({ length: 50 }, (_, i) => `d${i}`);
+    render(<DependenciesField taskId="z" dependencies={deps} allTasks={[]} onChange={vi.fn()} />);
+    expect(screen.getByLabelText(/search tasks/i)).toBeDisabled();
+    expect(screen.getByText(/dependency limit/i)).toBeInTheDocument();
+  });
+
+  it("should_show_no_matching_tasks_message_when_query_has_no_candidates", async () => {
+    const user = userEvent.setup();
+    render(
+      <DependenciesField
+        taskId="z"
+        dependencies={[]}
+        allTasks={[makeTask({ id: "z", title: "Ship it" })]}
+        onChange={vi.fn()}
+      />
+    );
+    await user.type(screen.getByLabelText(/search tasks/i), "anything");
+    expect(screen.getByText(/no matching tasks/i)).toBeInTheDocument();
+  });
 });
 
 describe("findDependencyCycleError", () => {

--- a/tests/ui/edit-drawer-dependencies.test.tsx
+++ b/tests/ui/edit-drawer-dependencies.test.tsx
@@ -180,6 +180,44 @@ describe("<DependenciesField>", () => {
     await user.type(screen.getByLabelText(/search tasks/i), "anything");
     expect(screen.getByText(/no matching tasks/i)).toBeInTheDocument();
   });
+
+  it("should_return_focus_to_search_input_after_picking_a_suggestion", async () => {
+    const user = userEvent.setup();
+    render(
+      <DependenciesField
+        dependencies={[]}
+        allTasks={[makeTask({ id: "a", title: "Alpha" })]}
+        onChange={vi.fn()}
+      />
+    );
+    const input = screen.getByLabelText(/search tasks/i);
+    await user.type(input, "alp");
+    await user.click(screen.getByTestId("dep-suggestion"));
+    expect(input).toHaveFocus();
+  });
+
+  it("should_describe_disabled_input_with_limit_caption_at_max", () => {
+    const deps = Array.from({ length: 50 }, (_, i) => `d${i}`);
+    render(<DependenciesField taskId="z" dependencies={deps} allTasks={[]} onChange={vi.fn()} />);
+    expect(screen.getByLabelText(/search tasks/i)).toHaveAccessibleDescription(
+      /dependency limit reached/i
+    );
+  });
+
+  it("should_mark_input_invalid_and_describe_it_with_error_text", () => {
+    render(
+      <DependenciesField
+        taskId="z"
+        dependencies={[]}
+        allTasks={[]}
+        onChange={vi.fn()}
+        error="Circular dependency: nope."
+      />
+    );
+    const input = screen.getByLabelText(/search tasks/i);
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAccessibleDescription(/circular dependency/i);
+  });
 });
 
 describe("findDependencyCycleError", () => {

--- a/tests/ui/edit-drawer-dependencies.test.tsx
+++ b/tests/ui/edit-drawer-dependencies.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  DependenciesField,
+  findDependencyCycleError,
+} from "@/components/matrix-simplified/edit-drawer-dependencies";
+import type { TaskRecord } from "@/lib/types";
+
+function makeTask(overrides: Partial<TaskRecord> & { id: string }): TaskRecord {
+  return {
+    title: overrides.id,
+    description: "",
+    urgent: true,
+    important: true,
+    quadrant: "urgent-important",
+    completed: false,
+    tags: [],
+    subtasks: [],
+    dependencies: [],
+    recurrence: "none",
+    notificationEnabled: false,
+    notificationSent: false,
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  } as TaskRecord;
+}
+
+describe("<DependenciesField>", () => {
+  it("should_render_chip_with_task_title_for_each_resolvable_dependency", () => {
+    const tasks = [
+      makeTask({ id: "a", title: "Write spec" }),
+      makeTask({ id: "b", title: "Review spec" }),
+      makeTask({ id: "z", title: "Ship it" }),
+    ];
+    render(
+      <DependenciesField taskId="z" dependencies={["a", "b"]} allTasks={tasks} onChange={vi.fn()} />
+    );
+    expect(screen.getAllByTestId("dep-chip")).toHaveLength(2);
+    expect(screen.getByText("Write spec")).toBeInTheDocument();
+    expect(screen.getByText("Review spec")).toBeInTheDocument();
+  });
+
+  it("should_not_render_chip_for_ghost_dependency_id", () => {
+    render(
+      <DependenciesField
+        taskId="z"
+        dependencies={["ghost-1"]}
+        allTasks={[makeTask({ id: "z", title: "Ship it" })]}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.queryAllByTestId("dep-chip")).toHaveLength(0);
+    expect(screen.getByLabelText(/search tasks/i)).toBeInTheDocument();
+  });
+
+  it("should_render_chip_for_completed_dependency_so_it_can_be_removed", () => {
+    const tasks = [
+      makeTask({ id: "a", title: "Done thing", completed: true }),
+      makeTask({ id: "z", title: "Ship it" }),
+    ];
+    render(<DependenciesField taskId="z" dependencies={["a"]} allTasks={tasks} onChange={vi.fn()} />);
+    expect(screen.getByText("Done thing")).toBeInTheDocument();
+  });
+});
+
+describe("findDependencyCycleError", () => {
+  it("should_return_message_naming_the_blocking_task_when_cycle_found", () => {
+    // "Alpha" depends on "Beta"; making Beta depend on Alpha closes the loop.
+    const tasks = [
+      makeTask({ id: "a", title: "Alpha", dependencies: ["b"] }),
+      makeTask({ id: "b", title: "Beta" }),
+    ];
+    expect(findDependencyCycleError("b", ["a"], tasks)).toMatch(/Alpha/);
+  });
+
+  it("should_return_null_for_ghost_ids_and_acyclic_dependencies", () => {
+    const tasks = [makeTask({ id: "a", title: "Alpha" }), makeTask({ id: "b", title: "Beta" })];
+    expect(findDependencyCycleError("b", ["a", "ghost-1"], tasks)).toBeNull();
+  });
+});

--- a/tests/ui/edit-drawer.test.tsx
+++ b/tests/ui/edit-drawer.test.tsx
@@ -227,4 +227,72 @@ describe("<EditDrawer>", () => {
       await waitFor(() => expect(trigger).toHaveFocus());
     });
   });
+
+  describe("dependencies field", () => {
+    const otherTask: TaskRecord = { ...mockTask, id: "t2", title: "Other task", dependencies: [] };
+
+    it("should_include_added_dependency_id_in_submitted_draft", async () => {
+      const onSubmit = vi.fn();
+      render(
+        <EditDrawer open task={mockTask} allTasks={[mockTask, otherTask]} onClose={vi.fn()} onSubmit={onSubmit} />
+      );
+      // Let the drawer's delayed title autofocus fire first — it blurs the
+      // dependency search, which (correctly) closes the suggestion list.
+      await waitFor(() => expect(screen.getByLabelText(/^title$/i)).toHaveFocus());
+      await user.type(screen.getByLabelText(/search tasks/i), "other");
+      await user.click(screen.getByTestId("dep-suggestion"));
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ dependencies: ["t2"] }),
+        "t1"
+      );
+    });
+
+    it("should_exclude_removed_dependency_id_from_submitted_draft", async () => {
+      const onSubmit = vi.fn();
+      const taskWithDep: TaskRecord = { ...mockTask, dependencies: ["t2"] };
+      render(
+        <EditDrawer open task={taskWithDep} allTasks={[taskWithDep, otherTask]} onClose={vi.fn()} onSubmit={onSubmit} />
+      );
+      await user.click(screen.getByRole("button", { name: "Remove dependency Other task" }));
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ dependencies: [] }),
+        "t1"
+      );
+    });
+
+    it("should_block_submit_and_show_inline_error_when_dependencies_would_cycle_at_save", async () => {
+      // Simulates a cycle that arrived via realtime sync after the drawer opened:
+      // t1 → t2 (this draft) while t2 → t1 (already in the store).
+      const onSubmit = vi.fn();
+      const blocker: TaskRecord = { ...otherTask, dependencies: ["t1"] };
+      const taskWithCycle: TaskRecord = { ...mockTask, dependencies: ["t2"] };
+      render(
+        <EditDrawer open task={taskWithCycle} allTasks={[taskWithCycle, blocker]} onClose={vi.fn()} onSubmit={onSubmit} />
+      );
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(screen.getByRole("alert")).toHaveTextContent(/circular dependency/i);
+    });
+
+    it("should_submit_dependencies_without_task_id_in_create_mode", async () => {
+      const onSubmit = vi.fn();
+      render(<EditDrawer open task={null} allTasks={[otherTask]} onClose={vi.fn()} onSubmit={onSubmit} />);
+      await user.type(screen.getByLabelText(/^title$/i), "Brand new task");
+      await user.type(screen.getByLabelText(/search tasks/i), "other");
+      await user.click(screen.getByTestId("dep-suggestion"));
+      await user.click(screen.getByRole("button", { name: /create task/i }));
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ dependencies: ["t2"] }),
+        undefined
+      );
+    });
+
+    it("should_render_without_all_tasks_prop_and_keep_existing_fields_working", () => {
+      render(<EditDrawer open task={mockTask} onClose={vi.fn()} onSubmit={vi.fn()} />);
+      expect(screen.getByLabelText(/search tasks/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/^title$/i)).toBeInTheDocument();
+    });
+  });
 });

--- a/tests/ui/edit-drawer.test.tsx
+++ b/tests/ui/edit-drawer.test.tsx
@@ -294,5 +294,24 @@ describe("<EditDrawer>", () => {
       expect(screen.getByLabelText(/search tasks/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/^title$/i)).toBeInTheDocument();
     });
+
+    it("should_close_suggestions_on_escape_without_closing_the_drawer", async () => {
+      const onClose = vi.fn();
+      render(
+        <EditDrawer open task={mockTask} allTasks={[mockTask, otherTask]} onClose={onClose} onSubmit={vi.fn()} />
+      );
+      await waitFor(() => expect(screen.getByLabelText(/^title$/i)).toHaveFocus());
+      await user.type(screen.getByLabelText(/search tasks/i), "other");
+      expect(screen.getByTestId("dep-suggestion")).toBeInTheDocument();
+
+      // First Escape only dismisses the suggestion popup.
+      await user.keyboard("{Escape}");
+      expect(onClose).not.toHaveBeenCalled();
+      expect(screen.queryByTestId("dep-suggestion")).not.toBeInTheDocument();
+
+      // Second Escape (popup closed) closes the drawer as before.
+      await user.keyboard("{Escape}");
+      expect(onClose).toHaveBeenCalled();
+    });
   });
 });

--- a/tests/ui/matrix-simplified.test.tsx
+++ b/tests/ui/matrix-simplified.test.tsx
@@ -208,6 +208,28 @@ describe("<MatrixSimplified>", () => {
     expect(await screen.findByRole("heading", { name: /new task/i })).toBeInTheDocument();
   });
 
+  it("passes drawer-selected dependencies to createTask on the create path", async () => {
+    const user = userEvent.setup();
+    tasksFixture.current = [makeTask({ id: "dep-1", title: "Prepare deck" })];
+    render(<MatrixSimplified />);
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("gsd:new-task"));
+    });
+    await screen.findByRole("heading", { name: /new task/i });
+
+    await user.type(screen.getByLabelText(/^title$/i), "Present deck");
+    await user.type(screen.getByLabelText(/search tasks/i), "prepare");
+    await user.click(screen.getByTestId("dep-suggestion"));
+    await user.click(screen.getByRole("button", { name: /create task/i }));
+
+    await waitFor(() =>
+      expect(createTask).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Present deck", dependencies: ["dep-1"] })
+      )
+    );
+  });
+
   it("highlights a task when the shell highlight event fires", async () => {
     tasksFixture.current = [makeTask({ id: "target", title: "Target task" })];
     render(<MatrixSimplified />);

--- a/tests/ui/matrix-simplified.test.tsx
+++ b/tests/ui/matrix-simplified.test.tsx
@@ -122,7 +122,7 @@ vi.mock("@/components/matrix-simplified/app-shell", () => ({
 }));
 
 import { MatrixSimplified } from "@/components/matrix-simplified";
-import { createTask, toggleCompleted, deleteTask, restoreTask } from "@/lib/tasks";
+import { createTask, toggleCompleted, updateTask, deleteTask, restoreTask } from "@/lib/tasks";
 import { celebrateCompletion } from "@/lib/confetti";
 
 describe("<MatrixSimplified>", () => {
@@ -226,6 +226,26 @@ describe("<MatrixSimplified>", () => {
     await waitFor(() =>
       expect(createTask).toHaveBeenCalledWith(
         expect.objectContaining({ title: "Present deck", dependencies: ["dep-1"] })
+      )
+    );
+  });
+
+  it("forwards ghost dependency ids untouched through the edit save path", async () => {
+    const user = userEvent.setup();
+    // "dep-ghost" has no local record (e.g. not yet synced) — it must survive
+    // an unrelated edit round-trip without being dropped.
+    tasksFixture.current = [makeTask({ id: "e1", title: "Editable", dependencies: ["dep-ghost"] })];
+    render(<MatrixSimplified />);
+
+    // Task cards render two "Edit task" buttons (desktop row + compact menu).
+    await user.click(screen.getAllByRole("button", { name: /^edit task$/i })[0]);
+    await screen.findByRole("heading", { name: /edit task/i });
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(updateTask).toHaveBeenCalledWith(
+        "e1",
+        expect.objectContaining({ dependencies: ["dep-ghost"] })
       )
     );
   });


### PR DESCRIPTION
## What changed

Restores the ability to link tasks together in the web app — lost when the v8 modular task form (including `task-form-dependencies.tsx`) was deleted in #238. The v9 edit drawer gains a **Depends on** field:

- New `components/matrix-simplified/edit-drawer-dependencies.tsx`: chip list of linked tasks, search input with ≤8 suggestions, candidates exclude self/already-linked/completed/cycle-creating tasks (via existing `lib/dependencies.ts` BFS), 50-dependency cap tied to `SCHEMA_LIMITS.MAX_DEPENDENCIES`.
- `EditDraft` carries `dependencies`; the drawer takes an `allTasks` prop and blocks save with an inline error if the selection would create a cycle at save time (e.g. after a realtime-sync race).
- **Ghost-ID preservation**: dependency IDs with no local record (created on another device, not yet synced) render no chip but are never dropped on save — verified end-to-end through the shell → drawer → `updateTask` path.
- a11y hardening per a11y-reviewer: focus returns to the search input after picking a suggestion; Escape dismisses the popup before it closes the drawer; error text uses the Inkwell `--rust` danger token (AA in both themes, replacing `text-red-400` at 2.77:1); `aria-describedby`/`aria-invalid` wiring for the limit caption and cycle error.

## Why

The data layer (schema, CRUD merge, PocketBase sync mapping, cycle detection, card badges, "Ready to work" smart view) survived the v9 refactor intact — only the editing surface was deleted, leaving dependencies write-only via MCP/JSON import. Spec: `tasks/spec.md` § 2026-07-05 · Plan: `docs/superpowers/plans/2026-07-05-edit-drawer-dependencies.md` · ADR 0011 addendum included.

## How to test

1. `bun dev`, create two tasks, open one in the edit drawer.
2. Type in **Depends on**, pick a suggestion, save → the task shows **Blocked by 1**, the other shows **Blocking 1**.
3. Reopen the drawer → chip re-hydrates; remove it, save → badges clear.
4. Create mode (quadrant **+**): dependencies can be attached at creation.

Verified live in Chrome (service-worker cache busted, IndexedDB seeded/cleaned) with a clean console. Suite: 2181 unit tests green, typecheck clean, touched files lint clean. New Playwright spec `tests/e2e/task-dependencies.spec.ts` defends the link → badges → unlink flow (chromium green; `task-crud.spec.ts` re-run green after the shared page-object change).

Review agents: pb-sync-reviewer **0 blocking** (diff is UI-only for sync; ghost round-trip verified); a11y-reviewer findings fixed as above except the deferred item below.

## Deferred follow-ups (tracked in tasks/todo.md)

- Full WAI-ARIA combobox semantics for the picker (roles + arrow-key navigation) — partial roles are worse than the current labeled, tabbable buttons.
- Systemic danger-color token (`text-red-400`-on-white also fails AA in two sync components untouched here).
- `restoreTask` doesn't re-create inbound dependency edges after delete/undo (pre-existing).
- Subtask editing is still drawer-less (also lost in #238).
- Pre-existing on `main`: `scripts/build-openwiki-site.cjs` has 2 ESLint errors from the OpenWiki commit, so repo-wide `bun lint` exits 1 independent of this branch.

https://claude.ai/code/session_013fpk68fJFAJkZFY5LihJhf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->