### PR TITLE
feat(pipeline): Builder + Gate 1 — local autonomous builder (cycle B)

### DIFF
--- a/.claude/commands/build-next.md
+++ b/.claude/commands/build-next.md
@@ -1,0 +1,44 @@
+---
+name: build-next
+description: Autonomous builder for the delivery pipeline (cycle B). Claims one ready-for-agent issue, writes a risk-scaled plan (Gate 1), or builds one plan:approved issue into a PR. Never merges.
+---
+
+# /build-next
+
+You are the **builder** for the GSD Task Manager delivery pipeline. Run headlessly and unattended. Do **one** unit of work this run, then stop. The full operating spec is `docs/agents/builder.md` — read it; this command is the executable summary. Definition of done is `coding-standards.md`. Issue-tracker `gh` conventions are in `docs/agents/issue-tracker.md`.
+
+**Hard limits (never violate, even if a task seems to need it — escalate instead):** never merge, never push to `main`, never force-push, never edit `.github/workflows/**`, `docker/**` deploy config, CloudFront config, or `SECURITY.md`/security config. You may only commit to a `claude/issue-<n>-*` branch, open a PR, comment, and move the pipeline labels.
+
+## Decide what to do (in this priority order)
+
+1. **A `plan:approved` issue exists** → do the **Build pass** on the oldest one.
+2. **Else a `ready-for-agent` issue exists** → do the **Plan pass** on the oldest one.
+3. **Else** → print "no actionable work" and stop.
+
+Process at most one issue. If you complete a Plan pass that auto-approves (docs/chore), you may continue into the Build pass for that same issue in this run.
+
+## Plan pass
+
+1. Read the issue and its contract fields (Summary, Acceptance criteria, Constraints, Out of scope, Rollback, Risk tier). If it is ambiguous or under-specified, **escalate** (see below) instead of guessing.
+2. Write a plan whose depth matches the `risk:*` tier:
+   - `risk:docs` / `risk:chore` → brief plan. Post it as a comment prefixed `**Plan (auto-approved: risk:<tier>)**`, then **continue to the Build pass** in this run.
+   - `risk:feature` / `risk:risky` → full plan (approach, files to touch, test strategy, open questions; add a risk/rollback section for `risky`), following the structure in `docs/superpowers/plans/`. Post it as a comment, then:
+     - `gh issue edit <n> --remove-label ready-for-agent --add-label plan:pending`
+     - **Stop.** Do not build. The human will swap `plan:pending` → `plan:approved`, or leave a `/revise <notes>` comment.
+   - No `risk:*` label → treat as `risk:feature` and note the missing tier in the plan.
+
+## Revise
+
+If the target issue is `plan:pending` and its newest comment is `/revise <notes>`, re-plan addressing the notes, post the updated plan, and keep `plan:pending`. (This case is only reached if such an issue is also `plan:approved`; normally a `plan:pending` issue waits for the human. Do not act on `plan:pending` issues that have no approval and no new `/revise`.)
+
+## Build pass
+
+1. **Claim:** `gh issue edit <n> --remove-label plan:approved --remove-label ready-for-agent --add-label agent:building`.
+2. **Isolate:** you are already in a dedicated worktree off `origin/main`. Create branch `claude/issue-<n>-<slug>`.
+3. **Build to the standard:** implement per `coding-standards.md` — write tests first (TDD), meet coverage thresholds, update docs. Run `bun run test`, `bun run lint`, `bun run typecheck` and get them green.
+4. **PR:** commit, push the branch, and `gh pr create` using `.github/pull_request_template.md`. Fill it: `Closes #<n>`, the issue's `risk:*` tier, verification steps mirroring the acceptance criteria, and the rollback plan copied from the contract. Do **not** merge.
+5. **Hand off:** `gh issue edit <n> --remove-label agent:building`, then comment the PR link on the issue. Stop — review, CI (a required gate), and Gate 2 are not yours.
+
+## Escalate (never guess)
+
+If the contract is ambiguous, the change needs human judgment, or a required step hits a hard limit: `gh issue edit <n> --add-label ready-for-human --remove-label agent:building,plan:pending,plan:approved` and comment a written reason stating exactly what is blocked and what input you need.

--- a/.claude/commands/build-next.md
+++ b/.claude/commands/build-next.md
@@ -12,8 +12,9 @@ You are the **builder** for the GSD Task Manager delivery pipeline. Run headless
 ## Decide what to do (in this priority order)
 
 1. **A `plan:approved` issue exists** → do the **Build pass** on the oldest one.
-2. **Else a `ready-for-agent` issue exists** → do the **Plan pass** on the oldest one.
-3. **Else** → print "no actionable work" and stop.
+2. **Else a `plan:revise` issue exists** → do the **Revise pass** on the oldest one.
+3. **Else a `ready-for-agent` issue exists** → do the **Plan pass** on the oldest one.
+4. **Else** → print "no actionable work" and stop.
 
 Process at most one issue. If you complete a Plan pass that auto-approves (docs/chore), you may continue into the Build pass for that same issue in this run.
 
