### PR TITLE
feat(pipeline): Telemetry + standards loop (cycle E)

### DIFF
--- a/.claude/commands/build-next.md
+++ b/.claude/commands/build-next.md
@@ -45,3 +45,10 @@ Note: a bare `plan:pending` issue (no `plan:revise`) is waiting on the human —
 ## Escalate (never guess)
 
 If the contract is ambiguous, the change needs human judgment, or a required step hits a hard limit: `gh issue edit <n> --add-label ready-for-human --remove-label agent:building,plan:pending,plan:approved,plan:revise` and comment a written reason stating exactly what is blocked and what input you need.
+
+## Report (required — last line of your output)
+
+End your final message with a machine-readable line so the run's token cost is recorded against the right PR (telemetry reads it):
+
+- If you opened a PR this run: `OPENED_PR=<number>`
+- Otherwise (planned and stopped, revised, escalated, or nothing to do): `OPENED_PR=none`

--- a/.github/workflows/telemetry.yml
+++ b/.github/workflows/telemetry.yml
@@ -35,11 +35,22 @@ jobs:
             const windowDays = 30;
             const since = new Date(Date.now() - windowDays * 86400000).toISOString();
 
-            // 1. Merged PRs in the window.
-            const closed = await github.paginate(github.rest.pulls.list, {
-              owner, repo, state: "closed", per_page: 100, sort: "updated", direction: "desc",
-            });
-            const merged = closed.filter((p) => p.merged_at && p.merged_at >= since);
+            // 1. Merged PRs in the window. Short-circuit pagination: results are
+            //    sorted by updated desc and a merge is an update, so once a PR was
+            //    updated before the window, every older-updated PR after it is out
+            //    of window too — no need to page through all closed-PR history.
+            const merged = await github.paginate(
+              github.rest.pulls.list,
+              { owner, repo, state: "closed", per_page: 100, sort: "updated", direction: "desc" },
+              (response, done) => {
+                const page = [];
+                for (const p of response.data) {
+                  if (p.updated_at < since) { done(); break; }
+                  if (p.merged_at && p.merged_at >= since) page.push(p);
+                }
+                return page;
+              }
+            );
 
             // 2. Per PR: linked issue created_at + reviewer thread count.
             const prs = [];
@@ -50,7 +61,7 @@ jobs:
                 try {
                   const iss = await github.rest.issues.get({ owner, repo, issue_number: Number(m[1]) });
                   if (!iss.data.pull_request) issueCreatedAt = iss.data.created_at;
-                } catch { /* linked issue gone */ }
+                } catch (e) { core.warning(`linked issue #${m[1]} fetch failed (cycle time may be understated): ${e.message}`); }
               }
               let reviewFindings = 0;
               try {
@@ -59,7 +70,7 @@ jobs:
                   { o: owner, r: repo, n: p.number }
                 );
                 reviewFindings = g?.repository?.pullRequest?.reviewThreads?.totalCount ?? 0;
-              } catch { /* leave 0 */ }
+              } catch (e) { core.warning(`review threads for PR #${p.number} failed (findings may be understated): ${e.message}`); }
               // Cycle-time end ≈ merge time until deploy↔PR correlation is added (v1 approximation).
               prs.push({ number: p.number, mergedAt: p.merged_at, issueCreatedAt, prodDeployedAt: p.merged_at, reviewFindings });
             }
@@ -76,8 +87,8 @@ jobs:
                 const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
                   owner, repo, issue_number: iss.number, per_page: 100,
                 });
-                revised = events.some((e) => e.event === "labeled" && e.label?.name === "plan:revise");
-              } catch { /* leave false */ }
+                revised = events.some((ev) => ev.event === "labeled" && ev.label?.name === "plan:revise");
+              } catch (e) { core.warning(`timeline for issue #${iss.number} failed (revision rate may be understated): ${e.message}`); }
               plans.push({ issue: iss.number, revised });
             }
 
@@ -126,7 +137,7 @@ jobs:
             let existingSha;
             try {
               existingSha = (await github.rest.repos.getContent({ owner, repo, path, ref: "telemetry" })).data.sha;
-            } catch { /* new file */ }
+            } catch (e) { core.debug(`no existing snapshot at ${path} (expected for a new day): ${e.message}`); }
             await github.rest.repos.createOrUpdateFileContents({
               owner, repo, path, branch: "telemetry",
               message: `chore(telemetry): snapshot ${date}`,

--- a/.github/workflows/telemetry.yml
+++ b/.github/workflows/telemetry.yml
@@ -1,0 +1,136 @@
+name: Telemetry
+
+# Weekly pipeline telemetry: computes cycle time, plan-revision rate, and review
+# findings/PR from the GitHub API, updates the pinned "Pipeline Telemetry" issue,
+# and archives a JSON snapshot to the `telemetry` branch (the main-protection
+# ruleset forbids pushing to main, by design). tokensPerPR is stubbed until the
+# builder/night-shift wrappers emit token records.
+on:
+  schedule:
+    - cron: "0 13 * * 1" # Mondays 13:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write # create the telemetry ref + put the snapshot file
+  issues: write # update the dashboard issue
+  pull-requests: read
+
+concurrency:
+  group: telemetry
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { computeMetrics } = require(`${process.env.GITHUB_WORKSPACE}/scripts/telemetry-metrics.cjs`);
+            const { owner, repo } = context.repo;
+            const windowDays = 30;
+            const since = new Date(Date.now() - windowDays * 86400000).toISOString();
+
+            // 1. Merged PRs in the window.
+            const closed = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: "closed", per_page: 100, sort: "updated", direction: "desc",
+            });
+            const merged = closed.filter((p) => p.merged_at && p.merged_at >= since);
+
+            // 2. Per PR: linked issue created_at + reviewer thread count.
+            const prs = [];
+            for (const p of merged) {
+              const m = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i.exec(p.body || "");
+              let issueCreatedAt = null;
+              if (m) {
+                try {
+                  const iss = await github.rest.issues.get({ owner, repo, issue_number: Number(m[1]) });
+                  if (!iss.data.pull_request) issueCreatedAt = iss.data.created_at;
+                } catch { /* linked issue gone */ }
+              }
+              let reviewFindings = 0;
+              try {
+                const g = await github.graphql(
+                  `query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:1){totalCount}}}}`,
+                  { o: owner, r: repo, n: p.number }
+                );
+                reviewFindings = g?.repository?.pullRequest?.reviewThreads?.totalCount ?? 0;
+              } catch { /* leave 0 */ }
+              // Cycle-time end ≈ merge time until deploy↔PR correlation is added (v1 approximation).
+              prs.push({ number: p.number, mergedAt: p.merged_at, issueCreatedAt, prodDeployedAt: p.merged_at, reviewFindings });
+            }
+
+            // 3. Plans: issues that reached plan:pending in-window, and whether plan:revise was ever applied.
+            const plannedIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: "all", labels: "plan:pending", per_page: 100, since,
+            });
+            const plans = [];
+            for (const iss of plannedIssues) {
+              if (iss.pull_request) continue;
+              let revised = false;
+              try {
+                const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
+                  owner, repo, issue_number: iss.number, per_page: 100,
+                });
+                revised = events.some((e) => e.event === "labeled" && e.label?.name === "plan:revise");
+              } catch { /* leave false */ }
+              plans.push({ issue: iss.number, revised });
+            }
+
+            // 4. Compute.
+            const metrics = computeMetrics({ prs, plans });
+            const generatedAt = new Date().toISOString();
+            const snapshot = { generatedAt, windowDays, prCount: prs.length, ...metrics };
+            core.info(`telemetry: ${JSON.stringify(snapshot)}`);
+
+            // 5. Dashboard — update the open "Pipeline Telemetry" issue.
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: "open", per_page: 100,
+            });
+            const dash = openIssues.find((i) => !i.pull_request && i.title === "Pipeline Telemetry");
+            const ct = metrics.cycleTime, pr = metrics.planRevisionRate, rf = metrics.reviewFindingsPerPR;
+            const body = [
+              "<!-- pipeline-telemetry -->",
+              `_Updated ${generatedAt} · window ${windowDays}d · ${prs.length} merged PRs._`,
+              "",
+              "| Metric | Value |",
+              "|---|---|",
+              `| Cycle time (issue→prod) median / p90 | ${ct.medianHours ?? "—"}h / ${ct.p90Hours ?? "—"}h (n=${ct.count}) |`,
+              `| Plan revision rate | ${pr.rate ?? "—"} (${pr.revised}/${pr.total}) |`,
+              `| Review findings / PR (mean) | ${rf.mean ?? "—"} (n=${rf.count}) |`,
+              `| Tokens / merged PR | _pending run instrumentation_ |`,
+              "",
+              "Snapshots: the `telemetry` branch (`docs/ops/telemetry/`). Audit process: `docs/ops/pipeline-audit.md`.",
+            ].join("\n");
+            if (dash) {
+              await github.rest.issues.update({ owner, repo, issue_number: dash.number, body });
+              core.info(`Updated dashboard issue #${dash.number}.`);
+            } else {
+              core.info('No open "Pipeline Telemetry" issue found; skipping dashboard update.');
+            }
+
+            // 6. Snapshot — commit to the telemetry branch via the Contents API.
+            const date = generatedAt.slice(0, 10);
+            const path = `docs/ops/telemetry/${date}.json`;
+            try {
+              await github.rest.git.getRef({ owner, repo, ref: "heads/telemetry" });
+            } catch {
+              const main = await github.rest.git.getRef({ owner, repo, ref: "heads/main" });
+              await github.rest.git.createRef({ owner, repo, ref: "refs/heads/telemetry", sha: main.data.object.sha });
+              core.info("Created telemetry branch.");
+            }
+            let existingSha;
+            try {
+              existingSha = (await github.rest.repos.getContent({ owner, repo, path, ref: "telemetry" })).data.sha;
+            } catch { /* new file */ }
+            await github.rest.repos.createOrUpdateFileContents({
+              owner, repo, path, branch: "telemetry",
+              message: `chore(telemetry): snapshot ${date}`,
+              content: Buffer.from(JSON.stringify(snapshot, null, 2)).toString("base64"),
+              sha: existingSha,
+            });
+            core.info(`Snapshot written to telemetry:${path}`);

