### PR TITLE
docs(archive): record the archivedTasks tombstone invariant

### DIFF
--- a/.claude/rules/archive-tombstone.md
+++ b/.claude/rules/archive-tombstone.md
@@ -1,0 +1,50 @@
+---
+name: archive-tombstone
+description: The archivedTasks tombstone invariant. Loads when writing to tasks or archivedTasks from archive, sync, migration, or the archive page.
+paths:
+  - lib/archive.ts
+  - lib/sync/**
+  - lib/db.ts
+  - lib/tasks/**
+  - app/(archive)/**
+---
+
+## The Invariant (ADR 0013)
+
+`archivedTasks` is a tombstone. Its presence suppresses re-creation of that task id from a remote source. The tombstone is **conditional**, not absolute.
+
+Four rules. Check all four before adding any writer to `tasks` or `archivedTasks`.
+
+**1. One table at a time.** A task id lives in `tasks` or in `archivedTasks`, never both. Any move between them runs in one Dexie transaction scoped to both tables, plus `syncQueue` if it enqueues.
+
+**2. A newer remote edit beats the tombstone.** If the remote `client_updated_at` is newer than the archived row's `archivedAt`, apply it, and delete the archived row. Use `isRemoteNewerThanArchive` from `lib/sync/pb-sync-helpers.ts`. Do not reimplement the comparison; two copies will drift.
+
+**3. Writes into `archivedTasks` are idempotent and never regress.** Use `put`, not `add`. Never overwrite an existing row with an older snapshot.
+
+**4. A shared id is not proof of resurrection.** `restoreTask` and replace-mode import legitimately put a live task under an archived id. Cleanup needs positive evidence of staleness, such as the row still satisfying the archive predicate.
+
+## Why This Exists
+
+Sync had no awareness of `archivedTasks`. Archiving deleted the task locally but the remote copy survived, so the next pull re-added it. The id then sat in both tables, `archiveOldTasks` used `bulkAdd`, and the resulting `ConstraintError` aborted the shared transaction. Auto-archive failed on every run and could not recover. One device reached 254 tasks with 167 duplicates.
+
+## Current Writers
+
+| Writer | Location | Obligation |
+|---|---|---|
+| `archiveOldTasks` | `lib/archive.ts` | Idempotent `put`, one transaction |
+| `restoreTask` | `lib/archive.ts` | One transaction, clears the archived row |
+| `archiveTaskNow` | `lib/archive.ts` | One transaction, idempotent `put` |
+| `reinstateArchivedTask` | `lib/archive.ts` | Writes only when the id is absent |
+| `applyRemoteRecords` | `lib/sync/pb-pull.ts` | Archive guard, un-archives on a newer edit |
+| `applyRemoteChange` | `lib/sync/pb-sync-engine.ts` | Same guard, realtime path |
+| Migration v15 | `lib/db.ts` | Deletes only duplicates that stay archivable |
+
+Adding a writer? Add it to this table and give it a test for each rule that applies.
+
+## Traps
+
+- **Resolve sync deps before opening a Dexie transaction.** Awaiting a non-Dexie promise inside one lets it commit early. A dynamic `import()` or a config read silently removes the atomicity you just added. `archiveOldTasks` and `restoreTask` both resolve `getSyncConfig` and `getSyncQueue` first.
+- **`bulkAdd` inside a transaction is all-or-nothing.** One duplicate key aborts the entire batch, which turns a single bad row into a permanent feature outage.
+- **Byte comparison does not identify resurrected rows.** Sync normalizes fields on the round trip. Measured against the affected dataset, content comparison matched zero of 167 duplicates.
+- **`archivedTasks` is never synced.** The remote copy is deleted when the task is archived, so undoing a permanent delete enqueues nothing.
+- **Verifying against one dataset proves less than it looks.** The production data that exposed this bug held no counterexamples to the absolute-tombstone version. A real-data check passed while the rule was still wrong. Reason about the invariant, then measure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ GSD Task Manager is a privacy-first Eisenhower matrix task manager built with Ne
 - `.claude/rules/testing.md` — Test runner, TDD workflow, jsdom/bun gotchas
 - `.claude/rules/sw-cache.md` — Service worker multi-cache strategy (ADR 0012)
 - `.claude/rules/mcp-server.md` — MCP server package conventions and tool layout
+- `.claude/rules/archive-tombstone.md` — The `archivedTasks` tombstone invariant (ADR 0013); read before writing to `tasks` or `archivedTasks`
 
 ## Design Context
 
@@ -68,6 +69,7 @@ Architecture details for these subsystems live in path-scoped rules:
 - PWA / service-worker cache strategy → `.claude/rules/sw-cache.md` (auto-loads on `public/sw*.js`, `lib/sw-cache-logic.ts`)
 - PocketBase sync + OAuth → `.claude/rules/pocketbase-sync.md` (auto-loads on `lib/sync/**`)
 - MCP server package → `.claude/rules/mcp-server.md` (auto-loads on `packages/mcp-server/**`)
+- Archive/sync tombstone invariant → `.claude/rules/archive-tombstone.md` (auto-loads on `lib/archive.ts`, `lib/sync/**`, `lib/db.ts`)
 
 **Quick refs that survive without opening a rule file**:
 - Backend: self-hosted PocketBase at `https://api.vinny.io`; admin UI at `/_/`.

--- a/docs/adr/0013-archived-tasks-conditional-tombstone.md
+++ b/docs/adr/0013-archived-tasks-conditional-tombstone.md
@@ -1,0 +1,71 @@
+# ADR 0013: `archivedTasks` Is a Conditional Tombstone
+
+- **Date:** 2026-07-31
+- **Status:** Accepted
+- **Deciders:** Vinny Carpenter
+
+## Context
+
+Archiving moves a task out of `tasks` and into `archivedTasks`, then enqueues a remote delete so other devices drop it too. The sync layer knew nothing about `archivedTasks`. A search for the table name across `lib/sync/` returned no hits.
+
+That gap produced a silent outage. The remote copy survived whenever its delete failed to propagate, so the next pull re-added the task through the `!localTask` branch in `applyRemoteRecords`. The id then existed in both tables. `archiveOldTasks` used `bulkAdd`, which threw `ConstraintError` on the existing key. The read and both writes shared one Dexie transaction, so a single collision aborted the whole batch.
+
+Auto-archive therefore failed on every run, hourly and on every page load, and it could not recover on its own. One affected device held 254 tasks, of which 167 were resurrected duplicates. Every archive attempt since mid-July had failed.
+
+Fixing the collision alone would have been a symptom fix. The real question was what `archivedTasks` means to the rest of the system.
+
+## Decision
+
+`archivedTasks` is a tombstone: its presence suppresses re-creation of that task id from a remote source. The tombstone is **conditional**, not absolute.
+
+Four rules govern it. Every writer that touches `tasks` or `archivedTasks` must honor all four.
+
+**1. One table at a time.** A task id belongs in `tasks` or in `archivedTasks`, never both. Any move between them runs in a single Dexie transaction scoped to both tables, plus `syncQueue` when the move enqueues a sync operation.
+
+**2. The tombstone yields to a newer remote edit.** A remote record whose `client_updated_at` is newer than the archived row's `archivedAt` wins, un-archives the task, and removes the archived row. This preserves the engine's edit-beats-delete rule under last-write-wins. `pb-push` deliberately abandons a delete whose remote changed after the delete was queued, and it relies on the next pull to restore that version. Suppressing it unconditionally stranded the edit forever once the cursor advanced. `isRemoteNewerThanArchive` in `lib/sync/pb-sync-helpers.ts` is the single shared implementation, so the pull path and the realtime path cannot drift apart.
+
+**3. Writes into `archivedTasks` are idempotent and never regress.** Archiving uses `put`, so a duplicate can never abort a batch again. The undo for a permanent delete writes only when the id is absent. An existing row is either the same undo repeated or a newer row that won a race. Neither should be overwritten by an older snapshot.
+
+**4. Sharing an id with an archived row is not proof of resurrection.** `restoreTask` and replace-mode import can both put a live task back under an archived id legitimately. Cleanup code must require positive evidence of staleness, such as the row still satisfying the archive predicate, rather than deleting every duplicate it finds.
+
+The writers bound by these rules today:
+
+| Writer | Location | Obligation |
+|---|---|---|
+| `archiveOldTasks` | `lib/archive.ts` | Idempotent `put`, one transaction |
+| `restoreTask` | `lib/archive.ts` | One transaction, clears the archived row |
+| `archiveTaskNow` | `lib/archive.ts` | One transaction, idempotent `put` |
+| `reinstateArchivedTask` | `lib/archive.ts` | Writes only when the id is absent |
+| `applyRemoteRecords` | `lib/sync/pb-pull.ts` | Archive guard, un-archives on a newer edit |
+| `applyRemoteChange` | `lib/sync/pb-sync-engine.ts` | Same guard for the realtime path |
+| Migration v15 | `lib/db.ts` | Deletes only duplicates that stay archivable |
+
+## Consequences
+
+**Easier:**
+
+- Archiving survives a resurrected duplicate instead of failing permanently.
+- An archived task stays archived across a sync, so the user's decision holds.
+- A concurrent edit from another device still reaches this device rather than disappearing.
+- New code has one place to read before writing to either table.
+
+**Harder:**
+
+- Every future writer must be checked against four rules, and none of them are enforced by the type system.
+- The pull path now reads `archivedTasks` on every batch, which adds an indexed lookup bounded by the pull size.
+- Rules 2 and 4 pull in opposite directions. Rule 2 says a newer remote edit beats the archive, and rule 4 says a live duplicate may be legitimate. Both need the same care, and neither is obvious from the call site.
+
+**Out of scope:**
+
+- Syncing `archivedTasks` itself. The archive stays device-local, and the remote copy is deleted when the task is archived.
+- A schema-level constraint. IndexedDB cannot express a cross-store uniqueness rule.
+
+## Alternatives
+
+| Alternative | Why rejected |
+|---|---|
+| Absolute tombstone (suppress every archived id) | Shipped first and reviewed as a defect. It overrides the engine's edit-beats-delete rule and strands a concurrent edit permanently once the pull cursor advances. |
+| Make archiving a hard remote delete | Destroys the task on every device with no recovery if the archive is later lost. |
+| Idempotent `bulkPut` with no pull-side guard | Stops the crash but leaves the resurrection loop. The same tasks re-archive every hour, so churn replaces the outage. |
+| Detect stale duplicates by comparing content | Measured against the affected dataset and it identified zero of 167 rows. Sync normalizes fields on the round trip, so no resurrected row matches its archived copy byte for byte. |
+| Merge the tables and add an `archived` boolean | A larger migration touching every task query, and it trades a cross-store invariant for a filter that every read must remember to apply. |


### PR DESCRIPTION
## What changed

Two documents and two registration lines:

- `docs/adr/0013-archived-tasks-conditional-tombstone.md`
- `.claude/rules/archive-tombstone.md` (auto-loads on `lib/archive.ts`, `lib/sync/**`, `lib/db.ts`, `lib/tasks/**`, `app/(archive)/**`)
- `CLAUDE.md`, both rule lists

No code changes.

## Why

The rule governing `archivedTasks` lived only in code comments spread across six writers in three files. That is how the seventh writer breaks it.

PRs #457, #459, and #460 each fixed a violation. Two of those violations were introduced by the previous fix in the same area: the pull-side guard added in #457 overrode the engine's edit-beats-delete rule, and the stale-snapshot clobber in #460 only became reachable because #457 and #459 made resurrection-then-re-archive a real sequence. A rule that keeps getting re-broken by its own fixes belongs somewhere a reader will find before writing code, not in a comment they will read after.

## The invariant

`archivedTasks` is a tombstone that suppresses remote re-creation of a task id. It is **conditional**, not absolute.

1. **One table at a time.** A task id lives in `tasks` or `archivedTasks`, never both. Moves run in one transaction over both tables, plus `syncQueue` when they enqueue.
2. **A newer remote edit beats the tombstone.** Newer than `archivedAt` wins, un-archives, and clears the archived row. `isRemoteNewerThanArchive` is the single shared implementation so the pull and realtime paths cannot drift.
3. **Writes into `archivedTasks` are idempotent and never regress.** `put`, not `add`, and never overwrite a newer row with an older snapshot.
4. **A shared id is not proof of resurrection.** `restoreTask` and replace-mode import produce one legitimately. Cleanup needs positive evidence of staleness.

The ADR also records the alternatives that were measured and rejected, including content comparison, which identified **zero of 167** affected rows because sync normalizes fields on the round trip.

## Verification

Every factual claim was checked against the code rather than written from memory:

| Claim | Check |
|---|---|
| All seven named writers exist | `rg` each, 1 hit each |
| Migration is v15 | `this.version(15)` present in `lib/db.ts` |
| `archiveOldTasks` uses `bulkPut` | present |
| `reinstateArchivedTask` writes only when absent | `if (existing)` guard present |
| `lib/sync/` had no `archivedTasks` reference pre-fix | 0 hits at `8046e47` |

Voice pass per the house style guide: no em dashes, en dashes, or prose double hyphens; no banned jargon or filler; four sentences over 25 words split (three other flags were the checker counting bold headings as sentence text).

Suite still **2357 passed, 1 skipped, 0 failed**; `bun lint` 0 errors. Frontmatter matches the four existing rule files.

`package.json`, `bun.lock`, and `public/sw.js` are left unstaged: they carry your in-progress bump to 10.5.1, and running a build here stamped the service worker version to match.

https://claude.ai/code/session_01Fa3tM7zeGUmsiM2PPW8SRy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->