### PR TITLE
fix(archive): prevent duplicate-archive race in archiveOldTasks

### DIFF
--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -43,6 +43,15 @@ export async function updateArchiveSettings(
 /**
  * Archive completed tasks older than specified days
  * Returns count of archived tasks
+ *
+ * The read (find eligible tasks), bulkAdd, and bulkDelete all run inside a
+ * single Dexie transaction. Without this, two overlapping calls (e.g. two
+ * open tabs, or the hourly auto-archive racing a manual "Archive now" click)
+ * can both read the same eligible tasks before either commits its
+ * bulkDelete, so the second call's bulkAdd collides with keys the first
+ * call already inserted. IndexedDB serializes transactions with overlapping
+ * table scope, so the second call now re-reads tasks after the first has
+ * already removed them.
  */
 export async function archiveOldTasks(
   daysOld: number
@@ -51,41 +60,48 @@ export async function archiveOldTasks(
   const cutoffDate = new Date();
   cutoffDate.setDate(cutoffDate.getDate() - daysOld);
   const cutoffIso = cutoffDate.toISOString();
-
-  // Find completed tasks older than cutoff
-  const allTasks = await db.tasks.toArray();
-  const tasksToArchive = allTasks.filter((task) => {
-    if (!task.completed || !task.completedAt) return false;
-    return task.completedAt < cutoffIso;
-  });
-
-  if (tasksToArchive.length === 0) {
-    return 0;
-  }
-
   const now = new Date().toISOString();
 
-  // Enqueue delete operations for sync (only if sync is enabled)
   const { getSyncConfig } = await import("@/lib/sync/config");
   const syncConfig = await getSyncConfig();
-  if (syncConfig?.enabled) {
-    const queue = getSyncQueue();
-    await Promise.all(
-      tasksToArchive.map((task) => queue.enqueue('delete', task.id, task))
-    );
-  }
+  const queue = getSyncQueue();
 
-  // Move tasks to archive table
-  const archivedTasks: TaskRecord[] = tasksToArchive.map((task) => ({
-    ...task,
-    archivedAt: now
-  }));
+  const tasksToArchive = await db.transaction(
+    "rw",
+    [db.tasks, db.archivedTasks, db.syncQueue],
+    async () => {
+      // Find completed tasks older than cutoff
+      const allTasks = await db.tasks.toArray();
+      const eligible = allTasks.filter((task) => {
+        if (!task.completed || !task.completedAt) return false;
+        return task.completedAt < cutoffIso;
+      });
 
-  await db.archivedTasks.bulkAdd(archivedTasks);
+      if (eligible.length === 0) {
+        return eligible;
+      }
 
-  // Remove from main tasks table
-  const taskIds = tasksToArchive.map((task) => task.id);
-  await db.tasks.bulkDelete(taskIds);
+      // Move tasks to archive table
+      const archivedTasks: TaskRecord[] = eligible.map((task) => ({
+        ...task,
+        archivedAt: now
+      }));
+
+      await db.archivedTasks.bulkAdd(archivedTasks);
+
+      // Remove from main tasks table
+      await db.tasks.bulkDelete(eligible.map((task) => task.id));
+
+      // Enqueue delete operations for sync (only if sync is enabled)
+      if (syncConfig?.enabled) {
+        await Promise.all(
+          eligible.map((task) => queue.enqueue('delete', task.id, task))
+        );
+      }
+
+      return eligible;
+    }
+  );
 
   return tasksToArchive.length;
 }

--- a/tests/data/archive.test.ts
+++ b/tests/data/archive.test.ts
@@ -208,6 +208,35 @@ describe("archive", () => {
       expect(archivedCount).toBe(0);
     });
 
+    it("should_not_throw_or_duplicate_when_called_concurrently", async () => {
+      // Regression test for a production BulkError: two overlapping calls to
+      // archiveOldTasks() (e.g. two open tabs, or the hourly auto-archive
+      // racing a manual "Archive now" click) both read the same eligible
+      // tasks before either had committed its bulkDelete, so the second
+      // call's bulkAdd collided with keys the first call had just inserted.
+      const db = getDb();
+      const oldDate = new Date();
+      oldDate.setDate(oldDate.getDate() - 60);
+
+      const tasks = Array.from({ length: 5 }, (_, i) =>
+        createMockTask({
+          id: `concurrent-task-${i}`,
+          completed: true,
+          completedAt: oldDate.toISOString(),
+        })
+      );
+      await db.tasks.bulkAdd(tasks);
+
+      const [countA, countB] = await Promise.all([
+        archiveOldTasks(30),
+        archiveOldTasks(30),
+      ]);
+
+      expect(countA + countB).toBe(5);
+      expect(await db.tasks.count()).toBe(0);
+      expect(await db.archivedTasks.count()).toBe(5);
+    });
+
     it("should_set_archivedAt_on_archived_tasks", async () => {
       const db = getDb();
       const oldDate = new Date();


### PR DESCRIPTION
Sentry reported archivedTasks.bulkAdd() failing 157/157 with ConstraintError. Two overlapping calls (multiple tabs, or the hourly auto-archive racing a manual "Archive now") both read the same eligible tasks before either committed its bulkDelete, so the second call's bulkAdd collided with keys the first call had just inserted. Wrap the read, bulkAdd, bulkDelete, and sync-queue enqueue in a single Dexie transaction so IndexedDB serializes overlapping calls instead of letting them race.

## Summary

<!-- What changed and why. Link the contract this implements. -->
Closes #

## Risk tier

<!-- Carry the risk:* label from the linked issue: docs | chore | feature | risky -->

## How to verify

<!-- Steps to exercise the change. Mirror the linked issue's acceptance criteria. -->
- [ ]

## Rollback plan

<!-- REQUIRED. How to undo this if it goes wrong in production.
     No rollback path, no release approval. -->

## Checklist

- [ ] Acceptance criteria from the linked issue are met
- [ ] Tests added/updated and passing (`bun run test`)
- [ ] Lint and typecheck clean (`bun run lint`, `bun run typecheck`)
- [ ] Coding standards followed (`coding-standards.md`)
- [ ] Rollback plan above is real

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->