### PR TITLE
docs(agents): link the visual pipeline map from the agents README

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -2,6 +2,7 @@
 
 Operating specs and conventions for the autonomous delivery pipeline and its agents.
 
+- [`../pipeline-summary.html`](../pipeline-summary.html) — "Two Gates & a Night Shift": a visual map of the whole delivery pipeline (cycles, gates, and the label state machine) as a single self-contained HTML page — open it in a browser.
 - [`builder.md`](builder.md) — Builder operating spec (cycle B): turns a fully-specified issue into a reviewed PR, pausing once for Gate 1 plan approval; never merges.
 - [`night-shift.md`](night-shift.md) — Night-shift operating spec (cycle D): nightly unattended triage of failing checks on the agent fleet's own open PRs.
 - [`issue-tracker.md`](issue-tracker.md) — GitHub issue-tracker conventions (`gh` CLI) for creating, reading, labeling, and closing issues.


### PR DESCRIPTION
## Summary

`docs/pipeline-summary.html` documents the live delivery pipeline, but nothing in the repo linked to it, so it was undiscoverable without knowing the exact filename. This adds one bullet to the `docs/agents/README.md` index linking it (relative path `../pipeline-summary.html`), described as the "Two Gates & a Night Shift" visual map of the pipeline, alongside the existing operating-spec links. No changes to `pipeline-summary.html` itself.

Closes #454

## Risk tier

docs

## How to verify

- [ ] `docs/agents/README.md` includes a link to `docs/pipeline-summary.html`
- [ ] The link resolves (relative path `../pipeline-summary.html` from `docs/agents/` points at the existing `docs/pipeline-summary.html`; GitHub renders it per-branch)
- [ ] The surrounding line explains what the page is (a visual map of the pipeline)

## Rollback plan

Revert the commit.

## Checklist

- [x] Acceptance criteria from the linked issue are met
- [x] Tests added/updated and passing (`bun run test` — 2304 passed, 1 skipped; docs-only change, no new tests per TDD policy for documentation-only changes)
- [x] Lint and typecheck clean (`bun run lint` — 0 errors, `bun run typecheck` — clean)
- [x] Coding standards followed (`coding-standards.md`)
- [x] Rollback plan above is real
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->