### PR TITLE
fix(build): stop the dev build-date fallback reading the clock

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from "next";
 import pkg from "./package.json" with { type: "json" };
 
-const buildDate = process.env.NEXT_PUBLIC_BUILD_DATE ?? new Date().toISOString().slice(0, 10);
+// Real builds pin this via scripts/generate-build-info.cjs -> .build-env.sh, so the
+// fallback only ever applies to `next dev`. It must not read the clock: the dev
+// server inlines this value into both the prerendered markup and the client
+// chunk, and those two are compiled at different moments — spanning a UTC
+// midnight (or reusing a cached render from a previous day) made them disagree
+// and React reported a hydration mismatch on every load.
+const buildDate = process.env.NEXT_PUBLIC_BUILD_DATE ?? "dev";
 const buildNumber = process.env.NEXT_PUBLIC_BUILD_NUMBER ?? pkg.version;
 
 const nextConfig: NextConfig = {

--- a/tests/data/build-config.test.ts
+++ b/tests/data/build-config.test.ts
@@ -50,4 +50,21 @@ describe("build configuration", () => {
 
     expect(configSource).toMatch(/turbopack:\s*\{\s*root:\s*__dirname\s*\}/);
   });
+
+  it("keeps the build-date fallback off the clock so dev never hydrate-mismatches", () => {
+    const configSource = readFileSync("next.config.ts", "utf8");
+    const fallbackLine = configSource
+      .split("\n")
+      .find((line) => line.includes("NEXT_PUBLIC_BUILD_DATE") && line.includes("??"));
+
+    expect(fallbackLine).toBeDefined();
+    // `next dev` never sources .build-env.sh, so this fallback is the value the
+    // dev server inlines. Deriving it from the clock makes the prerendered
+    // markup and a later-compiled client chunk disagree whenever the two span a
+    // UTC midnight, which React reports as a hydration mismatch — a scary
+    // console error that can mask real ones. Production is unaffected either
+    // way (the build script pins the env var), so the fallback should simply
+    // not depend on the current time.
+    expect(fallbackLine).not.toMatch(/new Date\(/);
+  });
 });


### PR DESCRIPTION
## What changed

One line in `next.config.ts`:

```diff
-const buildDate = process.env.NEXT_PUBLIC_BUILD_DATE ?? new Date().toISOString().slice(0, 10);
+const buildDate = process.env.NEXT_PUBLIC_BUILD_DATE ?? "dev";
```

## Why

The archive page logged a React hydration mismatch on every load in dev — prerendered markup said `2026-07-30`, the client rendered `2026-07-31`.

Real builds pin `NEXT_PUBLIC_BUILD_DATE`: `scripts/generate-build-info.cjs` writes `.build-env.sh` and `bun run build` sources it. So the fallback only ever applies to `next dev`, which does **not** source it. The dev server inlines that fallback into both the prerendered markup and the client chunk, and those two are compiled at different moments — so a session spanning a UTC midnight (or reusing a cached render from the previous day) made them disagree. React then discarded and re-rendered the tree, logging a hydration error loud enough to mask real ones.

A static string cannot drift, so the mismatch is structurally impossible now.

## Scope correction

**This is dev-only. Production was never affected, contrary to how I first reported it.**

A production build inlines a single pinned value into both artifacts. Verified on a clean `bun run build`:

- `.build-env.sh` pins `NEXT_PUBLIC_BUILD_DATE="Jul 30 at 2026, 8:09 PM"`
- that exact string appears in `out/index.html` **and** `out/archive/index.html`
- the same string appears in the emitted client chunks (`430pqkumdfgyu.js`, `2uxhkbayr44h4.js`, `1dvyzxl924gj0.js`)
- **no** ISO-form date appears in the prerendered HTML at all — the `2026-07-30` I saw was the dev fallback's format, never the production one

So this fixes a developer-experience defect, not a user-facing one. Worth doing — a permanent scary console error trains you to ignore console errors — but the severity is lower than I originally stated.

## How to test locally

```bash
bun run test -- --run tests/data/build-config.test.ts
```

The new test asserts the fallback expression contains no `new Date(`. It fails on `main` with:

```
AssertionError: expected 'const buildDate = process.env.NEXT_PU…' not to match /new Date\(/
```

## Verification

- Full suite: **2352 passed, 1 skipped, 0 failed**
- `bun typecheck` clean; `bun lint` 0 errors
- Ran the archive page in the browser against `bun dev` (service worker unregistered, `gsd-*` caches cleared): console now shows only React DevTools info, `[HMR] connected`, and the `[PWA]` log — **no hydration mismatch**. The footer reads `Created by Vinny Carpenter · v10.4.1 · dev`.

`public/sw.js` was bumped to 10.4.2 by `update-sw-version.cjs` while I ran the build; reverted, since it belongs to a release rather than this change.

https://claude.ai/code/session_01Fa3tM7zeGUmsiM2PPW8SRy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->