### PR TITLE
docs(agents): add index README for operating docs

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,9 @@
+# Agent operating docs
+
+Operating specs and conventions for the autonomous delivery pipeline and its agents.
+
+- [`builder.md`](builder.md) — Builder operating spec (cycle B): turns a fully-specified issue into a reviewed PR, pausing once for Gate 1 plan approval; never merges.
+- [`night-shift.md`](night-shift.md) — Night-shift operating spec (cycle D): nightly unattended triage of failing checks on the agent fleet's own open PRs.
+- [`issue-tracker.md`](issue-tracker.md) — GitHub issue-tracker conventions (`gh` CLI) for creating, reading, labeling, and closing issues.
+- [`triage-labels.md`](triage-labels.md) — Maps the five canonical triage roles to this repo's actual label strings.
+- [`domain.md`](domain.md) — How the engineering skills should consume this repo's domain docs (`CONTEXT.md`, `docs/adr/`) before exploring the codebase.


### PR DESCRIPTION
## Summary

Adds `docs/agents/README.md` — a short, standalone index of the agent operating docs in `docs/agents/`, so contributors can see at a glance what's there. Each entry has a one-line description and a relative link. No existing file is modified.

Closes #432

## Risk tier

chore

## How to verify

Mirrors the linked issue's acceptance criteria:

- [x] `docs/agents/README.md` exists
- [x] It lists each existing doc in `docs/agents/` (builder, night-shift, issue-tracker, triage-labels, domain) with a one-line description and a relative link — every link target resolves on disk
- [x] No existing file is modified (`git show --stat` = 1 file changed, 9 insertions, new file only)

## Rollback plan

Delete `docs/agents/README.md`. It is a new, standalone index — nothing depends on it.

## Checklist

- [x] Acceptance criteria from the linked issue are met
- [x] Tests added/updated and passing (`bun run test`) — docs-only change; issue forbids adding tests; full suite green (2265 passed, 1 skipped)
- [x] Lint and typecheck clean (`bun run lint` — 0 errors; `bun run typecheck` — clean)
- [x] Coding standards followed (`coding-standards.md`)
- [x] Rollback plan above is real
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->