### PR TITLE
test(security): follow the brace-expansion override bump to >=5.0.8

### DIFF
--- a/tests/data/security-hardening-scripts.test.ts
+++ b/tests/data/security-hardening-scripts.test.ts
@@ -105,7 +105,7 @@ describe('security hardening scripts and workflows', () => {
     const rootPackage = JSON.parse(readRepoFile('package.json'));
     const mcpPackage = JSON.parse(readRepoFile('packages/mcp-server/package.json'));
 
-    expect(rootPackage.overrides['brace-expansion']).toBe('>=5.0.7');
+    expect(rootPackage.overrides['brace-expansion']).toBe('>=5.0.8');
     expect(rootPackage.overrides.hono).toBe('>=4.12.29');
     expect(rootPackage.overrides.undici).toBe('>=7.28.0');
     expect(rootPackage.overrides.vite).toBe('>=8.1.4');


### PR DESCRIPTION
## What changed

One line in `tests/data/security-hardening-scripts.test.ts`:

```diff
-expect(rootPackage.overrides['brace-expansion']).toBe('>=5.0.7');
+expect(rootPackage.overrides['brace-expansion']).toBe('>=5.0.8');
```

## Why

PR #456 (`8046e47`) raised the `brace-expansion` override floor from `>=5.0.7` to `>=5.0.8` as a security bump, but did not update the guard test's pin. That test has been failing on `main` ever since — unrelated to any branch work.

The guard asserts **exact** pins on purpose: its whole job is to fail loudly when an override floor moves, forcing a conscious decision rather than silently accepting drift. So the correct fix is to follow the bump, not to relax the assertion into a semver range.

I audited all ten pins in that test against `package.json` and `packages/mcp-server/package.json`:

| Pin | Test | Actual | |
|---|---|---|---|
| `brace-expansion` | `>=5.0.7` | `>=5.0.8` | **drift** |
| `hono` | `>=4.12.29` | `>=4.12.29` | ok |
| `undici` | `>=7.28.0` | `>=7.28.0` | ok |
| `vite` | `>=8.1.4` | `>=8.1.4` | ok |
| `@babel/core` | `>=8.0.1` | `>=8.0.1` | ok |
| `@opentelemetry/core` | `>=2.9.0` | `>=2.9.0` | ok |
| `qs` | `>=6.15.2` | `>=6.15.2` | ok |
| `@sentry/node` (mcp) | `10.67.0` | `10.67.0` | ok |
| `vitest` (mcp) | `4.1.10` | `4.1.10` | ok |
| `@vitest/ui` (mcp) | `4.1.10` | `4.1.10` | ok |

`brace-expansion` was the only one that had drifted.

## How to test locally

```bash
bun run test -- --run tests/data/security-hardening-scripts.test.ts
```

## Verification

- Target test: 9 passed
- Full suite on this branch: **2322 passed, 1 skipped, 0 failed**

No production code touched; no dependency versions changed.

https://claude.ai/code/session_01Fa3tM7zeGUmsiM2PPW8SRy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->