@@ -27,9 +28,11 @@ Process at most one issue. If you complete a Plan pass that auto-approves (docs/
      - **Stop.** Do not build. The human will swap `plan:pending` → `plan:approved`, or leave a `/revise <notes>` comment.
    - No `risk:*` label → treat as `risk:feature` and note the missing tier in the plan.
 
-## Revise
+## Revise pass
 
-If the target issue is `plan:pending` and its newest comment is `/revise <notes>`, re-plan addressing the notes, post the updated plan, and keep `plan:pending`. (This case is only reached if such an issue is also `plan:approved`; normally a `plan:pending` issue waits for the human. Do not act on `plan:pending` issues that have no approval and no new `/revise`.)
+A `plan:revise` issue is one the human wants changed. Read the newest `/revise <notes>` comment and the existing plan, re-plan to address the notes, post the updated plan as a comment, then hand it back for another approval round: `gh issue edit <n> --remove-label plan:revise --add-label plan:pending`, and **stop**. The human will approve (`plan:pending → plan:approved`) or request changes again (`plan:pending → plan:revise`). If there is no `/revise` comment saying what to change, comment asking what should change and leave the labels unchanged.
+
+Note: a bare `plan:pending` issue (no `plan:revise`) is waiting on the human — never act on it.
 
 ## Build pass
 
@@ -41,4 +44,4 @@ If the target issue is `plan:pending` and its newest comment is `/revise <notes>
 
 ## Escalate (never guess)
 
-If the contract is ambiguous, the change needs human judgment, or a required step hits a hard limit: `gh issue edit <n> --add-label ready-for-human --remove-label agent:building,plan:pending,plan:approved` and comment a written reason stating exactly what is blocked and what input you need.
+If the contract is ambiguous, the change needs human judgment, or a required step hits a hard limit: `gh issue edit <n> --add-label ready-for-human --remove-label agent:building,plan:pending,plan:approved,plan:revise` and comment a written reason stating exactly what is blocked and what input you need.

--- a/docs/agents/builder.md
+++ b/docs/agents/builder.md
@@ -14,9 +14,9 @@ needs-triage + risk:*            (a filed contract, cycle A)
       ▼
 ready-for-agent ──run 1 (plan)──▶ plan:pending ──human swaps──▶ plan:approved ──run 2 (build)──▶ [PR opened]
       │                               │                                            │
-      │ risk:docs | risk:chore        │ /revise <notes>                            │ agent:building
-      │ auto-approve (plan+build       ▼   (next run re-plans)                      │  (claim-lock, removed
-      │  in one pass, logged)     plan:pending                                     │  when the PR is opened)
+      │ risk:docs | risk:chore        │ human swaps + /revise <notes>              │ agent:building
+      │ auto-approve (plan+build       ▼                                           │  (claim-lock, removed
+      │  in one pass, logged)     plan:revise ──run (re-plan)──▶ plan:pending      │  when the PR is opened)
       │
       └── ambiguous / needs judgment / hard limit hit ──▶ ready-for-human + written reason
 ```
@@ -41,8 +41,12 @@ If an issue has no `risk:*` label, treat it as `risk:feature` (require Gate 1) a
 1. Write the plan and post it as an issue comment.
 2. Move labels: remove `ready-for-agent`, add `plan:pending`.
 3. **Stop.** Do not build.
-4. The human approves by swapping `plan:pending` → `plan:approved` (from the GitHub mobile app), or requests changes with a `/revise <notes>` comment.
-5. On the next run: a `plan:approved` issue proceeds to build; a `plan:pending` issue with a newer `/revise` comment gets re-planned (address the notes, re-post, keep `plan:pending`).
+4. The human either:
+   - **approves** — swaps `plan:pending` → `plan:approved` (two taps on the GitHub mobile app); or
+   - **requests changes** — swaps `plan:pending` → `plan:revise` and comments `/revise <notes>`.
+5. On the next run: a `plan:approved` issue proceeds to build; a `plan:revise` issue is re-planned (address the notes, post the updated plan, then swap back to `plan:pending` for another approval round). A bare `plan:pending` issue is left alone — it is waiting on the human.
+
+Why "request changes" is a label swap and not just a comment: the scheduler's cheap pre-check counts labels and cannot see comments without an expensive query. Signalling a revise with the `plan:revise` label lets the builder wake for it without polling every pending plan on every run.
 
 ## Build
 

--- a/docs/agents/builder.md
+++ b/docs/agents/builder.md
@@ -1,0 +1,73 @@
+# Builder — operating spec
+
+The builder is a **local, scheduled** Claude Code routine (cycle B of the delivery pipeline). It turns a fully-specified issue into a reviewed pull request, pausing once for human plan approval (Gate 1). It **never merges**. It is launched by `scripts/builder-run.sh`; its per-run instructions live in `.claude/commands/build-next.md`; this file is the durable operating spec both reference.
+
+For all issue-tracker operations, follow `docs/agents/issue-tracker.md` (the `gh` conventions). For triage-label vocabulary, see `docs/agents/triage-labels.md`.
+
+## The loop (label state machine)
+
+The builder is **non-blocking**: each run does one unit of work and exits. Labels carry state between runs, so a closed laptop never orphans anything.
+
+```
+needs-triage + risk:*            (a filed contract, cycle A)
+      │  human triages a well-specified one
+      ▼
+ready-for-agent ──run 1 (plan)──▶ plan:pending ──human swaps──▶ plan:approved ──run 2 (build)──▶ [PR opened]
+      │                               │                                            │
+      │ risk:docs | risk:chore        │ /revise <notes>                            │ agent:building
+      │ auto-approve (plan+build       ▼   (next run re-plans)                      │  (claim-lock, removed
+      │  in one pass, logged)     plan:pending                                     │  when the PR is opened)
+      │
+      └── ambiguous / needs judgment / hard limit hit ──▶ ready-for-human + written reason
+```
+
+Process **at most one** issue per run (one planned OR one built), so a single run has a bounded blast radius.
+
+## Risk → plan depth
+
+The `risk:*` label (from the contract) decides how deep the plan is and whether Gate 1 applies:
+
+| Risk | Plan depth | Gate 1 |
+|---|---|---|
+| `risk:docs` | One or two lines: what changes, how verified. | **Auto-approved** — post the plan as a comment noting `auto-approved (risk:docs)`, then build in the same run. |
+| `risk:chore` | Short: approach + files touched + how verified. | **Auto-approved** — same, `auto-approved (risk:chore)`. |
+| `risk:feature` | Full plan: approach, files to touch, test strategy, open questions. Follow the structure in `docs/superpowers/plans/`. | **Required** — post plan, label `plan:pending`, stop. |
+| `risk:risky` | Full plan **plus** an explicit risk/rollback section and the specific safeguards. | **Required** — post plan, label `plan:pending`, stop. |
+
+If an issue has no `risk:*` label, treat it as `risk:feature` (require Gate 1) and note the missing tier in the plan.
+
+## Gate 1 protocol
+
+1. Write the plan and post it as an issue comment.
+2. Move labels: remove `ready-for-agent`, add `plan:pending`.
+3. **Stop.** Do not build.
+4. The human approves by swapping `plan:pending` → `plan:approved` (from the GitHub mobile app), or requests changes with a `/revise <notes>` comment.
+5. On the next run: a `plan:approved` issue proceeds to build; a `plan:pending` issue with a newer `/revise` comment gets re-planned (address the notes, re-post, keep `plan:pending`).
+
+## Build
+
+Only after `plan:approved` (or auto-approval):
+
+1. **Claim:** remove `plan:approved` / `ready-for-agent`, add `agent:building` (prevents a concurrent run from double-processing).
+2. **Build to the standard:** implement the change following `coding-standards.md` as the definition of done — TDD, tests, docs, coverage thresholds. The standards define done, not the builder's confidence.
+3. **Branch:** commit to `claude/issue-<n>-<slug>`. Never commit to `main`.
+4. **PR:** open a pull request using the repo's PR template. Include `Closes #<n>`, carry the issue's `risk:*` tier, and copy the rollback plan from the contract into the PR's rollback section.
+5. **Hand off:** remove `agent:building`, comment the PR link on the issue. The PR now enters review + CI (a required gate) + Gate 2 — none of which the builder performs.
+
+## Separation of duties — hard limits
+
+The builder **must never**:
+- merge any PR, push to `main`, or force-push anything;
+- edit `.github/workflows/**`, `docker/**` deploy config, CloudFront config/functions, or `SECURITY.md` / security configuration.
+
+The builder **may only**: create and commit to a `claude/issue-<n>-*` branch, open a PR, comment on issues/PRs, and move the workflow labels above.
+
+If a task genuinely requires any forbidden action, **escalate** — do not work around it.
+
+## Escalation
+
+When the contract is ambiguous, the change needs human judgment, a required change hits a hard limit, or the build cannot meet `coding-standards.md`: add `ready-for-human`, remove `agent:building`/`plan:*`, and comment a **written reason** explaining exactly what is blocked and what input is needed. Never guess and never silently proceed.
+
+## Kill switch
+
+`scripts/builder-run.sh` checks for an open issue labeled `builder:paused` before doing anything and exits if found. To halt the builder with no code change and no shell access, add `builder:paused` to the designated Builder Control issue; remove it to resume.

--- a/docs/superpowers/plans/2026-07-07-builder-gate1.md
+++ b/docs/superpowers/plans/2026-07-07-builder-gate1.md
@@ -1,0 +1,297 @@
+# Cycle B — Builder + Gate 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A local, scheduled Claude routine that claims a `ready-for-agent` contract, writes a risk-scaled plan, stops for a label-swap plan approval (Gate 1), then builds to `coding-standards.md` and opens a PR — never merging.
+
+**Architecture:** A launchd job runs `builder-run.sh` every 30 min. The wrapper pre-checks cheaply (kill switch + work check) and only invokes `claude -p "/build-next"` (in an isolated worktree) when there is work. The builder's behavior lives in versioned instructions (`build-next.md` + `builder.md`). Labels are the durable state machine across non-blocking runs.
+
+**Tech Stack:** Bash, `gh` CLI, Claude Code CLI (`claude -p`), launchd (macOS), Vitest (for the wrapper's decision-logic test), the cycle A `risk:*` labels + PR template.
+
+## Global Constraints
+
+- Additive only — `scripts/`, `.claude/commands/`, `docs/`. Do NOT modify runtime/app code, CI, or deploy config.
+- Risk tiers (from cycle A, verbatim): `docs`, `chore`, `feature`, `risky`. `docs`/`chore` auto-approve Gate 1; `feature`/`risky` require it.
+- New labels EXACTLY: `plan:pending`, `plan:approved`, `agent:building`, `builder:paused`. Reuse `ready-for-agent`, `ready-for-human` (do not rename).
+- Builder hard limits: never merge / push to main / force-push / edit `.github/workflows/**`, `docker/**`, CloudFront, or security config; ≤1 issue planned + ≤1 built per run; isolated worktree only.
+- Node helpers `.cjs`; tests `.test.ts` under `tests/` (excluded from `tsc`, run by Vitest). Commits: Conventional + `Vinny Carpenter <vscarpenter@gmail.com>` + `Claude-Session` trailer, no Co-Authored-By.
+- Repo slug: `vscarpenter/gsd-task-manager`.
+
+---
+
+### Task 1: New pipeline labels
+
+**Files:** Modify `scripts/setup-labels.sh`
+
+- [ ] **Step 1: Append the four builder labels** after the existing `risk:*` block, before the final echo:
+
+```bash
+create "plan:pending"    "fbca04" "Plan posted, awaiting Gate 1 approval"
+create "plan:approved"   "0e8a16" "Human approved the plan; build may proceed"
+create "agent:building"  "5319e7" "Builder is actively building (claim-lock)"
+create "builder:paused"  "b60205" "Kill switch — halts all builder runs"
+```
+
+- [ ] **Step 2: Verify syntax + idempotency guard**
+
+Run: `bash -n scripts/setup-labels.sh && grep -c '^create ' scripts/setup-labels.sh`
+Expected: no syntax error; `8` create lines (4 risk + 4 builder).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/setup-labels.sh
+git commit   # feat(pipeline): add builder/Gate-1 labels to setup-labels.sh
+```
+
+---
+
+### Task 2: `builder-run.sh` wrapper + decision-logic test (TDD)
+
+**Files:**
+- Create: `scripts/builder-run.sh`
+- Create: `tests/builder-run.test.ts`
+
+**Interfaces:**
+- Produces exit code 0 in all pre-check outcomes; prints one of the sentinel lines `PAUSED` / `NO_WORK` / `WORK` (so the test and logs are unambiguous). Modes: `--check` (pre-check only), `--dry-run` (pre-check + print intended invocation), default (full run).
+
+- [ ] **Step 1: Write the failing test** — `tests/builder-run.test.ts`
+
+```ts
+import { describe, it, expect, beforeAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, chmodSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SCRIPT = join(__dirname, "..", "scripts", "builder-run.sh");
+
+// Build a fake `gh` that returns a canned issue count per label query.
+function stubGh(counts: Record<string, number>): string {
+  const dir = mkdtempSync(join(tmpdir(), "ghstub-"));
+  const bin = join(dir, "gh");
+  // gh issue list --repo R --label L --state open --json number --jq length
+  const script = `#!/usr/bin/env bash
+label=""
+while [ "$#" -gt 0 ]; do case "$1" in --label) shift; label="$1";; esac; shift; done
+case "$label" in
+${Object.entries(counts).map(([l, n]) => `  "${l}") echo ${n};;`).join("\n")}
+  *) echo 0;;
+esac
+`;
+  writeFileSync(bin, script);
+  chmodSync(bin, 0o755);
+  return dir;
+}
+
+function run(mode: string, counts: Record<string, number>): string {
+  const stub = stubGh(counts);
+  return execFileSync("bash", [SCRIPT, mode], {
+    env: { ...process.env, PATH: `${stub}:${process.env.PATH}` },
+    encoding: "utf8",
+  });
+}
+
+describe("builder-run.sh pre-check", () => {
+  it("exits PAUSED when builder:paused is set", () => {
+    expect(run("--check", { "builder:paused": 1, "ready-for-agent": 5 })).toContain("PAUSED");
+  });
+  it("exits NO_WORK when nothing is actionable", () => {
+    const out = run("--check", { "builder:paused": 0, "ready-for-agent": 0, "plan:approved": 0 });
+    expect(out).toContain("NO_WORK");
+  });
+  it("reports WORK when ready-for-agent issues exist", () => {
+    expect(run("--check", { "builder:paused": 0, "ready-for-agent": 2, "plan:approved": 0 })).toContain("WORK");
+  });
+  it("reports WORK when plan:approved issues exist", () => {
+    expect(run("--check", { "builder:paused": 0, "ready-for-agent": 0, "plan:approved": 1 })).toContain("WORK");
+  });
+  it("dry-run prints the intended invocation without running claude", () => {
+    const out = run("--dry-run", { "builder:paused": 0, "ready-for-agent": 1, "plan:approved": 0 });
+    expect(out).toContain("WORK");
+    expect(out).toContain("/build-next");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun run test -- tests/builder-run.test.ts`
+Expected: FAIL — `scripts/builder-run.sh` does not exist.
+
+- [ ] **Step 3: Write `scripts/builder-run.sh`**
+
+```bash
+#!/usr/bin/env bash
+# GSD Builder — launchd entry point (cycle B: Builder + Gate 1).
+# Non-blocking: pre-checks cheaply and invokes the builder only when there is
+# work, so most scheduled wake-ups cost zero Claude tokens. Labels are the
+# durable state across runs. See docs/agents/builder.md.
+set -euo pipefail
+
+REPO="${GSD_BUILDER_REPO:-vscarpenter/gsd-task-manager}"
+WORKTREE="${GSD_BUILDER_WORKTREE:-$HOME/.gsd-builder/worktree}"
+SOURCE="${GSD_BUILDER_SOURCE:-$HOME/Projects/gsd-taskmanager}"
+LOG_DIR="${GSD_BUILDER_LOG_DIR:-$SOURCE/docs/ops/builder-logs}"
+
+MODE="run"
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) MODE="dry-run" ;;
+    --check)   MODE="check" ;;
+    "")        ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+count() { gh issue list --repo "$REPO" --label "$1" --state open --json number --jq 'length' 2>/dev/null || echo 0; }
+
+# 1. Kill switch.
+if [ "$(count "builder:paused")" != "0" ]; then
+  echo "PAUSED: builder:paused is set — exiting."
+  exit 0
+fi
+
+# 2. Cheap work check.
+to_plan="$(count "ready-for-agent")"
+to_build="$(count "plan:approved")"
+if [ "$to_plan" = "0" ] && [ "$to_build" = "0" ]; then
+  echo "NO_WORK: no ready-for-agent or plan:approved issues — exiting."
+  exit 0
+fi
+echo "WORK: ready-for-agent=$to_plan plan:approved=$to_build"
+
+if [ "$MODE" = "check" ]; then exit 0; fi
+if [ "$MODE" = "dry-run" ]; then
+  echo "DRYRUN: would run 'claude -p /build-next' in $WORKTREE"
+  exit 0
+fi
+
+# 3. Isolation — refresh a dedicated worktree off latest origin/main.
+mkdir -p "$(dirname "$WORKTREE")" "$LOG_DIR"
+git -C "$SOURCE" fetch origin main --quiet
+if [ -d "$WORKTREE/.git" ] || git -C "$SOURCE" worktree list | grep -q "$WORKTREE"; then
+  git -C "$SOURCE" -C "$WORKTREE" reset --hard origin/main
+else
+  git -C "$SOURCE" worktree add --force "$WORKTREE" origin/main
+fi
+
+# 4. Invoke the builder (scoped tools; bounded time). 5. Log.
+run_id="builder-$(git -C "$SOURCE" rev-parse --short origin/main)-$$"
+echo "RUN: $run_id"
+( cd "$WORKTREE" && claude -p "/build-next" \
+    --allowedTools "Bash(git*),Bash(gh*),Bash(bun*),Edit,Write,Read" \
+  ) 2>&1 | tee "$LOG_DIR/$run_id.log"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `chmod +x scripts/builder-run.sh && bun run test -- tests/builder-run.test.ts`
+Expected: PASS (5 cases).
+
+- [ ] **Step 5: Static lint + real dry-run against a stub**
+
+Run: `bash -n scripts/builder-run.sh` and a manual dry-run with a stubbed `gh` on PATH to observe `WORK` + `DRYRUN` lines.
+Expected: syntax OK; branches behave.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/builder-run.sh tests/builder-run.test.ts
+git commit   # feat(pipeline): builder-run.sh wrapper with tested pre-check + kill switch
+```
+
+---
+
+### Task 3: `docs/agents/builder.md` — operating spec
+
+**Files:** Create `docs/agents/builder.md`
+
+- [ ] **Step 1: Write the operating spec** with these sections (prose):
+  - **Role & loop** — the state machine diagram from the spec.
+  - **Risk → plan depth** — `docs`/`chore` lightweight + auto-approve; `feature`/`risky` full plan + Gate 1. Full-plan format references `docs/superpowers/plans/` structure.
+  - **Gate 1 protocol** — post plan comment; `ready-for-agent` → `plan:pending`; stop. `/revise <notes>` → re-plan. Approval = human swaps `plan:pending` → `plan:approved`.
+  - **Build** — claim (`agent:building`); TDD to `coding-standards.md`; branch `claude/issue-<n>-<slug>`; PR via cycle A template, `Closes #<n>`, carry `risk:*`, rollback from contract; remove `agent:building`; comment PR link.
+  - **Separation of duties** — the §5 hard limits, verbatim.
+  - **Escalation** — ambiguity/judgment/limit → `ready-for-human` + written reason; never guess.
+  - **Issue-tracker ops** — reference `docs/agents/issue-tracker.md` for `gh` conventions.
+
+- [ ] **Step 2: Cross-reference check** — every label and file the doc names exists.
+
+Run: `for l in ready-for-agent plan:pending plan:approved agent:building ready-for-human; do grep -q "$l" scripts/setup-labels.sh docs/agents/triage-labels.md || echo "MISSING: $l"; done; test -f coding-standards.md && echo "standards OK"`
+Expected: no MISSING lines; `standards OK`.
+
+- [ ] **Step 3: Commit** `docs(pipeline): builder operating spec (risk-scaled plan, Gate 1, SoD)`
+
+---
+
+### Task 4: `.claude/commands/build-next.md` — the builder command
+
+**Files:** Create `.claude/commands/build-next.md`
+
+- [ ] **Step 1: Write the command** (matches the `.claude/commands/` convention). Content: a tight, imperative instruction set that has Claude process **at most one** issue per run per §3 of the spec — plan pass (risk-scaled, auto-approve docs/chore, else `plan:pending`+stop), build pass (claim → TDD build → branch → PR → comment), revise handling, escalation — and points to `docs/agents/builder.md` for the full operating spec and `coding-standards.md` for the definition of done. Explicitly restates the separation-of-duties limits so a headless run cannot drift past them.
+
+- [ ] **Step 2: Verify it references the operating spec + standards**
+
+Run: `grep -q "builder.md" .claude/commands/build-next.md && grep -q "coding-standards.md" .claude/commands/build-next.md && echo OK`
+Expected: `OK`.
+
+- [ ] **Step 3: Commit** `feat(pipeline): /build-next builder command`
+
+---
+
+### Task 5: launchd plist template
+
+**Files:** Create `scripts/launchd/dev.vinny.gsd-builder.plist`
+
+- [ ] **Step 1: Write the plist** — `StartInterval` 1800s, runs `builder-run.sh`, redirects stdout/stderr to a log, `RunAtLoad` false:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>dev.vinny.gsd-builder</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/vinnycarpenter/Projects/gsd-taskmanager/scripts/builder-run.sh</string>
+  </array>
+  <key>StartInterval</key><integer>1800</integer>
+  <key>RunAtLoad</key><false/>
+  <key>StandardOutPath</key><string>/Users/vinnycarpenter/.gsd-builder/launchd.out.log</string>
+  <key>StandardErrorPath</key><string>/Users/vinnycarpenter/.gsd-builder/launchd.err.log</string>
+</dict>
+</plist>
+```
+
+- [ ] **Step 2: Validate the plist**
+
+Run: `plutil -lint scripts/launchd/dev.vinny.gsd-builder.plist`
+Expected: `OK`.
+
+- [ ] **Step 3: Commit** `chore(pipeline): launchd plist template for the builder (30-min cadence)`
+
+---
+
+## Full-suite verification (after all tasks)
+
+- [ ] `bun run test -- tests/builder-run.test.ts` — wrapper decision logic green.
+- [ ] `bash -n scripts/builder-run.sh scripts/setup-labels.sh` — shells parse.
+- [ ] `plutil -lint scripts/launchd/dev.vinny.gsd-builder.plist` — plist valid.
+- [ ] Cross-ref: labels in `build-next.md`/`builder.md` all exist in `setup-labels.sh`.
+- [ ] `bun run lint` — no new errors from added files.
+
+## Rollout (outside git — requires confirmation)
+
+1. `bash scripts/setup-labels.sh` — create the 4 new labels (idempotent; re-run).
+2. Push branch, open PR, merge (CI is now a required gate).
+3. Install launchd: copy plist to `~/Library/LaunchAgents/`, `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.vinny.gsd-builder.plist`.
+4. End-to-end: file a `risk:chore` contract → `ready-for-agent` → observe auto-approve + PR; file a `risk:feature` one → observe `plan:pending`, approve, observe build + PR.
+5. Kill-switch drill: open a "Builder Control" issue, add `builder:paused`, confirm the next run exits `PAUSED`.
+
+## Self-review (plan vs. spec)
+
+- Spec §1 labels → Task 1. §2 wrapper → Task 2 (+ TDD test). §3 command → Task 4. §4 operating spec → Task 3. §5 SoD → embedded in Tasks 3 & 4. §6 launchd → Task 5. Verification approach → Task 2 test + full-suite. **All spec sections covered.**
+- No placeholders in code steps; prose docs (Tasks 3–4) have concrete required-section lists.
+- Label/name consistency: `plan:pending`/`plan:approved`/`agent:building`/`builder:paused` identical across Tasks 1, 2, 3, 4; sentinel lines `PAUSED`/`NO_WORK`/`WORK` identical between wrapper (Task 2 Step 3) and test (Task 2 Step 1).

--- a/docs/superpowers/specs/2026-07-07-builder-gate1-design.md
+++ b/docs/superpowers/specs/2026-07-07-builder-gate1-design.md
@@ -1,0 +1,114 @@
+# Spec: Cycle B — The Builder + Gate 1 (local, blog-faithful)
+
+- **Date:** 2026-07-07
+- **Status:** Accepted (design approved 2026-07-07; proceeding to plan + implementation per standing correction)
+- **Deciders:** Vinny Carpenter
+- **Related:** `docs/superpowers/specs/2026-07-07-the-contract-design.md` (cycle A), `docs/agents/triage-labels.md` + `docs/agents/issue-tracker.md` (existing AFK-agent framework), `coding-standards.md`, blog "Two Gates and a Night Shift"
+
+## Goal
+
+A **local, scheduled** Claude Code routine that claims a fully-specified issue, writes a **risk-scaled plan**, stops for a **GitHub-native plan approval (Gate 1)**, and — once approved — builds the change to `coding-standards.md` and opens a pull request. The builder never merges. This is **cycle B** of five; it ends at "PR opened."
+
+## Scope & non-goals
+
+**In scope:**
+- Label state machine extending the existing AFK-agent labels (`ready-for-agent`, `ready-for-human`) with planning states (`plan:pending`, `plan:approved`, `agent:building`) and a kill switch (`builder:paused`).
+- A local launchd job + wrapper script (`scripts/builder-run.sh`) that pre-checks cheaply and invokes the builder only when there is work.
+- The builder's versioned instructions: a slash command (`.claude/commands/build-next.md`) + an operating spec (`docs/agents/builder.md`).
+- Risk-scaled behavior keyed off cycle A's `risk:*` labels: `docs`/`chore` auto-approved; `feature`/`risky` go through Gate 1.
+- Separation-of-duties constraints enforced in the builder's instructions.
+
+**Explicit non-goals (later cycles):**
+- **No reviewer, no merge, no Gate 2.** The builder opens a PR and stops. Review + CI-as-gate (now enforced) + Gate 2 are cycle C.
+- **No nightly triage** (cycle D). **No telemetry** (cycle E).
+- **No Telegram/Roci** — Gate 1 is GitHub-native (label swap, approved from the GitHub mobile app).
+- **No blocking wait** — the runner is stateless across runs; labels are the durable state.
+
+## Background — current state
+
+Cycle A gives every change an enforced contract with a `risk:*` tier. The repo already runs `anthropics/claude-code-action@v1` reactively (`claude.yml`, read-only, `@claude`-triggered) and documents an AFK-agent label vocabulary (`docs/agents/triage-labels.md`: `ready-for-agent` = "fully specified, ready for an AFK agent"; `ready-for-human` = "requires human implementation"). `main` is now protected by a ruleset requiring PR + passing CI (`lint`/`typecheck`/`test`/`build`) + thread resolution, so nothing the builder pushes can reach `main` without the gate.
+
+The gap: nothing autonomously turns a `ready-for-agent` contract into a reviewed PR, and there is no plan-approval gate.
+
+## Decision
+
+A **local scheduled routine**, not a GitHub Action, per the blog's model. It is **non-blocking and stateless across runs**; a label state machine is its memory. Gate 1 approval is a **label swap** (`plan:pending` → `plan:approved`) done from GitHub mobile; `/revise <notes>` requests changes.
+
+Why local over an Action: chosen explicitly (blog-faithful). Why non-blocking: a local process must not block for hours — a sleeping laptop would orphan the run; labels survive sleep. Why label-swap Gate 1: two-tap mobile approval, clean state machine, reuses the existing label framework.
+
+## Design
+
+### 1. Label state machine
+
+```
+needs-triage + risk:*        (cycle A output)
+      │  human triages
+      ▼
+ready-for-agent ──run 1 (plan)──▶ plan:pending ──YOU: swap──▶ plan:approved ──run 2 (build)──▶ [PR opened]
+      │                               │                                            │
+      │ risk:docs|chore               │ /revise <notes>                            │ agent:building (claim-lock,
+      │ (auto-approve: plan+build      ▼   (next run re-plans)                      │  removed when PR opened)
+      │  in one pass, logged)     plan:pending
+      │
+      └── cannot proceed / needs judgment ──▶ ready-for-human + written reason (comment)
+```
+
+New labels (added to `scripts/setup-labels.sh`):
+
+| Label | Meaning | Color |
+|---|---|---|
+| `plan:pending` | Plan posted, awaiting Gate 1 approval | `#fbca04` (yellow) |
+| `plan:approved` | Human approved the plan; build may proceed | `#0e8a16` (green) |
+| `agent:building` | Builder is actively building (claim-lock) | `#5319e7` (purple) |
+| `builder:paused` | Kill switch — on the Builder Control issue, halts all runs | `#b60205` (red) |
+
+Reused (unchanged): `ready-for-agent`, `ready-for-human`, `needs-triage`, `risk:*`.
+
+### 2. `scripts/builder-run.sh` — launchd entry point
+
+Responsibilities, in order:
+1. **Kill switch:** if any open issue has `builder:paused`, log one line and exit 0.
+2. **Cheap work check:** `gh issue list` for `ready-for-agent` (unplanned) or `plan:approved` (ready to build). If none, exit 0 without invoking Claude (most wake-ups cost zero tokens).
+3. **Isolation:** create/refresh a dedicated git worktree (`$BUILDER_WORKTREE`, default `~/.gsd-builder/worktree`) off latest `origin/main` — never the user's active checkout.
+4. **Invoke:** `claude -p "/build-next"` in the worktree with a scoped permission profile (git, `gh`, bun/test, in-repo edits; see §5). Timeout-bounded.
+5. **Log:** append run output to `docs/ops/builder-logs/` (or a configured dir) with a UTC-less run id.
+6. Supports `--dry-run` (print the decision + what it would invoke, without invoking Claude) for testing/verification, and `--check` (kill-switch + work-check only, print state, exit).
+
+Structured so the decision logic (`paused` / `no-work` / `work`) is observable via `--dry-run` against a stubbed `gh`.
+
+### 3. `.claude/commands/build-next.md` — the builder command
+
+Invoked headlessly. Instructs Claude to, in one run, process **at most one** issue:
+- **Plan pass:** pick the oldest open `ready-for-agent` issue. Read the contract (cycle A fields). Write a risk-scaled plan:
+  - `risk:docs`/`risk:chore` → lightweight plan; **auto-approve**: post the plan as a comment noting "auto-approved (risk:<tier>)", then proceed straight to the build pass in the same run.
+  - `risk:feature`/`risk:risky` → full plan (approach, files, test strategy, open questions, following the `docs/superpowers/` plan format). Post as a comment, swap `ready-for-agent` → `plan:pending`, and **stop**.
+- **Build pass:** pick the oldest `plan:approved` issue (or the just-auto-approved one). Claim it (`plan:approved`/`ready-for-agent` → `agent:building`). Build to `coding-standards.md` (TDD, tests, docs). Commit to `claude/issue-<n>-<slug>`, push, open a PR (cycle A PR template; `Closes #<n>`; carry `risk:*`; rollback from the contract). Remove `agent:building`. Comment the PR link on the issue.
+- **Revise:** if a `plan:pending` issue has a newer `/revise <notes>` comment, re-plan addressing the notes; re-post; keep `plan:pending`.
+- **Escalate:** if the contract is ambiguous, the change needs judgment, or a hard limit is hit → add `ready-for-human`, remove agent labels, and comment a written reason (never guess).
+
+### 4. `docs/agents/builder.md` — operating spec
+
+The durable "standard spec" the command references: risk-tier → plan-depth mapping; the label protocol; the plan format (reuse `docs/superpowers/`); `coding-standards.md` as definition of done; and the separation-of-duties limits (§5). Extends the existing `docs/agents/` set.
+
+### 5. Separation of duties (hard limits, enforced in the instructions + permission profile)
+
+The builder **must never**: merge, push to `main`, force-push, or edit `.github/workflows/**`, `docker/**` deploy config, CloudFront config, or `SECURITY.md`/security config. On needing any of those → escalate (`ready-for-human`).
+The builder **may only**: create/commit to a `claude/issue-<n>-*` branch, open a PR, comment on issues/PRs, and move the workflow labels in §1.
+Bounded blast radius: **≤1 issue planned and ≤1 issue built per run**; per-run timeout; operates only in the isolated worktree.
+
+### 6. Scheduling — launchd
+
+`scripts/launchd/dev.vinny.gsd-builder.plist` (versioned template) → installed to `~/Library/LaunchAgents/`. Runs `builder-run.sh` every **30 minutes**, `StartInterval`-based, non-overlapping (launchd serializes a single label). The cheap pre-check keeps empty wake-ups free. Install/load is a documented rollout step (`launchctl bootstrap`/`load`), not run by CI.
+
+## Verification approach
+
+Cycle B is prompts + scripts + a plist, not pure logic — so verification is behavioral and static, not a single unit test:
+- `builder-run.sh`: `bash -n`, shellcheck, and **`--dry-run` executed against a stubbed `gh`** to observe correct branching (paused → exit; no-work → exit; work → would-invoke). This is the real behavioral test.
+- `plist`: `plutil -lint`.
+- `setup-labels.sh`: idempotent re-run creates the four new labels.
+- Cross-reference check: labels named in `build-next.md`/`builder.md` exist in `setup-labels.sh`; the plan/PR formats referenced exist.
+- End-to-end (rollout): file a real `risk:chore` contract → `ready-for-agent` → observe auto-approve + PR; and a `risk:feature` one → observe `plan:pending`, approve, observe build + PR.
+
+## Rollback
+
+Everything is additive: new labels, one wrapper script, one command, one doc, one plist template. Rollback = unload the launchd job (`launchctl bootout`), delete the added files, and `gh label delete` the four new labels. No runtime/app/deploy surface is touched. The kill-switch label halts the builder instantly without any rollback.

--- a/docs/superpowers/specs/2026-07-07-builder-gate1-design.md
+++ b/docs/superpowers/specs/2026-07-07-builder-gate1-design.md
@@ -12,7 +12,7 @@ A **local, scheduled** Claude Code routine that claims a fully-specified issue, 
 ## Scope & non-goals
 
 **In scope:**
-- Label state machine extending the existing AFK-agent labels (`ready-for-agent`, `ready-for-human`) with planning states (`plan:pending`, `plan:approved`, `agent:building`) and a kill switch (`builder:paused`).
+- Label state machine extending the existing AFK-agent labels (`ready-for-agent`, `ready-for-human`) with planning states (`plan:pending`, `plan:revise`, `plan:approved`, `agent:building`) and a kill switch (`builder:paused`).
 - A local launchd job + wrapper script (`scripts/builder-run.sh`) that pre-checks cheaply and invokes the builder only when there is work.
 - The builder's versioned instructions: a slash command (`.claude/commands/build-next.md`) + an operating spec (`docs/agents/builder.md`).
 - Risk-scaled behavior keyed off cycle A's `risk:*` labels: `docs`/`chore` auto-approved; `feature`/`risky` go through Gate 1.
@@ -32,7 +32,7 @@ The gap: nothing autonomously turns a `ready-for-agent` contract into a reviewed
 
 ## Decision
 
-A **local scheduled routine**, not a GitHub Action, per the blog's model. It is **non-blocking and stateless across runs**; a label state machine is its memory. Gate 1 approval is a **label swap** (`plan:pending` → `plan:approved`) done from GitHub mobile; `/revise <notes>` requests changes.
+A **local scheduled routine**, not a GitHub Action, per the blog's model. It is **non-blocking and stateless across runs**; a label state machine is its memory. Gate 1 approval is a **label swap** (`plan:pending` → `plan:approved`) done from GitHub mobile; requesting changes is also a label swap (`plan:pending` → `plan:revise`) plus a `/revise <notes>` comment. Both signals are labels because the wrapper's cheap pre-check counts labels and cannot see comments.
 
 Why local over an Action: chosen explicitly (blog-faithful). Why non-blocking: a local process must not block for hours — a sleeping laptop would orphan the run; labels survive sleep. Why label-swap Gate 1: two-tap mobile approval, clean state machine, reuses the existing label framework.
 
@@ -46,9 +46,9 @@ needs-triage + risk:*        (cycle A output)
       ▼
 ready-for-agent ──run 1 (plan)──▶ plan:pending ──YOU: swap──▶ plan:approved ──run 2 (build)──▶ [PR opened]
       │                               │                                            │
-      │ risk:docs|chore               │ /revise <notes>                            │ agent:building (claim-lock,
-      │ (auto-approve: plan+build      ▼   (next run re-plans)                      │  removed when PR opened)
-      │  in one pass, logged)     plan:pending
+      │ risk:docs|chore               │ YOU: swap + /revise <notes>                │ agent:building (claim-lock,
+      │ (auto-approve: plan+build      ▼                                           │  removed when PR opened)
+      │  in one pass, logged)     plan:revise ──run: re-plan──▶ plan:pending
       │
       └── cannot proceed / needs judgment ──▶ ready-for-human + written reason (comment)
 ```
@@ -58,6 +58,7 @@ New labels (added to `scripts/setup-labels.sh`):
 | Label | Meaning | Color |
 |---|---|---|
 | `plan:pending` | Plan posted, awaiting Gate 1 approval | `#fbca04` (yellow) |
+| `plan:revise` | Human requested plan changes; builder re-plans (cheap-poll signal — see §3) | `#d876e3` (magenta) |
 | `plan:approved` | Human approved the plan; build may proceed | `#0e8a16` (green) |
 | `agent:building` | Builder is actively building (claim-lock) | `#5319e7` (purple) |
 | `builder:paused` | Kill switch — on the Builder Control issue, halts all runs | `#b60205` (red) |
@@ -68,7 +69,7 @@ Reused (unchanged): `ready-for-agent`, `ready-for-human`, `needs-triage`, `risk:
 
 Responsibilities, in order:
 1. **Kill switch:** if any open issue has `builder:paused`, log one line and exit 0.
-2. **Cheap work check:** `gh issue list` for `ready-for-agent` (unplanned) or `plan:approved` (ready to build). If none, exit 0 without invoking Claude (most wake-ups cost zero tokens).
+2. **Cheap work check:** `gh issue list` for `ready-for-agent` (unplanned), `plan:approved` (ready to build), or `plan:revise` (re-plan requested). If none, exit 0 without invoking Claude (most wake-ups cost zero tokens). A `gh` failure is logged to `gh-errors.log` and treated as zero (fail-safe), so a persistent outage is discoverable, not a silent permanent idle.
 3. **Isolation:** create/refresh a dedicated git worktree (`$BUILDER_WORKTREE`, default `~/.gsd-builder/worktree`) off latest `origin/main` — never the user's active checkout.
 4. **Invoke:** `claude -p "/build-next"` in the worktree with a scoped permission profile (git, `gh`, bun/test, in-repo edits; see §5). Timeout-bounded.
 5. **Log:** append run output to `docs/ops/builder-logs/` (or a configured dir) with a UTC-less run id.
@@ -83,7 +84,7 @@ Invoked headlessly. Instructs Claude to, in one run, process **at most one** iss
   - `risk:docs`/`risk:chore` → lightweight plan; **auto-approve**: post the plan as a comment noting "auto-approved (risk:<tier>)", then proceed straight to the build pass in the same run.
   - `risk:feature`/`risk:risky` → full plan (approach, files, test strategy, open questions, following the `docs/superpowers/` plan format). Post as a comment, swap `ready-for-agent` → `plan:pending`, and **stop**.
 - **Build pass:** pick the oldest `plan:approved` issue (or the just-auto-approved one). Claim it (`plan:approved`/`ready-for-agent` → `agent:building`). Build to `coding-standards.md` (TDD, tests, docs). Commit to `claude/issue-<n>-<slug>`, push, open a PR (cycle A PR template; `Closes #<n>`; carry `risk:*`; rollback from the contract). Remove `agent:building`. Comment the PR link on the issue.
-- **Revise:** if a `plan:pending` issue has a newer `/revise <notes>` comment, re-plan addressing the notes; re-post; keep `plan:pending`.
+- **Revise:** a `plan:revise` issue → re-plan addressing the newest `/revise <notes>` comment, re-post, and swap `plan:revise` → `plan:pending` for another approval round. Decision priority per run: `plan:approved` (build) → `plan:revise` (re-plan) → `ready-for-agent` (plan) → stop. A bare `plan:pending` issue is never acted on (it waits for the human).
 - **Escalate:** if the contract is ambiguous, the change needs judgment, or a hard limit is hit → add `ready-for-human`, remove agent labels, and comment a written reason (never guess).
 
 ### 4. `docs/agents/builder.md` — operating spec

--- a/scripts/builder-run.sh
+++ b/scripts/builder-run.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# GSD Builder — launchd entry point (cycle B: Builder + Gate 1).
+# Non-blocking: pre-checks cheaply and invokes the builder only when there is
+# work, so most scheduled wake-ups cost zero Claude tokens. Labels are the
+# durable state across runs. See docs/agents/builder.md.
+set -euo pipefail
+
+REPO="${GSD_BUILDER_REPO:-vscarpenter/gsd-task-manager}"
+WORKTREE="${GSD_BUILDER_WORKTREE:-$HOME/.gsd-builder/worktree}"
+SOURCE="${GSD_BUILDER_SOURCE:-$HOME/Projects/gsd-taskmanager}"
+LOG_DIR="${GSD_BUILDER_LOG_DIR:-$SOURCE/docs/ops/builder-logs}"
+
+MODE="run"
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) MODE="dry-run" ;;
+    --check)   MODE="check" ;;
+    "")        ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+# Count open issues carrying a label. Fail-safe to 0 so a gh hiccup never makes
+# the pre-check think there is work (and burn a Claude run) — it just idles.
+count() { gh issue list --repo "$REPO" --label "$1" --state open --json number --jq 'length' 2>/dev/null || echo 0; }
+
+# 1. Kill switch — checked first, before any work is considered.
+if [ "$(count "builder:paused")" != "0" ]; then
+  echo "PAUSED: builder:paused is set — exiting."
+  exit 0
+fi
+
+# 2. Cheap work check.
+to_plan="$(count "ready-for-agent")"
+to_build="$(count "plan:approved")"
+if [ "$to_plan" = "0" ] && [ "$to_build" = "0" ]; then
+  echo "NO_WORK: no ready-for-agent or plan:approved issues — exiting."
+  exit 0
+fi
+echo "WORK: ready-for-agent=$to_plan plan:approved=$to_build"
+
+if [ "$MODE" = "check" ]; then exit 0; fi
+if [ "$MODE" = "dry-run" ]; then
+  echo "DRYRUN: would run 'claude -p /build-next' in $WORKTREE"
+  exit 0
+fi
+
+# 3. Isolation — refresh a dedicated worktree off the latest origin/main so the
+#    builder never touches the user's active checkout or uncommitted work.
+mkdir -p "$(dirname "$WORKTREE")" "$LOG_DIR"
+git -C "$SOURCE" fetch origin main --quiet
+if git -C "$SOURCE" worktree list --porcelain | grep -q "^worktree $WORKTREE$"; then
+  git -C "$WORKTREE" reset --hard origin/main
+else
+  git -C "$SOURCE" worktree add --force "$WORKTREE" origin/main
+fi
+
+# 4. Invoke the builder with a scoped tool allow-list (never the full
+#    --dangerously-skip-permissions), bounded to git/gh/bun + in-repo edits.
+# 5. Log the run for audit.
+run_id="builder-$(git -C "$SOURCE" rev-parse --short origin/main)-$$"
+echo "RUN: $run_id"
+(
+  cd "$WORKTREE" &&
+  claude -p "/build-next" \
+    --allowedTools "Bash(git*),Bash(gh*),Bash(bun*),Edit,Write,Read"
+) 2>&1 | tee "$LOG_DIR/$run_id.log"