--- a/.github/workflows/telemetry.yml
+++ b/.github/workflows/telemetry.yml
@@ -71,8 +71,18 @@ jobs:
                 );
                 reviewFindings = g?.repository?.pullRequest?.reviewThreads?.totalCount ?? 0;
               } catch (e) { core.warning(`review threads for PR #${p.number} failed (findings may be understated): ${e.message}`); }
+              // Tokens: sum the builder's gsd-tokens markers on this PR (null if none).
+              let tokens = null;
+              try {
+                const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: p.number, per_page: 100 });
+                const marks = comments
+                  .map((c) => /<!--\s*gsd-tokens tokens=(\d+)\s*-->/.exec(c.body || ""))
+                  .filter(Boolean)
+                  .map((mm) => Number(mm[1]));
+                if (marks.length) tokens = marks.reduce((a, b) => a + b, 0);
+              } catch (e) { core.warning(`token markers for PR #${p.number} failed: ${e.message}`); }
               // Cycle-time end ≈ merge time until deploy↔PR correlation is added (v1 approximation).
-              prs.push({ number: p.number, mergedAt: p.merged_at, issueCreatedAt, prodDeployedAt: p.merged_at, reviewFindings });
+              prs.push({ number: p.number, mergedAt: p.merged_at, issueCreatedAt, prodDeployedAt: p.merged_at, reviewFindings, tokens });
             }
 
             // 3. Plans: issues that reached plan:pending in-window, and whether plan:revise was ever applied.
@@ -103,7 +113,7 @@ jobs:
               owner, repo, state: "open", per_page: 100,
             });
             const dash = openIssues.find((i) => !i.pull_request && i.title === "Pipeline Telemetry");
-            const ct = metrics.cycleTime, pr = metrics.planRevisionRate, rf = metrics.reviewFindingsPerPR;
+            const ct = metrics.cycleTime, pr = metrics.planRevisionRate, rf = metrics.reviewFindingsPerPR, tk = metrics.tokensPerPR;
             const body = [
               "<!-- pipeline-telemetry -->",
               `_Updated ${generatedAt} · window ${windowDays}d · ${prs.length} merged PRs._`,
@@ -113,7 +123,7 @@ jobs:
               `| Cycle time (issue→prod) median / p90 | ${ct.medianHours ?? "—"}h / ${ct.p90Hours ?? "—"}h (n=${ct.count}) |`,
               `| Plan revision rate | ${pr.rate ?? "—"} (${pr.revised}/${pr.total}) |`,
               `| Review findings / PR (mean) | ${rf.mean ?? "—"} (n=${rf.count}) |`,
-              `| Tokens / merged PR | _pending run instrumentation_ |`,
+              `| Tokens / merged PR (mean) | ${tk.mean ?? "— (no markers yet)"} (n=${tk.count}) |`,
               "",
               "Snapshots: the `telemetry` branch (`docs/ops/telemetry/`). Audit process: `docs/ops/pipeline-audit.md`.",
             ].join("\n");

--- a/docs/ops/pipeline-audit.md
+++ b/docs/ops/pipeline-audit.md
@@ -1,0 +1,37 @@
+# Pipeline audit — the standards loop
+
+Telemetry and gates tell you *whether* the pipeline is healthy; the audit is how you keep it that way. This doc is the **learning loop**: how findings from spot-checks and telemetry become durable rules in `coding-standards.md`, so each mistake is paid down once instead of rediscovered forever. It reuses the repo's existing standards machinery (§ "How a finding becomes a rule") rather than adding new.
+
+## The spot-check discipline
+
+Automated gates can share a blind spot: the builder, reviewer, and night shift are one model family, so a mistake one makes another can miss. The defense is a standing human audit.
+
+- **Spot-check ~1 in 10 merged PRs by hand** — deliberately including the ones the gates trust most: fast-lane (`risk:docs`/`risk:chore`) merges, night-shift fix PRs, and anything auto-approved at Gate 1.
+- **A "chore" that touches auth is not a chore.** Re-read the diff, not the label.
+- **The audit has teeth.** Each agent keeps its autonomy only while spot-checks stay clean. If audits start surfacing defects the reviewer missed at any meaningful rate, that agent's judgment stops counting for the gate (e.g. its `release-ready`/auto-approve privilege is revoked and human review returns) until it re-earns trust. Autonomy is earned continuously and can be lost the same way.
+
+## How telemetry surfaces audit candidates
+
+The **Pipeline Telemetry** issue (updated weekly by `telemetry.yml`) is where the pipeline flags where to look:
+
+- **High review-findings/PR** — a PR (or a category) the reviewer flagged heavily is worth a hand-read; a rising mean suggests a standards gap.
+- **Long cycle time / high plan-revision rate** — a slow or churny stretch points at a weak gate or an unclear contract, not just slow typing.
+- **Auto-approved / night-shift merges** — the merges with the least human contact; over-represent them in the 1-in-10 sample.
+
+The point is not to admire the dashboard — it is to find the next weak gate before it becomes the next escaped defect.
+
+## How a finding becomes a rule (reuse the existing loop)
+
+When a spot-check or a recurring reviewer category surfaces a real problem, do **not** just fix the code and move on — fix the **standard**, so every future build inherits the correction. Use the machinery already in the repo:
+
+1. Record the tactical finding in the deviations ledger, `tasks/implementation-notes.md` (`coding-standards.md §4`).
+2. Distill it via the **Self-Improvement Loop** (`coding-standards.md`) into `tasks/lessons.md` (a project learning) or `CLAUDE.md` (a behavioral rule) — then clear the ledger entry.
+3. For pipeline-wide rules (coverage thresholds, a class of mistake to reject in review), add the rule to `coding-standards.md` itself — the versioned interface every agent builds against.
+
+Because the builder, reviewer, and night shift all read `coding-standards.md`, a rule added once is enforced everywhere thereafter. The escaped defect that prompted it never gets reviewed twice.
+
+## Where this connects
+
+- **Telemetry:** `.github/workflows/telemetry.yml` → the Pipeline Telemetry issue + `telemetry` branch snapshots (`docs/ops/telemetry/`).
+- **Standards:** `coding-standards.md` (§4 Deviations Ledger, Self-Improvement Loop), `tasks/lessons.md`, `tasks/implementation-notes.md`.
+- **Gates the audit protects:** Gate 1 (plan), Gate 2 (`docs/ops/gate2.md`), the reviewer's `release-ready` call, and the night shift's fix PRs.

