### PR TITLE
test(navigation): cover rejecting ready promise in view transition

### DIFF
--- a/tests/data/use-view-transition.test.ts
+++ b/tests/data/use-view-transition.test.ts
@@ -79,13 +79,15 @@ describe("useViewTransition", () => {
     expect(mockPush).toHaveBeenCalledWith("/dashboard/");
   });
 
-  it("handles transition readiness failures without interrupting navigation", () => {
-    const readyCatch = vi.fn().mockReturnValue(Promise.resolve());
+  it("handles transition readiness failures without interrupting navigation", async () => {
+    // Real rejecting promise, matching a browser skipping the transition
+    const ready = Promise.reject<void>(new Error("transition skipped before setup"));
+    const catchSpy = vi.spyOn(ready, "catch");
     const mockStartViewTransition = vi.fn((callback: () => void) => {
       callback();
       return {
         finished: Promise.resolve(),
-        ready: { catch: readyCatch } as unknown as Promise<void>,
+        ready,
         updateCallbackDone: Promise.resolve(),
       };
     });
@@ -99,8 +101,14 @@ describe("useViewTransition", () => {
       result.current.navigateWithTransition("/about");
     });
 
-    expect(readyCatch).toHaveBeenCalledWith(expect.any(Function));
+    // The hook must consume the rejection synchronously during navigation,
+    // before the microtask queue can surface it as an unhandled rejection.
+    expect(catchSpy).toHaveBeenCalledTimes(1);
     expect(mockPush).toHaveBeenCalledWith("/about/");
+
+    // The attached handler must swallow the rejection, not rethrow it.
+    const [handler] = catchSpy.mock.calls[0];
+    await expect(ready.catch(handler)).resolves.toBeUndefined();
   });
 
   it("normalizes routes by adding trailing slash", () => {


### PR DESCRIPTION
## What changed
- `tests/data/use-view-transition.test.ts`: the "handles transition readiness failures" test now uses a real `Promise.reject()` for `transition.ready` instead of a plain object with a stubbed `catch`. It asserts the hook attaches its handler synchronously (before the microtask queue can surface an unhandled rejection) and that the attached handler actually swallows the rejection.

No version bump: test-only change, no shipped artifact differs.

## Why
Devin's review of #444 noted (informational): "Test mocks `ready` as a plain object rather than a rejecting promise, limiting coverage of the actual failure path." The old mock proved wiring existed but never ran the handler against a real rejection.

Red check: swapping in the pre-fix implementation from `6d62777` makes this test fail and vitest reports the escaping unhandled rejection — the exact regression it now guards against.

## How to test
- `bun run test -- tests/data/use-view-transition.test.ts` (9 pass)
- Full suite: 2,291 passed / 1 skipped; typecheck clean; lint 0 errors (11 pre-existing warnings).

https://claude.ai/code/session_01XfRiu7Qr4n3jDLhPQc39q4
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->