### PR TITLE
fix(sync): clamp far-future client_updated_at to prevent LWW poisoning

### DIFF
--- a/lib/constants/sync.ts
+++ b/lib/constants/sync.ts
@@ -47,6 +47,14 @@ export const SYNC_CONFIG = {
    * Bounds the wait so a bogus or hostile header can't freeze sync indefinitely.
    */
   MAX_RETRY_AFTER_MS: 5 * 60 * 1000,
+
+  /**
+   * Tolerated forward skew for a client-stamped `client_updated_at` (5 min).
+   * `client_updated_at` is the LWW authority and comes from the writing device's
+   * own unverifiable clock; a value beyond `now + this` is treated as untrustworthy
+   * so a skewed/forged far-future timestamp can't permanently win LWW and lock a task.
+   */
+  MAX_CLIENT_CLOCK_SKEW_MS: 5 * 60 * 1000,
 } as const;
 
 /**

--- a/lib/sync/pb-push.ts
+++ b/lib/sync/pb-push.ts
@@ -11,6 +11,7 @@ import { taskRecordToPocketBase } from './task-mapper';
 import { createLogger } from '@/lib/logger';
 import { THROTTLE_MS, delay, getDeviceId, getCurrentUserId, fetchRemoteTaskIndex } from './pb-sync-helpers';
 import { sanitizeSyncError, isTransientSyncFailure, extractRetryAfterMs } from './error-categorizer';
+import { SYNC_CONFIG } from '@/lib/constants/sync';
 import type { SyncQueueItem, RemoteTaskIndexEntry } from './types';
 
 const logger = createLogger('SYNC_ENGINE');
@@ -167,11 +168,17 @@ async function pushSingleItem(
 /**
  * Compare two ISO timestamps. Returns true iff remote is strictly newer than local.
  * Returns false for any NaN/invalid input — never skip a write because of bad data.
+ *
+ * A remote `client_updated_at` beyond `now + MAX_CLIENT_CLOCK_SKEW_MS` is treated
+ * as untrustworthy (skewed clock or forged value) and never considered newer, so a
+ * legitimate local edit can overwrite — and thereby heal — a poisoned remote record
+ * instead of being blocked by it forever.
  */
-function isRemoteNewer(remoteIso: string, localIso: string): boolean {
+function isRemoteNewer(remoteIso: string, localIso: string, nowMs: number = Date.now()): boolean {
   const r = new Date(remoteIso).getTime();
   const l = new Date(localIso).getTime();
   if (Number.isNaN(r) || Number.isNaN(l)) return false;
+  if (r > nowMs + SYNC_CONFIG.MAX_CLIENT_CLOCK_SKEW_MS) return false;
   return r > l;
 }
 

--- a/lib/sync/task-mapper.ts
+++ b/lib/sync/task-mapper.ts
@@ -11,9 +11,28 @@ import type { RecordModel } from 'pocketbase';
 import { z } from 'zod';
 import { quadrantIdSchema, recurrenceTypeSchema, subtaskSchema, timeEntrySchema } from '@/lib/schema';
 import { SCHEMA_LIMITS } from '@/lib/constants/schema';
+import { SYNC_CONFIG } from '@/lib/constants/sync';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('SYNC_PULL');
+
+/**
+ * Cap a client-stamped timestamp that is implausibly far in the future.
+ *
+ * `client_updated_at` is the last-write-wins authority and originates from the
+ * writing device's own clock, which the app cannot verify. A skewed clock — or a
+ * value forged via a direct API write — could stamp a time years ahead, winning
+ * every future LWW comparison and locking the task from all other devices. Values
+ * beyond `now + MAX_CLIENT_CLOCK_SKEW_MS` are treated as untrustworthy and capped
+ * to that bound; unparseable input is returned unchanged so Zod/NaN handling stays
+ * with the caller.
+ */
+export function clampClientTimestamp(iso: string, nowMs: number = Date.now()): string {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return iso;
+  const ceiling = nowMs + SYNC_CONFIG.MAX_CLIENT_CLOCK_SKEW_MS;
+  return t > ceiling ? new Date(ceiling).toISOString() : iso;
+}
 
 /** Shape of a task as stored in the PocketBase `tasks` collection */
 export interface PBTaskRecord {
@@ -148,7 +167,7 @@ export function pocketBaseToTaskRecord(record: RecordModel, existingLocal?: Task
     completed: r.completed,
     completedAt: r.completed_at || undefined,
     createdAt: r.client_created_at,
-    updatedAt: r.client_updated_at,
+    updatedAt: clampClientTimestamp(r.client_updated_at),
     recurrence: r.recurrence,
     tags: r.tags,
     subtasks: r.subtasks,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "10.2.4",
+	"version": "10.2.5",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/tests/data/sync/pb-push.test.ts
+++ b/tests/data/sync/pb-push.test.ts
@@ -134,6 +134,33 @@ describe('pushLocalChanges LWW guard', () => {
     expect(await getSyncQueue().getPendingCount()).toBe(0);
   });
 
+  it('pushes a legitimate local edit even when the remote client_updated_at is implausibly far in the future', async () => {
+    // A skewed/forged remote timestamp must not permanently block a real local
+    // write — otherwise a poisoned record could never be healed. The local edit
+    // is a plausible "just now"; the remote is years ahead and untrustworthy.
+    const localUpdatedAt = new Date(Date.now() - 60_000).toISOString();
+    const freshPayload = makeTask('t1', localUpdatedAt);
+    await getSyncQueue().enqueue('update', 't1', freshPayload);
+
+    fetchRemoteTaskIndexMock.mockResolvedValue({
+      index: new Map([
+        ['t1', { pbRecordId: 'rec-1', clientUpdatedAt: '2099-01-01T00:00:00.000Z' }],
+      ]),
+      fetchSucceeded: true,
+    });
+
+    const updateSpy = vi.fn(async () => ({ id: 'rec-1' }));
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({ create: vi.fn(), update: updateSpy, delete: vi.fn() }),
+    });
+
+    const result = await pushLocalChanges();
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(result.pushedCount).toBe(1);
+    expect(await getSyncQueue().getPendingCount()).toBe(0);
+  });
+
   it('does not push an upsert when the remote index fetch failed (LWW unverifiable)', async () => {
     const payload = makeTask('t1', '2026-05-18T12:00:00.000Z');
     await getSyncQueue().enqueue('update', 't1', payload);

--- a/tests/data/sync/task-mapper.test.ts
+++ b/tests/data/sync/task-mapper.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { taskRecordToPocketBase, pocketBaseToTaskRecord } from '@/lib/sync/task-mapper';
 import { SCHEMA_LIMITS } from '@/lib/constants/schema';
 import type { TaskRecord } from '@/lib/types';
@@ -307,6 +307,41 @@ describe('task-mapper', () => {
       expect(result!.subtasks).toEqual([]);
       expect(result!.dependencies).toEqual([]);
       expect(result!.timeEntries).toEqual([]);
+    });
+  });
+
+  describe('client_updated_at clamping (LWW poisoning guard)', () => {
+    // `client_updated_at` is the LWW authority and comes from the writing
+    // device's own (unverifiable) clock. A skewed/forged far-future value would
+    // permanently win every comparison and lock the task from other devices, so
+    // the mapper caps it to now + a small skew window at the ingestion boundary.
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-07-17T12:00:00.000Z'));
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should_clamp_a_far_future_client_updated_at_to_now_plus_skew_window', () => {
+      const pb = buildPBRecord({ client_updated_at: '2099-01-01T00:00:00.000Z' });
+      const result = pocketBaseToTaskRecord(pb);
+      expect(result).not.toBeNull();
+      // now (12:00:00) + 5 min skew ceiling
+      expect(result!.updatedAt).toBe('2026-07-17T12:05:00.000Z');
+    });
+
+    it('should_leave_a_normal_past_client_updated_at_unchanged', () => {
+      const pb = buildPBRecord({ client_updated_at: '2026-07-10T09:00:00.000Z' });
+      const result = pocketBaseToTaskRecord(pb);
+      expect(result!.updatedAt).toBe('2026-07-10T09:00:00.000Z');
+    });
+
+    it('should_leave_a_near_now_client_updated_at_within_the_skew_window_unchanged', () => {
+      // 2 minutes ahead — within tolerated inter-device skew, must not be clamped.
+      const pb = buildPBRecord({ client_updated_at: '2026-07-17T12:02:00.000Z' });
+      const result = pocketBaseToTaskRecord(pb);
+      expect(result!.updatedAt).toBe('2026-07-17T12:02:00.000Z');
     });
   });
 


