### PR TITLE
chore: trim CLAUDE.md and extract reference docs into skills

### DIFF
--- a/.claude/skills/claude-code-primitives/SKILL.md
+++ b/.claude/skills/claude-code-primitives/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: claude-code-primitives
+description: Reference for Claude Code's own mechanics — slash commands, skills, subagents, hooks — and how they route together. Use when creating or editing a slash command, skill, subagent, or hook, or when deciding which primitive fits a task.
+---
+
+## Claude Code Primitives
+
+* **Routing:** Commands initiate, subagents verify, hooks gate.
+* **Slash Commands (`.claude/commands/`):** Short, repeatable actions. Canonical text of prompts lives here (e.g., `/qspec`, `/tdd`, `/qcheck`).
+* **Skills (`.claude/skills/`):** Complex multi-step workflows. Write descriptions as triggers ("when should I fire?"). Provide goals, constraints, and a "Gotchas" section.
+* **Subagents (`.claude/agents/`):** Spawn for fanning out or parallel reads. Skip for <3 tool calls. Read-only agents use `haiku`; write agents use `sonnet`/`opus` with `isolation: worktree`.
+* **Agent teams vs subagents:** Use subagents for scoped delegation inside one workstream. Use teams when work should split across longer-lived sessions that coordinate.
+* **Hooks:** Enforce standards mechanically (e.g., `PostToolUse`, `Stop`). Hook types: shell commands, prompt hooks, MCP tool hooks.
+* Hooks receive event data as JSON on stdin. Read fields with `jq`, for example `.tool_input.file_path`; do not rely on `$CLAUDE_FILE_PATH` style variables unless explicitly configured.