--- a/docs/superpowers/plans/2026-07-08-telemetry.md
+++ b/docs/superpowers/plans/2026-07-08-telemetry.md
@@ -1,0 +1,226 @@
+# Cycle E — Telemetry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A weekly workflow that computes three pipeline metrics via a pure tested helper, publishes a Pipeline Telemetry issue dashboard, and archives JSON snapshots to a `telemetry` branch — plus a doc bridging audit findings into the existing standards loop.
+
+**Architecture:** `telemetry-metrics.cjs` is pure and unit-tested. `telemetry.yml` (weekly) fetches from the GitHub API, normalizes, calls the helper, updates the dashboard issue, and commits a snapshot to the `telemetry` branch via the Contents API (no `main` writes — the ruleset forbids them).
+
+**Tech Stack:** GitHub Actions (`actions/github-script@v7`, `schedule`), Node CommonJS (`.cjs`), Vitest.
+
+## Global Constraints
+
+- Additive; no `main` code touched by the workflow (snapshots go to the `telemetry` branch).
+- `tokensPerPR` is `null` this cycle (needs run instrumentation — a B/D follow-up).
+- Metrics are approximate v1 (prod-deploy time ≈ merge time until deploy↔PR correlation is added); documented as such.
+- Node helpers `.cjs`; tests `.test.ts` under `tests/`. Commits: Conventional + `Vinny Carpenter <vscarpenter@gmail.com>` + `Claude-Session` trailer, no Co-Authored-By. Repo slug `vscarpenter/gsd-task-manager`.
+
+---
+
+### Task 1: `telemetry-metrics` helper (TDD)
+
+**Files:**
+- Create: `scripts/telemetry-metrics.cjs`
+- Test: `tests/telemetry-metrics.test.ts`
+
+**Interfaces:**
+- `computeMetrics({ prs, plans }): { cycleTime, planRevisionRate, reviewFindingsPerPR, tokensPerPR }`; `percentile(sorted, p)`. Consumed by Task 2.
+
+- [ ] **Step 1: Write the failing test** — `tests/telemetry-metrics.test.ts`
+
+```ts
+import { describe, it, expect } from "vitest";
+import { computeMetrics, percentile } from "../scripts/telemetry-metrics.cjs";
+
+const day = (n: number) => new Date(Date.UTC(2026, 0, n)).toISOString();
+
+describe("percentile", () => {
+  it("interpolates between ranks", () => {
+    expect(percentile([10, 20, 30, 40], 50)).toBe(25);
+  });
+  it("returns null for empty", () => expect(percentile([], 50)).toBeNull());
+});
+
+describe("computeMetrics", () => {
+  it("returns nulls/zeros for empty input", () => {
+    const m = computeMetrics({});
+    expect(m.cycleTime).toEqual({ medianHours: null, p90Hours: null, count: 0 });
+    expect(m.planRevisionRate).toEqual({ rate: null, revised: 0, total: 0 });
+    expect(m.reviewFindingsPerPR).toEqual({ mean: null, count: 0 });
+    expect(m.tokensPerPR).toBeNull();
+  });
+
+  it("computes cycle time in hours from issueCreatedAt to prodDeployedAt", () => {
+    const m = computeMetrics({
+      prs: [{ number: 1, mergedAt: day(2), issueCreatedAt: day(1), prodDeployedAt: day(2), reviewFindings: 2 }],
+    });
+    expect(m.cycleTime).toEqual({ medianHours: 24, p90Hours: 24, count: 1 });
+    expect(m.reviewFindingsPerPR).toEqual({ mean: 2, count: 1 });
+  });
+
+  it("excludes PRs missing issue or prod timestamps from cycle time", () => {
+    const m = computeMetrics({
+      prs: [{ number: 1, mergedAt: day(2), issueCreatedAt: null, prodDeployedAt: day(2), reviewFindings: 0 }],
+    });
+    expect(m.cycleTime.count).toBe(0);
+  });
+
+  it("excludes negative durations", () => {
+    const m = computeMetrics({
+      prs: [{ number: 1, mergedAt: day(1), issueCreatedAt: day(3), prodDeployedAt: day(2), reviewFindings: 0 }],
+    });
+    expect(m.cycleTime.count).toBe(0);
+  });
+
+  it("takes the median of multiple durations", () => {
+    const m = computeMetrics({
+      prs: [
+        { number: 1, mergedAt: day(2), issueCreatedAt: day(1), prodDeployedAt: day(2), reviewFindings: 0 },
+        { number: 2, mergedAt: day(3), issueCreatedAt: day(1), prodDeployedAt: day(3), reviewFindings: 0 },
+        { number: 3, mergedAt: day(4), issueCreatedAt: day(1), prodDeployedAt: day(4), reviewFindings: 0 },
+      ],
+    });
+    expect(m.cycleTime.medianHours).toBe(48); // 24h, 48h, 72h -> median 48h
+  });
+
+  it("computes plan revision rate", () => {
+    const m = computeMetrics({ plans: [{ revised: true }, { revised: false }, { revised: false }] });
+    expect(m.planRevisionRate).toEqual({ rate: 0.33, revised: 1, total: 3 });
+  });
+
+  it("averages review findings over merged PRs only", () => {
+    const m = computeMetrics({
+      prs: [
+        { number: 1, mergedAt: day(2), reviewFindings: 4 },
+        { number: 2, mergedAt: null, reviewFindings: 100 },
+      ],
+    });
+    expect(m.reviewFindingsPerPR).toEqual({ mean: 4, count: 1 });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails** — `bun run test -- tests/telemetry-metrics.test.ts` → FAIL (module missing).
+
+- [ ] **Step 3: Write implementation** — `scripts/telemetry-metrics.cjs`
+
+```js
+"use strict";
+
+const HOUR_MS = 3600000;
+
+function toMs(iso) {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? null : t;
+}
+
+function percentile(sorted, p) {
+  if (!sorted.length) return null;
+  if (sorted.length === 1) return sorted[0];
+  const rank = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (rank - lo);
+}
+
+function round(x, dp) {
+  if (x == null) return null;
+  const f = 10 ** dp;
+  return Math.round(x * f) / f;
+}
+
+// Pure pipeline metrics. Inputs are normalized by the telemetry workflow:
+//   prs:   [{ number, mergedAt, issueCreatedAt, prodDeployedAt, reviewFindings }]
+//   plans: [{ issue, revised }]  (issues that reached plan:pending)
+function computeMetrics(input) {
+  const prs = Array.isArray(input && input.prs) ? input.prs : [];
+  const plans = Array.isArray(input && input.plans) ? input.plans : [];
+
+  const durations = prs
+    .map((pr) => {
+      const start = toMs(pr && pr.issueCreatedAt);
+      const end = toMs(pr && pr.prodDeployedAt);
+      return start != null && end != null ? (end - start) / HOUR_MS : null;
+    })
+    .filter((h) => h != null && h >= 0)
+    .sort((a, b) => a - b);
+
+  const total = plans.length;
+  const revised = plans.filter((p) => p && p.revised).length;
+
+  const merged = prs.filter((pr) => pr && pr.mergedAt);
+  const findingsSum = merged.reduce((s, pr) => s + (Number(pr.reviewFindings) || 0), 0);
+
+  return {
+    cycleTime: {
+      medianHours: round(percentile(durations, 50), 1),
+      p90Hours: round(percentile(durations, 90), 1),
+      count: durations.length,
+    },
+    planRevisionRate: {
+      rate: total ? round(revised / total, 2) : null,
+      revised,
+      total,
+    },
+    reviewFindingsPerPR: {
+      mean: merged.length ? round(findingsSum / merged.length, 1) : null,
+      count: merged.length,
+    },
+    tokensPerPR: null,
+  };
+}
+
+module.exports = { computeMetrics, percentile };
+```
+
+- [ ] **Step 4: Run test to verify it passes** — `bun run test -- tests/telemetry-metrics.test.ts` → PASS.
+
+- [ ] **Step 5: Commit** `feat(pipeline): telemetry-metrics pure aggregation helper`
+
+---
+
+### Task 2: `telemetry.yml` weekly collector
+
+**Files:** Create `.github/workflows/telemetry.yml`
+
+**Interfaces:** Consumes `computeMetrics` (Task 1).
+
+- [ ] **Step 1: Write the workflow** — weekly `schedule` + `workflow_dispatch`; `contents: write` + `issues: write` + `pull-requests: read`. A single `github-script` step that: (1) lists merged PRs in a 30-day window; (2) per PR resolves the linked issue's `created_at` (parse `Closes/Fixes/Resolves #n`) and the reviewer thread count (GraphQL `reviewThreads.totalCount`), using `mergedAt` as the cycle-time end (prod-deploy correlation is a follow-up); (3) lists `plan:pending` issues in-window and checks their timeline for a `plan:revise` label event; (4) calls `computeMetrics`; (5) finds the open issue titled `Pipeline Telemetry` and updates its body with a metrics table; (6) ensures a `telemetry` branch (create from `main` head via the refs API if absent) and `createOrUpdateFileContents` at `docs/ops/telemetry/<date>.json`. Empty-window safe. Full github-script written at implementation.
+
+- [ ] **Step 2: Validate** — `node`-based YAML parse of `telemetry.yml`; confirm `permissions` = `{contents: write, issues: write, pull-requests: read}` and the parser require path matches Task 1's file.
+
+- [ ] **Step 3: Commit** `feat(pipeline): weekly telemetry collector workflow`
+
+---
+
+### Task 3: `docs/ops/pipeline-audit.md` — audit→standards bridge
+
+**Files:** Create `docs/ops/pipeline-audit.md`
+
+- [ ] **Step 1: Write the doc** — sections: the ~1-in-10 spot-check discipline (incl. fast-lane + night-shift merges; autonomy retained only while spot-checks stay clean); how the Telemetry issue surfaces audit candidates (high findings, long cycle time, auto-approved/night-shift merges); and how a confirmed finding becomes a `coding-standards.md` rule via the **existing** `tasks/implementation-notes.md` ledger → `tasks/lessons.md` → self-improvement loop (reuse, not new machinery).
+
+- [ ] **Step 2: Cross-reference check** — `grep -q "tasks/lessons.md" docs/ops/pipeline-audit.md && grep -q "coding-standards.md" docs/ops/pipeline-audit.md && grep -q "Pipeline Telemetry" docs/ops/pipeline-audit.md && echo OK`.
+
+- [ ] **Step 3: Commit** `docs(pipeline): audit->standards bridge (spot-checks + telemetry -> standards)`
+
+---
+
+## Full-suite verification (after all tasks)
+
+- [ ] `bun run test -- tests/telemetry-metrics.test.ts` — helper green.
+- [ ] `bun run lint` — no new errors.
+- [ ] `telemetry.yml` parses; permissions minimal; parser require path correct.
+- [ ] Cross-refs in `pipeline-audit.md` resolve.
+
+## Rollout (outside git — requires confirmation)
+
+1. Push, open PR, merge (CI required; `release-ready.yml` runs on it).
+2. Create the pinned **Pipeline Telemetry** issue.
+3. `workflow_dispatch` the telemetry workflow once → confirm it updates the issue and creates the `telemetry` branch with a snapshot (data will be sparse until A–D run live).
+
+## Self-review (plan vs. spec)
+
+- Spec §1 helper → Task 1 (TDD). §2 workflow → Task 2. §3 bridge → Task 3. §4 issue → rollout. Verification → Task 1 test + full-suite. **All spec sections covered.**
+- No placeholders in tested code (Task 1 full). `computeMetrics`/`percentile` names identical across Task 1 (def) and Task 2 (consumer). `telemetry` branch + `docs/ops/telemetry/<date>.json` path consistent between spec and Task 2.

