### PR TITLE
fix(lint): treat .cjs files as CommonJS (unbreak main lint)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,6 +52,14 @@ const config = [
         },
     },
     {
+        // .cjs files are CommonJS by definition, so require()/module.exports are
+        // the correct syntax — the TS no-require-imports rule must not apply.
+        files: ["**/*.cjs"],
+        rules: {
+            "@typescript-eslint/no-require-imports": "off",
+        },
+    },
+    {
         files: ["docker/pb_hooks/**/*.d.ts"],
         rules: {
             "@typescript-eslint/no-explicit-any": "off",

--- a/packages/mcp-server/decode-jwt.cjs
+++ b/packages/mcp-server/decode-jwt.cjs
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
 
 // Get token from Claude Desktop config
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const fs = require('fs');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const path = require('path');
 
 const configPath = path.join(

--- a/scripts/generate-build-info.cjs
+++ b/scripts/generate-build-info.cjs
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const fs = require('fs');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const path = require('path');
 
 const PACKAGE_JSON = path.join(__dirname, '..', 'package.json');

--- a/scripts/update-sw-version.cjs
+++ b/scripts/update-sw-version.cjs
@@ -10,9 +10,7 @@
  * is missing (e.g. running this script standalone before a build).
  */
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const fs = require('fs');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const path = require('path');
 
 const BUILD_INFO = path.join(__dirname, '..', '.build-info.json');


### PR DESCRIPTION
## Summary

`main` has been **red on lint** for several runs: `scripts/build-openwiki-site.cjs` uses `require()`, which `@typescript-eslint/no-require-imports` forbids — but `.cjs` is CommonJS by definition, so `require()`/`module.exports` are correct there. The eslint config only exempted `docker/**/*.js`, not `.cjs`.

This adds a `**/*.cjs` override (mirroring the existing docker override) and removes six now-redundant inline `eslint-disable` directives in `decode-jwt.cjs`, `generate-build-info.cjs`, and `update-sw-version.cjs`.

Found while landing the delivery-pipeline work (#421), which introduces a `.cjs` script and inherited this pre-existing failure.

## Risk tier

**chore** — lint-config only + comment removals. No runtime, app, or behavior change.

## How to verify

- `bun run lint` → **0 errors** (was 2), 10 pre-existing warnings unchanged.
- `bun run typecheck` → passes.

## Rollback plan

Revert this PR. Lint returns to its prior (already-red) state; nothing runtime is affected.

## Checklist

- [x] `bun run lint` clean (0 errors)
- [x] `bun run typecheck` passes
- [x] Config change mirrors the existing `docker/**/*.js` override pattern
- [x] Rollback plan above is real

https://claude.ai/code/session_01VTzjLGNTCEByQKuedNvBoB
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->