### PR TITLE
chore(hooks): run Stop-hook checks async, narrow lint to changed files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,15 +58,19 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun typecheck 2>&1 | tail -10",
-            "timeout": 60,
-            "statusMessage": "Type-check verification gate..."
+            "command": "out=$(bun typecheck 2>&1) || { printf '%s\\n' \"$out\" | tail -40; exit 2; }",
+            "timeout": 120,
+            "asyncRewake": true,
+            "rewakeSummary": "Type-check failed",
+            "statusMessage": "Type-check (async)..."
           },
           {
             "type": "command",
-            "command": "bun lint 2>&1 | tail -10",
-            "timeout": 60,
-            "statusMessage": "Lint verification gate..."
+            "command": "files=$(git diff --name-only --diff-filter=ACMR HEAD -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs' 2>/dev/null; git ls-files --others --exclude-standard -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs' 2>/dev/null); [ -z \"$files\" ] && exit 0; out=$(printf '%s\\n' \"$files\" | sort -u | xargs bun x eslint 2>&1) || { printf '%s\\n' \"$out\" | tail -40; exit 2; }",
+            "timeout": 120,
+            "asyncRewake": true,
+            "rewakeSummary": "Lint failed on changed files",
+            "statusMessage": "Lint changed files (async)..."
           }
         ]
       }


### PR DESCRIPTION
## What
Convert the project Stop hook (`.claude/settings.json`) from blocking whole-tree `bun typecheck` + `bun lint` to background `asyncRewake` checks.

## Why
The hook ran ~4.5s on every turn completion. Worse, both commands ended in `| tail -10`, so the pipeline always exited 0 — it printed output every turn but never actually gated.

## How
- Both checks use `asyncRewake: true`: run in the background (zero per-turn latency), silent on success, exit 2 on failure to wake the agent with the errors.
- **Typecheck** stays whole-program (`tsc --noEmit`) — TypeScript is cross-file, so narrowing to changed files would drop real errors.
- **Lint** narrows to changed JS/TS files (`git diff` vs HEAD + untracked), so it's faster and only flags files the session touched.

## Testing
Ran the exact stored commands against a clean tree (both exit 0, silent) and a forced failure (exit 2 with output shown). JSON validated with `jq`.

Dev-tooling only — no app code, no version bump.

https://claude.ai/code/session_015ZiXS2vGPsunTy8cBDHkAP
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->