--- a/scripts/builder-run.sh
+++ b/scripts/builder-run.sh
@@ -22,7 +22,18 @@ done
 
 # Count open issues carrying a label. Fail-safe to 0 so a gh hiccup never makes
 # the pre-check think there is work (and burn a Claude run) — it just idles.
-count() { gh issue list --repo "$REPO" --label "$1" --state open --json number --jq 'length' 2>/dev/null || echo 0; }
+# A failure is logged (not silently swallowed) so a persistent gh/auth outage is
+# discoverable rather than an invisible permanent idle.
+count() {
+  local out
+  if out=$(gh issue list --repo "$REPO" --label "$1" --state open --json number --jq 'length' 2>/dev/null); then
+    printf '%s\n' "$out"
+  else
+    mkdir -p "$LOG_DIR" 2>/dev/null || true
+    printf '%s gh count failed for label %q\n' "$(date -u +%FT%TZ)" "$1" >> "$LOG_DIR/gh-errors.log" 2>/dev/null || true
+    echo 0
+  fi
+}
 
 # 1. Kill switch — checked first, before any work is considered.
 if [ "$(count "builder:paused")" != "0" ]; then
@@ -30,14 +41,17 @@ if [ "$(count "builder:paused")" != "0" ]; then
   exit 0
 fi
 
