### PR TITLE
fix(pipeline): give the launchd wrappers a working PATH

### DIFF
--- a/scripts/builder-run.sh
+++ b/scripts/builder-run.sh
@@ -5,6 +5,12 @@
 # durable state across runs. See docs/agents/builder.md.
 set -euo pipefail
 
+# launchd starts jobs with a minimal PATH (/usr/bin:/bin:...), so the toolchain
+# (gh/git in Homebrew, node/claude in ~/.local/bin, bun in ~/.bun/bin) isn't
+# found and gh silently fails the pre-check. Append (don't prepend) the tool
+# dirs so an existing gh on PATH — e.g. a test stub — still wins.
+export PATH="$PATH:/opt/homebrew/bin:$HOME/.local/bin:$HOME/.bun/bin"
+
 REPO="${GSD_BUILDER_REPO:-vscarpenter/gsd-task-manager}"
 WORKTREE="${GSD_BUILDER_WORKTREE:-$HOME/.gsd-builder/worktree}"
 SOURCE="${GSD_BUILDER_SOURCE:-$HOME/Projects/gsd-taskmanager}"

--- a/scripts/triage-run.sh
+++ b/scripts/triage-run.sh
@@ -5,6 +5,12 @@
 # failing work. See docs/agents/night-shift.md.
 set -euo pipefail
 
+# launchd starts jobs with a minimal PATH (/usr/bin:/bin:...), so the toolchain
+# (gh/git in Homebrew, node/claude in ~/.local/bin, bun in ~/.bun/bin) isn't
+# found and gh silently fails the pre-check. Append (don't prepend) the tool
+# dirs so an existing gh on PATH — e.g. a test stub — still wins.
+export PATH="$PATH:/opt/homebrew/bin:$HOME/.local/bin:$HOME/.bun/bin"
+
 REPO="${GSD_TRIAGE_REPO:-vscarpenter/gsd-task-manager}"
 WORKTREE="${GSD_TRIAGE_WORKTREE:-$HOME/.gsd-night-shift/worktree}"
 SOURCE="${GSD_TRIAGE_SOURCE:-$HOME/Projects/gsd-taskmanager}"


### PR DESCRIPTION
## Summary

The first live builder run (shakedown) exited `NO_WORK` even with a `ready-for-agent` issue queued. Root cause: **launchd starts jobs with a minimal `PATH`** (`/usr/bin:/bin:...`), so the toolchain — `gh`/`git` in `/opt/homebrew/bin`, `node`/`claude` in `~/.local/bin`, `bun` in `~/.bun/bin` — wasn't found. `builder-run.sh`'s `count()` then failed safe to `0` and reported no work. (Surfaced immediately by the `gh-errors.log` from the earlier never-swallow-exceptions fix.)

Both wrappers now **append** the tool dirs to `PATH` — append, not prepend, so a test's stubbed `gh` still wins.

## Risk tier

**chore** — two one-line `export PATH` additions to `scripts/builder-run.sh` and `scripts/triage-run.sh`. No behavior change beyond making the tools findable under launchd.

## How to verify

- Wrapper tests still green (append preserves stub isolation): `bun run test -- tests/builder-run.test.ts tests/triage-run.test.ts`.
- Proven live: after this change, the builder found the queued contract and opened PR #433.

## Rollback plan

Revert this PR. Reverting only removes the `PATH` line; the launchd jobs return to the (broken) minimal-PATH behavior.

## Checklist

- [x] Wrapper tests passing
- [x] Verified live (builder ran end-to-end after the fix)
- [x] Rollback plan is real

https://claude.ai/code/session_01VTzjLGNTCEByQKuedNvBoB
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->