### PR TITLE
fix(archive): make restore and its Undo atomic

### DIFF
--- a/app/(archive)/archive/page.tsx
+++ b/app/(archive)/archive/page.tsx
@@ -8,7 +8,7 @@ import { RefreshCcwIcon, Trash2Icon } from "lucide-react";
 import { AppShell } from "@/components/matrix-simplified/app-shell";
 import { Button } from "@/components/ui/button";
 import { TaskCard } from "@/components/task-card";
-import { listArchivedTasks, restoreTask, deleteArchivedTask } from "@/lib/archive";
+import { listArchivedTasks, restoreTask, deleteArchivedTask, archiveTaskNow } from "@/lib/archive";
 import type { TaskRecord } from "@/lib/types";
 import { toast } from "sonner";
 import { getDb } from "@/lib/db";
@@ -87,14 +87,16 @@ export default function ArchivePage() {
         action: {
           label: "Undo",
           onClick: async () => {
-            // Re-archive by moving back: delete from main tasks, add to archive
-            const db = getDb();
-            const restored = await db.tasks.get(task.id);
-            if (restored) {
-              await db.archivedTasks.add({ ...restored, archivedAt: new Date().toISOString() });
-              await db.tasks.delete(task.id);
+            // archiveTaskNow re-archives and queues the remote delete in one
+            // transaction. Doing it inline here left the task in both tables if
+            // either write failed, and never told other devices.
+            try {
+              await archiveTaskNow(task.id);
               queryClient.invalidateQueries({ queryKey: ARCHIVED_TASKS_KEY });
               toast.success("Restore undone");
+            } catch (err) {
+              const errorMsg = err instanceof Error ? err.message : `Failed to undo "${task.title}"`;
+              toast.error(errorMsg);
             }
           },
         },

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -126,28 +126,42 @@ export async function listArchivedTasks(): Promise<TaskRecord[]> {
 export async function restoreTask(taskId: string): Promise<void> {
   const db = getDb();
 
-  const archivedTask = await db.archivedTasks.get(taskId);
-  if (!archivedTask) {
-    throw new Error("Task not found in archive");
-  }
-
-  // Remove archivedAt timestamp
-  const { archivedAt: _archivedAt, ...taskWithoutArchive } = archivedTask;
-
-  // Move back to main tasks table; load the sync-config module concurrently
-  // since the import does not depend on the write completing.
-  const [, { getSyncConfig }] = await Promise.all([
-    db.tasks.add(taskWithoutArchive),
-    import("@/lib/sync/config"),
-  ]);
+  // Resolve the sync dependencies BEFORE opening the transaction. Awaiting a
+  // non-Dexie promise (the dynamic import, the config read) inside a Dexie
+  // transaction lets it commit early, which would reopen the very atomicity
+  // hole the transaction exists to close. Same ordering as archiveOldTasks.
+  const { getSyncConfig } = await import("@/lib/sync/config");
   const syncConfig = await getSyncConfig();
-  if (syncConfig?.enabled) {
-    const queue = getSyncQueue();
-    await queue.enqueue('update', taskWithoutArchive.id, taskWithoutArchive);
-  }
+  const queue = getSyncQueue();
 
-  // Remove from archive
-  await db.archivedTasks.delete(taskId);
+  // The read, both writes, and the sync enqueue commit as one unit. Previously
+  // the task was added to `tasks` and only removed from `archivedTasks` several
+  // awaits later, so any failure in between (or a closed tab) left it in BOTH
+  // tables — a live task wearing an archived id, which the v15 cleanup then has
+  // to be careful not to delete. Reading the archived row inside the
+  // transaction also closes the TOCTOU gap between two concurrent restores:
+  // IndexedDB serializes transactions with overlapping scope, so the second
+  // one sees the row already gone instead of colliding on `tasks.add`.
+  await db.transaction(
+    "rw",
+    [db.tasks, db.archivedTasks, db.syncQueue],
+    async () => {
+      const archivedTask = await db.archivedTasks.get(taskId);
+      if (!archivedTask) {
+        throw new Error("Task not found in archive");
+      }
+
+      // Remove archivedAt timestamp
+      const { archivedAt: _archivedAt, ...taskWithoutArchive } = archivedTask;
+
+      await db.tasks.add(taskWithoutArchive);
+      await db.archivedTasks.delete(taskId);
+
+      if (syncConfig?.enabled) {
+        await queue.enqueue('update', taskWithoutArchive.id, taskWithoutArchive);
+      }
+    }
+  );
 }
 
 /**

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -165,6 +165,45 @@ export async function restoreTask(taskId: string): Promise<void> {
 }
 
 /**
+ * Move a single live task straight into the archive, regardless of its age.
+ *
+ * This is the exact inverse of restoreTask and backs the "Undo" affordance on a
+ * restore, so it carries the same guarantees: one transaction (a failure between
+ * the two writes would strand the task in both tables), and a queued remote
+ * delete so other devices drop it too — matching what archiveOldTasks does.
+ *
+ * Uses put rather than add for the same reason archiveOldTasks uses bulkPut: a
+ * stale archived row must not make the undo permanently fail.
+ */
+export async function archiveTaskNow(taskId: string): Promise<void> {
+  const db = getDb();
+
+  // Resolved before the transaction opens — see restoreTask for why awaiting a
+  // non-Dexie promise inside a Dexie transaction breaks its atomicity.
+  const { getSyncConfig } = await import("@/lib/sync/config");
+  const syncConfig = await getSyncConfig();
+  const queue = getSyncQueue();
+
+  await db.transaction(
+    "rw",
+    [db.tasks, db.archivedTasks, db.syncQueue],
+    async () => {
+      const task = await db.tasks.get(taskId);
+      if (!task) {
+        throw new Error("Task not found");
+      }
+
+      await db.archivedTasks.put({ ...task, archivedAt: new Date().toISOString() });
+      await db.tasks.delete(taskId);
+
+      if (syncConfig?.enabled) {
+        await queue.enqueue('delete', taskId, task);
+      }
+    }
+  );
+}
+
+/**
  * Permanently delete an archived task
  */
 export async function deleteArchivedTask(taskId: string): Promise<void> {

--- a/tests/data/archive.test.ts
+++ b/tests/data/archive.test.ts
@@ -5,6 +5,7 @@ import {
   archiveOldTasks,
   listArchivedTasks,
   restoreTask,
+  archiveTaskNow,
   deleteArchivedTask,
   getArchivedCount,
 } from "@/lib/archive";
@@ -460,6 +461,72 @@ describe("archive", () => {
       expect([first.status, second.status].sort()).toEqual(["fulfilled", "rejected"]);
       expect(await db.tasks.count()).toBe(1);
       expect(await db.archivedTasks.count()).toBe(0);
+    });
+  });
+
+  describe("archiveTaskNow", () => {
+    it("should_move_a_live_task_into_the_archive", async () => {
+      const db = getDb();
+      await db.tasks.add(createMockTask({ id: "undo-me", title: "Undo Me" }));
+
+      await archiveTaskNow("undo-me");
+
+      expect(await db.tasks.count()).toBe(0);
+      const archived = await db.archivedTasks.get("undo-me");
+      expect(archived).toBeDefined();
+      expect(archived!.archivedAt).toBeTruthy();
+    });
+
+    it("should_throw_when_the_task_is_not_live", async () => {
+      await expect(archiveTaskNow("nonexistent")).rejects.toThrow("Task not found");
+    });
+
+    it("should_leave_both_tables_untouched_when_the_sync_enqueue_fails", async () => {
+      // Inverse of the restoreTask hole: without a transaction the archived row
+      // is written before the live row is removed, so a failure between them
+      // leaves the task in both tables.
+      const db = getDb();
+      vi.mocked(getSyncConfig).mockResolvedValue({ enabled: true } as never);
+      enqueueMock.mockRejectedValue(new Error("sync queue write failed"));
+      await db.tasks.add(createMockTask({ id: "atomic-undo", title: "Atomic Undo" }));
+
+      await expect(archiveTaskNow("atomic-undo")).rejects.toThrow();
+
+      expect(await db.tasks.count()).toBe(1);
+      expect(await db.archivedTasks.count()).toBe(0);
+    });
+
+    it("should_enqueue_a_delete_so_other_devices_drop_the_task", async () => {
+      const db = getDb();
+      vi.mocked(getSyncConfig).mockResolvedValue({ enabled: true } as never);
+      await db.tasks.add(createMockTask({ id: "sync-undo", title: "Sync Undo" }));
+
+      await archiveTaskNow("sync-undo");
+
+      expect(enqueueMock).toHaveBeenCalledWith(
+        "delete",
+        "sync-undo",
+        expect.objectContaining({ id: "sync-undo" })
+      );
+    });
+
+    it("should_overwrite_a_stale_archived_copy_instead_of_colliding", async () => {
+      // Same reasoning as archiveOldTasks' bulkPut: re-archiving must be
+      // idempotent, or a lingering archived row makes undo permanently fail.
+      const db = getDb();
+      const task = createMockTask({ id: "already-archived", title: "Newer Title" });
+      await db.archivedTasks.add({
+        ...createMockTask({ id: "already-archived", title: "Stale Title" }),
+        archivedAt: "2026-07-05T00:00:00.000Z",
+      });
+      await db.tasks.add(task);
+
+      await archiveTaskNow("already-archived");
+
+      expect(await db.tasks.count()).toBe(0);
+      expect(await db.archivedTasks.count()).toBe(1);
+      const archived = await db.archivedTasks.get("already-archived");
+      expect(archived!.title).toBe("Newer Title");
     });
   });
 

--- a/tests/data/archive.test.ts
+++ b/tests/data/archive.test.ts
@@ -10,10 +10,14 @@ import {
 } from "@/lib/archive";
 import { getDb } from "@/lib/db";
 import { createMockTask } from "@/tests/fixtures";
+import { getSyncConfig } from "@/lib/sync/config";
+
+// Stable across calls so individual tests can make the enqueue fail.
+const { enqueueMock } = vi.hoisted(() => ({ enqueueMock: vi.fn() }));
 
 vi.mock("@/lib/sync/queue", () => ({
   getSyncQueue: () => ({
-    enqueue: vi.fn(),
+    enqueue: enqueueMock,
   }),
 }));
 
@@ -27,6 +31,8 @@ describe("archive", () => {
     await db.tasks.clear();
     await db.archivedTasks.clear();
     await db.archiveSettings.clear();
+    enqueueMock.mockReset();
+    vi.mocked(getSyncConfig).mockResolvedValue({ enabled: false } as never);
   });
 
   describe("getArchiveSettings", () => {
@@ -378,6 +384,82 @@ describe("archive", () => {
       await expect(restoreTask("nonexistent")).rejects.toThrow(
         "Task not found in archive"
       );
+    });
+
+    it("should_leave_both_tables_untouched_when_the_sync_enqueue_fails", async () => {
+      // Without a transaction the task is added to `tasks` before the enqueue
+      // runs and only removed from `archivedTasks` afterwards, so a failure here
+      // strands the task in BOTH tables — the exact state the v15 migration has
+      // to tolerate. The restore must be all-or-nothing instead.
+      const db = getDb();
+      const now = new Date().toISOString();
+      vi.mocked(getSyncConfig).mockResolvedValue({ enabled: true } as never);
+      enqueueMock.mockRejectedValue(new Error("sync queue write failed"));
+
+      await db.archivedTasks.add(
+        createMockTask({
+          id: "atomic-restore",
+          title: "Atomic Restore",
+          completed: true,
+          completedAt: now,
+          archivedAt: now,
+        })
+      );
+
+      await expect(restoreTask("atomic-restore")).rejects.toThrow();
+
+      expect(await db.tasks.count()).toBe(0);
+      expect(await db.archivedTasks.count()).toBe(1);
+    });
+
+    it("should_enqueue_the_restore_for_sync_when_sync_is_enabled", async () => {
+      const db = getDb();
+      const now = new Date().toISOString();
+      vi.mocked(getSyncConfig).mockResolvedValue({ enabled: true } as never);
+
+      await db.archivedTasks.add(
+        createMockTask({
+          id: "synced-restore",
+          title: "Synced Restore",
+          completed: true,
+          completedAt: now,
+          archivedAt: now,
+        })
+      );
+
+      await restoreTask("synced-restore");
+
+      expect(enqueueMock).toHaveBeenCalledWith(
+        "update",
+        "synced-restore",
+        expect.objectContaining({ id: "synced-restore" })
+      );
+      expect(await db.tasks.count()).toBe(1);
+      expect(await db.archivedTasks.count()).toBe(0);
+    });
+
+    it("should_not_duplicate_when_the_task_is_already_live", async () => {
+      // Reading the archived row inside the transaction closes the TOCTOU gap
+      // between two concurrent restores (two tabs, or a double-click).
+      const db = getDb();
+      const now = new Date().toISOString();
+      const task = createMockTask({
+        id: "already-live",
+        title: "Already Live",
+        completed: true,
+        completedAt: now,
+        archivedAt: now,
+      });
+      await db.archivedTasks.add(task);
+
+      const [first, second] = await Promise.allSettled([
+        restoreTask("already-live"),
+        restoreTask("already-live"),
+      ]);
+
+      expect([first.status, second.status].sort()).toEqual(["fulfilled", "rejected"]);
+      expect(await db.tasks.count()).toBe(1);
+      expect(await db.archivedTasks.count()).toBe(0);
     });
   });
 

--- a/tests/ui/archive-page.test.tsx
+++ b/tests/ui/archive-page.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { TaskRecord } from "@/lib/types";
+import { toast } from "sonner";
 
 // Mock @tanstack/react-virtual since jsdom has no layout engine
 vi.mock("@tanstack/react-virtual", () => ({
@@ -49,11 +50,13 @@ vi.mock("next/navigation", () => ({
 const mockListArchivedTasks = vi.fn<() => Promise<TaskRecord[]>>();
 const mockRestoreTask = vi.fn<(id: string) => Promise<void>>();
 const mockDeleteArchivedTask = vi.fn<(id: string) => Promise<void>>();
+const mockArchiveTaskNow = vi.fn<(id: string) => Promise<void>>();
 
 vi.mock("@/lib/archive", () => ({
   listArchivedTasks: (...args: unknown[]) => mockListArchivedTasks(...args as []),
   restoreTask: (...args: unknown[]) => mockRestoreTask(...args as [string]),
   deleteArchivedTask: (...args: unknown[]) => mockDeleteArchivedTask(...args as [string]),
+  archiveTaskNow: (...args: unknown[]) => mockArchiveTaskNow(...args as [string]),
 }));
 
 // Mock sonner toast
@@ -197,6 +200,64 @@ describe("ArchivePage with TanStack Query + Virtual", () => {
     await waitFor(() => {
       expect(mockRestoreTask).toHaveBeenCalledWith("task-1");
     });
+  });
+
+  it("undoes a restore through archiveTaskNow rather than raw Dexie writes", async () => {
+    // The Undo lives inside the success toast's action, so it is only reachable
+    // by invoking the callback sonner was handed.
+    const user = userEvent.setup();
+    mockListArchivedTasks.mockResolvedValue([
+      createMockArchivedTask({ id: "task-1", title: "Restorable Task" }),
+    ]);
+    mockRestoreTask.mockResolvedValue(undefined);
+    mockArchiveTaskNow.mockResolvedValue(undefined);
+
+    render(<ArchivePage />, { wrapper: createQueryWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("Restorable Task")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /restore/i }));
+    await waitFor(() => {
+      expect(mockRestoreTask).toHaveBeenCalledWith("task-1");
+    });
+
+    const successCall = vi.mocked(toast.success).mock.calls.find(
+      ([message]) => typeof message === "string" && message.includes("Restored")
+    );
+    expect(successCall).toBeDefined();
+    const action = (successCall![1] as { action?: { onClick: () => Promise<void> } })?.action;
+    expect(action).toBeDefined();
+
+    await action!.onClick();
+
+    expect(mockArchiveTaskNow).toHaveBeenCalledWith("task-1");
+  });
+
+  it("surfaces an error when undoing a restore fails", async () => {
+    const user = userEvent.setup();
+    mockListArchivedTasks.mockResolvedValue([
+      createMockArchivedTask({ id: "task-1", title: "Restorable Task" }),
+    ]);
+    mockRestoreTask.mockResolvedValue(undefined);
+    mockArchiveTaskNow.mockRejectedValue(new Error("could not re-archive"));
+
+    render(<ArchivePage />, { wrapper: createQueryWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText("Restorable Task")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /restore/i }));
+    await waitFor(() => {
+      expect(mockRestoreTask).toHaveBeenCalledWith("task-1");
+    });
+
+    const successCall = vi.mocked(toast.success).mock.calls.find(
+      ([message]) => typeof message === "string" && message.includes("Restored")
+    );
+    const action = (successCall![1] as { action?: { onClick: () => Promise<void> } })?.action;
+
+    // A rejected undo must not escape as an unhandled rejection.
+    await expect(action!.onClick()).resolves.toBeUndefined();
+    expect(toast.error).toHaveBeenCalled();
   });
 
   it("deletes task with confirmation via useMutation", async () => {


### PR DESCRIPTION
## What changed

`restoreTask` added the task to `tasks`, then awaited a dynamic import, a sync-config read, and a queue write before finally deleting from `archivedTasks`:

```ts
const [, { getSyncConfig }] = await Promise.all([db.tasks.add(taskWithoutArchive), import(...)]);
const syncConfig = await getSyncConfig();
if (syncConfig?.enabled) { await queue.enqueue(...) }
await db.archivedTasks.delete(taskId);   // ← only now
```

Any failure in that window — or a closed tab — left the task in **both** tables: a live task wearing an archived id. That is precisely the state the v15 cleanup in #457 has to defensively tolerate, so this removes the cause rather than the symptom.

The read, both writes, and the sync enqueue now commit as one Dexie transaction over `[tasks, archivedTasks, syncQueue]`, matching the pattern `archiveOldTasks` already uses in this file.

## Why the sync deps are resolved before the transaction

This ordering is load-bearing, not stylistic. Awaiting a **non-Dexie** promise (the dynamic `import()`, the config read) inside a Dexie transaction lets that transaction auto-commit early — which would silently reopen the exact hole this change closes. So `getSyncConfig` and `getSyncQueue` are resolved up front and only Dexie operations run inside.

`runTaskSyncTransaction` (`lib/tasks/crud/helpers.ts`) resolves them up front for the same reason, but its scope is `[tasks, syncQueue]` and does not cover `archivedTasks`, so widening a shared helper used across the CRUD layer wasn't warranted for one call site.

## Bonus: a TOCTOU gap closed

Moving the archived-row read inside the transaction also fixes concurrent restores (two tabs, or a double-click). IndexedDB serializes transactions with overlapping scope, so the second restore now sees the row already gone and reports `Task not found in archive` rather than colliding on `tasks.add`.

## How to test locally

```bash
bun run test -- --run tests/data/archive.test.ts
```

## Verification

- New test fails on `main` for the right reason: `expected 1 to be +0` — the task was added to `tasks` and left there alongside the archived row.
- Full suite: **2344 passed, 1 skipped, 0 failed**
- `bun typecheck` clean; `bun lint` 0 errors
- `archive.ts` coverage: statements 92.3% → **96.3%**, branches 85.7% → **92.9%**

Three tests added: rollback on a failing enqueue, the sync-enabled enqueue path, and concurrent restores. The concurrency one is a control test — it passes before and after, guarding the behaviour rather than driving the fix.

## Also fixed: the restore-Undo path

The **Undo** action on a successful restore had the same defect mirrored, plus two more. It re-archived with two raw Dexie writes inline in the toast handler:

```ts
await db.archivedTasks.add({ ...restored, archivedAt: ... });
await db.tasks.delete(task.id);
```

- **Not atomic** — a failure between the writes strands the task in both tables, same as `restoreTask` did.
- **`add`, not `put`** — a lingering archived row made undo fail permanently with a `ConstraintError`.
- **No sync operation** — the restore propagated to other devices but undoing it never did, leaving them silently divergent.

New `archiveTaskNow(taskId)` in `lib/archive.ts` is the exact inverse of `restoreTask` with the same guarantees: one transaction over `[tasks, archivedTasks, syncQueue]`, sync deps resolved before it opens, idempotent `put`, and a queued remote delete matching `archiveOldTasks`. The page calls it and handles rejection, so a failed undo shows a toast instead of an unhandled rejection.

**This includes a deliberate behaviour change:** undoing a restore now propagates to other devices, which it never did before. That is a fix, not a refactor — flagging it explicitly for review.

### Verification of the Undo path

Ran in the browser against a local dev server (service worker unregistered and `gsd-*` caches cleared first, seeded archived task, production data untouched):

| Step | tasks | archivedTasks | both? |
|---|---|---|---|
| seeded | 4 | 1 | no |
| after Restore | 5 | 0 | no |
| after Undo | 4 | 1 | **no** |

`archivedAt` refreshed on the way back, `Restore undone` toast shown, archive list returned to "1 archived task". Console clean across two full cycles — no errors, warnings, or unhandled rejections. Seeded row removed afterwards.

7 tests added. The two page tests reach the handler by invoking the action callback sonner is handed — that path had **no coverage at all** before, since `sonner` is mocked and the callback was never called.

## Combined verification

- Full suite: **2351 passed, 1 skipped, 0 failed**
- `bun typecheck` clean; `bun lint` 0 errors
- `archive.ts` coverage: statements 92.3% → **97.0%**, branches 85.7% → **94.4%**

## Still not included

The **delete**-Undo (`page.tsx:118-126`) writes `db.archivedTasks.add(task)` directly. It is a single write, so it has no atomicity gap — but it uses `add` rather than `put` (a double-undo throws `ConstraintError`) and has no `try`/`catch`, so a rejection escapes as an unhandled promise rejection. A smaller, different defect; left for a separate change.

https://claude.ai/code/session_01Fa3tM7zeGUmsiM2PPW8SRy