-# 2. Cheap work check.
+# 2. Cheap work check. plan:revise is included so a human /revise request on a
+#    pending plan actually wakes the builder (label counts can't see comments,
+#    so "request changes" is a label swap: plan:pending -> plan:revise).
 to_plan="$(count "ready-for-agent")"
 to_build="$(count "plan:approved")"
-if [ "$to_plan" = "0" ] && [ "$to_build" = "0" ]; then
-  echo "NO_WORK: no ready-for-agent or plan:approved issues — exiting."
+to_revise="$(count "plan:revise")"
+if [ "$to_plan" = "0" ] && [ "$to_build" = "0" ] && [ "$to_revise" = "0" ]; then
+  echo "NO_WORK: no ready-for-agent, plan:approved, or plan:revise issues — exiting."
   exit 0
 fi
-echo "WORK: ready-for-agent=$to_plan plan:approved=$to_build"
+echo "WORK: ready-for-agent=$to_plan plan:approved=$to_build plan:revise=$to_revise"
 
 if [ "$MODE" = "check" ]; then exit 0; fi
 if [ "$MODE" = "dry-run" ]; then

--- a/scripts/launchd/dev.vinny.gsd-builder.plist
+++ b/scripts/launchd/dev.vinny.gsd-builder.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  launchd template for the GSD Task Manager builder (cycle B).
+  Runs scripts/builder-run.sh every 30 minutes; the wrapper pre-checks and
+  exits immediately when there is no work, so empty wake-ups are cheap.
+
+  Install:
+    cp scripts/launchd/dev.vinny.gsd-builder.plist ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.vinny.gsd-builder.plist
+  Halt without uninstalling: add the `builder:paused` label to the Builder
+  Control issue (the wrapper exits on it).
+  Uninstall:
+    launchctl bootout gui/$(id -u)/dev.vinny.gsd-builder
+    rm ~/Library/LaunchAgents/dev.vinny.gsd-builder.plist
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>dev.vinny.gsd-builder</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/vinnycarpenter/Projects/gsd-taskmanager/scripts/builder-run.sh</string>
+  </array>
+
+  <key>StartInterval</key>
+  <integer>1800</integer>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/vinnycarpenter/.gsd-builder/launchd.out.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/vinnycarpenter/.gsd-builder/launchd.err.log</string>
+</dict>
+</plist>

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -1,16 +1,26 @@
 #!/usr/bin/env bash
