### PR TITLE
fix(security): harden PocketBase admin surface and night-shift PR trust

### DIFF
--- a/.claude/commands/triage-prs.md
+++ b/.claude/commands/triage-prs.md
@@ -11,7 +11,7 @@ You are the **night shift** for the GSD Task Manager pipeline. Run headlessly an
 
 ## Select work
 
-List open PRs whose head branch starts with `claude/` and that have at least one failing check (use `gh pr list --state open --json number,headRefName,statusCheckRollup`). Process oldest-first. Skip any PR already labeled `ready-for-human`. Stop once you have opened **3 fix PRs**.
+List open PRs whose head branch starts with `claude/`, that **originate from this repository itself** (not a fork), and that have at least one failing check (use `gh pr list --state open --json number,headRefName,headRepositoryOwner,isCrossRepository,statusCheckRollup`). A `claude/` branch name alone is **not** proof the PR is the fleet's own — a fork author picks their own branch names — so a PR only counts when `isCrossRepository` is `false` (equivalently, `headRepositoryOwner.login` equals this repo's owner). **Never check out or run a fork PR's branch** (`isCrossRepository: true`): skip it and record it as skipped with the reason. Process oldest-first. Skip any PR already labeled `ready-for-human`. Stop once you have opened **3 fix PRs**.
 
 ## For each failing check on a PR
 

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -49,12 +49,20 @@
 	# ---- PocketBase reverse proxy ----
 	# Block administrative PocketBase API routes at the public origin. Superuser
 	# auth lives under /api/collections/_superusers/* (PB v0.23+); /api/admins/*