--- a/docs/superpowers/plans/2026-07-08-tokens-per-pr.md
+++ b/docs/superpowers/plans/2026-07-08-tokens-per-pr.md
@@ -1,0 +1,46 @@
+# Tokens-per-PR Instrumentation Plan (cycle E follow-up)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans. Steps use `- [ ]`.
+
+**Goal:** Record the builder run's token cost against the PR it opens, and report tokens-per-merged-PR in telemetry.
+
+**Global constraints:** Builder-only. Marker format exactly `<!-- gsd-tokens tokens=<n> -->`. Command reports `OPENED_PR=<n>` / `OPENED_PR=none`. `.cjs` helpers, `.test.ts` tests. Best-effort — token capture never fails a builder run. Commits: Conventional + `Vinny Carpenter <vscarpenter@gmail.com>` + `Claude-Session` trailer.
+
+---
+
+### Task 1: `extract-run-tokens.cjs` (TDD)
+
+**Files:** Create `scripts/extract-run-tokens.cjs`, `tests/extract-run-tokens.test.ts`
+
+- [ ] **Test** — `extractRunTokens(json) -> { tokens, pr }`: full usage summed (input+output+cache); missing usage → 0; `OPENED_PR=123` in result → 123; absent / `=none` → null; JSON string parsed; malformed → `{tokens:0, pr:null}`. `totalTokens`, `parsePr` exported.
+- [ ] **Implement** — sum all `*_tokens` fields in `usage`; regex `/OPENED_PR=(\d+)/` on `result`; CLI mode reads stdin, prints `"<tokens> <pr|none>"`.
+- [ ] **Verify** `bun run test -- tests/extract-run-tokens.test.ts` + CLI sanity.
+- [ ] **Commit** `feat(pipeline): extract-run-tokens helper (claude usage -> tokens + PR)`
+
+### Task 2: builder emits the marker
+
+**Files:** Modify `scripts/builder-run.sh`, `.claude/commands/build-next.md`
+
+- [ ] **build-next.md** — add a required final line: `OPENED_PR=<number>` (or `OPENED_PR=none`).
+- [ ] **builder-run.sh** — invoke `claude -p "/build-next" --output-format json` (stdout→run log, stderr→`<log>.err`); pipe the JSON through `extract-run-tokens.cjs`; if a PR + non-zero tokens, `gh pr comment <pr> --repo "$REPO" --body "<!-- gsd-tokens tokens=<n> -->"` (best-effort).
+- [ ] **Verify** `bash -n scripts/builder-run.sh`; `grep -q "OPENED_PR" .claude/commands/build-next.md`.
+- [ ] **Commit** `feat(pipeline): builder records run tokens as a PR marker`
+
+### Task 3: telemetry reads markers + computes tokensPerPR
+
+**Files:** Modify `.github/workflows/telemetry.yml`, `scripts/telemetry-metrics.cjs`, `tests/telemetry-metrics.test.ts`
+
+- [ ] **telemetry-metrics test** — update empty case to `tokensPerPR: {mean:null, count:0}`; add: mean over PRs with numeric `tokens`; PRs without tokens excluded. Run → fail.
+- [ ] **telemetry-metrics.cjs** — `tokensPerPR = merged with numeric tokens → {mean: round(sum/n,0), count} else {mean:null,count:0}`.
+- [ ] **telemetry.yml** — per PR, `listComments`, sum `<!-- gsd-tokens tokens=(\d+) -->` → `pr.tokens` (null if none; errors `core.warning`ed); dashboard row shows `tokensPerPR.mean (n=count)`.
+- [ ] **Verify** `bun run test -- tests/telemetry-metrics.test.ts`; `telemetry.yml` parses.
+- [ ] **Commit** `feat(pipeline): telemetry sums token markers into tokensPerPR`
+
+---
+
+## Full-suite verification
+- [ ] `bun run test -- tests/extract-run-tokens.test.ts tests/telemetry-metrics.test.ts` green.
+- [ ] `bun run lint` no new errors; `bash -n scripts/builder-run.sh`; both YAML parse.
+
+## Self-review
+Spec §1→T1, §2→T2 (build-next), §3→T2 (builder-run), §4→T3 (telemetry), §5→T3 (metrics). Marker string identical across builder-run.sh (write) and telemetry.yml (read). `OPENED_PR=` identical across build-next.md and extract-run-tokens.cjs.

