### PR TITLE
fix(sync): forward Zod validation errors to Sentry via allowlisted key

### DIFF
--- a/lib/sync/task-mapper.ts
+++ b/lib/sync/task-mapper.ts
@@ -130,7 +130,7 @@ export function pocketBaseToTaskRecord(record: RecordModel, existingLocal?: Task
   if (!parsed.success) {
     logger.error('PocketBase record failed validation, skipping', undefined, {
       taskId: record['task_id'] as string,
-      errors: parsed.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; '),
+      validationErrors: parsed.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; '),
     });
 
     return null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "10.2.1",
+	"version": "10.2.2",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/data/sync/task-mapper.test.ts
+++ b/tests/data/sync/task-mapper.test.ts
@@ -3,14 +3,20 @@ import { taskRecordToPocketBase, pocketBaseToTaskRecord } from '@/lib/sync/task-
 import { SCHEMA_LIMITS } from '@/lib/constants/schema';
 import type { TaskRecord } from '@/lib/types';
 
-// Mock logger to avoid side effects
-vi.mock('@/lib/logger', () => ({
-  createLogger: () => ({
+// Mock logger to avoid side effects. Shared spy instance so tests can assert
+// on the metadata passed to logger.error (createLogger is called once at
+// module load in task-mapper.ts, so every call must return the same object).
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
     debug: vi.fn(),
-  }),
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => mockLogger,
 }));
 
 function buildLocalTask(overrides?: Partial<TaskRecord>): TaskRecord {
@@ -210,6 +216,18 @@ describe('task-mapper', () => {
       const pb = buildPBRecord({ quadrant: 'invalid-quadrant' });
       const result = pocketBaseToTaskRecord(pb);
       expect(result).toBeNull();
+    });
+
+    it('should log the Zod issues under the validationErrors key so Sentry forwarding keeps them', () => {
+      mockLogger.error.mockClear();
+      const pb = buildPBRecord({ quadrant: 'invalid-quadrant' });
+      pocketBaseToTaskRecord(pb);
+
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
+      const [, , metadata] = mockLogger.error.mock.calls[0]!;
+      expect(metadata).toHaveProperty('validationErrors');
+      expect(metadata.validationErrors).toContain('quadrant');
+      expect(metadata).not.toHaveProperty('errors');
     });
 
     it('should strip unknown fields from PB record', () => {


### PR DESCRIPTION
## Summary
- Investigated a Sentry issue (`PocketBase record failed validation, skipping`) triggered during a sync pull — a single remote task record failed the `pbTaskRecordSchema` Zod validation and was correctly skipped (no crash, sync continued normally for the other ~90+ records in that pull).
- Found that the actual Zod issue detail was never reaching Sentry: `pocketBaseToTaskRecord()` logged it under an `errors` metadata key, but `logger.ts`'s `SENTRY_SAFE_METADATA_KEYS` allowlist only forwards `validationErrors` — so every occurrence of this error type has only ever shown a bare `taskId` in Sentry, with no way to diagnose which field failed or why.
- Renamed the metadata key from `errors` → `validationErrors` so it passes the allowlist and future occurrences are actually debuggable from the Sentry event.

## Why
This is a telemetry bug, not a sync-correctness bug — the skip-and-log behavior at the validation boundary is working as intended. But without the fix, this class of error is permanently opaque in Sentry, which defeats the purpose of logging it in the first place.

## Test plan
- [x] Added a regression test (`should log the Zod issues under the validationErrors key so Sentry forwarding keeps them`) asserting `logger.error` is called with a `validationErrors` metadata key and not `errors`; confirmed it fails for the right reason before the fix.
- [x] `bun run test -- tests/data/sync/task-mapper.test.ts` — 21/21 passing
- [x] `bun run test` (full suite) — 150 files / 2182 tests passing
- [x] `bun typecheck` — clean
- [x] `bunx eslint lib/sync/task-mapper.ts tests/data/sync/task-mapper.test.ts` — clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->