--- a/.claude/skills/sentry-verification/SKILL.md
+++ b/.claude/skills/sentry-verification/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: sentry-verification
+description: Verify Sentry error capture is working after a DSN change or deploy. Use when testing Sentry, confirming error reporting works, or debugging why errors aren't showing up in the Sentry dashboard.
+---
+
+## Sentry verification (recurring debugging task)
+
+When testing Sentry capture after a DSN change or deploy:
+
+1. Confirm DSN is loaded: `console.log` in `lib/sentry/init.ts` (or wherever Sentry.init runs) and grep dev console for "Sentry initialized".
+2. Trigger a test error: `Sentry.captureException(new Error("manual-test-from-claude"))` in a dev-only handler, OR throw from a component error boundary.
+3. Verify in Sentry dashboard within ~30s.
+4. Remove the test trigger before commit (it's not a regression — leave it out of source).

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ sync.md
 !.claude/skills/pb-collection/
 !.claude/skills/branch-preflight/
 !.claude/skills/verify-frontend-change/
+!.claude/skills/claude-code-primitives/
+!.claude/skills/sentry-verification/
 
 *.tsbuildinfo
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,37 +33,18 @@ Strategic design intent lives in `PRODUCT.md` (root). Read it before UI/UX work 
 
 ### Development
 - `bun install` - Install dependencies
-- `bun dev` - Start development server at http://localhost:3000
-- `bun typecheck` - Run TypeScript type checking
 
 ### Testing & Quality
 - `bun run test` - Run Vitest tests in CI mode (`bun test` invokes bun's built-in runner, not vitest)
 - `bun run test:watch` - Run Vitest in watch mode
 - `bun run test -- --coverage` - Generate coverage report (target: ≥80%)
-- `bun lint` - Run ESLint
-- `bun run test:e2e` - Run Playwright end-to-end tests
-- `bun run test:e2e:ui` - Run Playwright tests with UI mode
-- `bun run test:e2e:debug` - Run Playwright tests in debug mode
 
 ### Build & Deployment
-- `bun run build` - Build production bundle
-- `bun run export` - Generate static export for S3/CloudFront
 - `./scripts/deploy-cloudfront-function.sh` - Deploy CloudFront Function for SPA routing
 
 **CloudFront Edge Routing**: Required because S3 doesn't auto-serve `index.html` for directory paths. Run the deploy script after adding new App Router routes.
 
 ## Architecture
-
-### Data Layer
-- **IndexedDB via Dexie** (`lib/db.ts`): `tasks`, `archivedTasks`, `smartViews`, `notificationSettings`, `appPreferences` (plus sync-internal tables) at schema v14
-- **CRUD Operations** (`lib/tasks.ts`): Task mutations, subtask/dependency management
-- **Bulk Operations** (`lib/bulk-operations.ts`): Batch operations for multi-select
-- **Live Queries** (`lib/use-tasks.ts`): `useTasks()` hook with live updates
-- **Schema Validation** (`lib/schema.ts`): Zod schemas for all data types
-- **Analytics** (`lib/analytics/`): Modular productivity metrics
-- **Notifications** (`lib/notifications/`): Modular notification system
-- **Dependencies** (`lib/dependencies.ts`): Circular dependency detection, blocking/blocked queries
-- **Structured Logging** (`lib/logger.ts`): Environment-aware logger with contexts and secret sanitization
 
 ### Quadrant System
 Tasks are classified by `urgent` and `important` boolean flags:
@@ -73,19 +54,6 @@ Tasks are classified by `urgent` and `important` boolean flags:
 - `not-urgent-not-important` - Eliminate (Q4)
 
 Logic in `lib/quadrants.ts` with `resolveQuadrantId()` and `quadrantOrder`.
-
-### Component Structure
-- **App Router** (`app/`): Matrix view, dashboard, archive, sync-history, install pages
-- **UI Components** (`components/ui/`): shadcn-style primitives
-- **Domain Components**:
-  - `components/matrix-simplified/` - v9 single-matrix shell (app-shell, capture-bar, edit-drawer, help-drawer, matrix-grid, topbar, icon-rail)
-  - `components/task-card/` - Task card with header/metadata/actions sub-components
-  - `components/sync/` - Sync button, auth dialog, OAuth buttons
-  - `components/settings/` - Settings sections (appearance, notifications, sync, archive, data-management, about)
-  - `components/settings-page/` - Full-page settings shell (used by `app/settings/`)
-  - `components/dashboard/` - Analytics charts and metrics
-  - `components/about/` - About page sections
-  - `components/command-palette/` - ⌘K palette implementation (currently not wired into v9 shell — resurrection planned)
 
 ### Key Patterns
 - **Client-side only**: All components use `"use client"` - no server rendering
@@ -161,13 +129,6 @@ These packages are not self-explanatory from their names alone:
 
 ### Cloud Sync, MCP Server, OAuth
 Detail moved to path-scoped rules — see `.claude/rules/pocketbase-sync.md` and `.claude/rules/mcp-server.md`. Those auto-load when you edit the relevant subtrees.
-
-### Sentry verification (recurring debugging task)
-When testing Sentry capture after a DSN change or deploy:
-1. Confirm DSN is loaded: `console.log` in `lib/sentry/init.ts` (or wherever Sentry.init runs) and grep dev console for "Sentry initialized".
-2. Trigger a test error: `Sentry.captureException(new Error("manual-test-from-claude"))` in a dev-only handler, OR throw from a component error boundary.
-3. Verify in Sentry dashboard within ~30s.
-4. Remove the test trigger before commit (it's not a regression — leave it out of source).
 
 ### Test-Driven Development (TDD)
 

--- a/coding-standards.md
+++ b/coding-standards.md
@@ -162,13 +162,7 @@ Required when a decision is hard to reverse, affects multiple systems or teams, 
 
 *Claude Code specific. Omit from Codex `AGENTS.md`.*
 
-* **Routing:** Commands initiate, subagents verify, hooks gate.
-* **Slash Commands (`.claude/commands/`):** Short, repeatable actions. Canonical text of prompts lives here (e.g., `/qspec`, `/tdd`, `/qcheck`).
-* **Skills (`.claude/skills/`):** Complex multi-step workflows. Write descriptions as triggers ("when should I fire?"). Provide goals, constraints, and a "Gotchas" section.
-* **Subagents (`.claude/agents/`):** Spawn for fanning out or parallel reads. Skip for <3 tool calls. Read-only agents use `haiku`; write agents use `sonnet`/`opus` with `isolation: worktree`.
-* **Agent teams vs subagents:** Use subagents for scoped delegation inside one workstream. Use teams when work should split across longer-lived sessions that coordinate.
-* **Hooks:** Enforce standards mechanically (e.g., `PostToolUse`, `Stop`). Hook types: shell commands, prompt hooks, MCP tool hooks.
-* Hooks receive event data as JSON on stdin. Read fields with `jq`, for example `.tool_input.file_path`; do not rely on `$CLAUDE_FILE_PATH` style variables unless explicitly configured.
+Moved to `.claude/skills/claude-code-primitives/SKILL.md` — loads on demand when creating or editing a slash command, skill, subagent, or hook, instead of every session.
 
 ---
 


### PR DESCRIPTION
## Summary
- Trimmed CLAUDE.md: removed repo-tour bullet lists (Component Structure, Data Layer) and package.json-duplicate command lines, kept genuine gotchas (`bun test` vs `bun run test`, CloudFront routing rationale)
- Migrated coding-standards.md Part 5 (Claude Code Primitives) and CLAUDE.md's Sentry verification runbook into two new on-demand skills instead of always-loaded docs
- Fixed `.gitignore`'s `.claude/skills/*` allowlist to include the two new skills — otherwise they'd be invisible to anyone else cloning the repo

## Why
Both files load in full every session regardless of whether the content is needed. This content is either derivable from the codebase (directory/file listings) or only needed occasionally (configuring hooks/skills/subagents, debugging Sentry), so it's better served on-demand via skills.

## Test plan
- [ ] Confirm CLAUDE.md and coding-standards.md still render correctly and reference the right files
- [ ] Confirm the two new skills (`claude-code-primitives`, `sentry-verification`) show up in the skill listing and trigger appropriately
- [ ] No app code changed — no functional testing needed

https://claude.ai/code/session_017jW5JfGouERiqfB3fmdkCL
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->