### PR TITLE
feat(pipeline): The Contract — enforced issue templates + risk labels (cycle A)

### DIFF
--- a/.github/ISSUE_TEMPLATE/change_request.yml
+++ b/.github/ISSUE_TEMPLATE/change_request.yml
@@ -1,0 +1,84 @@
+name: New Change
+description: File a change as a pipeline contract — enforced spec + risk tier.
+title: "[change]: "
+labels: ["needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Every change enters the pipeline through this contract. Fields marked with * are required.
+        Write it like a spec, not a sticky note — a vague contract produces a plausible plan for the wrong problem.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What needs to change and why. State the problem, not just the solution.
+      placeholder: "Today the app … which causes … . We want …"
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: How we'll know it's done. Prefer a checklist of observable outcomes.
+      placeholder: |
+        - [ ] …
+        - [ ] …
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: Must / must-not — performance, compatibility, security, UX. Write "None" if there are none.
+      placeholder: "Must not change the sync protocol. Must keep the bundle under budget."
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: Explicit non-goals — what this change will NOT do.
+      placeholder: "Not touching the MCP server. Not redesigning the matrix."
+    validations:
+      required: true
+  - type: textarea
+    id: rollback
+    attributes:
+      label: Rollback considerations
+      description: If this ships and goes wrong, how do we undo it? No rollback path, no release approval.
+      placeholder: "Revert PR and redeploy the previous tag. / Flip the feature flag off. / Migration is reversible via …"
+    validations:
+      required: true
+  - type: dropdown
+    id: risk
+    attributes:
+      label: Risk tier
+      description: |
+        Drives how deep a plan the builder writes and whether it stops for human approval.
+        docs — docs/content only ·
+        chore — deps, config, tooling; no user-facing behavior change ·
+        feature — new/changed user-facing behavior ·
+        risky — touches security, auth, data, deploy/CI, or migrations
+      options:
+        - docs
+        - chore
+        - feature
+        - risky
+    validations:
+      required: true
+  - type: input
+    id: affected_areas
+    attributes:
+      label: Affected areas (optional)
+      description: Components or paths you expect to touch.
+      placeholder: "components/matrix, lib/sync, .github/workflows"
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context (optional)
+      description: Links, screenshots, prior art, related issues.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+# Every issue must go through the contract; no blank issues.
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/vscarpenter/gsd-task-manager/security/policy
+    about: Please do not file security issues publicly — see SECURITY.md.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- What changed and why. Link the contract this implements. -->
+Closes #
+
+## Risk tier
+
+<!-- Carry the risk:* label from the linked issue: docs | chore | feature | risky -->
+
+## How to verify
+
+<!-- Steps to exercise the change. Mirror the linked issue's acceptance criteria. -->
+- [ ]
+
+## Rollback plan
+
+<!-- REQUIRED. How to undo this if it goes wrong in production.
+     No rollback path, no release approval. -->
+
+## Checklist
+
+- [ ] Acceptance criteria from the linked issue are met
+- [ ] Tests added/updated and passing (`bun run test`)
+- [ ] Lint and typecheck clean (`bun run lint`, `bun run typecheck`)
+- [ ] Coding standards followed (`coding-standards.md`)
+- [ ] Rollback plan above is real

--- a/.github/workflows/apply-risk-label.yml
+++ b/.github/workflows/apply-risk-label.yml
@@ -1,0 +1,58 @@
+name: Apply risk label
+
+# Reads the risk dropdown on the issue contract and applies the matching
+# risk:* label. Safe for issues from any author: it only ever applies one of
+# four fixed labels derived from the body, holds no secrets, and executes no
+# issue-supplied content — so no author_association gate is needed (unlike
+# claude.yml, which is secret-bearing).
+on:
+  issues:
+    types: [opened, edited]
+
+concurrency:
+  group: apply-risk-label-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # checkout the parser module
+  issues: write # the single power this job holds
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { parseRiskTier } = require(`${process.env.GITHUB_WORKSPACE}/scripts/parse-risk-tier.cjs`);
+            const tier = parseRiskTier(context.payload.issue.body);
+            if (!tier) {
+              core.info("No valid risk tier in issue body; leaving labels unchanged.");
+              return;
+            }
+            const target = `risk:${tier}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.issue.number;
+
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number });
+            const riskLabels = labels.map((l) => l.name).filter((n) => n.startsWith("risk:"));
+
+            if (riskLabels.length === 1 && riskLabels[0] === target) {
+              core.info(`Already labeled ${target}; nothing to do.`);
+              return;
+            }
+            for (const name of riskLabels) {
+              if (name !== target) {
+                await github.rest.issues
+                  .removeLabel({ owner, repo, issue_number, name })
+                  .catch((e) => { if (e.status !== 404) throw e; });
+              }
+            }
+            if (!riskLabels.includes(target)) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [target] });
+            }
+            core.info(`Applied ${target}.`);

--- a/docs/superpowers/plans/2026-07-07-the-contract.md
+++ b/docs/superpowers/plans/2026-07-07-the-contract.md
@@ -1,0 +1,465 @@
+# The Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an enforced, machine-parseable GitHub issue contract that carries a risk tier, plus the labels, auto-labeler, and PR template that make it the pipeline's front door.
+
+**Architecture:** A GitHub Issue Form enforces the contract fields and a required risk dropdown. A pure `.cjs` parser extracts the chosen tier from the issue body; a thin `actions/github-script` workflow calls that parser and applies the matching `risk:*` label. Labels are provisioned by an idempotent `gh` script. Nothing here touches runtime, deploy, or CI-gate behavior.
+
+**Tech Stack:** GitHub Issue Forms (YAML), GitHub Actions (`actions/github-script@v7`, `actions/checkout@v4`), `gh` CLI, Node CommonJS (`.cjs`), Vitest (`.test.ts`).
+
+## Global Constraints
+
+- Additive only — confined to `.github/`, `scripts/`, `docs/`. Do not modify `ci.yml`, `deploy-dev.yml`, `deploy-prod.yml`, or any runtime/app code.
+- Risk tiers are exactly: `docs`, `chore`, `feature`, `risky` (lowercase, bare words).
+- `risk:*` is a distinct label namespace; do NOT create/rename existing `ready-for-agent` / `ready-for-human` / `needs-triage` labels.
+- Node helpers use `.cjs` (repo convention, `type: module`). Tests use `.test.ts` (Vitest default glob).
+- Commits: Conventional Commits with scope, author `Vinny Carpenter <vscarpenter@gmail.com>`, trailer `Claude-Session: https://claude.ai/code/session_01VTzjLGNTCEByQKuedNvBoB`, no Co-Authored-By footer.
+- The dropdown field label is exactly `Risk tier` (renders as `### Risk tier` in the issue body) — the parser depends on this string.
+
+---
+
+### Task 1: Risk-tier parser (the one piece with real logic — TDD)
+
+**Files:**
+- Create: `scripts/parse-risk-tier.cjs`
+- Test: `scripts/parse-risk-tier.test.ts`
+
+**Interfaces:**
+- Produces: `parseRiskTier(body: string | null | undefined): 'docs'|'chore'|'feature'|'risky'|null` and `RISK_TIERS: string[]`, exported via `module.exports`. Consumed by Task 4's workflow.
+
+- [ ] **Step 1: Write the failing test** — `scripts/parse-risk-tier.test.ts`
+
+```ts
+import { describe, it, expect } from "vitest";
+import { parseRiskTier, RISK_TIERS } from "./parse-risk-tier.cjs";
+
+const body = (value: string) =>
+  `### Summary\n\nDo the thing\n\n### Risk tier\n\n${value}\n\n### Additional context\n\n_No response_`;
+
+describe("parseRiskTier", () => {
+  it("exposes the four canonical tiers", () => {
+    expect(RISK_TIERS).toEqual(["docs", "chore", "feature", "risky"]);
+  });
+
+  it.each(RISK_TIERS)("parses a valid tier: %s", (tier) => {
+    expect(parseRiskTier(body(tier))).toBe(tier);
+  });
+
+  it("is case- and whitespace-insensitive", () => {
+    expect(parseRiskTier(body("  Feature  "))).toBe("feature");
+  });
+
+  it("handles CRLF line endings", () => {
+    expect(parseRiskTier("### Risk tier\r\n\r\nrisky\r\n")).toBe("risky");
+  });
+
+  it("returns null when the heading is absent", () => {
+    expect(parseRiskTier("### Summary\n\nno risk field here")).toBeNull();
+  });
+
+  it("returns null for an unanswered dropdown (_No response_)", () => {
+    expect(parseRiskTier(body("_No response_"))).toBeNull();
+  });
+
+  it("returns null when the answer is not one of the four tiers", () => {
+    expect(parseRiskTier(body("medium"))).toBeNull();
+  });
+
+  it("returns null when the section is empty (next heading follows)", () => {
+    expect(parseRiskTier("### Risk tier\n\n### Next\n\nx")).toBeNull();
+  });
+
+  it.each([null, undefined, "", 123 as unknown as string])(
+    "returns null for non-string/empty input: %s",
+    (input) => {
+      expect(parseRiskTier(input as string)).toBeNull();
+    }
+  );
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test -- scripts/parse-risk-tier.test.ts`
+Expected: FAIL — cannot resolve `./parse-risk-tier.cjs`.
+
+- [ ] **Step 3: Write minimal implementation** — `scripts/parse-risk-tier.cjs`
+
+```js
+"use strict";
+
+// Canonical risk tiers, in escalation order. Must match the dropdown options
+// in .github/ISSUE_TEMPLATE/change_request.yml exactly (bare lowercase words).
+const RISK_TIERS = ["docs", "chore", "feature", "risky"];
+
+/**
+ * Extract the selected risk tier from a GitHub Issue Form body.
+ * The form renders the dropdown as an "### Risk tier" heading followed by the
+ * chosen option on the next non-empty line. Returns null for anything that is
+ * not exactly one of RISK_TIERS (unanswered, junk, malformed, non-string).
+ *
+ * @param {string|null|undefined} body
+ * @returns {"docs"|"chore"|"feature"|"risky"|null}
+ */
+function parseRiskTier(body) {
+  if (typeof body !== "string" || body.length === 0) return null;
+  const lines = body.replace(/\r\n/g, "\n").split("\n");
+  const headingIdx = lines.findIndex((line) =>
+    /^#{1,6}\s+Risk tier\s*$/i.test(line.trim())
+  );
+  if (headingIdx === -1) return null;
+  for (let i = headingIdx + 1; i < lines.length; i++) {
+    const value = lines[i].trim();
+    if (value === "") continue;
+    if (/^#{1,6}\s+/.test(value)) return null; // hit next heading = empty answer
+    const normalized = value.toLowerCase();
+    return RISK_TIERS.includes(normalized) ? normalized : null;
+  }
+  return null;
+}
+
+module.exports = { parseRiskTier, RISK_TIERS };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun run test -- scripts/parse-risk-tier.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/parse-risk-tier.cjs scripts/parse-risk-tier.test.ts
+git commit  # feat(pipeline): risk-tier parser for issue contract  + Claude-Session trailer
+```
+
+---
+
+### Task 2: Risk labels provisioning script
+
+**Files:**
+- Create: `scripts/setup-labels.sh`
+
+**Interfaces:**
+- Produces the four `risk:*` labels in the GitHub repo. Consumed operationally by Task 4 (labeler assumes labels exist).
+
+- [ ] **Step 1: Write the script** — `scripts/setup-labels.sh`
+
+```bash
+#!/usr/bin/env bash
+# Provision the risk:* labels used by the delivery pipeline (sub-project A:
+# "The Contract"). Idempotent — `gh label create --force` upserts, so this is
+# safe to re-run. Requires an authenticated `gh` CLI with repo scope.
+set -euo pipefail
+
+create() {
+  gh label create "$1" --color "$2" --description "$3" --force
+}
+
+create "risk:docs"    "0075ca" "Docs/content only"
+create "risk:chore"   "c5def5" "Deps, config, tooling — no user-facing behavior change"
+create "risk:feature" "0e8a16" "New/changed user-facing behavior"
+create "risk:risky"   "b60205" "Touches security, auth, data, deploy/CI, or migrations"
+
+echo "risk:* labels created/updated."
+```
+
+- [ ] **Step 2: Make executable + shell-lint**
+
+Run: `chmod +x scripts/setup-labels.sh && bash -n scripts/setup-labels.sh && (command -v shellcheck >/dev/null && shellcheck scripts/setup-labels.sh || echo "shellcheck not installed; syntax OK")`
+Expected: no syntax errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/setup-labels.sh
+git commit  # chore(pipeline): idempotent risk:* label provisioning script
+```
+
+(Actual label creation against GitHub happens at rollout, not in this task — see Rollout.)
+
+---
+
+### Task 3: Issue Form contract + config
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/change_request.yml`
+- Create: `.github/ISSUE_TEMPLATE/config.yml`
+
+**Interfaces:**
+- Produces an issue body whose `### Risk tier` section holds a bare tier word — the exact shape Task 1 parses and Task 4 reads.
+
+- [ ] **Step 1: Write the Issue Form** — `.github/ISSUE_TEMPLATE/change_request.yml`
+
+```yaml
+name: New Change
+description: File a change as a pipeline contract — enforced spec + risk tier.
+title: "[change]: "
+labels: ["needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Every change enters the pipeline through this contract. Fields marked with * are required.
+        Write it like a spec, not a sticky note — a vague contract produces a plausible plan for the wrong problem.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What needs to change and why. State the problem, not just the solution.
+      placeholder: "Today the app … which causes … . We want …"
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: How we'll know it's done. Prefer a checklist of observable outcomes.
+      placeholder: |
+        - [ ] …
+        - [ ] …
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: Must / must-not — performance, compatibility, security, UX. Write "None" if there are none.
+      placeholder: "Must not change the sync protocol. Must keep the bundle under budget."
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: Explicit non-goals — what this change will NOT do.
+      placeholder: "Not touching the MCP server. Not redesigning the matrix."
+    validations:
+      required: true
+  - type: textarea
+    id: rollback
+    attributes:
+      label: Rollback considerations
+      description: If this ships and goes wrong, how do we undo it? No rollback path, no release approval.
+      placeholder: "Revert PR and redeploy the previous tag. / Flip the feature flag off. / Migration is reversible via …"
+    validations:
+      required: true
+  - type: dropdown
+    id: risk
+    attributes:
+      label: Risk tier
+      description: |
+        Drives how deep a plan the builder writes and whether it stops for human approval.
+        docs — docs/content only ·
+        chore — deps, config, tooling; no user-facing behavior change ·
+        feature — new/changed user-facing behavior ·
+        risky — touches security, auth, data, deploy/CI, or migrations
+      options:
+        - docs
+        - chore
+        - feature
+        - risky
+    validations:
+      required: true
+  - type: input
+    id: affected_areas
+    attributes:
+      label: Affected areas (optional)
+      description: Components or paths you expect to touch.
+      placeholder: "components/matrix, lib/sync, .github/workflows"
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context (optional)
+      description: Links, screenshots, prior art, related issues.
+    validations:
+      required: false
+```
+
+- [ ] **Step 2: Write the config** — `.github/ISSUE_TEMPLATE/config.yml`
+
+```yaml
+# Every issue must go through the contract; no blank issues.
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/vscarpenter/gsd-task-manager/security/policy
+    about: Please do not file security issues publicly — see SECURITY.md.
+```
+
+- [ ] **Step 3: Validate YAML + Issue Form shape**
+
+Run: `node -e "const y=require('js-yaml'); for (const f of ['.github/ISSUE_TEMPLATE/change_request.yml','.github/ISSUE_TEMPLATE/config.yml']){const d=y.load(require('fs').readFileSync(f,'utf8')); console.log(f,'OK')}"` (fallback if `js-yaml` absent: `python3 -c "import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]; print('OK')" .github/ISSUE_TEMPLATE/change_request.yml .github/ISSUE_TEMPLATE/config.yml`)
+Then assert the dropdown options equal the parser's tiers.
+Expected: both parse; dropdown options == `["docs","chore","feature","risky"]`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/change_request.yml .github/ISSUE_TEMPLATE/config.yml
+git commit  # feat(pipeline): enforced New Change issue contract + templates config
+```
+
+---
+
+### Task 4: Auto-labeler workflow
+
+**Files:**
+- Create: `.github/workflows/apply-risk-label.yml`
+
+**Interfaces:**
+- Consumes: `parseRiskTier` / `RISK_TIERS` from `scripts/parse-risk-tier.cjs` (Task 1) and the `risk:*` labels (Task 2).
+
+- [ ] **Step 1: Write the workflow** — `.github/workflows/apply-risk-label.yml`
+
+```yaml
+name: Apply risk label
+
+# Reads the risk dropdown on the issue contract and applies the matching
+# risk:* label. Safe for issues from any author: it only ever applies one of
+# four fixed labels derived from the body, holds no secrets, and executes no
+# issue-supplied content — so no author_association gate is needed (unlike
+# claude.yml, which is secret-bearing).
+on:
+  issues:
+    types: [opened, edited]
+
+concurrency:
+  group: apply-risk-label-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read   # checkout the parser module
+  issues: write    # the single power this job holds
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { parseRiskTier } = require(`${process.env.GITHUB_WORKSPACE}/scripts/parse-risk-tier.cjs`);
+            const tier = parseRiskTier(context.payload.issue.body);
+            if (!tier) {
+              core.info("No valid risk tier in issue body; leaving labels unchanged.");
+              return;
+            }
+            const target = `risk:${tier}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.issue.number;
+
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number });
+            const riskLabels = labels.map((l) => l.name).filter((n) => n.startsWith("risk:"));
+
+            if (riskLabels.length === 1 && riskLabels[0] === target) {
+              core.info(`Already labeled ${target}; nothing to do.`);
+              return;
+            }
+            for (const name of riskLabels) {
+              if (name !== target) {
+                await github.rest.issues
+                  .removeLabel({ owner, repo, issue_number, name })
+                  .catch((e) => { if (e.status !== 404) throw e; });
+              }
+            }
+            if (!riskLabels.includes(target)) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [target] });
+            }
+            core.info(`Applied ${target}.`);
+```
+
+- [ ] **Step 2: Validate workflow YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/apply-risk-label.yml')); print('OK')"`
+Expected: `OK`.
+
+- [ ] **Step 3: Confirm the parser path in the workflow matches Task 1's file**
+
+Run: `test -f scripts/parse-risk-tier.cjs && grep -q 'scripts/parse-risk-tier.cjs' .github/workflows/apply-risk-label.yml && echo LINKED`
+Expected: `LINKED`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/apply-risk-label.yml
+git commit  # feat(pipeline): auto-apply risk:* label from issue contract
+```
+
+---
+
+### Task 5: PR contract template
+
+**Files:**
+- Create: `.github/pull_request_template.md`
+
+- [ ] **Step 1: Write the PR template** — `.github/pull_request_template.md`
+
+```markdown
+## Summary
+
+<!-- What changed and why. Link the contract this implements. -->
+Closes #
+
+## Risk tier
+
+<!-- Carry the risk:* label from the linked issue: docs | chore | feature | risky -->
+
+## How to verify
+
+<!-- Steps to exercise the change. Mirror the linked issue's acceptance criteria. -->
+- [ ]
+
+## Rollback plan
+
+<!-- REQUIRED. How to undo this if it goes wrong in production.
+     No rollback path, no release approval. -->
+
+## Checklist
+
+- [ ] Acceptance criteria from the linked issue are met
+- [ ] Tests added/updated and passing (`bun run test`)
+- [ ] Lint and typecheck clean (`bun run lint`, `bun run typecheck`)
+- [ ] Coding standards followed (`coding-standards.md`)
+- [ ] Rollback plan above is real
+```
+
+- [ ] **Step 2: Sanity-check it renders (headings present)**
+
+Run: `grep -c '^## ' .github/pull_request_template.md`
+Expected: `5`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/pull_request_template.md
+git commit  # feat(pipeline): PR contract template with required rollback plan
+```
+
+---
+
+## Full-suite verification (after all tasks)
+
+- [ ] `bun run test -- scripts/parse-risk-tier.test.ts` — parser green.
+- [ ] `bun run lint` — no new lint errors from added files.
+- [ ] Re-parse every new YAML file to confirm validity.
+- [ ] Confirm dropdown options in `change_request.yml` === `RISK_TIERS` in the parser (drift guard).
+
+## Rollout (operational, outside git — requires confirmation before running)
+
+1. `bash scripts/setup-labels.sh` — create the `risk:*` labels (mutates the live repo).
+2. Push branch, open PR, merge.
+3. Verify end-to-end: open a test issue via **New Change**, pick a tier, confirm `apply-risk-label.yml` applies `risk:<tier>`; edit the tier, confirm the label swaps.
+
+## Self-review (plan vs. spec)
+
+- Spec §1 Issue Form → Task 3. §2 config → Task 3. §3 labels+script → Task 2. §4 labeler → Task 4. §5 PR template → Task 5. §6 taxonomy → documented in spec (no code). Verification approach → Task 1 tests + full-suite section. **All spec sections covered.**
+- No placeholders: every code step contains complete content.
+- Type consistency: `parseRiskTier` / `RISK_TIERS` names identical across Task 1 (def), Task 3 (drift guard), Task 4 (consumer). Dropdown option strings identical to `RISK_TIERS`.

--- a/docs/superpowers/specs/2026-07-07-the-contract-design.md
+++ b/docs/superpowers/specs/2026-07-07-the-contract-design.md
@@ -1,0 +1,130 @@
+# Spec: The Contract — Enforced Issue Templates + Risk Labels
+
+- **Date:** 2026-07-07
+- **Status:** Accepted (design approved 2026-07-07; per standing correction, proceeding straight to plan + implementation)
+- **Deciders:** Vinny Carpenter
+- **Related:** `coding-standards.md` (the "standards are the interface" doc), `.github/REPOSITORY_SETTINGS.md`, blog post "Two Gates and a Night Shift" (the target operating model)
+
+## Goal
+
+Make every change enter the delivery pipeline as an **enforced, machine-parseable contract that carries a risk tier**, so a human is forced to write the spec well *before* any agent reads it, and so downstream automation can scale plan depth by risk.
+
+This is **sub-project A ("The Contract")** — the first of five cycles that together reproduce the "Two Gates and a Night Shift" pipeline for GSD Task Manager. It builds the pipeline's *entry point* only.
+
+## Scope & non-goals
+
+**In scope:**
+- One enforced GitHub Issue Form (`change_request.yml`) with required contract fields + a required risk dropdown.
+- `config.yml` that disables blank issues and routes security reports away from public contracts.
+- Four `risk:*` labels + an idempotent script that creates them.
+- One small `apply-risk-label.yml` workflow that reads the risk dropdown and applies the matching label.
+- A PR template carrying the linked issue, risk tier, and a required rollback plan.
+- A documented forward-looking label taxonomy for cycles B–E (documented, **not** created).
+
+**Explicit non-goals (deferred to later cycles):**
+- **No agents.** The builder (cycle B), reviewer hardening (cycle C), and night shift (cycle D) are not built here.
+- **No deploy/CI behavior change.** Existing `ci.yml`, `deploy-dev.yml`, `deploy-prod.yml` are untouched.
+- **No Telegram/Roci bot** and **no ephemeral preview environments** — the pipeline is GitHub-native by decision.
+- **No separate Bug Report template** — every change flows through the single uniform contract for now (trivially added later).
+- **Creating** the `plan:*` / `release-ready` state labels — documented only; each future cycle creates the labels it wires up.
+
+## Background — current state
+
+The repo already implements ~half of the target pipeline: `coding-standards.md` (the versioned standards), a reviewer agent (`.github/workflows/claude-code-review.yml`), a reactive builder (`.github/workflows/claude.yml`), CI, dev/prod deploys, and a real Gate 2 (`deploy-prod.yml` uses a GitHub `production` environment with a required-reviewer gate).
+
+What is missing is the **front door**: there is no `.github/ISSUE_TEMPLATE/`, no PR template, and no risk taxonomy. Issues today can be filed blank, so nothing forces the acceptance criteria / constraints / rollback that a downstream builder agent needs, and there is no risk signal to scale plan depth against.
+
+**Existing labels to align with (not duplicate):** the repo already has an AFK-agent vocabulary — `ready-for-agent` ("Fully specified, ready for an AFK agent"), `ready-for-human`, `needs-triage`, `needs-info`, plus `bug`, `documentation`, `enhancement`, `security`, `tech-debt`, `ci-cd`. The new `risk:*` labels occupy a **distinct namespace**: they encode *plan depth / blast radius*, an orthogonal axis to *readiness* (`ready-for-agent`) and *type* (`bug`/`enhancement`). The taxonomy doc reconciles the two rather than inventing parallel `needs-human`-style labels.
+
+## Decision
+
+A single enforced **GitHub Issue Form** (YAML) is the contract, with a required **risk dropdown**, and a small dependency-free workflow that maps the dropdown answer to a `risk:*` label.
+
+Why this over the alternatives (from brainstorming):
+- **Enforcement.** Issue Forms block submission on empty required fields; classic markdown templates only suggest a shape. The blog's whole premise is "raise the floor before an agent sees the work" — only Forms actually raise it.
+- **Machine-parseable.** Structured Form fields render as predictable `### Heading` + value blocks, so cycle B's builder can parse the contract deterministically.
+- **One source of truth.** A single template + a dropdown beats four near-duplicate per-tier templates; the risk axis lives in one field, not in the choice of file.
+
+## Design
+
+### 1. `.github/ISSUE_TEMPLATE/change_request.yml` — the enforced contract
+
+GitHub Issue Form. Required fields (mirroring the blog's spec, adapted to GSD):
+
+| Field (id) | Type | Required | Notes |
+|---|---|---|---|
+| `summary` | textarea | yes | Problem statement — what & why |
+| `acceptance_criteria` | textarea | yes | How we know it's done (checklist-friendly) |
+| `constraints` | textarea | yes | Must / must-not; placeholder guides "write None if none" |
+| `out_of_scope` | textarea | yes | Explicit non-goals |
+| `rollback` | textarea | yes | How to undo if it goes wrong |
+| `risk` | dropdown | yes | `docs` / `chore` / `feature` / `risky`, each with a one-line meaning |
+| `affected_areas` | input | no | Optional: components/paths likely touched |
+| `context` | textarea | no | Optional: links, screenshots, prior art |
+
+- `name: "New Change"`, `description` explains this is the pipeline contract.
+- `labels: [needs-triage]` applied on creation (aligns with existing `needs-triage`).
+- The dropdown includes a leading "Select a risk tier" non-answer so an unset value is detectable, but the field is `required: true` so submission is blocked until a real tier is chosen.
+
+### 2. `.github/ISSUE_TEMPLATE/config.yml`
+
+```yaml
+blank_issues_enabled: false        # every issue goes through the contract
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/vscarpenter/gsd-task-manager/security/policy
+    about: Do not file security issues publicly — see SECURITY.md.
+```
+
+### 3. `risk:*` labels + `scripts/setup-labels.sh`
+
+| Label | Meaning | Color |
+|---|---|---|
+| `risk:docs` | Docs/content only | `#0075ca` (blue) |
+| `risk:chore` | Deps, config, tooling — no user-facing behavior change | `#c5def5` (light blue) |
+| `risk:feature` | New/changed user-facing behavior | `#0e8a16` (green) |
+| `risk:risky` | Touches security, auth, data, deploy/CI, or migrations | `#b60205` (red) |
+
+`scripts/setup-labels.sh`: idempotent, uses `gh label create "<name>" --color <hex> --description "<desc>" --force` (with `--force`, create acts as upsert). Re-runnable safely. Follows the repo's existing `scripts/*.sh` convention.
+
+### 4. `.github/workflows/apply-risk-label.yml` — the auto-labeler
+
+- **Trigger:** `issues: [opened, edited]`.
+- **Permissions:** `issues: write` only (single power — separation of duties in miniature). `contents: read`.
+- **Logic (via `actions/github-script`, no third-party action):**
+  1. Read `context.payload.issue.body`.
+  2. Extract the answer under the `### Risk tier` heading that GitHub Forms renders.
+  3. Normalize and match against the fixed enum `{docs, chore, feature, risky}`. Anything else → no-op (safe against malformed/malicious bodies).
+  4. Remove any existing `risk:*` label on the issue (so editing the dropdown updates the label).
+  5. Apply `risk:<tier>`.
+- **Concurrency:** group per-issue so rapid edits don't race.
+- The parsing contract (the exact `### Risk tier` heading and the dropdown option strings) is defined by §1 and must stay in sync with it; a comment in each file points at the other.
+
+### 5. `.github/pull_request_template.md` — the PR contract
+
+Sections: `Closes #<issue>` linkage; summary of change; **risk tier** (carried from the issue); a test / acceptance-criteria checklist; a **required rollback command/plan** (the blog's Gate 2 rule — "no rollback path, no approval" — captured at PR time); and a reviewer/CI checklist.
+
+### 6. Forward-looking label taxonomy (documented, not created)
+
+Recorded in this spec for cycles B–E to key off, reconciled with existing labels:
+
+| Future label | Cycle | Purpose | Reconciliation |
+|---|---|---|---|
+| `risk:{docs,chore,feature,risky}` | **A (now)** | Plan-depth / blast-radius axis | New namespace |
+| `ready-for-agent` *(exists)* | B | Contract complete → builder may claim | Reuse existing |
+| `plan:pending` | B | Plan drafted, awaiting Gate 1 | New |
+| `plan:approved` | B | Gate 1 passed → build may proceed | New |
+| `ready-for-human` *(exists)* | B/D | Needs human judgment / implementation | Reuse existing (do **not** add `needs-human`) |
+| `release-ready` | C | Review clean + CI green → awaiting Gate 2 | New |
+| `triage:paused` | D | Night-shift kill switch | New |
+
+## Verification approach
+
+Per the repo's TDD/verification standards:
+- **YAML validity + schema parse** for `change_request.yml`, `config.yml`, and `apply-risk-label.yml` (Forms schema fields, workflow schema).
+- **Labeler logic** exercised against sample issue bodies — each valid tier, missing/unselected tier, and junk input — asserting correct label vs. no-op. This is the one component with real logic, so it gets real test cases (the parse/match/normalize function is extracted so it is unit-testable without GitHub).
+- **Script idempotency** — `setup-labels.sh` re-run produces no error and no drift.
+
+## Rollback
+
+Everything here is additive and confined to `.github/` + one script + one doc. Rollback = delete the added files and `gh label delete risk:docs risk:chore risk:feature risk:risky`. No runtime, deploy, or data surface is touched.

--- a/scripts/parse-risk-tier.cjs
+++ b/scripts/parse-risk-tier.cjs
@@ -1,0 +1,33 @@
+"use strict";
+
+// Canonical risk tiers, in escalation order. Must match the dropdown options
+// in .github/ISSUE_TEMPLATE/change_request.yml exactly (bare lowercase words).
+const RISK_TIERS = ["docs", "chore", "feature", "risky"];
+
+/**
+ * Extract the selected risk tier from a GitHub Issue Form body.
+ * The form renders the dropdown as an "### Risk tier" heading followed by the
+ * chosen option on the next non-empty line. Returns null for anything that is
+ * not exactly one of RISK_TIERS (unanswered, junk, malformed, non-string).
+ *
+ * @param {string|null|undefined} body
+ * @returns {"docs"|"chore"|"feature"|"risky"|null}
+ */
+function parseRiskTier(body) {
+  if (typeof body !== "string" || body.length === 0) return null;
+  const lines = body.replace(/\r\n/g, "\n").split("\n");
+  const headingIdx = lines.findIndex((line) =>
+    /^#{1,6}\s+Risk tier\s*$/i.test(line.trim())
+  );
+  if (headingIdx === -1) return null;
+  for (let i = headingIdx + 1; i < lines.length; i++) {
+    const value = lines[i].trim();
+    if (value === "") continue;
+    if (/^#{1,6}\s+/.test(value)) return null; // hit next heading = empty answer
+    const normalized = value.toLowerCase();
+    return RISK_TIERS.includes(normalized) ? normalized : null;
+  }
+  return null;
+}
+
+module.exports = { parseRiskTier, RISK_TIERS };

--- a/scripts/parse-risk-tier.test.ts
+++ b/scripts/parse-risk-tier.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { parseRiskTier, RISK_TIERS } from "./parse-risk-tier.cjs";
+
+const body = (value: string) =>
+  `### Summary\n\nDo the thing\n\n### Risk tier\n\n${value}\n\n### Additional context\n\n_No response_`;
+
+describe("parseRiskTier", () => {
+  it("exposes the four canonical tiers", () => {
+    expect(RISK_TIERS).toEqual(["docs", "chore", "feature", "risky"]);
+  });
+
+  it.each(RISK_TIERS)("parses a valid tier: %s", (tier) => {
+    expect(parseRiskTier(body(tier))).toBe(tier);
+  });
+
+  it("is case- and whitespace-insensitive", () => {
+    expect(parseRiskTier(body("  Feature  "))).toBe("feature");
+  });
+
+  it("handles CRLF line endings", () => {
+    expect(parseRiskTier("### Risk tier\r\n\r\nrisky\r\n")).toBe("risky");
+  });
+
+  it("returns null when the heading is absent", () => {
+    expect(parseRiskTier("### Summary\n\nno risk field here")).toBeNull();
+  });
+
+  it("returns null for an unanswered dropdown (_No response_)", () => {
+    expect(parseRiskTier(body("_No response_"))).toBeNull();
+  });
+
+  it("returns null when the answer is not one of the four tiers", () => {
+    expect(parseRiskTier(body("medium"))).toBeNull();
+  });
+
+  it("returns null when the section is empty (next heading follows)", () => {
+    expect(parseRiskTier("### Risk tier\n\n### Next\n\nx")).toBeNull();
+  });
+
+  it.each([null, undefined, "", 123 as unknown as string])(
+    "returns null for non-string/empty input: %s",
+    (input) => {
+      expect(parseRiskTier(input as string)).toBeNull();
+    }
+  );
+});

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Provision the risk:* labels used by the delivery pipeline (sub-project A:
+# "The Contract"). Idempotent — `gh label create --force` upserts, so this is
+# safe to re-run. Requires an authenticated `gh` CLI with repo scope.
+set -euo pipefail
+
+create() {
+  gh label create "$1" --color "$2" --description "$3" --force
+}
+
+create "risk:docs"    "0075ca" "Docs/content only"
+create "risk:chore"   "c5def5" "Deps, config, tooling — no user-facing behavior change"
+create "risk:feature" "0e8a16" "New/changed user-facing behavior"
+create "risk:risky"   "b60205" "Touches security, auth, data, deploy/CI, or migrations"
+
+echo "risk:* labels created/updated."

--- a/tests/parse-risk-tier.test.ts
+++ b/tests/parse-risk-tier.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseRiskTier, RISK_TIERS } from "./parse-risk-tier.cjs";
+import { parseRiskTier, RISK_TIERS } from "../scripts/parse-risk-tier.cjs";
 
 const body = (value: string) =>
   `### Summary\n\nDo the thing\n\n### Risk tier\n\n${value}\n\n### Additional context\n\n_No response_`;

--- a/tests/parse-risk-tier.test.ts
+++ b/tests/parse-risk-tier.test.ts
@@ -37,6 +37,11 @@ describe("parseRiskTier", () => {
     expect(parseRiskTier("### Risk tier\n\n### Next\n\nx")).toBeNull();
   });
 
+  it("returns null when the heading has no following value at all", () => {
+    expect(parseRiskTier("### Risk tier")).toBeNull();
+    expect(parseRiskTier("### Risk tier\n\n   \n")).toBeNull();
+  });
+
   it.each([null, undefined, "", 123 as unknown as string])(
     "returns null for non-string/empty input: %s",
     (input) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,7 +27,8 @@ export default defineConfig({
         "app/**/*.ts",
         "app/**/*.tsx",
         "scripts/**/*.ts",
-        "scripts/**/*.js"
+        "scripts/**/*.js",
+        "scripts/**/*.cjs"
       ],
       exclude: [
         "**/*.test.ts",


### PR DESCRIPTION
## Summary

Bootstraps the delivery-pipeline **front door** — sub-project A ("The Contract") of the "Two Gates and a Night Shift" agentic SDLC. Every change will enter as an enforced, machine-parseable issue carrying a risk tier, so a human writes the spec before any agent reads it.

No prior issue to `Closes #` — this PR *is* the issue-contract system being introduced. Spec: `docs/superpowers/specs/2026-07-07-the-contract-design.md`, plan: `docs/superpowers/plans/2026-07-07-the-contract.md`.

Adds:
- `.github/ISSUE_TEMPLATE/change_request.yml` — enforced Issue Form (6 required fields + risk dropdown)
- `.github/ISSUE_TEMPLATE/config.yml` — blank issues off; security → SECURITY.md
- `scripts/parse-risk-tier.cjs` (+ Vitest, 15 cases) — pure risk parser
- `.github/workflows/apply-risk-label.yml` — applies `risk:*` from the dropdown (`issues:write` only)
- `scripts/setup-labels.sh` — idempotent `risk:{docs,chore,feature,risky}` provisioning
- `.github/pull_request_template.md` — this template

`risk:*` is a **distinct namespace** from the existing `ready-for-agent`/`ready-for-human` AFK-agent labels (plan-depth axis vs. readiness axis). Cycles B–E (builder+Gate 1, review+Gate 2, night shift, telemetry) build on this.

## Risk tier

**chore** — additive `.github/` + `scripts/` scaffolding. No runtime, app, deploy, or CI-gate behavior changed.

## How to verify

Locally verified: parser 15/15 green, eslint clean, all YAML parses, dropdown options === parser `RISK_TIERS`.

Post-merge (labeler + form only take effect from the default branch):
1. `bash scripts/setup-labels.sh` — create the four `risk:*` labels **before** the first real issue.
2. Open a test issue via **New Change**, pick a tier → confirm `apply-risk-label.yml` applies `risk:<tier>`.
3. Edit the dropdown → confirm the label swaps.

## Rollback plan

Revert this PR (all changes are additive and confined to `.github/`, `scripts/`, `docs/`), then `gh label delete risk:docs risk:chore risk:feature risk:risky` if the labels were created. No runtime/deploy/data surface is touched, so rollback is immediate.

## Checklist

- [x] Tests added/updated and passing (`bun run test -- scripts/parse-risk-tier.test.ts`, 15/15)
- [x] Lint clean on new files (`bunx eslint scripts/parse-risk-tier.*`)
- [x] Coding standards followed (`coding-standards.md`)
- [x] Rollback plan above is real
- [ ] Post-merge: `setup-labels.sh` run + end-to-end label test

https://claude.ai/code/session_01VTzjLGNTCEByQKuedNvBoB
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->