### PR TITLE
ci: allow Cursor bot Claude reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,6 +40,6 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          allowed_bots: "cursor[bot]"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## What changed

- Allow `cursor[bot]` to initiate the Claude Code Review action.
- Keep the allowlist scoped to Cursor instead of permitting every bot.

## Why

PR #441 was opened by Cursor automation, and its `claude-review` check failed before review execution because the action rejects bot-initiated workflows by default.

## Impact

Cursor-authored pull requests can now receive the same automated Claude review as human-authored pull requests. Other bot identities remain blocked.

## Validation

- Parsed `.github/workflows/claude-code-review.yml` successfully as YAML.
- Ran `git diff --check` successfully.

## Scope

Only `.github/workflows/claude-code-review.yml` is included. Existing local changes to `package.json` and `public/sw.js` were excluded.