-# Provision the risk:* labels used by the delivery pipeline (sub-project A:
-# "The Contract"). Idempotent — `gh label create --force` upserts, so this is
-# safe to re-run. Requires an authenticated `gh` CLI with repo scope.
+# Provision the labels used by the delivery pipeline. Idempotent —
+# `gh label create --force` upserts, so this is safe to re-run. Requires an
+# authenticated `gh` CLI with repo scope.
+#   Cycle A ("The Contract"):  risk:* — plan-depth / blast-radius tier.
+#   Cycle B ("Builder + Gate 1"): plan:* / agent:* / builder:* — the builder
+#                                 state machine and kill switch.
 set -euo pipefail
 
 create() {
   gh label create "$1" --color "$2" --description "$3" --force
 }
 
+# Cycle A — risk tiers (the contract).
 create "risk:docs"    "0075ca" "Docs/content only"
 create "risk:chore"   "c5def5" "Deps, config, tooling — no user-facing behavior change"
 create "risk:feature" "0e8a16" "New/changed user-facing behavior"
 create "risk:risky"   "b60205" "Touches security, auth, data, deploy/CI, or migrations"
 
-echo "risk:* labels created/updated."
+# Cycle B — builder state machine + Gate 1.
+create "plan:pending"    "fbca04" "Plan posted, awaiting Gate 1 approval"
+create "plan:approved"   "0e8a16" "Human approved the plan; build may proceed"
+create "agent:building"  "5319e7" "Builder is actively building (claim-lock)"
+create "builder:paused"  "b60205" "Kill switch — halts all builder runs"
+
+echo "pipeline labels created/updated."

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -19,6 +19,7 @@ create "risk:risky"   "b60205" "Touches security, auth, data, deploy/CI, or migr
 
 # Cycle B — builder state machine + Gate 1.
 create "plan:pending"    "fbca04" "Plan posted, awaiting Gate 1 approval"
