### PR TITLE
feat(pipeline): The Night Shift — nightly triage of failing agent PRs (cycle D)

### DIFF
--- a/.claude/commands/triage-prs.md
+++ b/.claude/commands/triage-prs.md
@@ -1,0 +1,37 @@
+---
+name: triage-prs
+description: Night-shift maintenance routine (cycle D). Triages failing checks on the agent fleet's own (claude/*) open PRs — auto-fixing mechanical classes as fix PRs, escalating judgment ones, skipping the rest. Never merges.
+---
+
+# /triage-prs
+
+You are the **night shift** for the GSD Task Manager pipeline. Run headlessly and unattended. Triage failing checks on the fleet's own open PRs, then stop. The full operating spec is `docs/agents/night-shift.md` — read it; this command is the executable summary. Definition of done is `coding-standards.md`. Issue/PR ops follow `docs/agents/issue-tracker.md`.
+
+**Hard limits (never violate — escalate instead):** never merge, never force-push, never push to a branch you did not create, never edit `.github/workflows/**`, `docker/**` deploy config, CloudFront config, or `SECURITY.md`/security config, and **never patch around a security-scan failure**. You may only create `claude/fix-*` branches, open fix PRs targeting the failing branch, comment, and apply `ready-for-human` / labels. **At most 3 fix PRs this run.**
+
+## Select work
+
+List open PRs whose head branch starts with `claude/` and that have at least one failing check (use `gh pr list --state open --json number,headRefName,statusCheckRollup`). Process oldest-first. Skip any PR already labeled `ready-for-human`. Stop once you have opened **3 fix PRs**.
+
+## For each failing check on a PR
+
+1. **Reproduce.** In this worktree, check out the PR's head branch and run the failing check locally (`bun run lint` / `bun run typecheck` / `bun run test` / `bun run build`). If you cannot reproduce it (flaky, external, environment) → **skip + log**.
+2. **Classify and act:**
+   - **Formatting / lint** → `bun run lint` issues fixable by `eslint . --fix`; style drift by `prettier --write`.
+   - **Stale lockfile** → `bun install` to regenerate `bun.lock`.
+   - **Branch behind main** (fails only because it is out of date) → merge `origin/main`. Trivial conflicts (lockfile, generated files) only.
+   - **Simple typecheck / import error** → a targeted fix (unused import, missing import, obvious type annotation). Do **not** attempt logic changes.
+3. **Verify before submitting.** Re-run the failing check. **Only proceed if it now passes.** If your fix does not make the check pass, revert it and **escalate**.
+4. **Deliver a fix PR.** Commit the verified fix to a fresh `claude/fix-<branch>-<runid>` branch, push, and `gh pr create --base <failing-branch>` (the fix targets the failing branch, so it re-enters review + CI). Comment the fix PR link on the original PR. **Do not merge.**
+
+## Escalate (never guess)
+
+A logic **test** failure, **any security-scan failure**, an ambiguous type error, a non-trivial merge conflict, or a fix that failed to verify → `gh pr edit <n> --add-label ready-for-human` and comment a written reason stating exactly what is blocked and what input is needed. Security failures are always escalated, never worked around.
+
+## Skip + log
+
+Anything you cannot reproduce, that is flaky/external, or that is already `ready-for-human` → record it in your report as skipped, with the reason.
+
+## Self-audit report (always, at the end)
+
+Post one comment to the **Night Shift Control** issue (the pinned issue that also carries the `triage:paused` kill switch) summarizing this run: for each PR touched, what you **fixed** (with fix-PR links), **escalated** (with reasons), or **skipped** (with reasons); the fix-PR count vs. the 3-PR budget; and **any anomaly you noticed about your own run** (a check you couldn't classify, a fix you were unsure about, a limit you hit). If you did nothing, say so in one line.

--- a/docs/agents/night-shift.md
+++ b/docs/agents/night-shift.md
@@ -1,0 +1,57 @@
+# Night shift — operating spec
+
+The night shift is a **nightly, unattended** local Claude Code routine (cycle D — the maintenance loop). At 20:00 it triages failing checks on the agent fleet's own open PRs, clearing mechanical failures before they cost you attention. It **never merges**. It is launched by `scripts/triage-run.sh`; its per-run instructions live in `.claude/commands/triage-prs.md`; this file is the durable operating spec both reference.
+
+Issue/PR operations follow `docs/agents/issue-tracker.md`. Triage-label vocabulary is in `docs/agents/triage-labels.md`. Definition of done for any fix is `coding-standards.md`.
+
+## The nightly loop
+
+```
+20:00 launchd → triage-run.sh
+   triage:paused set? → post one line, exit                       (kill switch)
+   find open claude/* PRs with a failing check → none? exit
+   else: worktree off origin/main → claude -p "/triage-prs"
+         → for each failing claude/* PR (oldest first, ≤3 fix PRs):
+              reproduce → classify → fix+verify → fix PR   |  escalate  |  skip
+         → post self-audit report to the Night Shift Control issue
+```
+
+Scope is **`claude/*` PRs only** — the fleet's own output. It never touches hand-authored branches.
+
+## Auto-fix / escalate / skip policy
+
+| Failing check | Action |
+|---|---|
+| Lint / formatting drift | **Fix** — `eslint . --fix`, `prettier --write` |
+| Stale `bun.lock` | **Fix** — `bun install` |
+| Branch behind `main` (fails only for being out of date) | **Fix** — merge `origin/main` (trivial conflicts only) |
+| Simple typecheck / import error (unused/missing import, obvious annotation) | **Fix** — targeted, no logic changes |
+| Logic **test** failure | **Escalate** (`ready-for-human` + reason) |
+| **Any security-scan failure** | **Escalate** — never patch around |
+| Ambiguous type error / non-trivial conflict / a fix that didn't verify | **Escalate** |
+| Can't reproduce / flaky / external / already `ready-for-human` | **Skip + log** |
+
+Every fix is delivered as a fix PR on a fresh `claude/fix-<branch>-<runid>` branch **targeting the failing branch**, so it re-enters review + CI. The night shift never merges.
+
+## The two safety invariants
+
+The broad auto-fix set is safe only because both hold:
+
+1. **Verify before submit.** After applying a fix, re-run the failing check. Open a fix PR **only if it now passes** locally. A fix that doesn't make the check green is reverted and escalated — a plausible-but-wrong fix never leaves the machine.
+2. **Fixes re-enter the gate.** Fix PRs face the same CI-required + reviewer + thread-resolution gate as daytime work, and the night shift **never merges**. Nothing it produces reaches a branch without human/gate sign-off.
+
+## Hard limits
+
+Never: merge, force-push, push to a branch it did not create, edit `.github/workflows/**` / `docker/**` deploy config / CloudFront config / `SECURITY.md` / security config, or patch around a security-scan failure. Only: create `claude/fix-*` branches, open fix PRs targeting the failing branch, comment, and apply `ready-for-human` / labels. **≤3 fix PRs per run.** Operate only in the isolated worktree.
+
+## Escalation
+
+When a check needs judgment (logic test, security, ambiguity, non-trivial conflict) or a fix fails to verify: add `ready-for-human` to the PR and comment a written reason stating exactly what is blocked and what input is needed. Never guess; never silently proceed.
+
+## Self-audit report
+
+At the end of every run, post one comment to the **Night Shift Control** issue (pinned; also carries the `triage:paused` kill switch): what was **fixed** (fix-PR links), **escalated** (reasons), and **skipped** (reasons); the fix-PR count vs. the 3-PR budget; and **any anomaly the run noticed about itself** — a check it couldn't classify, a fix it was unsure about, a limit it hit. An unattended agent that files its own incident report is one you can leave alone at night. If it did nothing, it says so in one line.
+
+## Kill switch
+
+`scripts/triage-run.sh` checks for an open issue labeled `triage:paused` before doing anything and exits if found. To halt the night shift with no code change and no shell access, add `triage:paused` to the Night Shift Control issue; remove it to resume.

--- a/docs/superpowers/plans/2026-07-08-night-shift.md
+++ b/docs/superpowers/plans/2026-07-08-night-shift.md
@@ -1,0 +1,403 @@
+# Cycle D — The Night Shift Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A nightly local routine that triages failing checks on `claude/*` PRs — auto-fixing mechanical classes on fix PRs, escalating judgment ones, skipping the rest — never merging, with a self-audit report.
+
+**Architecture:** A launchd job at 20:00 runs `triage-run.sh`, which checks the `triage:paused` kill switch and finds failing `claude/*` PRs (via the tested `failing-agent-prs.cjs` filter) before invoking `claude -p "/triage-prs"` in an isolated worktree. Reuses cycle B's wrapper/worktree/logging patterns.
+
+**Tech Stack:** Bash, `gh` CLI, Claude Code CLI, launchd (`StartCalendarInterval`), Node CommonJS (`.cjs`), Vitest.
+
+## Global Constraints
+
+- Scope: `claude/*` PRs only. Never touch hand-authored branches.
+- Hard limits: never merge / force-push / push to a branch it didn't create / edit `.github/workflows/**`, `docker/**`, CloudFront, or security config; never patch around a security-scan failure (escalate); ≤3 fix PRs/run; isolated worktree only.
+- Two safety invariants: **verify-before-submit** (open a fix PR only if the failing check now passes locally) and **fixes re-enter the gate** (never merge).
+- Escalation label: `ready-for-human` (reuse). Kill switch label: `triage:paused` (new).
+- Node helpers `.cjs`; tests `.test.ts` under `tests/`. Commits: Conventional + `Vinny Carpenter <vscarpenter@gmail.com>` + `Claude-Session` trailer, no Co-Authored-By. Repo slug `vscarpenter/gsd-task-manager`.
+
+---
+
+### Task 1: `failing-agent-prs` filter (TDD)
+
+**Files:**
+- Create: `scripts/failing-agent-prs.cjs`
+- Test: `tests/failing-agent-prs.test.ts`
+
+**Interfaces:**
+- `isAgentBranch(headRefName): boolean`; `isFailingCheck(check): boolean`; `failingAgentPRs(prs): object[]`. CLI mode: read `gh pr list --json …` JSON from stdin, print the failing count. Consumed by Task 2.
+
+- [ ] **Step 1: Write the failing test** — `tests/failing-agent-prs.test.ts`
+
+```ts
+import { describe, it, expect } from "vitest";
+import { isAgentBranch, isFailingCheck, failingAgentPRs } from "../scripts/failing-agent-prs.cjs";
+
+const pr = (headRefName: string, checks: object[]) => ({ headRefName, statusCheckRollup: checks });
+
+describe("isAgentBranch", () => {
+  it.each([["claude/fix-a", true], ["claude/issue-3-x", true], ["feat/x", false], ["", false]])(
+    "%s -> %s",
+    (name, expected) => expect(isAgentBranch(name as string)).toBe(expected)
+  );
+  it("is false for non-strings", () => expect(isAgentBranch(undefined as unknown as string)).toBe(false));
+});
+
+describe("isFailingCheck", () => {
+  it.each([
+    [{ conclusion: "FAILURE" }, true],
+    [{ conclusion: "TIMED_OUT" }, true],
+    [{ conclusion: "ACTION_REQUIRED" }, true],
+    [{ conclusion: "SUCCESS" }, false],
+    [{ conclusion: null, status: "IN_PROGRESS" }, false],
+    [{ state: "ERROR" }, true],
+    [{ state: "FAILURE" }, true],
+    [{ state: "SUCCESS" }, false],
+    [{}, false],
+  ])("%o -> %s", (check, expected) => expect(isFailingCheck(check)).toBe(expected));
+  it("is false for null", () => expect(isFailingCheck(null)).toBe(false));
+});
+
+describe("failingAgentPRs", () => {
+  it("includes an agent branch with a failing check", () => {
+    expect(failingAgentPRs([pr("claude/fix-a", [{ conclusion: "FAILURE" }])])).toHaveLength(1);
+  });
+  it("excludes an agent branch whose checks all pass", () => {
+    expect(failingAgentPRs([pr("claude/fix-a", [{ conclusion: "SUCCESS" }])])).toHaveLength(0);
+  });
+  it("excludes an agent branch with only pending checks", () => {
+    expect(failingAgentPRs([pr("claude/fix-a", [{ conclusion: null, status: "QUEUED" }])])).toHaveLength(0);
+  });
+  it("excludes a NON-agent branch even if failing", () => {
+    expect(failingAgentPRs([pr("feat/mine", [{ conclusion: "FAILURE" }])])).toHaveLength(0);
+  });
+  it("includes when any one check fails (mixed)", () => {
+    expect(failingAgentPRs([pr("claude/fix-a", [{ conclusion: "SUCCESS" }, { state: "FAILURE" }])])).toHaveLength(1);
+  });
+  it("returns [] for empty/malformed input", () => {
+    expect(failingAgentPRs([])).toEqual([]);
+    expect(failingAgentPRs(null as unknown as object[])).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails** — `bun run test -- tests/failing-agent-prs.test.ts` → FAIL (module missing).
+
+- [ ] **Step 3: Write implementation** — `scripts/failing-agent-prs.cjs`
+
+```js
+"use strict";
+
+const FAIL_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required", "startup_failure"]);
+const FAIL_STATES = new Set(["failure", "error"]);
+
+function isAgentBranch(headRefName) {
+  return typeof headRefName === "string" && headRefName.startsWith("claude/");
+}
+
+// A statusCheckRollup entry is failing if its CheckRun conclusion or its
+// StatusContext state indicates failure. Pending/success/neutral/skipped are not.
+function isFailingCheck(check) {
+  if (!check || typeof check !== "object") return false;
+  const conclusion = String(check.conclusion || "").toLowerCase();
+  const state = String(check.state || "").toLowerCase();
+  return FAIL_CONCLUSIONS.has(conclusion) || FAIL_STATES.has(state);
+}
+
+function failingAgentPRs(prs) {
+  if (!Array.isArray(prs)) return [];
+  return prs.filter(
+    (pr) =>
+      pr &&
+      isAgentBranch(pr.headRefName) &&
+      Array.isArray(pr.statusCheckRollup) &&
+      pr.statusCheckRollup.some(isFailingCheck)
+  );
+}
+
+module.exports = { isAgentBranch, isFailingCheck, failingAgentPRs };
+
+// CLI: read `gh pr list --json number,headRefName,statusCheckRollup` from stdin,
+// print the count of failing agent PRs. Fail-safe to 0 on bad input.
+if (require.main === module) {
+  let input = "";
+  process.stdin.on("data", (c) => (input += c));
+  process.stdin.on("end", () => {
+    let prs = [];
+    try {
+      prs = JSON.parse(input);
+    } catch {
+      prs = [];
+    }
+    process.stdout.write(String(failingAgentPRs(prs).length));
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes** — `bun run test -- tests/failing-agent-prs.test.ts` → PASS.
+
+- [ ] **Step 5: Commit** `feat(pipeline): failing-agent-prs filter for the night shift`
+
+---
+
+### Task 2: `triage-run.sh` nightly wrapper (+ integration test)
+
+**Files:**
+- Create: `scripts/triage-run.sh`
+- Test: `tests/triage-run.test.ts`
+
+**Interfaces:** Consumes `failing-agent-prs.cjs` (Task 1). Modes `--check` / `--dry-run` / run; sentinels `PAUSED` / `NO_WORK` / `WORK`.
+
+- [ ] **Step 1: Write the failing test** — `tests/triage-run.test.ts`
+
+```ts
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SCRIPT = join(__dirname, "..", "scripts", "triage-run.sh");
+const HELPER = join(__dirname, "..", "scripts", "failing-agent-prs.cjs");
+
+// Stub gh: `gh issue list …` -> paused count; `gh pr list …` -> PR JSON.
+function stubGh(pausedCount: number, prsJson: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), "ghstub-"));
+  const prsFile = join(dir, "prs.json");
+  writeFileSync(prsFile, JSON.stringify(prsJson));
+  const bin = join(dir, "gh");
+  writeFileSync(
+    bin,
+    `#!/usr/bin/env bash
+case "$1" in
+  issue) echo ${pausedCount} ;;
+  pr) cat ${prsFile} ;;
+  *) echo "" ;;
+esac
+`
+  );
+  chmodSync(bin, 0o755);
+  return dir;
+}
+
+function run(mode: string, pausedCount: number, prsJson: unknown): string {
+  const stub = stubGh(pausedCount, prsJson);
+  return execFileSync("bash", [SCRIPT, mode], {
+    env: { ...process.env, PATH: `${stub}:${process.env.PATH}`, GSD_TRIAGE_HELPER: HELPER },
+    encoding: "utf8",
+  });
+}
+
+const failingAgentPr = { headRefName: "claude/fix-a", statusCheckRollup: [{ conclusion: "FAILURE" }] };
+const passingAgentPr = { headRefName: "claude/fix-b", statusCheckRollup: [{ conclusion: "SUCCESS" }] };
+const failingUserPr = { headRefName: "feat/mine", statusCheckRollup: [{ conclusion: "FAILURE" }] };
+
+describe("triage-run.sh pre-check", () => {
+  it("exits PAUSED when triage:paused is set", () => {
+    expect(run("--check", 1, [failingAgentPr])).toContain("PAUSED");
+  });
+  it("exits NO_WORK when no claude/* PR is failing", () => {
+    expect(run("--check", 0, [passingAgentPr, failingUserPr])).toContain("NO_WORK");
+  });
+  it("reports WORK when a claude/* PR is failing", () => {
+    expect(run("--check", 0, [failingAgentPr, failingUserPr])).toMatch(/^WORK:/m);
+  });
+  it("dry-run prints the intended invocation", () => {
+    const out = run("--dry-run", 0, [failingAgentPr]);
+    expect(out).toMatch(/^WORK:/m);
+    expect(out).toContain("/triage-prs");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails** — `bun run test -- tests/triage-run.test.ts` → FAIL (script missing).
+
+- [ ] **Step 3: Write `scripts/triage-run.sh`**
+
+```bash
+#!/usr/bin/env bash
+# GSD Night Shift — launchd entry point (cycle D). Nightly, unattended: triages
+# failing checks on the agent fleet's own (claude/*) open PRs. Non-blocking;
+# checks the triage:paused kill switch and only invokes Claude when there is
+# failing work. See docs/agents/night-shift.md.
+set -euo pipefail
+
+REPO="${GSD_TRIAGE_REPO:-vscarpenter/gsd-task-manager}"
+WORKTREE="${GSD_TRIAGE_WORKTREE:-$HOME/.gsd-night-shift/worktree}"
+SOURCE="${GSD_TRIAGE_SOURCE:-$HOME/Projects/gsd-taskmanager}"
+LOG_DIR="${GSD_TRIAGE_LOG_DIR:-$SOURCE/docs/ops/night-shift-logs}"
+HELPER="${GSD_TRIAGE_HELPER:-$SOURCE/scripts/failing-agent-prs.cjs}"
+
+MODE="run"
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) MODE="dry-run" ;;
+    --check)   MODE="check" ;;
+    "")        ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+gh_fail_log() {
+  mkdir -p "$LOG_DIR" 2>/dev/null || true
+  printf '%s %s\n' "$(date -u +%FT%TZ)" "$1" >> "$LOG_DIR/gh-errors.log" 2>/dev/null || true
+}
+
+# 1. Kill switch.
+paused=0
+if out=$(gh issue list --repo "$REPO" --label "triage:paused" --state open --json number --jq 'length' 2>/dev/null); then
+  paused="$out"
+else
+  gh_fail_log "issue list triage:paused failed"
+fi
+if [ "$paused" != "0" ]; then
+  echo "PAUSED: triage:paused is set — exiting."
+  exit 0
+fi
+
+# 2. Work check — failing claude/* PRs (filter lives in the tested helper).
+prs_json='[]'
+if out=$(gh pr list --repo "$REPO" --state open --json number,headRefName,statusCheckRollup 2>/dev/null); then
+  prs_json="$out"
+else
+  gh_fail_log "pr list failed"
+fi
+failing="$(printf '%s' "$prs_json" | node "$HELPER" 2>/dev/null || echo 0)"
+if [ "$failing" = "0" ]; then
+  echo "NO_WORK: no failing claude/* PRs — exiting."
+  exit 0
+fi
+echo "WORK: failing claude/* PRs=$failing"
+
+if [ "$MODE" = "check" ]; then exit 0; fi
+if [ "$MODE" = "dry-run" ]; then
+  echo "DRYRUN: would run 'claude -p /triage-prs' in $WORKTREE"
+  exit 0
+fi
+
+# 3. Isolation — dedicated worktree off latest origin/main.
+mkdir -p "$(dirname "$WORKTREE")" "$LOG_DIR"
+git -C "$SOURCE" fetch origin main --quiet
+if git -C "$SOURCE" worktree list --porcelain | grep -q "^worktree $WORKTREE$"; then
+  git -C "$WORKTREE" reset --hard origin/main
+else
+  git -C "$SOURCE" worktree add --force "$WORKTREE" origin/main
+fi
+
+# 4. Invoke + 5. Log.
+run_id="night-shift-$(git -C "$SOURCE" rev-parse --short origin/main)-$$"
+echo "RUN: $run_id"
+(
+  cd "$WORKTREE" &&
+  claude -p "/triage-prs" \
+    --allowedTools "Bash(git*),Bash(gh*),Bash(bun*),Bash(node*),Edit,Write,Read"
+) 2>&1 | tee "$LOG_DIR/$run_id.log"
+```
+
+- [ ] **Step 4: Run test to verify it passes** — `bun run test -- tests/triage-run.test.ts` → PASS (4 cases).
+
+- [ ] **Step 5: `bash -n scripts/triage-run.sh`** → no syntax error.
+
+- [ ] **Step 6: Commit** `feat(pipeline): triage-run.sh nightly wrapper with tested pre-check`
+
+---
+
+### Task 3: `triage:paused` label
+
+**Files:** Modify `scripts/setup-labels.sh`
+
+- [ ] **Step 1: Add** in a new "Cycle D" block:
+
+```bash
+# Cycle D — the night shift.
+create "triage:paused"   "b60205" "Kill switch — halts the nightly triage routine"
+```
+
+- [ ] **Step 2: Verify** — `bash -n scripts/setup-labels.sh && grep -c '^create ' scripts/setup-labels.sh` → `11`.
+
+- [ ] **Step 3: Commit** `feat(pipeline): add triage:paused kill-switch label`
+
+---
+
+### Task 4: `.claude/commands/triage-prs.md`
+
+**Files:** Create `.claude/commands/triage-prs.md`
+
+- [ ] **Step 1: Write the command** (matches `.claude/commands/` convention). Content: the per-run triage loop from spec §3 — iterate failing `claude/*` PRs oldest-first, ≤3 fix PRs; per failing check reproduce → classify (eslint --fix / prettier --write / bun install / merge origin/main / simple typecheck+import) → **verify the check now passes** → open a fix PR targeting the failing branch (never merge, fresh `claude/fix-*` branch), else escalate (`ready-for-human` + written reason; security failures always escalate) or skip+log. Restate the hard limits inline. End by writing the self-audit report to the Night Shift Control issue. Points to `docs/agents/night-shift.md` and `coding-standards.md`.
+
+- [ ] **Step 2: Verify references** — `grep -q "night-shift.md" .claude/commands/triage-prs.md && grep -q "ready-for-human" .claude/commands/triage-prs.md && echo OK`.
+
+- [ ] **Step 3: Commit** `feat(pipeline): /triage-prs night-shift command`
+
+---
+
+### Task 5: `docs/agents/night-shift.md`
+
+**Files:** Create `docs/agents/night-shift.md`
+
+- [ ] **Step 1: Write the operating spec** — sections: role & nightly loop; the auto-fix / escalate / skip policy table; the two safety invariants (verify-before-submit, re-enter-gate); the hard limits (spec §5 verbatim); the self-audit report format; the `triage:paused` kill switch. Extends `docs/agents/`.
+
+- [ ] **Step 2: Cross-reference check** — `for l in triage:paused ready-for-human; do grep -q "$l" scripts/setup-labels.sh docs/agents/triage-labels.md || echo "MISSING: $l"; done; grep -q "verify" docs/agents/night-shift.md && echo OK`.
+
+- [ ] **Step 3: Commit** `docs(pipeline): night-shift operating spec + self-audit report`
+
+---
+
+### Task 6: launchd plist (nightly 20:00)
+
+**Files:** Create `scripts/launchd/dev.vinny.gsd-night-shift.plist`
+
+- [ ] **Step 1: Write the plist** — `StartCalendarInterval` Hour 20, runs `triage-run.sh`, `RunAtLoad` false, logs to `~/.gsd-night-shift/`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  launchd template for the GSD night shift (cycle D). Runs at 20:00 local.
+  Install:   cp scripts/launchd/dev.vinny.gsd-night-shift.plist ~/Library/LaunchAgents/
+             launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.vinny.gsd-night-shift.plist
+  Halt:      add the triage:paused label to the Night Shift Control issue.
+  Uninstall: launchctl bootout gui/$(id -u)/dev.vinny.gsd-night-shift; rm ~/Library/LaunchAgents/dev.vinny.gsd-night-shift.plist
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>dev.vinny.gsd-night-shift</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/vinnycarpenter/Projects/gsd-taskmanager/scripts/triage-run.sh</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict><key>Hour</key><integer>20</integer><key>Minute</key><integer>0</integer></dict>
+  <key>RunAtLoad</key><false/>
+  <key>StandardOutPath</key><string>/Users/vinnycarpenter/.gsd-night-shift/launchd.out.log</string>
+  <key>StandardErrorPath</key><string>/Users/vinnycarpenter/.gsd-night-shift/launchd.err.log</string>
+</dict>
+</plist>
+```
+
+- [ ] **Step 2: Validate** — `plutil -lint scripts/launchd/dev.vinny.gsd-night-shift.plist` → `OK`.
+
+- [ ] **Step 3: Commit** `chore(pipeline): launchd plist for the night shift (nightly 20:00)`
+
+---
+
+## Full-suite verification (after all tasks)
+
+- [ ] `bun run test -- tests/failing-agent-prs.test.ts tests/triage-run.test.ts` — green.
+- [ ] `bash -n scripts/triage-run.sh scripts/setup-labels.sh`; `plutil -lint` the plist.
+- [ ] Cross-ref: `triage:paused` / `ready-for-human` resolve; command references the operating spec.
+- [ ] `bun run lint` — no new errors.
+
+## Rollout (outside git — requires confirmation)
+
+1. `bash scripts/setup-labels.sh` — create `triage:paused` (idempotent).
+2. Push, open PR, merge (CI required).
+3. Create the **Night Shift Control** issue (pinned; add `triage:paused` to halt).
+4. Install launchd (staged activation): `--dry-run` first, then `launchctl bootstrap`.
+5. E2E: a `claude/*` PR with a lint failure → confirm a fix PR appears; `triage:paused` drill → confirm `PAUSED`.
+
+## Self-review (plan vs. spec)
+
+- Spec §1 filter → Task 1 (TDD). §2 wrapper → Task 2 (+ integration test). §3 command → Task 4. §4 operating spec → Task 5. §5 hard limits → Tasks 4 & 5. §6 report + kill switch → Tasks 3, 4, 5. §7 launchd → Task 6. Verification → Task 1/2 tests + full-suite. **All spec sections covered.**
+- No placeholders in code steps. `failingAgentPRs`/`isAgentBranch`/`isFailingCheck` names identical across Task 1 (def), Task 2 (consumer via CLI). Sentinels `PAUSED`/`NO_WORK`/`WORK` identical between wrapper and test. Labels `triage:paused` / `ready-for-human` consistent across Tasks 2–5.

--- a/docs/superpowers/specs/2026-07-08-night-shift-design.md
+++ b/docs/superpowers/specs/2026-07-08-night-shift-design.md
@@ -1,0 +1,93 @@
+# Spec: Cycle D — The Night Shift
+
+- **Date:** 2026-07-08
+- **Status:** Accepted (design approved 2026-07-08; proceeding to plan + implementation per standing correction)
+- **Deciders:** Vinny Carpenter
+- **Related:** cycle B (`2026-07-07-builder-gate1-design.md`, whose wrapper/worktree/kill-switch patterns this reuses), `docs/agents/builder.md`, `coding-standards.md`, blog "Two Gates and a Night Shift"
+
+## Goal
+
+A nightly, unattended local routine that triages failing checks on the agent fleet's own open PRs — repairing the mechanical ones on fresh branches as fix PRs, escalating the ones that need judgment, and skipping the rest — with the same guardrails as the builder plus a self-audit report. It **never merges**. This is **cycle D** of five (the maintenance loop).
+
+## Scope & non-goals
+
+**In scope:**
+- `triage-run.sh` — a nightly launchd wrapper (cycle B's skeleton) that checks the `triage:paused` kill switch and finds failing `claude/*` PRs before invoking the triage agent.
+- `failing-agent-prs.cjs` (+ test) — the substantive filter: which open PRs are `claude/*` with a failing check.
+- `.claude/commands/triage-prs.md` + `docs/agents/night-shift.md` — the triage brain and its operating spec.
+- `triage:paused` label; a launchd plist at 20:00.
+
+**Explicit non-goals:**
+- **No merging, ever** (that stays the two gates). No pushing to a branch it did not create. No editing `.github/workflows/**` / deploy / security config.
+- **Scope: `claude/*` PRs only** (agent-created). It never touches hand-authored WIP branches.
+- **No telemetry** (cycle E).
+- Not a re-implementation of the builder — it reuses B's wrapper/worktree/kill-switch/logging patterns.
+
+## Background — current state
+
+Cycle B built the local builder: `builder-run.sh` (launchd wrapper, kill switch, isolated worktree, scoped `claude -p`, logging), separation-of-duties limits, and `.claude/commands/build-next.md`. Cycle C added the reviewer gate + `release-ready`. The delivery loop and its gates exist; nothing clears the **mechanical** failures (lint drift, stale lockfile, branch behind main, trivial type errors) that accumulate on open PRs and steal attention.
+
+## Decision
+
+A **nightly local routine** modeled on the builder, **non-blocking** and stateless. It triages only `claude/*` PRs. Auto-fix set (chosen): formatting (`eslint --fix`, `prettier --write`), stale lockfile (`bun install`), branch-behind-main (merge `origin/main`), and simple typecheck/import fixes. Everything else escalates or is skipped. The broad auto-fix set is made safe by two invariants: **verify-before-submit** (only open a fix PR if the failing check now passes locally) and **fixes re-enter the gate** (CI-required + reviewer + thread-resolution; the night shift never merges).
+
+## Design
+
+### 1. `scripts/failing-agent-prs.cjs` (+ `tests/failing-agent-prs.test.ts`)
+
+Pure filter, dual-mode (module + CLI). Exports:
+- `isAgentBranch(headRefName): boolean` — `headRefName.startsWith("claude/")`.
+- `isFailingCheck(check): boolean` — a `statusCheckRollup` entry whose `conclusion` ∈ {FAILURE, TIMED_OUT, CANCELLED, ACTION_REQUIRED, STARTUP_FAILURE} or `state` ∈ {FAILURE, ERROR} (case-insensitive). Pending/success/neutral/skipped are not failing.
+- `failingAgentPRs(prs): PR[]` — the subset that are agent branches **and** have ≥1 failing check.
+- CLI (`require.main === module`): read `gh pr list --json …` JSON from stdin, print `failingAgentPRs(...).length`.
+
+`.cjs` (repo convention) so `triage-run.sh` can pipe `gh` output through it and Vitest can unit-test the classification. TDD.
+
+### 2. `scripts/triage-run.sh` — nightly launchd wrapper
+
+Mirrors `builder-run.sh`:
+1. **Kill switch:** an open issue labeled `triage:paused` → post one line, exit 0.
+2. **Work check:** `gh pr list --state open --json number,headRefName,statusCheckRollup` piped through `failing-agent-prs.cjs`. Zero → exit 0 (no Claude run). `gh` failure logs to `gh-errors.log` and fails safe to 0 (as in cycle B).
+3. **Isolation:** refresh a dedicated worktree off latest `origin/main`.
+4. **Invoke:** `claude -p "/triage-prs"` with a scoped tool allow-list, time-bounded.
+5. **Log** to `docs/ops/night-shift-logs/`.
+Modes `--check` / `--dry-run` for testing (observable `PAUSED` / `NO_WORK` / `WORK` sentinels).
+
+### 3. `.claude/commands/triage-prs.md` — the triage command
+
+Per run, oldest-first, **≤3 fix PRs total**. For each failing `claude/*` PR, per failing check:
+1. **Reproduce** in the worktree (checkout the PR branch, run the check).
+2. **Classify + act:**
+   - **Fix classes** — `eslint --fix`; `prettier --write`; `bun install` (stale lockfile); merge `origin/main` (branch behind, trivial conflicts only); a targeted simple typecheck/import fix.
+   - **Verify:** re-run the check. Proceed **only if it now passes**. If the fix does not make the check pass → escalate.
+   - **Deliver:** commit to `claude/fix-<branch>-<runid>`, open a fix PR **targeting the failing branch** (`base` = failing branch). Comment the fix PR link on the original PR. Never merge.
+3. **Escalate** — a logic **test** failure, **any security-scan failure**, an ambiguous type error, a non-trivial conflict, or a fix that failed to verify → add `ready-for-human` to the PR + a written reason. Never guess, never patch around security.
+4. **Skip + log** — can't reproduce, flaky/external, or already `ready-for-human`.
+Stop at 3 fix PRs; log the rest as skipped-for-budget.
+
+### 4. `docs/agents/night-shift.md` — operating spec
+
+The triage loop, the auto-fix/escalate/skip policy table, the hard limits (§ below), and the **self-audit report** format.
+
+### 5. Hard limits (enforced in the command + wrapper)
+
+Never: merge, force-push, push to a branch it did not create, edit `.github/workflows/**` / `docker/**` deploy / CloudFront / security config, or patch around a security-scan failure. Only: create `claude/fix-*` branches, open fix PRs targeting the failing branch, comment, apply `ready-for-human` / labels. ≤3 fix PRs per run; isolated worktree only.
+
+### 6. Self-audit report + kill switch
+
+A designated **Night Shift Control** issue holds `triage:paused` (kill switch: wrapper exits if present) and receives, at the end of each run, a report comment: fixed / escalated / skipped with PR links, count vs. the ≤3 budget, and any anomaly the agent noticed about its own run ("files its own incident report"). Reviewed with morning coffee.
+
+### 7. Scheduling — launchd
+
+`scripts/launchd/dev.vinny.gsd-night-shift.plist` — `StartCalendarInterval` Hour 20 (8 p.m. local), `RunAtLoad` false, non-overlapping. Installed manually at activation.
+
+## Verification approach
+
+- **`failing-agent-prs.cjs`:** Vitest — agent-branch failing (included), agent-branch passing/pending (excluded), non-agent failing (excluded), the several check shapes (CheckRun conclusion vs. StatusContext state), empty/malformed input. The substantive logic unit; real coverage.
+- **`triage-run.sh`:** `bash -n`; a `--check` test against a stubbed `gh` (issue list → paused; pr list → PR JSON) exercising `PAUSED` / `NO_WORK` / `WORK` through the real helper.
+- **plist:** `plutil -lint`. **`setup-labels.sh`:** idempotent; `triage:paused` created.
+- **End-to-end (rollout):** create a `claude/*` PR with a lint failure → confirm a fix PR appears; a `triage:paused` drill → confirm the run exits `PAUSED`.
+
+## Rollback
+
+Additive: one label, two scripts, one command, one doc, one plist. Rollback = unload the launchd job (`launchctl bootout`), delete the files, `gh label delete triage:paused`. The kill-switch label halts it instantly with no code change. No runtime/deploy surface touched.

--- a/scripts/failing-agent-prs.cjs
+++ b/scripts/failing-agent-prs.cjs
@@ -1,0 +1,46 @@
+"use strict";
+
+const FAIL_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required", "startup_failure"]);
+const FAIL_STATES = new Set(["failure", "error"]);
+
+function isAgentBranch(headRefName) {
+  return typeof headRefName === "string" && headRefName.startsWith("claude/");
+}
+
+// A statusCheckRollup entry is failing if its CheckRun conclusion or its
+// StatusContext state indicates failure. Pending/success/neutral/skipped are not.
+function isFailingCheck(check) {
+  if (!check || typeof check !== "object") return false;
+  const conclusion = String(check.conclusion || "").toLowerCase();
+  const state = String(check.state || "").toLowerCase();
+  return FAIL_CONCLUSIONS.has(conclusion) || FAIL_STATES.has(state);
+}
+
+function failingAgentPRs(prs) {
+  if (!Array.isArray(prs)) return [];
+  return prs.filter(
+    (pr) =>
+      pr &&
+      isAgentBranch(pr.headRefName) &&
+      Array.isArray(pr.statusCheckRollup) &&
+      pr.statusCheckRollup.some(isFailingCheck)
+  );
+}
+
+module.exports = { isAgentBranch, isFailingCheck, failingAgentPRs };
+
+// CLI: read `gh pr list --json number,headRefName,statusCheckRollup` from stdin,
+// print the count of failing agent PRs. Fail-safe to 0 on bad input.
+if (require.main === module) {
+  let input = "";
+  process.stdin.on("data", (c) => (input += c));
+  process.stdin.on("end", () => {
+    let prs = [];
+    try {
+      prs = JSON.parse(input);
+    } catch {
+      prs = [];
+    }
+    process.stdout.write(String(failingAgentPRs(prs).length));
+  });
+}

--- a/scripts/launchd/dev.vinny.gsd-night-shift.plist
+++ b/scripts/launchd/dev.vinny.gsd-night-shift.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  launchd template for the GSD night shift (cycle D). Runs scripts/triage-run.sh
+  nightly at 20:00 local; the wrapper pre-checks and exits when there is no
+  failing claude/* PR, so idle nights are cheap.
+
+  Install:
+    cp scripts/launchd/dev.vinny.gsd-night-shift.plist ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.vinny.gsd-night-shift.plist
+  Halt without uninstalling: add the `triage:paused` label to the Night Shift
+  Control issue (the wrapper exits on it).
+  Uninstall:
+    launchctl bootout gui/$(id -u)/dev.vinny.gsd-night-shift
+    rm ~/Library/LaunchAgents/dev.vinny.gsd-night-shift.plist
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>dev.vinny.gsd-night-shift</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/vinnycarpenter/Projects/gsd-taskmanager/scripts/triage-run.sh</string>
+  </array>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>20</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/vinnycarpenter/.gsd-night-shift/launchd.out.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/vinnycarpenter/.gsd-night-shift/launchd.err.log</string>
+</dict>
+</plist>

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -27,4 +27,7 @@ create "builder:paused"  "b60205" "Kill switch — halts all builder runs"
 # Cycle C — review + Gate 2.
 create "release-ready"   "1d76db" "Reviewed + CI green + no open threads — ready to merge, test, and release"
 
+# Cycle D — the night shift.
+create "triage:paused"   "b60205" "Kill switch — halts the nightly triage routine"
+
 echo "pipeline labels created/updated."

--- a/scripts/triage-run.sh
+++ b/scripts/triage-run.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# GSD Night Shift — launchd entry point (cycle D). Nightly, unattended: triages
+# failing checks on the agent fleet's own (claude/*) open PRs. Non-blocking;
+# checks the triage:paused kill switch and only invokes Claude when there is
+# failing work. See docs/agents/night-shift.md.
+set -euo pipefail
+
+REPO="${GSD_TRIAGE_REPO:-vscarpenter/gsd-task-manager}"
+WORKTREE="${GSD_TRIAGE_WORKTREE:-$HOME/.gsd-night-shift/worktree}"
+SOURCE="${GSD_TRIAGE_SOURCE:-$HOME/Projects/gsd-taskmanager}"
+LOG_DIR="${GSD_TRIAGE_LOG_DIR:-$SOURCE/docs/ops/night-shift-logs}"
+HELPER="${GSD_TRIAGE_HELPER:-$SOURCE/scripts/failing-agent-prs.cjs}"
+
+MODE="run"
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) MODE="dry-run" ;;
+    --check)   MODE="check" ;;
+    "")        ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+gh_fail_log() {
+  mkdir -p "$LOG_DIR" 2>/dev/null || true
+  printf '%s %s\n' "$(date -u +%FT%TZ)" "$1" >> "$LOG_DIR/gh-errors.log" 2>/dev/null || true
+}
+
+# 1. Kill switch.
+paused=0
+if out=$(gh issue list --repo "$REPO" --label "triage:paused" --state open --json number --jq 'length' 2>/dev/null); then
+  paused="$out"
+else
+  gh_fail_log "issue list triage:paused failed"
+fi
+if [ "$paused" != "0" ]; then
+  echo "PAUSED: triage:paused is set — exiting."
+  exit 0
+fi
+
+# 2. Work check — failing claude/* PRs (filter lives in the tested helper).
+prs_json='[]'
+if out=$(gh pr list --repo "$REPO" --state open --json number,headRefName,statusCheckRollup 2>/dev/null); then
+  prs_json="$out"
+else
+  gh_fail_log "pr list failed"
+fi
+failing="$(printf '%s' "$prs_json" | node "$HELPER" 2>/dev/null || echo 0)"
+if [ "$failing" = "0" ]; then
+  echo "NO_WORK: no failing claude/* PRs — exiting."
+  exit 0
+fi
+echo "WORK: failing claude/* PRs=$failing"
+
+if [ "$MODE" = "check" ]; then exit 0; fi
+if [ "$MODE" = "dry-run" ]; then
+  echo "DRYRUN: would run 'claude -p /triage-prs' in $WORKTREE"
+  exit 0
+fi
+
+# 3. Isolation — dedicated worktree off latest origin/main.
+mkdir -p "$(dirname "$WORKTREE")" "$LOG_DIR"
+git -C "$SOURCE" fetch origin main --quiet
+if git -C "$SOURCE" worktree list --porcelain | grep -q "^worktree $WORKTREE$"; then
+  git -C "$WORKTREE" reset --hard origin/main
+else
+  git -C "$SOURCE" worktree add --force "$WORKTREE" origin/main
+fi
+
+# 4. Invoke the night shift with a scoped tool allow-list. 5. Log.
+run_id="night-shift-$(git -C "$SOURCE" rev-parse --short origin/main)-$$"
+echo "RUN: $run_id"
+(
+  cd "$WORKTREE" &&
+  claude -p "/triage-prs" \
+    --allowedTools "Bash(git*),Bash(gh*),Bash(bun*),Bash(node*),Edit,Write,Read"
+) 2>&1 | tee "$LOG_DIR/$run_id.log"

--- a/tests/failing-agent-prs.test.ts
+++ b/tests/failing-agent-prs.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { isAgentBranch, isFailingCheck, failingAgentPRs } from "../scripts/failing-agent-prs.cjs";
+
+const pr = (headRefName: string, checks: object[]) => ({ headRefName, statusCheckRollup: checks });
+
+describe("isAgentBranch", () => {
+  it.each([
+    ["claude/fix-a", true],
+    ["claude/issue-3-x", true],
+    ["feat/x", false],
+    ["", false],
+  ])("%s -> %s", (name, expected) => expect(isAgentBranch(name as string)).toBe(expected));
+  it("is false for non-strings", () => expect(isAgentBranch(undefined as unknown as string)).toBe(false));
+});
+
+describe("isFailingCheck", () => {
+  it.each([
+    [{ conclusion: "FAILURE" }, true],
+    [{ conclusion: "TIMED_OUT" }, true],
+    [{ conclusion: "ACTION_REQUIRED" }, true],
+    [{ conclusion: "SUCCESS" }, false],
+    [{ conclusion: null, status: "IN_PROGRESS" }, false],
+    [{ state: "ERROR" }, true],
+    [{ state: "FAILURE" }, true],
+    [{ state: "SUCCESS" }, false],
+    [{}, false],
+  ])("%o -> %s", (check, expected) => expect(isFailingCheck(check)).toBe(expected));
+  it("is false for null", () => expect(isFailingCheck(null)).toBe(false));
+});
+
+describe("failingAgentPRs", () => {
+  it("includes an agent branch with a failing check", () => {
+    expect(failingAgentPRs([pr("claude/fix-a", [{ conclusion: "FAILURE" }])])).toHaveLength(1);
+  });
+  it("excludes an agent branch whose checks all pass", () => {
+    expect(failingAgentPRs([pr("claude/fix-a", [{ conclusion: "SUCCESS" }])])).toHaveLength(0);
+  });
+  it("excludes an agent branch with only pending checks", () => {
+    expect(failingAgentPRs([pr("claude/fix-a", [{ conclusion: null, status: "QUEUED" }])])).toHaveLength(0);
+  });
+  it("excludes a NON-agent branch even if failing", () => {
+    expect(failingAgentPRs([pr("feat/mine", [{ conclusion: "FAILURE" }])])).toHaveLength(0);
+  });
+  it("includes when any one check fails (mixed)", () => {
+    expect(failingAgentPRs([pr("claude/fix-a", [{ conclusion: "SUCCESS" }, { state: "FAILURE" }])])).toHaveLength(1);
+  });
+  it("returns [] for empty/malformed input", () => {
+    expect(failingAgentPRs([])).toEqual([]);
+    expect(failingAgentPRs(null as unknown as object[])).toEqual([]);
+  });
+});

--- a/tests/triage-run.test.ts
+++ b/tests/triage-run.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SCRIPT = join(__dirname, "..", "scripts", "triage-run.sh");
+const HELPER = join(__dirname, "..", "scripts", "failing-agent-prs.cjs");
+
+// Stub gh: `gh issue list …` -> paused count; `gh pr list …` -> PR JSON.
+function stubGh(pausedCount: number, prsJson: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), "ghstub-"));
+  const prsFile = join(dir, "prs.json");
+  writeFileSync(prsFile, JSON.stringify(prsJson));
+  const bin = join(dir, "gh");
+  writeFileSync(
+    bin,
+    `#!/usr/bin/env bash
+case "$1" in
+  issue) echo ${pausedCount} ;;
+  pr) cat ${prsFile} ;;
+  *) echo "" ;;
+esac
+`
+  );
+  chmodSync(bin, 0o755);
+  return dir;
+}
+
+function run(mode: string, pausedCount: number, prsJson: unknown): string {
+  const stub = stubGh(pausedCount, prsJson);
+  return execFileSync("bash", [SCRIPT, mode], {
+    env: { ...process.env, PATH: `${stub}:${process.env.PATH}`, GSD_TRIAGE_HELPER: HELPER },
+    encoding: "utf8",
+  });
+}
+
+const failingAgentPr = { headRefName: "claude/fix-a", statusCheckRollup: [{ conclusion: "FAILURE" }] };
+const passingAgentPr = { headRefName: "claude/fix-b", statusCheckRollup: [{ conclusion: "SUCCESS" }] };
+const failingUserPr = { headRefName: "feat/mine", statusCheckRollup: [{ conclusion: "FAILURE" }] };
+
+describe("triage-run.sh pre-check", () => {
+  it("exits PAUSED when triage:paused is set", () => {
+    expect(run("--check", 1, [failingAgentPr])).toContain("PAUSED");
+  });
+  it("exits NO_WORK when no claude/* PR is failing", () => {
+    expect(run("--check", 0, [passingAgentPr, failingUserPr])).toContain("NO_WORK");
+  });
+  it("reports WORK when a claude/* PR is failing", () => {
+    expect(run("--check", 0, [failingAgentPr, failingUserPr])).toMatch(/^WORK:/m);
+  });
+  it("dry-run prints the intended invocation", () => {
+    const out = run("--dry-run", 0, [failingAgentPr]);
+    expect(out).toMatch(/^WORK:/m);
+    expect(out).toContain("/triage-prs");
+  });
+});


### PR DESCRIPTION
## Summary

Cycle D — the maintenance loop. A nightly (20:00) local routine that triages failing checks on the agent fleet's own (`claude/*`) open PRs: auto-fixing mechanical classes as fix PRs, escalating judgment ones, skipping the rest. It **never merges**. Reuses cycle B's launchd/worktree/kill-switch/logging skeleton.

Spec: `docs/superpowers/specs/2026-07-08-night-shift-design.md`, plan: `docs/superpowers/plans/2026-07-08-night-shift.md`, ops: `docs/agents/night-shift.md`.

Adds:
- `scripts/failing-agent-prs.cjs` (+21 Vitest cases) — the filter for which open PRs are `claude/*` with a failing check. This is where the "agent-created only" blast-radius decision lives.
- `scripts/triage-run.sh` (+4 integration tests, stubbed `gh` + real filter) — launchd wrapper: `triage:paused` kill switch → find failing `claude/*` PRs → worktree → `claude -p /triage-prs`. gh failures logged, fail-safe to 0.
- `.claude/commands/triage-prs.md` + `docs/agents/night-shift.md` — the triage brain + operating spec.
- `scripts/launchd/dev.vinny.gsd-night-shift.plist` — nightly 20:00 (installed manually at activation).
- `triage:paused` kill-switch label (created on the repo).

**Auto-fix set (broad, per design):** eslint/prettier, stale lockfile, branch-behind-main, simple typecheck/import. Made safe by two invariants: **verify-before-submit** (open a fix PR only if the check now passes) and **fixes re-enter the gate** (never merges). Logic tests, security failures, and ambiguous type errors escalate (`ready-for-human`).

## Risk tier

**chore** — additive tooling (`scripts/`, `.claude/`, `docs/`). No runtime, app, CI, or deploy change. The night shift does nothing until launchd is installed manually.

## How to verify

- `bun run test -- tests/failing-agent-prs.test.ts tests/triage-run.test.ts` — 25/25.
- `plutil -lint scripts/launchd/dev.vinny.gsd-night-shift.plist` — OK.
- Cross-ref: `triage:paused` / `ready-for-human` resolve; command references the operating spec.

## Rollback plan

Revert this PR (additive; `scripts/`+`.claude/`+`docs/` only) and `gh label delete triage:paused`. The night shift is off unless launchd is loaded; `launchctl bootout` and the `triage:paused` label both stop it instantly. No runtime/deploy surface touched.

## Checklist

- [x] Tests added/updated and passing (25/25)
- [x] Lint clean on new files
- [x] Coding standards followed (`coding-standards.md`)
- [x] Rollback plan above is real
- [ ] Post-merge: Night Shift Control issue + launchd install (staged activation)

https://claude.ai/code/session_01VTzjLGNTCEByQKuedNvBoB
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->