-	# is the legacy path. The browser app never needs either — it authenticates
-	# via OAuth against the users collection — so keeping admin auth off the
-	# public origin matches the "admin is not exposed" boundary that the /_/*
-	# rule already enforces. handle blocks match most-specific-first, so these
-	# deny rules take precedence over the broad /api/* proxy below.
+	# is the legacy path. PocketBase resolves /api/collections/{idOrName}/... by
+	# a collection's fixed system ID as well as its name, so denying the name
+	# alone is bypassable — the _superusers collection is also reachable at its
+	# ID pbc_3142635823 ("pbc_" + crc32("auth_superusers"), fixed in PB v0.23+).
+	# Both the name and the ID form are denied below. The browser app never needs
+	# any of these — it authenticates via OAuth against the users collection — so
+	# keeping admin auth off the public origin matches the "admin is not exposed"
+	# boundary that the /_/* rule already enforces. handle blocks match
+	# most-specific-first, so these deny rules take precedence over the broad
+	# /api/* proxy below.
 	handle /api/collections/_superusers/* {
+		respond "PocketBase admin API is not exposed through this origin." 404
+	}
+	handle /api/collections/pbc_3142635823/* {
 		respond "PocketBase admin API is not exposed through this origin." 404
 	}
 	handle /api/admins/* {

--- a/scripts/failing-agent-prs.cjs
+++ b/scripts/failing-agent-prs.cjs
@@ -2,9 +2,30 @@
 
 const FAIL_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required", "startup_failure"]);
 const FAIL_STATES = new Set(["failure", "error"]);
+// GitHub authorAssociation values that mark a trusted maintainer rather than an
+// arbitrary external contributor. Only honored when a caller supplies the field
+// (`gh pr list` does not expose it; `gh pr view` does).
+const TRUSTED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
 function isAgentBranch(headRefName) {
   return typeof headRefName === "string" && headRefName.startsWith("claude/");
+}
+
+// A `claude/`-prefixed head branch name is attacker-controlled on a fork PR, so
+// the prefix alone must NOT confer the "fleet's own output" trust that lets the
+// night shift check out the branch and run its build/test/lint locally. Require
+// provenance: the head branch must live in the base repo itself (not a fork), or
+// the PR author must be a trusted maintainer. Missing/ambiguous data is treated
+// as untrusted (fail safe — exclude).
+function isTrustedProvenance(pr, repoOwner) {
+  if (!pr || typeof pr !== "object") return false;
+  // GitHub reports head repo == base repo — a same-repo branch, not a fork.
+  if (pr.isCrossRepository === false) return true;
+  // Head repo is owned by the base repo's owner (same-repo branch, not a fork).
+  const headOwner = pr.headRepositoryOwner && pr.headRepositoryOwner.login;
+  if (typeof repoOwner === "string" && repoOwner !== "" && headOwner === repoOwner) return true;
+  // Trusted maintainer as author (only present if the caller fetched it).
+  return TRUSTED_ASSOCIATIONS.has(String(pr.authorAssociation || "").toUpperCase());
 }
 
 // A statusCheckRollup entry is failing if its CheckRun conclusion or its
@@ -16,21 +37,24 @@ function isFailingCheck(check) {
   return FAIL_CONCLUSIONS.has(conclusion) || FAIL_STATES.has(state);
 }
 
-function failingAgentPRs(prs) {
+function failingAgentPRs(prs, repoOwner) {
   if (!Array.isArray(prs)) return [];
   return prs.filter(
     (pr) =>
       pr &&
       isAgentBranch(pr.headRefName) &&
+      isTrustedProvenance(pr, repoOwner) &&
       Array.isArray(pr.statusCheckRollup) &&
       pr.statusCheckRollup.some(isFailingCheck)
   );
 }
 
-module.exports = { isAgentBranch, isFailingCheck, failingAgentPRs };
+module.exports = { isAgentBranch, isTrustedProvenance, isFailingCheck, failingAgentPRs };
 
-// CLI: read `gh pr list --json number,headRefName,statusCheckRollup` from stdin,
-// print the count of failing agent PRs. Fail-safe to 0 on bad input.
+// CLI: read `gh pr list --json number,headRefName,headRepositoryOwner,isCrossRepository,statusCheckRollup`
+// from stdin, print the count of failing agent PRs. The base-repo owner is supplied
+// via GSD_TRIAGE_REPO_OWNER so same-repo branches can be told apart from forks.
+// Fail-safe to 0 on bad input.
 if (require.main === module) {
   let input = "";
   process.stdin.on("data", (c) => (input += c));
@@ -41,6 +65,6 @@ if (require.main === module) {
     } catch {
       prs = [];
     }
-    process.stdout.write(String(failingAgentPRs(prs).length));
+    process.stdout.write(String(failingAgentPRs(prs, process.env.GSD_TRIAGE_REPO_OWNER).length));
   });
 }

--- a/scripts/triage-run.sh
+++ b/scripts/triage-run.sh
@@ -44,14 +44,19 @@ if [ "$paused" != "0" ]; then
   exit 0
 fi
 
-# 2. Work check — failing claude/* PRs (filter lives in the tested helper).
+# 2. Work check — failing claude/* PRs from a trusted origin (provenance +
+# failing-check filtering live in the tested helper). Fetch headRepositoryOwner /
+# isCrossRepository so fork PRs — whose head branch name is attacker-controlled —
+# are told apart from the fleet's own same-repo branches, and pass the base-repo
+# owner so the helper can confirm same-repo provenance.
+REPO_OWNER="${REPO%%/*}"
 prs_json='[]'
-if out=$(gh pr list --repo "$REPO" --state open --json number,headRefName,statusCheckRollup 2>/dev/null); then
+if out=$(gh pr list --repo "$REPO" --state open --json number,headRefName,headRepositoryOwner,isCrossRepository,statusCheckRollup 2>/dev/null); then
   prs_json="$out"
 else
   gh_fail_log "pr list failed"
 fi
-failing="$(printf '%s' "$prs_json" | node "$HELPER" 2>/dev/null || echo 0)"
+failing="$(printf '%s' "$prs_json" | GSD_TRIAGE_REPO_OWNER="$REPO_OWNER" node "$HELPER" 2>/dev/null || echo 0)"
 if [ "$failing" = "0" ]; then
   echo "NO_WORK: no failing claude/* PRs — exiting."
   exit 0

--- a/tests/failing-agent-prs.test.ts
+++ b/tests/failing-agent-prs.test.ts
@@ -1,7 +1,19 @@
 import { describe, it, expect } from "vitest";
-import { isAgentBranch, isFailingCheck, failingAgentPRs } from "../scripts/failing-agent-prs.cjs";
+import {
+  isAgentBranch,
+  isTrustedProvenance,
+  isFailingCheck,
+  failingAgentPRs,
+} from "../scripts/failing-agent-prs.cjs";
 
-const pr = (headRefName: string, checks: object[]) => ({ headRefName, statusCheckRollup: checks });
+// Default provenance is a same-repo branch (`isCrossRepository: false`) so the
+// existing checks-focused cases stay about check state; pass an override to model
+// a fork or a bare (no-provenance) PR.
+const pr = (headRefName: string, checks: object[], provenance: object = { isCrossRepository: false }) => ({
+  headRefName,
+  statusCheckRollup: checks,
+  ...provenance,
+});
 
 describe("isAgentBranch", () => {
   it.each([
@@ -11,6 +23,35 @@ describe("isAgentBranch", () => {
     ["", false],
   ])("%s -> %s", (name, expected) => expect(isAgentBranch(name as string)).toBe(expected));
   it("is false for non-strings", () => expect(isAgentBranch(undefined as unknown as string)).toBe(false));
+});
+
+describe("isTrustedProvenance", () => {
+  it("trusts a same-repo branch (isCrossRepository false)", () =>
+    expect(isTrustedProvenance({ isCrossRepository: false })).toBe(true));
+  it("trusts a head repo owned by the base-repo owner", () =>
+    expect(isTrustedProvenance({ headRepositoryOwner: { login: "vscarpenter" } }, "vscarpenter")).toBe(true));
+  it.each([["OWNER"], ["MEMBER"], ["COLLABORATOR"]])(
+    "trusts a %s author",
+    (assoc) => expect(isTrustedProvenance({ authorAssociation: assoc })).toBe(true)
+  );
+  it("distrusts a fork by an external contributor", () =>
+    expect(
+      isTrustedProvenance(
+        { isCrossRepository: true, headRepositoryOwner: { login: "attacker" }, authorAssociation: "CONTRIBUTOR" },
+        "vscarpenter"
+      )
+    ).toBe(false));
+  it("distrusts a fork whose head owner differs from the base-repo owner", () =>
+    expect(isTrustedProvenance({ headRepositoryOwner: { login: "attacker" } }, "vscarpenter")).toBe(false));
+  it("still trusts a fork opened by a trusted maintainer author", () =>
+    expect(
+      isTrustedProvenance({ isCrossRepository: true, headRepositoryOwner: { login: "attacker" }, authorAssociation: "MEMBER" }, "vscarpenter")
+    ).toBe(true));
+  it("fails safe: no provenance data is untrusted", () =>
+    expect(isTrustedProvenance({}, "vscarpenter")).toBe(false));
+  it("fails safe: missing head owner with no base owner is untrusted", () =>
+    expect(isTrustedProvenance({ headRepositoryOwner: { login: "vscarpenter" } })).toBe(false));
+  it("is false for null", () => expect(isTrustedProvenance(null)).toBe(false));
 });
 
 describe("isFailingCheck", () => {
@@ -29,8 +70,12 @@ describe("isFailingCheck", () => {
 });
 
 describe("failingAgentPRs", () => {
-  it("includes an agent branch with a failing check", () => {
+  it("includes a same-repo agent branch with a failing check", () => {
     expect(failingAgentPRs([pr("claude/fix-a", [{ conclusion: "FAILURE" }])])).toHaveLength(1);
+  });
+  it("includes a same-repo agent branch matched by base-repo owner", () => {
+    const own = pr("claude/fix-a", [{ conclusion: "FAILURE" }], { headRepositoryOwner: { login: "vscarpenter" } });
+    expect(failingAgentPRs([own], "vscarpenter")).toHaveLength(1);
   });
   it("excludes an agent branch whose checks all pass", () => {
     expect(failingAgentPRs([pr("claude/fix-a", [{ conclusion: "SUCCESS" }])])).toHaveLength(0);
@@ -40,6 +85,17 @@ describe("failingAgentPRs", () => {
   });
   it("excludes a NON-agent branch even if failing", () => {
     expect(failingAgentPRs([pr("feat/mine", [{ conclusion: "FAILURE" }])])).toHaveLength(0);
+  });
+  it("excludes a FORK agent branch even if failing (spoofed claude/ prefix)", () => {
+    const fork = pr("claude/fix-ci", [{ conclusion: "FAILURE" }], {
+      isCrossRepository: true,
+      headRepositoryOwner: { login: "attacker" },
+    });
+    expect(failingAgentPRs([fork], "vscarpenter")).toHaveLength(0);
+  });
+  it("fails safe: excludes a failing agent branch with no provenance data", () => {
+    const bare = { headRefName: "claude/fix-a", statusCheckRollup: [{ conclusion: "FAILURE" }] };
+    expect(failingAgentPRs([bare], "vscarpenter")).toHaveLength(0);
   });
   it("includes when any one check fails (mixed)", () => {
     expect(failingAgentPRs([pr("claude/fix-a", [{ conclusion: "SUCCESS" }, { state: "FAILURE" }])])).toHaveLength(1);

--- a/tests/triage-run.test.ts
+++ b/tests/triage-run.test.ts
@@ -51,9 +51,17 @@ function run(mode: string, pausedCount: number, prsJson: unknown): string {
   });
 }
 
-const failingAgentPr = { headRefName: "claude/fix-a", statusCheckRollup: [{ conclusion: "FAILURE" }] };
-const passingAgentPr = { headRefName: "claude/fix-b", statusCheckRollup: [{ conclusion: "SUCCESS" }] };
+// Same-repo (isCrossRepository:false) marks these as the fleet's own PRs.
+const failingAgentPr = { headRefName: "claude/fix-a", statusCheckRollup: [{ conclusion: "FAILURE" }], isCrossRepository: false };
+const passingAgentPr = { headRefName: "claude/fix-b", statusCheckRollup: [{ conclusion: "SUCCESS" }], isCrossRepository: false };
 const failingUserPr = { headRefName: "feat/mine", statusCheckRollup: [{ conclusion: "FAILURE" }] };
+// A fork PR with a spoofed claude/ branch name — must never count as work.
+const forkAgentPr = {
+  headRefName: "claude/fix-ci",
+  statusCheckRollup: [{ conclusion: "FAILURE" }],
+  isCrossRepository: true,
+  headRepositoryOwner: { login: "attacker" },
+};
 
 describe("triage-run.sh pre-check", () => {
   it("exits PAUSED when triage:paused is set", () => {
@@ -74,6 +82,9 @@ describe("triage-run.sh pre-check", () => {
   });
   it("exits NO_WORK when no claude/* PR is failing", () => {
     expect(run("--check", 0, [passingAgentPr, failingUserPr])).toContain("NO_WORK");
+  });
+  it("exits NO_WORK for a failing fork claude/* PR (not the fleet's own)", () => {
+    expect(run("--check", 0, [forkAgentPr])).toContain("NO_WORK");
   });
   it("reports WORK when a claude/* PR is failing", () => {
     expect(run("--check", 0, [failingAgentPr, failingUserPr])).toMatch(/^WORK:/m);


### PR DESCRIPTION
## What changed

Two MEDIUM-severity findings from a Claude Security scan of the repository, each a distinct concern in a different subsystem.

### F1 — PocketBase admin surface reachable by collection ID (`docker/Caddyfile`)
The public origin denied the `_superusers` superuser-auth collection only by name, but PocketBase resolves `/api/collections/{idOrName}/...` by the collection's fixed system ID as well. An unauthenticated request to the ID form (`/api/collections/pbc_3142635823/auth-with-password`) slipped past the name-only deny and reached superuser login. Added a deny handle for the `_superusers` system ID (`pbc_3142635823`, confirmed against the pinned PocketBase 0.26.6 source) so both addressing forms are blocked. (CWE-288)

### F2 — Night-shift trusted a spoofable `claude/*` branch prefix (`scripts/failing-agent-prs.cjs`, `scripts/triage-run.sh`, `.claude/commands/triage-prs.md`)
The unattended night-shift triage treated any `claude/`-prefixed head branch as the fleet's own — eligible for checkout and local `bun build/test/lint`. A fork PR with a spoofed `claude/*` branch name could therefore run attacker code with the maintainer's credentials. Added an `isTrustedProvenance` gate (same-repo `isCrossRepository === false`, head-repo owner equals base-repo owner, or trusted `authorAssociation`), enforced in both the `failingAgentPRs` filter and the agent's own selection step. Missing provenance fails safe to excluded. (CWE-863)

## Why

Both findings were confirmed by the scan's adversarial verification panel, then re-verified per patch by an independent reviewer plus a fresh adversarial pass over the diff.

## How to test

- `bun run test tests/failing-agent-prs.test.ts tests/triage-run.test.ts` — provenance gate, fork exclusion, and fail-safe cases (41 passed).
- Full suite green (2310 passed, 1 skipped).
- `caddy validate --config docker/Caddyfile --adapter caddyfile` → Valid configuration. Note: the Caddyfile change has no runtime test in the project suite, so its behaviour rests on review plus an ad-hoc routing harness that confirmed the exploit path 404s and legitimate routes still proxy.

https://claude.ai/code/session_01UquJ74XvhE1fK9T5wJodWB
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->