--- a/docs/superpowers/specs/2026-07-08-telemetry-design.md
+++ b/docs/superpowers/specs/2026-07-08-telemetry-design.md
@@ -1,0 +1,83 @@
+# Spec: Cycle E — Telemetry + the standards loop
+
+- **Date:** 2026-07-08
+- **Status:** Accepted (design approved 2026-07-08; proceeding to plan + implementation per standing correction)
+- **Deciders:** Vinny Carpenter
+- **Related:** cycles A–D, `coding-standards.md §4` (Deviations Ledger), `tasks/lessons.md` + `tasks/implementation-notes.md` (existing standards loop), `.github/workflows/openwiki-freshness.yml` (scheduled-workflow pattern), blog "Two Gates and a Night Shift"
+
+## Goal
+
+Record the metrics that tell you where the pipeline drags, and connect audit findings back into the standards — the learning loop that keeps the delivery and maintenance loops honest. This is **cycle E** of five, the last.
+
+## Scope & non-goals
+
+**In scope:**
+- `telemetry-metrics.cjs` (+ test) — the pure aggregation for cycle time, plan-revision rate, and review findings per PR.
+- `telemetry.yml` — a weekly workflow that fetches from the GitHub API, computes the metrics, updates a pinned **Pipeline Telemetry** issue (the dashboard), and commits a JSON snapshot to an unprotected **`telemetry` branch**.
+- `docs/ops/pipeline-audit.md` — the audit→standards bridge, reusing the existing ledger/lessons loop.
+
+**Explicit non-goals:**
+- **No new standards-loop machinery.** `coding-standards.md §4`, `tasks/lessons.md`, and the self-improvement loop already exist; E only bridges pipeline findings into them.
+- **`tokensPerPR` is stubbed** (`null`) this cycle — it needs the local builder/night-shift wrappers to emit token+PR records, a small follow-up once B/D run live.
+- **No commits to `main` from the workflow** — the ruleset (correctly) requires a PR; JSON snapshots go to the `telemetry` branch.
+- **No dashboard app** — the essay's point is "not to admire the dashboard." The Telemetry issue is the surface.
+
+## Background — current state
+
+The standards loop is already in the repo: `coding-standards.md §4` is a "Deviations Ledger & Stop Conditions"; `tasks/lessons.md` holds project learnings; the "Self-Improvement Loop" distills `tasks/implementation-notes.md` → `lessons.md` / `CLAUDE.md`. Cycles A–D emit the raw signals E measures: contract issues (A), `plan:pending`/`plan:revise` (B), reviewer threads + `release-ready` (C), fix PRs + escalations (D). Nothing aggregates them. `main` is protected by a ruleset requiring PRs, so a scheduled workflow cannot push to `main`.
+
+## Decision
+
+A **weekly scheduled workflow** computes three GitHub-API-derivable metrics via a **pure, unit-tested helper**, publishes a human dashboard to a **pinned Telemetry issue**, and archives a JSON snapshot to a **`telemetry` branch** (git history without bypassing the gate). `tokensPerPR` is schema-present but `null`. The standards loop is **reused**, bridged by one doc.
+
+## Design
+
+### 1. `scripts/telemetry-metrics.cjs` (+ `tests/telemetry-metrics.test.ts`)
+
+Pure function `computeMetrics({ prs, plans })`, no network. Inputs (normalized by the workflow):
+- `prs`: `[{ number, mergedAt, issueCreatedAt, prodDeployedAt, reviewFindings }]`
+- `plans`: `[{ issue, revised }]` — issues that reached `plan:pending`.
+
+Returns:
+```
+{
+  cycleTime:           { medianHours, p90Hours, count },   // prodDeployedAt − issueCreatedAt, ≥0 only
+  planRevisionRate:    { rate, revised, total },            // revised/total (from plan:revise)
+  reviewFindingsPerPR: { mean, count },                     // mean reviewer threads over merged PRs
+  tokensPerPR:         null                                 // schema-ready; needs run instrumentation
+}
+```
+Empty inputs yield `null` values with `count`/`total` 0. `percentile` uses linear interpolation between closest ranks. Rounded to 1 dp (hours) / 2 dp (rate). `.cjs` so the workflow can `require` it and Vitest can test it. TDD.
+
+### 2. `.github/workflows/telemetry.yml`
+
+- **Triggers:** `schedule` (weekly cron) + `workflow_dispatch`.
+- **Permissions:** `contents: write` (create the `telemetry` ref + put the snapshot file), `issues: write` (update the dashboard issue), `pull-requests: read`.
+- **`github-script` step:**
+  1. Fetch merged PRs in a rolling window (e.g. last 30 days), each PR's linked issue (parse `Closes #<n>`), its reviewer thread count (GraphQL `reviewThreads`), and the prod-deploy time (the `deploy-prod` run / release that shipped it, best-effort).
+  2. Fetch issues that reached `plan:pending` and whether `plan:revise` was ever applied (label timeline).
+  3. Normalize to `{ prs, plans }`; call `computeMetrics`.
+  4. **Dashboard:** find the open issue titled `Pipeline Telemetry`; update its body with a metrics table + generated-at timestamp (skip with a log if absent).
+  5. **Snapshot:** ensure a `telemetry` branch exists (create from `main` head via the Git refs API if missing), then `createOrUpdateFileContents` at `docs/ops/telemetry/<date>.json` on that branch.
+- **Empty-window safe:** with no data the dashboard shows "no data yet" and the snapshot records zero counts.
+
+### 3. `docs/ops/pipeline-audit.md`
+
+The audit→standards bridge:
+- The **spot-check discipline** — ~1 in 10 merged PRs reviewed by hand, including fast-lane and night-shift merges; agents keep their autonomy only while spot-checks stay clean (the essay's "audit has teeth").
+- **How telemetry feeds it** — the Telemetry issue surfaces audit candidates (high `reviewFindings` PRs, long cycle times, night-shift/auto-approved merges).
+- **How a finding becomes a rule** — a confirmed audit finding or recurring reviewer category is written into `coding-standards.md` via the **existing** `tasks/implementation-notes.md` (ledger) → `tasks/lessons.md` → self-improvement loop. Each mistake paid down once.
+
+### 4. Pipeline Telemetry issue (rollout)
+
+A pinned issue titled `Pipeline Telemetry` created at rollout; the workflow keeps its body current.
+
+## Verification approach
+
+- **`telemetry-metrics.cjs`:** Vitest — empty inputs (all null, zero counts); single PR cycle time; PRs missing issue/prod timestamps excluded; negative durations excluded; median/p90 on several durations; revision-rate math; findings mean over merged only; `tokensPerPR` always null.
+- **`telemetry.yml`:** YAML parses; permissions minimal; the fetch→normalize→compute→publish path reviewed. (The branch-commit + issue-update behavior is a rollout verification — it needs the workflow to run.)
+- **`pipeline-audit.md`:** references the existing `tasks/lessons.md` / `coding-standards.md` ledger.
+
+## Rollback
+
+Additive: one helper + test, one workflow, one doc; a self-contained `telemetry` branch. Rollback = revert the PR and delete the `telemetry` branch (`git push origin --delete telemetry`). No `main` code, runtime, or deploy surface is touched.

--- a/docs/superpowers/specs/2026-07-08-tokens-per-pr-design.md
+++ b/docs/superpowers/specs/2026-07-08-tokens-per-pr-design.md
@@ -1,0 +1,54 @@
+# Spec: Tokens-per-PR instrumentation (cycle E follow-up)
+
+- **Date:** 2026-07-08
+- **Status:** Accepted (design approved 2026-07-08; extends cycle E / PR #429)
+- **Deciders:** Vinny Carpenter
+- **Related:** `2026-07-08-telemetry-design.md` (cycle E), `scripts/builder-run.sh` + `.claude/commands/build-next.md` (cycle B), `.github/workflows/telemetry.yml`
+
+## Goal
+
+Fill in the `tokensPerPR` metric that cycle E stubbed: record the token cost of the builder's run against the PR it opens, so the weekly telemetry can report tokens per merged PR.
+
+## Scope & non-goals
+
+- **In scope:** builder-only token capture (builder opens exactly one PR/run → clean attribution). Produce a token marker on the PR; telemetry sums markers; `computeMetrics` reports the mean.
+- **Non-goals:** night-shift token tracking (≤3 PRs/run — ambiguous split; its files aren't on this branch) — a follow-up after cycle D merges. Reviewer token tracking (separate concern).
+
+## Decision
+
+The token data crosses a local→cloud boundary via a **machine-readable marker comment on the PR** (where the cloud workflow already has access). The local run reports which PR it opened; the wrapper posts the marker.
+
+## Design
+
+### 1. `scripts/extract-run-tokens.cjs` (+ test)
+
+Pure, dual-mode. `extractRunTokens(json)` takes a `claude -p --output-format json` object (or JSON string) → `{ tokens, pr }`:
+- `tokens` = sum of all `*_tokens` fields present in `usage` (`input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`) — robust to which exist.
+- `pr` = the number in `OPENED_PR=<n>` parsed from `result`, or `null`.
+CLI (`require.main`): read the JSON from stdin, print `"<tokens> <pr|none>"`. TDD.
+
+### 2. `.claude/commands/build-next.md`
+
+Add a required final line to the builder's output: `OPENED_PR=<number>` when it opened a PR this run, else `OPENED_PR=none`.
+
+### 3. `scripts/builder-run.sh`
+
+Invoke `claude -p "/build-next" --output-format json` (stdout=JSON to the run log, stderr to `<log>.err`). After the run, pipe the JSON through `extract-run-tokens.cjs`; if a PR and non-zero tokens, `gh pr comment <pr> --body "<!-- gsd-tokens tokens=<n> -->"`. Best-effort — a failure here never fails the run.
+
+### 4. `.github/workflows/telemetry.yml`
+
+Per merged PR, read its comments for `<!-- gsd-tokens tokens=<n> -->` markers and sum them into `pr.tokens` (`null` if none). Errors logged, not swallowed. Update the dashboard row from "pending" to the computed mean.
+
+### 5. `scripts/telemetry-metrics.cjs`
+
+`tokensPerPR` becomes `{ mean, count }` over merged PRs that have a numeric `tokens` (`mean: null, count: 0` when none). Update its tests (the empty-input case changes shape).
+
+## Verification
+
+- `extract-run-tokens.cjs`: Vitest — full usage summed, missing usage → 0, `OPENED_PR` parsed / absent / `=none`, string vs object input, malformed → `{0, null}`.
+- `telemetry-metrics.cjs`: updated tests — empty → `{mean:null,count:0}`; tokens averaged over PRs that have them; PRs without tokens excluded from the mean.
+- `builder-run.sh`: `bash -n`. `build-next.md`: the `OPENED_PR=` instruction present. `telemetry.yml`: parses; marker regex correct.
+
+## Rollback
+
+Additive/edits confined to two scripts, one command, one workflow. Rollback = revert. Marker comments are inert HTML comments; the metric returns to `null` if the producer half is removed.

--- a/scripts/builder-run.sh
+++ b/scripts/builder-run.sh
@@ -9,6 +9,7 @@ REPO="${GSD_BUILDER_REPO:-vscarpenter/gsd-task-manager}"
 WORKTREE="${GSD_BUILDER_WORKTREE:-$HOME/.gsd-builder/worktree}"
 SOURCE="${GSD_BUILDER_SOURCE:-$HOME/Projects/gsd-taskmanager}"
 LOG_DIR="${GSD_BUILDER_LOG_DIR:-$SOURCE/docs/ops/builder-logs}"
+TOKENS_HELPER="${GSD_BUILDER_TOKENS_HELPER:-$SOURCE/scripts/extract-run-tokens.cjs}"
 
 MODE="run"
 for arg in "$@"; do
@@ -71,11 +72,23 @@ fi
 
 # 4. Invoke the builder with a scoped tool allow-list (never the full
 #    --dangerously-skip-permissions), bounded to git/gh/bun + in-repo edits.
-# 5. Log the run for audit.
+#    --output-format json so the run's token usage + OPENED_PR can be recorded.
+# 5. Log the run for audit (JSON to the run log, stderr alongside).
 run_id="builder-$(git -C "$SOURCE" rev-parse --short origin/main)-$$"
+run_log="$LOG_DIR/$run_id.json"
 echo "RUN: $run_id"
 (
   cd "$WORKTREE" &&
-  claude -p "/build-next" \
+  claude -p "/build-next" --output-format json \
     --allowedTools "Bash(git*),Bash(gh*),Bash(bun*),Edit,Write,Read"
-) 2>&1 | tee "$LOG_DIR/$run_id.log"
+) > "$run_log" 2> "$run_log.err" || true
+
+# 6. Record the run's token cost against the PR it opened (best-effort; a
+#    failure here never fails the run). The builder ends its output with
+#    OPENED_PR=<n>; extract-run-tokens.cjs pairs it with the usage total.
+read -r tokens pr < <(node "$TOKENS_HELPER" < "$run_log" 2>/dev/null || echo "0 none")
+if [ "$pr" != "none" ] && [ "$tokens" != "0" ]; then
+  gh pr comment "$pr" --repo "$REPO" --body "<!-- gsd-tokens tokens=$tokens -->" 2>/dev/null \
+    && echo "RECORDED: $tokens tokens on PR #$pr" \
+    || echo "WARN: could not post token marker on PR #$pr"
+fi

--- a/scripts/extract-run-tokens.cjs
+++ b/scripts/extract-run-tokens.cjs
@@ -1,0 +1,42 @@
+"use strict";
+
+const TOKEN_FIELDS = ["input_tokens", "output_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"];
+
+// Sum every *_tokens field present in a claude usage object (robust to which exist).
+function totalTokens(usage) {
+  if (!usage || typeof usage !== "object") return 0;
+  return TOKEN_FIELDS.reduce((sum, f) => sum + (Number(usage[f]) || 0), 0);
+}
+
+// The PR number the builder reported via its final `OPENED_PR=<n>` line, or null.
+function parsePr(resultText) {
+  if (typeof resultText !== "string") return null;
+  const m = /OPENED_PR=(\d+)/.exec(resultText);
+  return m ? Number(m[1]) : null;
+}
+
+// Extract { tokens, pr } from a `claude -p --output-format json` run (object or JSON string).
+function extractRunTokens(json) {
+  let obj = json;
+  if (typeof json === "string") {
+    try {
+      obj = JSON.parse(json);
+    } catch {
+      return { tokens: 0, pr: null };
+    }
+  }
+  if (!obj || typeof obj !== "object") return { tokens: 0, pr: null };
+  return { tokens: totalTokens(obj.usage), pr: parsePr(obj.result) };
+}
+
+module.exports = { extractRunTokens, totalTokens, parsePr };
+
+// CLI: read the claude JSON from stdin, print "<tokens> <pr|none>".
+if (require.main === module) {
+  let input = "";
+  process.stdin.on("data", (c) => (input += c));
+  process.stdin.on("end", () => {
+    const { tokens, pr } = extractRunTokens(input);
+    process.stdout.write(`${tokens} ${pr == null ? "none" : pr}`);
+  });
+}

--- a/scripts/telemetry-metrics.cjs
+++ b/scripts/telemetry-metrics.cjs
@@ -46,6 +46,9 @@ function computeMetrics(input) {
   const merged = prs.filter((pr) => pr && pr.mergedAt);
   const findingsSum = merged.reduce((s, pr) => s + (Number(pr.reviewFindings) || 0), 0);
 
+  const withTokens = merged.filter((pr) => typeof pr.tokens === "number");
+  const tokensSum = withTokens.reduce((s, pr) => s + pr.tokens, 0);
+
   return {
     cycleTime: {
       medianHours: round(percentile(durations, 50), 1),
@@ -61,7 +64,10 @@ function computeMetrics(input) {
       mean: merged.length ? round(findingsSum / merged.length, 1) : null,
       count: merged.length,
     },
-    tokensPerPR: null,
+    tokensPerPR: {
+      mean: withTokens.length ? round(tokensSum / withTokens.length, 0) : null,
+      count: withTokens.length,
+    },
   };
 }
 

--- a/scripts/telemetry-metrics.cjs
+++ b/scripts/telemetry-metrics.cjs
@@ -1,0 +1,68 @@
+"use strict";
+
+const HOUR_MS = 3600000;
+
+function toMs(iso) {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? null : t;
+}
+
+function percentile(sorted, p) {
+  if (!sorted.length) return null;
+  if (sorted.length === 1) return sorted[0];
+  const rank = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (rank - lo);
+}
+
+function round(x, dp) {
+  if (x == null) return null;
+  const f = 10 ** dp;
+  return Math.round(x * f) / f;
+}
+
+// Pure pipeline metrics. Inputs are normalized by the telemetry workflow:
+//   prs:   [{ number, mergedAt, issueCreatedAt, prodDeployedAt, reviewFindings }]
+//   plans: [{ issue, revised }]  (issues that reached plan:pending)
+function computeMetrics(input) {
+  const prs = Array.isArray(input && input.prs) ? input.prs : [];
+  const plans = Array.isArray(input && input.plans) ? input.plans : [];
+
+  const durations = prs
+    .map((pr) => {
+      const start = toMs(pr && pr.issueCreatedAt);
+      const end = toMs(pr && pr.prodDeployedAt);
+      return start != null && end != null ? (end - start) / HOUR_MS : null;
+    })
+    .filter((h) => h != null && h >= 0)
+    .sort((a, b) => a - b);
+
+  const total = plans.length;
+  const revised = plans.filter((p) => p && p.revised).length;
+
+  const merged = prs.filter((pr) => pr && pr.mergedAt);
+  const findingsSum = merged.reduce((s, pr) => s + (Number(pr.reviewFindings) || 0), 0);
+
+  return {
+    cycleTime: {
+      medianHours: round(percentile(durations, 50), 1),
+      p90Hours: round(percentile(durations, 90), 1),
+      count: durations.length,
+    },
+    planRevisionRate: {
+      rate: total ? round(revised / total, 2) : null,
+      revised,
+      total,
+    },
+    reviewFindingsPerPR: {
+      mean: merged.length ? round(findingsSum / merged.length, 1) : null,
+      count: merged.length,
+    },
+    tokensPerPR: null,
+  };
+}
+
+module.exports = { computeMetrics, percentile };

--- a/tests/extract-run-tokens.test.ts
+++ b/tests/extract-run-tokens.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { extractRunTokens, totalTokens, parsePr } from "../scripts/extract-run-tokens.cjs";
+
+const runJson = (overrides: Record<string, unknown> = {}) => ({
+  type: "result",
+  result: "Opened the PR.\nOPENED_PR=123",
+  usage: { input_tokens: 1000, output_tokens: 500, cache_creation_input_tokens: 200, cache_read_input_tokens: 3000 },
+  ...overrides,
+});
+
+describe("totalTokens", () => {
+  it("sums all *_tokens fields present", () => {
+    expect(totalTokens({ input_tokens: 10, output_tokens: 5 })).toBe(15);
+    expect(totalTokens({ input_tokens: 1000, output_tokens: 500, cache_creation_input_tokens: 200, cache_read_input_tokens: 3000 })).toBe(4700);
+  });
+  it("is 0 for missing/invalid usage", () => {
+    expect(totalTokens(undefined)).toBe(0);
+    expect(totalTokens(null)).toBe(0);
+  });
+});
+
+describe("parsePr", () => {
+  it("parses OPENED_PR=<n>", () => expect(parsePr("done\nOPENED_PR=42")).toBe(42));
+  it("returns null for none/absent", () => {
+    expect(parsePr("OPENED_PR=none")).toBeNull();
+    expect(parsePr("no marker here")).toBeNull();
+    expect(parsePr(undefined as unknown as string)).toBeNull();
+  });
+});
+
+describe("extractRunTokens", () => {
+  it("extracts tokens and pr from a run object", () => {
+    expect(extractRunTokens(runJson())).toEqual({ tokens: 4700, pr: 123 });
+  });
+  it("parses a JSON string", () => {
+    expect(extractRunTokens(JSON.stringify(runJson()))).toEqual({ tokens: 4700, pr: 123 });
+  });
+  it("returns 0 tokens when usage is missing", () => {
+    expect(extractRunTokens(runJson({ usage: undefined }))).toEqual({ tokens: 0, pr: 123 });
+  });
+  it("returns null pr when the run opened none", () => {
+    expect(extractRunTokens(runJson({ result: "Planned only.\nOPENED_PR=none" }))).toEqual({ tokens: 4700, pr: null });
+  });
+  it("is safe on malformed input", () => {
+    expect(extractRunTokens("not json")).toEqual({ tokens: 0, pr: null });
+    expect(extractRunTokens(null)).toEqual({ tokens: 0, pr: null });
+  });
+});

--- a/tests/telemetry-metrics.test.ts
+++ b/tests/telemetry-metrics.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { computeMetrics, percentile } from "../scripts/telemetry-metrics.cjs";
+
+const day = (n: number) => new Date(Date.UTC(2026, 0, n)).toISOString();
+
+describe("percentile", () => {
+  it("interpolates between ranks", () => {
+    expect(percentile([10, 20, 30, 40], 50)).toBe(25);
+  });
+  it("returns null for empty", () => expect(percentile([], 50)).toBeNull());
+});
+
+describe("computeMetrics", () => {
+  it("returns nulls/zeros for empty input", () => {
+    const m = computeMetrics({});
+    expect(m.cycleTime).toEqual({ medianHours: null, p90Hours: null, count: 0 });
+    expect(m.planRevisionRate).toEqual({ rate: null, revised: 0, total: 0 });
+    expect(m.reviewFindingsPerPR).toEqual({ mean: null, count: 0 });
+    expect(m.tokensPerPR).toBeNull();
+  });
+
+  it("computes cycle time in hours from issueCreatedAt to prodDeployedAt", () => {
+    const m = computeMetrics({
+      prs: [{ number: 1, mergedAt: day(2), issueCreatedAt: day(1), prodDeployedAt: day(2), reviewFindings: 2 }],
+    });
+    expect(m.cycleTime).toEqual({ medianHours: 24, p90Hours: 24, count: 1 });
+    expect(m.reviewFindingsPerPR).toEqual({ mean: 2, count: 1 });
+  });
+
+  it("excludes PRs missing issue or prod timestamps from cycle time", () => {
+    const m = computeMetrics({
+      prs: [{ number: 1, mergedAt: day(2), issueCreatedAt: null, prodDeployedAt: day(2), reviewFindings: 0 }],
+    });
+    expect(m.cycleTime.count).toBe(0);
+  });
+
+  it("excludes negative durations", () => {
+    const m = computeMetrics({
+      prs: [{ number: 1, mergedAt: day(1), issueCreatedAt: day(3), prodDeployedAt: day(2), reviewFindings: 0 }],
+    });
+    expect(m.cycleTime.count).toBe(0);
+  });
+
+  it("takes the median of multiple durations", () => {
+    const m = computeMetrics({
+      prs: [
+        { number: 1, mergedAt: day(2), issueCreatedAt: day(1), prodDeployedAt: day(2), reviewFindings: 0 },
+        { number: 2, mergedAt: day(3), issueCreatedAt: day(1), prodDeployedAt: day(3), reviewFindings: 0 },
+        { number: 3, mergedAt: day(4), issueCreatedAt: day(1), prodDeployedAt: day(4), reviewFindings: 0 },
+      ],
+    });
+    expect(m.cycleTime.medianHours).toBe(48); // 24h, 48h, 72h -> median 48h
+  });
+
+  it("computes plan revision rate", () => {
+    const m = computeMetrics({ plans: [{ revised: true }, { revised: false }, { revised: false }] });
+    expect(m.planRevisionRate).toEqual({ rate: 0.33, revised: 1, total: 3 });
+  });
+
+  it("averages review findings over merged PRs only", () => {
+    const m = computeMetrics({
+      prs: [
+        { number: 1, mergedAt: day(2), reviewFindings: 4 },
+        { number: 2, mergedAt: null, reviewFindings: 100 },
+      ],
+    });
+    expect(m.reviewFindingsPerPR).toEqual({ mean: 4, count: 1 });
+  });
+});

--- a/tests/telemetry-metrics.test.ts
+++ b/tests/telemetry-metrics.test.ts
@@ -16,7 +16,18 @@ describe("computeMetrics", () => {
     expect(m.cycleTime).toEqual({ medianHours: null, p90Hours: null, count: 0 });
     expect(m.planRevisionRate).toEqual({ rate: null, revised: 0, total: 0 });
     expect(m.reviewFindingsPerPR).toEqual({ mean: null, count: 0 });
-    expect(m.tokensPerPR).toBeNull();
+    expect(m.tokensPerPR).toEqual({ mean: null, count: 0 });
+  });
+
+  it("averages tokens over merged PRs that have token data", () => {
+    const m = computeMetrics({
+      prs: [
+        { number: 1, mergedAt: day(2), tokens: 1000 },
+        { number: 2, mergedAt: day(2), tokens: 3000 },
+        { number: 3, mergedAt: day(2) }, // no token data -> excluded from the mean
+      ],
+    });
+    expect(m.tokensPerPR).toEqual({ mean: 2000, count: 2 });
   });
 
   it("computes cycle time in hours from issueCreatedAt to prodDeployedAt", () => {


### PR DESCRIPTION
## Summary

Cycle E — the learning loop, and the final cycle of the "Two Gates and a Night Shift" pipeline. A weekly workflow computes pipeline metrics, publishes a living dashboard issue, and archives JSON snapshots — plus a doc bridging audit findings into the existing standards loop.

Spec: `docs/superpowers/specs/2026-07-08-telemetry-design.md`, plan: `docs/superpowers/plans/2026-07-08-telemetry.md`.

Adds:
- `scripts/telemetry-metrics.cjs` (+9 Vitest cases) — pure aggregation: cycle time (median/p90), plan-revision rate, review findings/PR. `tokensPerPR` stubbed null (needs run instrumentation — a B/D follow-up).
- `.github/workflows/telemetry.yml` — weekly (+ dispatch): fetches merged PRs (linked issue, reviewer thread count) and `plan:pending` issues (`plan:revise` timeline), calls the helper, updates a pinned **Pipeline Telemetry** issue, and commits a snapshot to a **`telemetry` branch** via the Contents API. Scoped `contents:write` + `issues:write` + `pull-requests:read`.
- `docs/ops/pipeline-audit.md` — the audit→standards bridge (spot-check discipline + telemetry candidates → `coding-standards.md` via the existing ledger/lessons loop).

**Why the `telemetry` branch:** your `main-protection` ruleset (correctly) requires a PR to write to `main`, so the workflow archives snapshots to an unprotected `telemetry` branch — git history of metrics without bypassing the gate. The Pipeline Telemetry issue is the human dashboard.

**Note:** metrics are approximate v1 (cycle-time end ≈ merge time until deploy↔PR correlation is added). Data will be sparse until the pipeline runs live.

## Risk tier

**chore** — additive tooling. New scoped telemetry workflow (no deploy, no secrets, no existing-CI change), one tested helper, one doc. No runtime/app change.

## How to verify

- `bun run test -- tests/telemetry-metrics.test.ts` — 9/9.
- `telemetry.yml` parses; permissions `{contents:write, issues:write, pull-requests:read}`.
- `pipeline-audit.md` cross-refs resolve (`coding-standards.md`, `tasks/lessons.md`).

## Rollback plan

Revert this PR and delete the branch: `git push origin --delete telemetry`. No `main` code, runtime, or deploy surface is touched (the workflow only ever writes to the `telemetry` branch and the dashboard issue).

## Checklist

- [x] Tests added/updated and passing (9/9)
- [x] Lint clean on new files
- [x] Rollback plan above is real
- [ ] Post-merge: create Pipeline Telemetry issue + dispatch once

https://claude.ai/code/session_01VTzjLGNTCEByQKuedNvBoB
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->