### PR TITLE
fix(navigation): handle view transition rejections

### DIFF
--- a/components/global-error-listener.tsx
+++ b/components/global-error-listener.tsx
@@ -2,9 +2,6 @@
 
 import { useEffect } from "react";
 import { toast } from "sonner";
-import { createLogger } from "@/lib/logger";
-
-const logger = createLogger("GLOBAL_ERROR");
 
 const THROTTLE_MS = 2000;
 
@@ -12,16 +9,7 @@ export function GlobalErrorListener() {
   useEffect(() => {
     let lastToastTime = 0;
 
-    function handleRejection(event: PromiseRejectionEvent) {
-      const error =
-        event.reason instanceof Error
-          ? event.reason
-          : new Error(String(event.reason ?? "Unknown rejection"));
-
-      logger.error("Unhandled promise rejection", error, {
-        type: event.reason instanceof Error ? event.reason.name : typeof event.reason,
-      });
-
+    function handleRejection() {
       const now = Date.now();
       if (now - lastToastTime >= THROTTLE_MS) {
         lastToastTime = now;

--- a/lib/use-view-transition.ts
+++ b/lib/use-view-transition.ts
@@ -70,11 +70,15 @@ export function useViewTransition() {
 
     // Wrapping router.push in startTransition ensures React can batch updates
     // during the transition, preventing UI flickering and improving performance.
-    doc.startViewTransition(() => {
+    const transition = doc.startViewTransition(() => {
       startTransition(() => {
         router.push(normalizedHref);
       });
     });
+
+    // A view transition is progressive enhancement: setup failures must not turn
+    // successful navigation into an unhandled rejection reported as an app error.
+    void transition.ready.catch(() => undefined);
   };
 
   return { navigateWithTransition, isPending };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "10.2.3",
+	"version": "10.2.4",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '10.2.3';
+const CACHE_VERSION = '10.2.4';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,6 +2,30 @@
 
 ---
 
+## Done — 2026-07-12: Handle failed view transitions without duplicate Sentry events
+
+**Branch:** `fix/view-transition-rejection-telemetry` · **Tier:** Standard (two bounded frontend error-handling changes; no visual or public contract change).
+
+**Plan (TDD):**
+- [x] RED: prove rejected `ViewTransition.ready` promises are consumed while navigation still runs.
+- [x] RED: prove the global rejection listener does not manually capture an event already owned by Sentry's browser integration.
+- [x] GREEN: handle the transition readiness promise as progressive enhancement and keep the listener toast-only.
+- [x] Verify targeted tests, typecheck, lint, full tests, build, and clean browser navigation including a forced invalid transition.
+
+**Out of scope:** changing page-transition visuals, suppressing all `InvalidStateError` events globally, or modifying unrelated generated/version files.
+
+**Verification:** targeted tests 16 passed; full suite 2,291 passed / 1 skipped;
+typecheck and lint passed (11 pre-existing warnings); static build passed. Mobile
+browser checks for normal navigation, forced invalid transition setup, and a
+synchronous double-click all reached `/about/` with no page error or unexpected
+error toast. The forced failure also passed against the built static export.
+
+**Resuming From Here:** implementation is complete and scoped for commit. The
+pre-existing `package.json` and `public/sw.js` version edits remain untouched and
+outside this change.
+
+---
+
 ## Done — 2026-07-10: Resolve all application-audit findings
 
 **Branch:** `codex/fix-audit-findings` · **Tier:** Non-trivial · **Contract:**

--- a/tests/data/use-view-transition.test.ts
+++ b/tests/data/use-view-transition.test.ts
@@ -79,6 +79,30 @@ describe("useViewTransition", () => {
     expect(mockPush).toHaveBeenCalledWith("/dashboard/");
   });
 
+  it("handles transition readiness failures without interrupting navigation", () => {
+    const readyCatch = vi.fn().mockReturnValue(Promise.resolve());
+    const mockStartViewTransition = vi.fn((callback: () => void) => {
+      callback();
+      return {
+        finished: Promise.resolve(),
+        ready: { catch: readyCatch } as unknown as Promise<void>,
+        updateCallbackDone: Promise.resolve(),
+      };
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (document as any).startViewTransition = mockStartViewTransition;
+
+    const { result } = renderHook(() => useViewTransition());
+
+    act(() => {
+      result.current.navigateWithTransition("/about");
+    });
+
+    expect(readyCatch).toHaveBeenCalledWith(expect.any(Function));
+    expect(mockPush).toHaveBeenCalledWith("/about/");
+  });
+
   it("normalizes routes by adding trailing slash", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (document as any).startViewTransition;

--- a/tests/ui/global-error-listener.test.tsx
+++ b/tests/ui/global-error-listener.test.tsx
@@ -2,27 +2,19 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, cleanup } from "@testing-library/react";
 import { GlobalErrorListener } from "@/components/global-error-listener";
 
-const mockLogger = vi.hoisted(() => ({
-  error: vi.fn(),
-  warn: vi.fn(),
-  info: vi.fn(),
-  debug: vi.fn(),
-}));
-
 const mockToast = vi.hoisted(() => ({
   error: vi.fn(),
 }));
 
-vi.mock("@/lib/logger", () => ({
-  createLogger: vi.fn(() => mockLogger),
-}));
+const mockCaptureException = vi.hoisted(() => vi.fn());
 
 vi.mock("sonner", () => ({
   toast: mockToast,
 }));
 
 vi.mock("@/lib/sentry", () => ({
-  captureException: vi.fn(),
+  captureException: mockCaptureException,
+  captureMessage: vi.fn(),
 }));
 
 describe("GlobalErrorListener", () => {
@@ -63,7 +55,7 @@ describe("GlobalErrorListener", () => {
     );
   });
 
-  it("should log error details for Error rejection", () => {
+  it("should not manually capture a rejection already owned by Sentry", () => {
     render(<GlobalErrorListener />);
 
     const handler = addEventSpy.mock.calls.find(
@@ -76,11 +68,7 @@ describe("GlobalErrorListener", () => {
     });
     handler(event);
 
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      "Unhandled promise rejection",
-      expect.any(Error),
-      expect.any(Object)
-    );
+    expect(mockCaptureException).not.toHaveBeenCalled();
   });
 
   it("should show toast for unhandled rejection", () => {
@@ -112,7 +100,8 @@ describe("GlobalErrorListener", () => {
     });
     handler(event);
 
-    expect(mockLogger.error).toHaveBeenCalled();
+    expect(mockToast.error).toHaveBeenCalledWith("An unexpected error occurred");
+    expect(mockCaptureException).not.toHaveBeenCalled();
   });
 
   it("should throttle rapid successive rejections", () => {


### PR DESCRIPTION
## What changed
- `lib/use-view-transition.ts`: capture the `ViewTransition` object returned by `document.startViewTransition()` and swallow `transition.ready` rejections — a skipped transition is progressive enhancement, not an app error.
- `components/global-error-listener.tsx`: stop routing unhandled rejections through `logger.error` (which fed error telemetry); keep the throttled user-facing toast.
- Version bump `10.2.3` → `10.2.4` (patch), with `public/sw.js` `CACHE_VERSION` kept in sync.

## Why
`startViewTransition().ready` rejects whenever the browser skips a transition (rapid navigation, reduced motion, tab hidden). These rejections bubbled to the global unhandled-rejection listener and were reported as errors, polluting telemetry for navigations that actually succeeded.

## How to test
- `bun run test` — new spec `tests/data/use-view-transition.test.ts` and updated `tests/ui/global-error-listener.test.tsx` cover the behavior.
- Manually: navigate rapidly between pages (matrix ↔ dashboard ↔ settings); no error toasts and no unhandled-rejection console errors.

https://claude.ai/code/session_01XfRiu7Qr4n3jDLhPQc39q4
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->