+create "plan:revise"     "d876e3" "Human requested plan changes; builder re-plans"
 create "plan:approved"   "0e8a16" "Human approved the plan; build may proceed"
 create "agent:building"  "5319e7" "Builder is actively building (claim-lock)"
 create "builder:paused"  "b60205" "Kill switch — halts all builder runs"

--- a/tests/builder-run.test.ts
+++ b/tests/builder-run.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, chmodSync } from "node:fs";
+import { mkdtempSync, writeFileSync, chmodSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -26,10 +26,22 @@ esac
   return dir;
 }
 
+// A fake `gh` that always fails (simulates expired auth / network outage).
+function failingGh(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ghfail-"));
+  const bin = join(dir, "gh");
+  writeFileSync(bin, `#!/usr/bin/env bash\necho "gh: simulated failure" >&2\nexit 1\n`);
+  chmodSync(bin, 0o755);
+  return dir;
+}
+
 function run(mode: string, counts: Record<string, number>): string {
-  const stub = stubGh(counts);
+  return runWith(mode, stubGh(counts));
+}
+
+function runWith(mode: string, ghDir: string, extraEnv: Record<string, string> = {}): string {
   return execFileSync("bash", [SCRIPT, mode], {
-    env: { ...process.env, PATH: `${stub}:${process.env.PATH}` },
+    env: { ...process.env, PATH: `${ghDir}:${process.env.PATH}`, ...extraEnv },
     encoding: "utf8",
   });
 }