### PR DESCRIPTION
## What changed
`client_updated_at` is the last-write-wins (LWW) authority for cross-device sync, but it was validated only as `z.string()` with no upper bound and comes from the writing device's own unverifiable clock. This fix bounds it.

- **Ingestion clamp** — `pocketBaseToTaskRecord` now caps `client_updated_at` to `now + MAX_CLIENT_CLOCK_SKEW_MS` (5 min) via the new `clampClientTimestamp` helper. This covers both the **pull** path (`applyRemoteRecords`) and the **realtime/SSE** path (`applyRemoteChange`), which both route through the mapper.
- **Push-guard healing** — `isRemoteNewer` now treats a remote `client_updated_at` beyond `now + skew` as *untrustworthy → not newer*, so a legitimate local edit can overwrite and **heal** a poisoned remote record instead of being blocked by it forever.
- New constant `SYNC_CONFIG.MAX_CLIENT_CLOCK_SKEW_MS` (5 min), consistent with the existing `MAX_RETRY_AFTER_MS`.

## Why
A device with a skewed clock (e.g. system date set to 2099), or a value forged via a direct PocketBase API write (`updateRule` pins `owner`, not field values), could stamp a `client_updated_at` years in the future. That value would win **every** future LWW comparison, permanently locking the task from edits on all other devices. Reported as **H1 (High)** in the codebase quality audit.

The cursor authority (server-stamped `updated`) is deliberately left untouched — it needs no clamp (a single server clock can't skew against itself), preserving the documented two-timestamp invariant.

## How to test locally
```
bun run test -- tests/data/sync/task-mapper.test.ts tests/data/sync/pb-push.test.ts
```
- `task-mapper.test.ts` — far-future `client_updated_at` is clamped; normal/near-now values pass through unchanged.
- `pb-push.test.ts` — a legitimate local edit pushes (heals) even when the remote `client_updated_at` is implausibly far in the future.

Full suite: 2295 passing / 0 failing · `bun typecheck` clean · `bun lint` clean. Reviewed by the `pb-sync-reviewer` agent (ship-with-notes, 0 blocking).

## Deferred follow-ups (non-blocking)
- Derive the ingestion clamp ceiling from the record's server-stamped `updated` rather than `Date.now()`, so a static poisoned record isn't re-clamped to a creeping ceiling on repeated full re-pulls.
- Add a pending-sync-queue guard to the realtime `applyRemoteChange` update branch (pre-existing gap; makes the transient SSE-overwrite window smaller).

https://claude.ai/code/session_01RXfoFwtVoRY1F3LPnETj8s
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->