@@ -41,25 +53,53 @@ describe("builder-run.sh pre-check", () => {
 
   it("exits NO_WORK when nothing is actionable", () => {
     expect(
-      run("--check", { "builder:paused": 0, "ready-for-agent": 0, "plan:approved": 0 })
+      run("--check", {
+        "builder:paused": 0,
+        "ready-for-agent": 0,
+        "plan:approved": 0,
+        "plan:revise": 0,
+      })
     ).toContain("NO_WORK");
   });
 
+  // Anchor to a line start: "NO_WORK:" also *contains* "WORK:", so a bare
+  // toContain("WORK") would pass on the idle path too.
   it("reports WORK when ready-for-agent issues exist", () => {
     expect(
-      run("--check", { "builder:paused": 0, "ready-for-agent": 2, "plan:approved": 0 })
-    ).toContain("WORK");
+      run("--check", { "builder:paused": 0, "ready-for-agent": 2, "plan:approved": 0, "plan:revise": 0 })
+    ).toMatch(/^WORK:/m);
   });
 
   it("reports WORK when plan:approved issues exist", () => {
     expect(
-      run("--check", { "builder:paused": 0, "ready-for-agent": 0, "plan:approved": 1 })
-    ).toContain("WORK");
+      run("--check", { "builder:paused": 0, "ready-for-agent": 0, "plan:approved": 1, "plan:revise": 0 })
+    ).toMatch(/^WORK:/m);
+  });
+
+  it("reports WORK when plan:revise issues exist (so /revise gets processed)", () => {
+    expect(
+      run("--check", { "builder:paused": 0, "ready-for-agent": 0, "plan:approved": 0, "plan:revise": 1 })
+    ).toMatch(/^WORK:/m);
   });
 
   it("dry-run prints the intended invocation without running claude", () => {
-    const out = run("--dry-run", { "builder:paused": 0, "ready-for-agent": 1, "plan:approved": 0 });
-    expect(out).toContain("WORK");
+    const out = run("--dry-run", {
+      "builder:paused": 0,
+      "ready-for-agent": 1,
+      "plan:approved": 0,
+      "plan:revise": 0,
+    });
+    expect(out).toMatch(/^WORK:/m);
     expect(out).toContain("/build-next");
+  });
+
+  it("stays NO_WORK and logs a record when gh fails persistently", () => {
+    const logDir = mkdtempSync(join(tmpdir(), "ghlog-"));
+    const out = runWith("--check", failingGh(), { GSD_BUILDER_LOG_DIR: logDir });
+    // Fail-safe: a gh outage must not be mistaken for actionable work.
+    expect(out).toContain("NO_WORK");
+    // But it must be discoverable, not silent.
+    const log = readFileSync(join(logDir, "gh-errors.log"), "utf8");
+    expect(log.length).toBeGreaterThan(0);
   });
 });

--- a/tests/builder-run.test.ts
+++ b/tests/builder-run.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SCRIPT = join(__dirname, "..", "scripts", "builder-run.sh");
+
+// Build a fake `gh` on PATH that returns a canned open-issue count per label.
+function stubGh(counts: Record<string, number>): string {
+  const dir = mkdtempSync(join(tmpdir(), "ghstub-"));
+  const bin = join(dir, "gh");
+  const cases = Object.entries(counts)
+    .map(([l, n]) => `  "${l}") echo ${n};;`)
+    .join("\n");
+  const script = `#!/usr/bin/env bash
+label=""
+while [ "$#" -gt 0 ]; do case "$1" in --label) shift; label="$1";; esac; shift; done
+case "$label" in
+${cases}
+  *) echo 0;;
+esac
+`;
+  writeFileSync(bin, script);
+  chmodSync(bin, 0o755);
+  return dir;
+}
+
+function run(mode: string, counts: Record<string, number>): string {
+  const stub = stubGh(counts);
+  return execFileSync("bash", [SCRIPT, mode], {
+    env: { ...process.env, PATH: `${stub}:${process.env.PATH}` },
+    encoding: "utf8",
+  });
+}
+
+describe("builder-run.sh pre-check", () => {
+  it("exits PAUSED when builder:paused is set (before any work check)", () => {
+    expect(run("--check", { "builder:paused": 1, "ready-for-agent": 5 })).toContain("PAUSED");
+  });
+
+  it("exits NO_WORK when nothing is actionable", () => {
+    expect(
+      run("--check", { "builder:paused": 0, "ready-for-agent": 0, "plan:approved": 0 })
+    ).toContain("NO_WORK");
+  });
+
+  it("reports WORK when ready-for-agent issues exist", () => {
+    expect(
+      run("--check", { "builder:paused": 0, "ready-for-agent": 2, "plan:approved": 0 })
+    ).toContain("WORK");
+  });
+
+  it("reports WORK when plan:approved issues exist", () => {
+    expect(
+      run("--check", { "builder:paused": 0, "ready-for-agent": 0, "plan:approved": 1 })
+    ).toContain("WORK");
+  });
+
+  it("dry-run prints the intended invocation without running claude", () => {
+    const out = run("--dry-run", { "builder:paused": 0, "ready-for-agent": 1, "plan:approved": 0 });
+    expect(out).toContain("WORK");
+    expect(out).toContain("/build-next");
+  });
+});


### PR DESCRIPTION
## Summary

Cycle B of the "Two Gates and a Night Shift" pipeline: a **local, scheduled** Claude routine that claims a `ready-for-agent` contract, writes a **risk-scaled plan**, stops for a GitHub-native **Gate 1** approval (label swap), then builds to `coding-standards.md` and opens a PR. It **never merges**.

No prior issue to `Closes #` — this introduces the builder itself. Spec: `docs/superpowers/specs/2026-07-07-builder-gate1-design.md`, plan: `docs/superpowers/plans/2026-07-07-builder-gate1.md`.

Adds:
- `scripts/builder-run.sh` — launchd wrapper: `builder:paused` kill-switch check, cheap work-check (idle wake-ups cost zero tokens), isolated worktree off `origin/main`, scoped `claude -p /build-next`. Decision logic covered by `tests/builder-run.test.ts` (5 cases, stubbed `gh`).
- `.claude/commands/build-next.md` — the builder command (plan pass / build pass / revise / escalate; SoD hard limits restated inline).
- `docs/agents/builder.md` — durable operating spec (extends `docs/agents/`).
- `scripts/launchd/dev.vinny.gsd-builder.plist` — 30-min cadence template (installed manually at activation).
- 4 labels in `scripts/setup-labels.sh`: `plan:pending`, `plan:approved`, `agent:building`, `builder:paused` (already created on the repo).

Non-blocking label state machine: `ready-for-agent → plan:pending → (you approve) plan:approved → PR`. `docs`/`chore` auto-approve Gate 1. Builder can't reach `main` — CI is now a required check and it never merges.

## Risk tier

**chore** — additive tooling (`scripts/`, `.claude/`, `docs/`). No runtime, app, CI, or deploy change. The builder does nothing until launchd is installed manually.

## How to verify

- `bun run test -- tests/builder-run.test.ts` — 5/5 (wrapper branches: PAUSED / NO_WORK / WORK / dry-run).
- `plutil -lint scripts/launchd/dev.vinny.gsd-builder.plist` — OK.
- Cross-ref: labels/files named in `build-next.md` + `builder.md` all resolve.
- Post-merge e2e: file a `risk:chore` contract → `ready-for-agent` → auto-approve + PR; a `risk:feature` one → `plan:pending` → approve → build + PR.

## Rollback plan

Revert this PR (additive; `scripts/`+`.claude/`+`docs/` only) and `gh label delete plan:pending plan:approved agent:building builder:paused`. The builder is off unless launchd is loaded; `launchctl bootout` + the `builder:paused` label both stop it instantly. No runtime/deploy surface touched.

## Checklist

- [x] Tests added/updated and passing (`tests/builder-run.test.ts`, 5/5)
- [x] Lint clean on new files
- [x] Coding standards followed (`coding-standards.md`)
- [x] Rollback plan above is real
- [ ] Post-merge: install launchd (staged activation) + e2e

https://claude.ai/code/session_01VTzjLGNTCEByQKuedNvBoB
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->