### PR TITLE
feat(matrix): add loading state, fix WCAG AA, reskin quadrant language

### DIFF
--- a/.ui-craft/brief.md
+++ b/.ui-craft/brief.md
@@ -1,0 +1,92 @@
+# Project Brief
+
+<!-- Always-loaded by the ui-craft skill. Keep this concise — it anchors every design decision.
+     Source of truth for strategic intent is PRODUCT.md at the repo root; this file is the
+     working design contract distilled from it. When they disagree, PRODUCT.md wins. -->
+
+## Design Intent
+
+A quiet desk, not a cockpit. GSD turns the Eisenhower Matrix into a working surface: the
+urgent/important split is a structural decision the app makes visible, not a label the user has
+to remember. The interface is unhurried and low-noise — the user should feel clear-headed and in
+control, never overwhelmed, never behind, never nagged.
+
+The visual system is Inkwell 1.3.1: serif display against a system sans, the 1.5px hairline,
+cool-stone surfaces, and a four-colour quadrant language (rust / tide / ochre / slate) that is
+the one place strong colour is spent.
+
+## Audience
+
+Individuals managing their own work and life — not teams running shared projects. They arrive
+when a flat to-do list has stopped helping and they need to decide *what actually matters* before
+doing anything. The defining trait is a desire for control over both priorities and data: many
+choose GSD specifically because it runs locally and asks for nothing.
+
+Context of use is varied and often quick: a desktop browser during a planning block, a phone as
+an installed PWA between meetings, occasionally Claude Desktop via the MCP server.
+
+## Voice and Tone
+
+Plain and direct. Respects the reader's attention and intelligence. Names what the product
+literally does. No productivity hype, no buzzwords, no exclamation-point cheerleading.
+Encouraging without being saccharine — completion is worth a brief celebration; everything else
+stays composed.
+
+## Principles
+
+<!-- Numbered in conflict-resolution order. These are the override registry: a finding that
+     conflicts with a principle is deferred against it, citing the number. -->
+
+1. **The tool disappears into the task.** Minimal chrome; no decoration competing with content.
+   Users come to decide and act, not to admire the UI. When in doubt, remove.
+2. **Privacy is the foundation, not a feature to advertise.** Local-first by default, sync
+   strictly opt-in, no tracking, no dark patterns.
+3. **The matrix is the argument.** Design reinforces the urgent/important distinction — the
+   four-quadrant colour language, washes and accents carry meaning rather than flattening tasks
+   back into a generic list.
+4. **Earned familiarity over novelty.** Drag-and-drop, command palette, keyboard shortcuts and
+   standard form controls, all done well. Don't reinvent standard affordances for flavour.
+5. **Delight in moments, restraint on pages.** Reserve celebration and personality for genuine
+   moments (task completion). Every other surface stays composed.
+
+## Anti-references
+
+GSD must not look or feel like:
+
+- **A flashy AI startup** — no purple gradients, glassmorphism-by-default, gradient text, or
+  supercharge/streamline/seamless copy.
+- **A gamified todo toy** — no mascots, no points/badges economy, no juvenile illustration, no
+  emoji standing in for designed icons. (One completion confetti is the deliberate exception.)
+- **A dense enterprise PM tool** — not Jira/Asana. Complexity is a failure, not a feature.
+- **A generic SaaS dashboard** — no cookie-cutter card grids, no hero-metric template, no
+  interchangeable enterprise sameness.
+
+## Constraints
+
+- **WCAG 2.1 AA is the floor**, enforced by construction and review: body text ≥4.5:1, large text
+  ≥3:1, ≥44px touch targets on coarse pointers, `prefers-reduced-motion` fallback on every
+  animation, and colour never the sole carrier of meaning.
+- **Dark mode is first-class**, not an inversion — Inkwell Pattern B (system preference with
+  manual override), hues lifted to hold contrast on dark surfaces.
+- **Offline-first PWA.** Every surface must render from IndexedDB with no network. Data surfaces
+  must distinguish "loading" from "empty" — an empty state asserts something specific and must
+  never be shown before the local read resolves.
+- **Static export.** No SSR or API routes; all components are client components.
+
+## Learned constraints
+
+<!-- Corrections made on this project. Each is binding: they override skill defaults but never
+     the a11y floor. Add new ones with /remember. -->
+
+1. **Colour on the matrix means quadrant, and only quadrant.** Tag chips, status pills and other
+   metadata read neutral. Tinting them with the quadrant pigment restates a fact the pane header
+   and card spine already carry, and implies the tag itself says something about urgency — "home"
+   and "infra" are orthogonal to the matrix. (2026-07-30, supersedes the earlier
+   "tag chips in the quadrant wash" rule.)
+2. **State the quadrant twice, with conviction — not five times at half volume.** The pigment's
+   home is the pane header (band, icon, title, 3px rule) and the card (spine, completion disc).
+   Washes are quiet ground. Redundant signalling forces every statement to be timid, which is
+   what reads as generic. (2026-07-30)
+3. **Quadrant titles use `--q*-ink`, not `--q*`.** Ochre misses AA against its own header tint at
+   15px; the ink token darkens the text rather than lightening the header, which preserves the
+   10/10/12/14 tint ladder that equalises perceived header weight. (2026-07-31)

--- a/.ui-craft/decisions.md
+++ b/.ui-craft/decisions.md
@@ -1,0 +1,52 @@
+# Design Decisions
+
+<!-- Lazy-loaded — loaded only when a task requires prior rationale or decision reference.
+     Append-only log. Never delete entries; mark superseded ones with a note.
+     Format: ### YYYY-MM-DD — {title} followed by **Status**: accepted | rejected | tried -->
+
+### 2026-01-01 — Example decision entry
+
+**Status**: accepted
+
+We chose X over Y because Z. The key constraint was [constraint]. Alternatives considered:
+- Option A — rejected because [reason]
+- Option B — tried but caused [issue]
+
+### 2026-07-30 — Matrix reskin: state the quadrant twice, not five times
+
+**Status**: accepted
+
+The matrix read "dated/generic" despite a mature token system. The cause was not
+missing design but **redundant signaling**: each quadrant asserted its identity
+five ways at once (pane wash, 3px top rule, tinted header band, header text
+color, card spine) plus quadrant-tinted tag chips. Five simultaneous statements
+force each one to be quiet, and uniformly quiet color is what reads as generic.
+
+Kept at full strength (the pigment's real home): pane header, 3px rule, card
+spine, completion disc. Demoted:
+
+- **Pane washes → ~45% of former strength.** A half-empty quadrant used to be a
+  large flat field of pigment; four such fields around white cards read as a
+  kanban board, not a matrix. Washes stay because PRODUCT.md names them as
+  carrying meaning — this tunes the tint, it does not remove the language.
+- **Tag chips → neutral.** Reverses the earlier tested rule ("tag chips in the
+  quadrant wash + accent, not neutral gray", tests/ui/task-card-anatomy.test.tsx).
+  Tags are orthogonal to the matrix: "home" and "infra" say nothing about
+  urgency, so tinting them implied a meaning they don't carry. Color on this
+  surface now means quadrant, and only quadrant.
+- **Dark-mode washes** additionally sat *lighter* than `--paper`, so cards
+  appeared recessed into their own pane. Now page < pane < card.
+
+Alternatives considered:
+- Remove washes entirely (Linear/Things-style neutral panes) — rejected:
+  PRODUCT.md principle 3 names the washes as part of "the matrix is the
+  argument". Out of bounds for a reskin without being asked.
+- Drop the card spine instead of softening washes — rejected: the spine is the
+  only quadrant cue that survives drag, search results, and dense panes.
+
+Also replaced the smart-view strip's nine emoji with the Lucide set already used
+app-wide (PRODUCT.md anti-reference: "a gamified todo toy"). Built-in views are
+computed at read time, never persisted, so `icon` values changed from glyphs to
+registry keys with no migration; custom views with legacy glyphs still render.
+
+<!-- Add new decisions above this comment, newest first. -->

--- a/.ui-craft/patterns.md
+++ b/.ui-craft/patterns.md
@@ -1,0 +1,24 @@
+# Patterns
+
+<!-- Lazy-loaded — loaded only when a task references a known pattern or composition.
+     Document validated component and layout patterns so the skill can reuse them
+     without reinventing. Each pattern includes a description, where it's used, and
+     any usage constraints. -->
+
+## Pattern: [Name]
+
+<!-- Replace [Name] with the pattern identifier (e.g. "Data Table Row", "Sidebar Nav Item") -->
+
+**Description**: What this pattern does and what problem it solves.
+
+**Usage**: Where this pattern appears in the product (surfaces, components).
+
+**Constraints**: Any rules about when NOT to use this, or variations to avoid.
+
+**Example structure**:
+
+```
+<!-- Paste a minimal code snippet or describe the composition -->
+```
+
+<!-- Add more patterns below. Each gets its own ## Pattern: [Name] block. -->

--- a/.ui-craft/tokens.md
+++ b/.ui-craft/tokens.md
@@ -1,0 +1,40 @@
+# Design Tokens
+
+<!-- Always-loaded by the ui-craft skill. Document the actual token values used in this project.
+     Keep in sync with your CSS variables, Tailwind config, or design-tokens file. -->
+
+## Colors
+
+<!-- Neutral ramp, accent color(s), semantic colors (success/error/warning), surface colors.
+     Example:
+     - Accent: #2563eb (blue-600) — used for CTAs, active states, links
+     - Neutral: zinc ramp (zinc-50 to zinc-950)
+     - Surface: zinc-50 (light), zinc-900 (dark)
+     - Error: red-600 / Success: green-600 -->
+
+## Typography
+
+<!-- Font families, size scale, weight usage, line-height.
+     Example:
+     - Body: Inter, 14px/1.5, weight 400
+     - Display: Inter, weight 600, tracking-tight above 24px
+     - Mono: JetBrains Mono for code -->
+
+## Spacing
+
+<!-- Spacing scale (4px base, 8/12/16/24/32/48/64 steps or Tailwind scale).
+     Note any deviations from the default scale.
+     Example: "4px grid. Component padding: 12px (sm), 16px (md), 24px (lg)." -->
+
+## Radius
+
+<!-- Border-radius tokens for each element class.
+     Example: inputs 6px, cards 10px, modals 14px, badges 4px, pill 9999px -->
+
+## Shadows
+
+<!-- Elevation shadow tokens.
+     Example:
+     - sm: 0 1px 2px rgba(0,0,0,0.05)
+     - md: 0 4px 6px rgba(0,0,0,0.07), 0 2px 4px rgba(0,0,0,0.05)
+     - lg: 0 10px 15px rgba(0,0,0,0.1), 0 4px 6px rgba(0,0,0,0.05) -->

--- a/app/globals.css
+++ b/app/globals.css
@@ -119,10 +119,28 @@
   --q2: #2C6680;  /* Schedule  — tide  */
   --q3: #8A6A22;  /* Delegate  — ochre */
   --q4: #6F685F;  /* Eliminate — slate */
-  --q1-wash: #F4E4E0;
-  --q2-wash: #E1ECF1;
-  --q3-wash: #F0E9D8;
-  --q4-wash: #ECE9E3;
+  /* Pane washes sit ~45% of their former strength, close to --ivory. The pane
+     is *ground*, not a colored panel: at the old intensity a half-empty
+     quadrant became a large flat field of pigment, and four such fields around
+     white cards read as a kanban board rather than a matrix. The pigment still
+     states itself at full strength where it carries information — the pane
+     header, the 3px rule, and the card spine. */
+  --q1-wash: #F4EBE5;
+  --q2-wash: #E9EFF1;
+  --q3-wash: #F2EDE1;
+  --q4-wash: #EFEDE7;
+
+  /* Text-safe pigment for quadrant titles. Identical to the pigment except
+     where the pigment misses WCAG AA against its own header tint: ochre is the
+     lightest of the four, and "Delegate" at 15px measured 4.32:1 on
+     .quadrant-header-q3 (AA needs 4.5:1). Darkening the *ink* rather than the
+     header tint keeps the 10/10/12/14 tint ladder that equalizes perceived
+     header weight across pigments of differing lightness. Dark mode clears AA
+     on all four (4.60-6.36), so it rebinds every ink back to the pigment. */
+  --q1-ink: var(--q1);
+  --q2-ink: var(--q2);
+  --q3-ink: #7A5D1E;  /* ochre, one step darker — 5.27:1 */
+  --q4-ink: var(--q4);
 
   /* Wash/header component classes mix off these; repointed to the pigments so
      the matrix backdrops follow the four-color language automatically. */
@@ -169,12 +187,19 @@
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
     --q1: #E0705F; --q2: #6FAACB; --q3: #CFB266; --q4: #A9A096;
-    --q1-wash: #3A211D; --q2-wash: #173039; --q3-wash: #322B17; --q4-wash: #2A2620;
+    /* Softened to match light mode, and pulled below --paper so elevation
+       reads page < pane < card. The old values sat *lighter* than the card
+       surface, so cards appeared recessed into their own quadrant. */
+    --q1-wash: #231914; --q2-wash: #171E1E; --q3-wash: #201D12; --q4-wash: #1E1B15;
+    /* Dark pigments clear AA on their own header tints; no darker ink needed. */
+    --q3-ink: var(--q3);
   }
 }
 :root[data-theme="dark"] {
   --q1: #E0705F; --q2: #6FAACB; --q3: #CFB266; --q4: #A9A096;
-  --q1-wash: #3A211D; --q2-wash: #173039; --q3-wash: #322B17; --q4-wash: #2A2620;
+  /* Keep in lockstep with the prefers-color-scheme branch above. */
+  --q1-wash: #231914; --q2-wash: #171E1E; --q3-wash: #201D12; --q4-wash: #1E1B15;
+  --q3-ink: var(--q3);
 }
 
 /* =====================================================================

--- a/bun.lock
+++ b/bun.lock
@@ -186,11 +186,11 @@
 
     "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
-    "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+    "@emnapi/core": ["@emnapi/core@2.0.0-alpha.3", "", { "dependencies": { "@emnapi/wasi-threads": "2.0.1", "tslib": "^2.4.0" } }, "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+    "@emnapi/runtime": ["@emnapi/runtime@2.0.0-alpha.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA=="],
 
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@2.0.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
@@ -354,7 +354,7 @@
 
     "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.100", "", { "os": "win32", "cpu": "x64" }, "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.1", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3" } }, "sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ=="],
 
     "@next/env": ["@next/env@16.2.11", "", {}, "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA=="],
 
@@ -412,7 +412,7 @@
 
     "@openai/codex-sdk": ["@openai/codex-sdk@0.144.6", "", { "dependencies": { "@openai/codex": "0.144.6" } }, "sha512-jFgXHjFq2//PTfJa8CySqhUilRBPVmCLuQoH5F+iJ2x4owZwPlnqmIbCkWIJJ6IxDuQdjf3ewg0LaDtc3i6h9Q=="],
 
-    "@openai/codex-security": ["@openai/codex-security@0.1.1", "", { "dependencies": { "@inquirer/prompts": "8.3.0", "@octokit/core": "7.0.6", "@openai/codex": "0.144.6", "@openai/codex-sdk": "0.144.6", "ajv": "8.20.0", "extract-zip": "2.0.1", "fast-uri": "3.1.4", "fflate": "0.8.2", "incur": "0.4.13", "papaparse": "5.5.3", "pdfjs-dist": "5.6.205", "smol-toml": "1.6.1" }, "bin": { "codex-security": "bin/codex-security.mjs" } }, "sha512-sNxULf7IyicJRgYnycguaEzO2ZeANEv3oyrupjMoKVq5TjRrmIhORpaa7U2LVIpEHJP7//icGZV37MRIlp9X/A=="],
+    "@openai/codex-security": ["@openai/codex-security@0.1.4", "", { "dependencies": { "@inquirer/prompts": "8.3.0", "@octokit/core": "7.0.6", "@openai/codex": "0.144.6", "@openai/codex-sdk": "0.144.6", "ajv": "8.20.0", "extract-zip": "2.0.1", "fast-uri": "3.1.4", "fflate": "0.8.2", "incur": "0.4.13", "papaparse": "5.5.3", "pdfjs-dist": "5.6.205", "smol-toml": "1.6.1" }, "bin": { "codex-security": "bin/codex-security.mjs" } }, "sha512-BOElTCc8oxlIVemL7j9a0Ekmsrb3/zboGzzyVf7i4opr9+Ij5D6qdMHcP5kcdPSowg+/rZhAndSJ3t7+Or0oKw=="],
 
     "@openai/codex-win32-arm64": ["@openai/codex@0.144.6-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-SpMjXJLW43JzMP0K62mVcYfmFcpk0BK4AOgYmWSfyZHs3iRtHMd0UYw7605n/9lwkT2EqbwQLT2omZFeKJFzwA=="],
 
@@ -434,9 +434,9 @@
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+    "@oxc-project/types": ["@oxc-project/types@0.142.0", "", {}, "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ=="],
 
-    "@playwright/test": ["@playwright/test@1.62.0", "", { "dependencies": { "playwright": "1.62.0" }, "bin": { "playwright": "cli.js" } }, "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA=="],
+    "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -504,35 +504,35 @@
 
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.1", "", { "os": "android", "cpu": "arm64" }, "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.1", "", { "os": "linux", "cpu": "arm" }, "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.1", "", { "os": "none", "cpu": "arm64" }, "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.2.1", "", { "dependencies": { "@emnapi/core": "2.0.0-alpha.3", "@emnapi/runtime": "2.0.0-alpha.3", "@napi-rs/wasm-runtime": "^1.2.0" } }, "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
@@ -1304,29 +1304,29 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
-    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+    "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
 
-    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
 
-    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg=="],
 
-    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.33.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ=="],
 
-    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.33.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg=="],
 
-    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ=="],
 
-    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg=="],
 
-    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ=="],
 
-    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg=="],
 
-    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw=="],
 
-    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
 
-    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
@@ -1454,15 +1454,15 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
-    "playwright": ["playwright@1.62.0", "", { "dependencies": { "playwright-core": "1.62.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw=="],
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
 
-    "playwright-core": ["playwright-core@1.62.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA=="],
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
     "pocketbase": ["pocketbase@0.27.0", "", {}, "sha512-K5N6d93UP/BNMbMnlZ6BUfy9VPCIvLyqhJFOsNI8OsZwzvKWEAfyD36boi5K4ECIOl5HMlo0TzuaeGdKpMwizQ=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
+    "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -1524,7 +1524,7 @@
 
     "rimraf": ["rimraf@6.1.3", "", { "dependencies": { "glob": "^13.0.3", "package-json-from-dist": "^1.0.1" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA=="],
 
-    "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
+    "rolldown": ["rolldown@1.2.1", "", { "dependencies": { "@oxc-project/types": "=0.142.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.1", "@rolldown/binding-darwin-arm64": "1.2.1", "@rolldown/binding-darwin-x64": "1.2.1", "@rolldown/binding-freebsd-x64": "1.2.1", "@rolldown/binding-linux-arm-gnueabihf": "1.2.1", "@rolldown/binding-linux-arm64-gnu": "1.2.1", "@rolldown/binding-linux-arm64-musl": "1.2.1", "@rolldown/binding-linux-ppc64-gnu": "1.2.1", "@rolldown/binding-linux-s390x-gnu": "1.2.1", "@rolldown/binding-linux-x64-gnu": "1.2.1", "@rolldown/binding-linux-x64-musl": "1.2.1", "@rolldown/binding-openharmony-arm64": "1.2.1", "@rolldown/binding-wasm32-wasi": "1.2.1", "@rolldown/binding-win32-arm64-msvc": "1.2.1", "@rolldown/binding-win32-x64-msvc": "1.2.1" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
@@ -1700,7 +1700,7 @@
 
     "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
-    "vite": ["vite@8.1.5", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.17", "rolldown": "~1.1.5", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw=="],
+    "vite": ["vite@8.2.0", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.23", "rolldown": "~1.2.0", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ=="],
 
     "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
 
@@ -1781,6 +1781,8 @@
     "@bramus/specificity/css-tree": ["css-tree@3.1.0", "", { "dependencies": { "mdn-data": "2.12.2", "source-map-js": "^1.0.1" } }, "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
@@ -1902,6 +1904,8 @@
 
     "@reduxjs/toolkit/reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
+    "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
@@ -1913,6 +1917,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tailwindcss/postcss/postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "@testing-library/jest-dom/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
@@ -1970,6 +1976,8 @@
 
     "make-dir/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
+    "next/postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
+
     "path-scurry/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
@@ -1981,6 +1989,8 @@
     "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
+
+    "vitest/vite": ["vite@8.1.5", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.17", "rolldown": "~1.1.5", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw=="],
 
     "whatwg-url/@exodus/bytes": ["@exodus/bytes@1.14.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ=="],
 
@@ -2062,6 +2072,30 @@
 
     "@radix-ui/react-visually-hidden/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.1", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-compose-refs": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Bu/aAQHFFh6/QAvXAeUMurJ9fbW0JUIqlojU/yBXZ7cAVqy75Y7JYYyuCr9zLNF0p4WWoJYV54CTUIf4l7FzTw=="],
 
+    "@tailwindcss/node/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "@tailwindcss/postcss/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
     "@unrs/resolver-binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
     "@unrs/resolver-binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
@@ -2073,6 +2107,14 @@
     "cmdk/@radix-ui/react-id/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
 
     "cmdk/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
+
+    "next/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
+    "vitest/vite/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "vitest/vite/postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
+
+    "vitest/vite/rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
 
     "@radix-ui/react-arrow/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/primitive": ["@radix-ui/primitive@1.1.7", "", {}, "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q=="],
 
@@ -2087,5 +2129,69 @@
     "@radix-ui/react-visually-hidden/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-pWJo6lQAfR6uy1n7ii7PaCc9dLPwTXDYbQpORZU5B548Aqvl2pP1SM1vJGKyxIFqZMHRopRO4CQYX2iXAIB5jA=="],
 
     "@unrs/resolver-binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+
+    "vitest/vite/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "vitest/vite/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "vitest/vite/lightningcss/lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "vitest/vite/lightningcss/lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "vitest/vite/lightningcss/lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "vitest/vite/lightningcss/lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "vitest/vite/lightningcss/lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "vitest/vite/lightningcss/lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "vitest/vite/lightningcss/lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "vitest/vite/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "vitest/vite/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "vitest/vite/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
+    "vitest/vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
   }
 }

--- a/components/app-footer.tsx
+++ b/components/app-footer.tsx
@@ -14,9 +14,11 @@ export function AppFooter() {
           href="https://vinny.dev/"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-accent hover:underline"
+          className="rounded-xs text-accent underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
         >
-          Vinny Carpenter
+          {/* Non-breaking space keeps the name whole — at 320px the footer
+              otherwise breaks it as "Vinny / Carpenter". */}
+          Vinny&nbsp;Carpenter
         </a>
         <span aria-hidden="true">{" · "}</span>
         <span className="text-foreground-muted/70">

--- a/components/matrix-simplified/capture-bar.tsx
+++ b/components/matrix-simplified/capture-bar.tsx
@@ -137,7 +137,11 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
       className={cn(
         "flex items-center gap-3 rounded-xl border border-border bg-card px-4 py-3.5",
         // Flat at rest on the hairline; lifts only when engaged (Inkwell flat-at-rest signature).
-        "transition-shadow focus-within:border-foreground-muted focus-within:shadow-lg"
+        "transition-shadow focus-within:border-foreground-muted focus-within:shadow-lg",
+        // The input clears its own outline, so the bar carries the focus ring for
+        // it. A lift alone is not a focus indicator — it disappears under
+        // forced-colors and reads as decoration rather than position.
+        "focus-within:ring-2 focus-within:ring-accent focus-within:ring-offset-2"
       )}
     >
       <ZapIcon
@@ -154,6 +158,10 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
         onKeyDown={onInputKey}
         placeholder="Capture a task..."
         aria-label="Capture a task"
+        // The focus indicator lives on the parent <form> (focus-within:ring-2
+        // ring-accent), which is the visible affordance for this borderless
+        // input. The rule matches per element and cannot see the parent.
+        // ui-craft-detect-ignore-next-line
         className="touch-target min-w-0 flex-1 border-0 bg-transparent text-[15px] leading-snug text-foreground outline-none placeholder:text-foreground-muted"
       />
       {text.trim() ? (
@@ -164,7 +172,7 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
             type="button"
             onClick={cycleQuadrant}
             title="Tab to cycle quadrant"
-            className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[11px] font-medium animate-quadrant-pill-in"
+            className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[11px] font-medium animate-quadrant-pill-in focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
             style={{
               backgroundColor: `color-mix(in srgb, ${accent} 20%, transparent)`,
               color: accent,
@@ -194,7 +202,7 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
               // Enters just behind the quadrant pill (40ms) so the trailing controls
               // arrive as one coherent cluster instead of the pill animating alone.
               style={{ animationDelay: "40ms" }}
-              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-foreground-muted transition-colors hover:bg-background-muted hover:text-foreground animate-quadrant-pill-in"
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-foreground-muted transition-colors hover:bg-background-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 animate-quadrant-pill-in"
             >
               Details ↗
             </button>
@@ -211,6 +219,7 @@ export function CaptureBar({ onSubmit, onMoreOptions, inputRef: externalRef }: C
         aria-disabled={!parsed.title}
         className={cn(
           "touch-target inline-flex h-9 items-center gap-1.5 rounded-lg px-4 text-[14px] font-semibold transition-[background-color,color,transform] duration-[120ms]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
           parsed.title
             ? "bg-accent text-card hover:bg-accent-hover active:scale-[0.97]"
             : "bg-accent/15 text-accent hover:bg-accent/20"

--- a/components/matrix-simplified/edit-drawer-dependencies.tsx
+++ b/components/matrix-simplified/edit-drawer-dependencies.tsx
@@ -77,11 +77,14 @@ export function DependenciesField({
               className="inline-flex items-center gap-1 rounded bg-background-muted px-2 py-0.5 text-[11.5px] font-medium text-foreground-muted"
             >
               {t.title}
+              {/* Unsaved-draft chip removal, same as the tag chips: reversible
+                  by re-searching, and nothing is written until Save. */}
+              {/* ui-craft-detect-ignore-next-line */}
               <button
                 type="button"
                 onClick={() => onChange(dependencies.filter((id) => id !== t.id))}
                 aria-label={`Remove dependency ${t.title}`}
-                className="hover:text-foreground"
+                className="rounded-xs hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
               >
                 <XIcon className="h-3 w-3" />
               </button>
@@ -110,7 +113,7 @@ export function DependenciesField({
             aria-label="Search tasks to add as a dependency"
             aria-invalid={error ? true : undefined}
             aria-describedby={describedBy}
-            className="min-w-[80px] flex-1 border-0 bg-transparent text-[13px] text-foreground outline-none disabled:cursor-not-allowed"
+            className="min-w-[80px] flex-1 rounded-xs border-0 bg-transparent text-[13px] text-foreground outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent disabled:cursor-not-allowed"
           />
         </div>
         <Suggestions

--- a/components/matrix-simplified/edit-drawer-fields.tsx
+++ b/components/matrix-simplified/edit-drawer-fields.tsx
@@ -102,7 +102,7 @@ export function DueDateField({
                 className={cn(
                   // Selected due-date preset reads in tide tint (reference §07);
                   // unselected presets stay graphite.
-                  "rounded-md px-3 py-1.5 text-[12.5px] font-medium transition-all duration-200",
+                  "rounded-md px-3 py-1.5 text-[12.5px] font-medium transition-[background-color,color,box-shadow] duration-200",
                   isActive
                     ? "bg-accent-tint text-accent font-semibold shadow-sm"
                     : "text-foreground-muted hover:text-foreground"
@@ -172,7 +172,7 @@ function CustomDateInput({
       type="date"
       onChange={(e) => { if (e.target.value) { onCustomDateChange(e.target.value); onToggleCustomInput(false); } }}
       onBlur={() => onToggleCustomInput(false)}
-      className="rounded-md border border-border bg-background px-2.5 py-1 text-[12.5px] font-medium text-foreground outline-none focus:border-foreground-muted"
+      className="rounded-md border border-border bg-background px-2.5 py-1 text-[12.5px] font-medium text-foreground outline-none focus:border-foreground-muted focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
       aria-label="Pick a custom due date"
     />
   );
@@ -200,11 +200,15 @@ export function TagsField({ tags, tagInput, onTagInputChange, onAddTag, onRemove
           >
             <span className="opacity-60">#</span>
             {t}
+            {/* Removes a chip from an unsaved draft — nothing is persisted until
+                Save, and re-adding is one keystroke. A confirmation dialog on a
+                tag chip would be worse UX than the risk it guards. */}
+            {/* ui-craft-detect-ignore-next-line */}
             <button
               type="button"
               onClick={() => onRemoveTag(t)}
               aria-label={`Remove ${t}`}
-              className="hover:text-foreground"
+              className="rounded-xs hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             >
               <XIcon className="h-3 w-3" />
             </button>
@@ -217,7 +221,9 @@ export function TagsField({ tags, tagInput, onTagInputChange, onAddTag, onRemove
           onBlur={onAddTag}
           placeholder={tags.length ? "" : "Add a tag…"}
           aria-label="Add a tag"
-          className="min-w-[80px] flex-1 border-0 bg-transparent text-[13px] text-foreground outline-none"
+          // Inset ring: this input is borderless inside a bordered chip box, so
+          // an offset ring would draw outside the field it belongs to.
+          className="min-w-[80px] flex-1 rounded-xs border-0 bg-transparent text-[13px] text-foreground outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent"
         />
       </div>
     </Field>

--- a/components/matrix-simplified/edit-drawer.tsx
+++ b/components/matrix-simplified/edit-drawer.tsx
@@ -88,10 +88,20 @@ function EditDrawerForm({ task, initialDraft, allTasks = [], onClose, onSubmit }
     void onSubmit(draft.toDraft(), task?.id);
   };
 
+  const heading = isCreateMode ? "New task" : "Edit task";
+
+  // Deliberately hand-rolled rather than Radix <Dialog>. ui-craft-detect flags
+  // this as a11y/modal-without-dialog, but the behaviours that rule protects are
+  // covered by explicit tests here (role/aria-modal, focus restore on close, and
+  // Escape layering). Radix's DismissableLayer handles Escape at the document
+  // level, which would break the layered-Escape contract the dependency
+  // suggestion popup relies on — a first Escape closes the popup, a second
+  // closes the drawer. See .ui-craft/decisions.md (2026-07-31).
   return (
     <div
       onClick={onClose}
       role="presentation"
+      // ui-craft-detect-ignore-next-line
       className="fixed inset-0 z-[60] flex justify-end bg-black/30 animate-drawer-overlay"
     >
       <form
@@ -103,11 +113,11 @@ function EditDrawerForm({ task, initialDraft, allTasks = [], onClose, onSubmit }
         onKeyDown={trapKeyDown}
         onSubmit={submit}
         className="flex h-full w-full max-w-[520px] flex-col border-l border-border bg-card shadow-2xl animate-drawer-slide-in"
-        aria-label={isCreateMode ? "New task" : "Edit task"}
+        aria-label={heading}
       >
         <header className="flex items-center gap-2.5 border-b border-border/60 px-5 py-4">
           <span aria-hidden className="h-2 w-2 rounded-full" style={{ backgroundColor: accent }} />
-          <h2 className="rd-serif text-[22px] text-foreground">{isCreateMode ? "New task" : "Edit task"}</h2>
+          <h2 className="rd-serif text-[22px] text-foreground">{heading}</h2>
           {activeQuadrant ? (
             <span className="ml-1 text-[11px] font-semibold uppercase tracking-wider" style={{ color: accent }}>
               {activeQuadrant.title}
@@ -117,7 +127,7 @@ function EditDrawerForm({ task, initialDraft, allTasks = [], onClose, onSubmit }
             type="button"
             onClick={onClose}
             aria-label="Close"
-            className="touch-target ml-auto inline-flex h-8 w-8 items-center justify-center rounded-md text-foreground-muted hover:bg-background-muted"
+            className="touch-target ml-auto inline-flex h-8 w-8 items-center justify-center rounded-md text-foreground-muted hover:bg-background-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
           >
             <XIcon className="h-4 w-4" />
           </button>
@@ -130,7 +140,7 @@ function EditDrawerForm({ task, initialDraft, allTasks = [], onClose, onSubmit }
             value={draft.title}
             onChange={(e) => draft.setTitle(e.target.value)}
             placeholder="What needs doing?"
-            className="w-full rounded-lg border border-border bg-background px-3 py-3 text-[18px] font-medium text-foreground outline-none focus:border-foreground-muted placeholder:font-normal"
+            className="w-full rounded-lg border border-border bg-background px-3 py-3 text-[18px] font-medium text-foreground outline-none focus:border-foreground-muted focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 placeholder:font-normal"
             aria-label="Title"
           />
 
@@ -142,7 +152,7 @@ function EditDrawerForm({ task, initialDraft, allTasks = [], onClose, onSubmit }
               rows={4}
               placeholder="Optional details, links, context"
               aria-label="Description"
-              className="w-full resize-y rounded-lg border border-border bg-background px-3 py-2.5 text-[13.5px] leading-relaxed text-foreground outline-none focus:border-foreground-muted"
+              className="w-full resize-y rounded-lg border border-border bg-background px-3 py-2.5 text-[13.5px] leading-relaxed text-foreground outline-none focus:border-foreground-muted focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
             />
           </Field>
 

--- a/components/matrix-simplified/help-drawer.tsx
+++ b/components/matrix-simplified/help-drawer.tsx
@@ -75,21 +75,21 @@ export function HelpDrawer({ open, onClose }: HelpDrawerProps) {
           </Section>
 
           <Section label="The four quadrants">
-            <QuadrantLine rdKey="q1" title="Do First" hint="Urgent & important — crises, deadlines. Handle now." />
-            <QuadrantLine rdKey="q2" title="Schedule" hint="Important, not urgent — strategy, growth. Protect time." />
-            <QuadrantLine rdKey="q3" title="Delegate" hint="Urgent, not important — interruptions. Hand these off." />
-            <QuadrantLine rdKey="q4" title="Eliminate" hint="Neither — noise. Stop doing these." />
+            <QuadrantLine rdKey="q1" title="Do First" hint="Urgent & important: crises, deadlines. Handle now." />
+            <QuadrantLine rdKey="q2" title="Schedule" hint="Important, not urgent: strategy, growth. Protect time." />
+            <QuadrantLine rdKey="q3" title="Delegate" hint="Urgent, not important: interruptions. Hand these off." />
+            <QuadrantLine rdKey="q4" title="Eliminate" hint="Neither: noise. Stop doing these." />
           </Section>
 
           <Section label="Quick-add smart syntax">
             <p style={bodyStyle}>
-              Type into the bar at the top. It parses priority markers from your text as you type — the dot on the left previews
+              Type into the bar at the top. It parses priority markers from your text as you type. The dot on the left previews
               which quadrant the task will land in.
             </p>
             <SyntaxRow symbol="!" meaning="Marks the task urgent" />
             <SyntaxRow symbol="!!" meaning="Urgent and important (Do First)" />
             <SyntaxRow symbol="*" meaning="Marks the task important" />
-            <SyntaxRow symbol="#tag" meaning="Adds a tag — any word-like token" />
+            <SyntaxRow symbol="#tag" meaning="Adds a tag (any word-like token)" />
             <p style={{ ...bodyStyle, color: "var(--ink-3)" }}>
               Example: <code style={codeStyle}>!! ship the deck #work #q2</code> creates an urgent + important task tagged{" "}
               <code style={codeStyle}>#work</code> and <code style={codeStyle}>#q2</code>.
@@ -113,15 +113,15 @@ export function HelpDrawer({ open, onClose }: HelpDrawerProps) {
 
           <Section label="Editing, completing, and drag-drop">
             <p style={bodyStyle}>
-              <strong>Complete</strong> — tap the checkbox on any task card. Recurring tasks automatically spawn the next instance.
+              <strong>Complete</strong>: tap the checkbox on any task card. Recurring tasks automatically spawn the next instance.
             </p>
             <p style={bodyStyle}>
-              <strong>Edit</strong> — click anywhere on a task card (except the checkbox) to open the composer pre-filled with that
-              task&rsquo;s details. Save to update, close without saving to cancel.
+              <strong>Edit</strong>: hover a task card and click the pencil to open the composer pre-filled with that
+              task&rsquo;s details. On a phone the pencil is always visible. Save to update, close without saving to cancel.
             </p>
             <p style={bodyStyle}>
-              <strong>Drag to reclassify</strong> — drag a task onto any other quadrant. An 8-pixel activation distance
-              means plain clicks still open the editor.
+              <strong>Drag to reclassify</strong>: drag a task onto any other quadrant. An 8-pixel activation distance
+              means a stray click never starts a drag.
             </p>
           </Section>
 

--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -20,6 +20,7 @@ import { ShareTaskDialog } from "@/components/share-task-dialog";
 import { AppShell } from "./app-shell";
 import { CaptureBar, type CapturePayload } from "./capture-bar";
 import { MatrixGrid } from "./matrix-grid";
+import { MatrixGridSkeleton } from "./matrix-grid-skeleton";
 import { EditDrawer, type EditDraft } from "./edit-drawer";
 import { SmartViewStrip } from "./smart-view-strip";
 import { deriveMatrixView } from "./matrix-view";
@@ -129,7 +130,7 @@ async function handleToggle(task: TaskRecord, completedNext: boolean): Promise<v
 }
 
 export function MatrixSimplified() {
-  const { all } = useTasks();
+  const { all, isLoading } = useTasks();
   const { handleError, handleSuccess } = useErrorHandlerWithUndo();
   const { sensors, activeId, handleDragStart, handleDragEnd } = useDragAndDrop(handleError);
 
@@ -297,17 +298,21 @@ export function MatrixSimplified() {
             </div>
           ) : null}
         </div>
-        <MatrixGrid
-          tasks={visibleTasks}
-          allTasks={all}
-          onEdit={handleEditOpen}
-          onToggleComplete={handleToggle}
-          onDelete={handleDelete}
-          onShare={handleShareOpen}
-          onAddInQuadrant={handleAddInQuadrant}
-          highlightedTaskId={highlightedTaskId}
-          onTaskRef={handleTaskRef}
-        />
+        {isLoading ? (
+          <MatrixGridSkeleton />
+        ) : (
+          <MatrixGrid
+            tasks={visibleTasks}
+            allTasks={all}
+            onEdit={handleEditOpen}
+            onToggleComplete={handleToggle}
+            onDelete={handleDelete}
+            onShare={handleShareOpen}
+            onAddInQuadrant={handleAddInQuadrant}
+            highlightedTaskId={highlightedTaskId}
+            onTaskRef={handleTaskRef}
+          />
+        )}
       </AppShell>
 
       <ShareTaskDialog

--- a/components/matrix-simplified/matrix-grid-skeleton.tsx
+++ b/components/matrix-simplified/matrix-grid-skeleton.tsx
@@ -1,0 +1,73 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { quadrants } from "@/lib/quadrants";
+import { QUADRANT_ACCENT } from "@/lib/quadrants";
+import { cn } from "@/lib/utils";
+
+const WASH_CLASS = ["quadrant-wash-q1", "quadrant-wash-q2", "quadrant-wash-q3", "quadrant-wash-q4"];
+const POSITION_RULES = [
+  "",
+  "lg:border-l lg:border-border",
+  "lg:border-t lg:border-border",
+  "lg:border-l lg:border-t lg:border-border",
+];
+
+/** Card placeholder counts per pane. Uneven on purpose — four identical columns
+ *  read as a loading *pattern* rather than a preview of the real layout. */
+const CARD_COUNT = [3, 2, 2, 1];
+
+/**
+ * Loading state for the matrix.
+ *
+ * Geometry mirrors <MatrixGrid> exactly (same grid wrapper, pane borders, wash,
+ * quadrant rule and header row) so the swap to real content doesn't shift
+ * layout. It exists because the empty states assert something specific —
+ * "Nothing on fire." — which must not be shown before the read completes.
+ */
+export function MatrixGridSkeleton() {
+  return (
+    <div
+      data-testid="matrix-grid-skeleton"
+      role="status"
+      aria-busy="true"
+      aria-label="Loading tasks"
+      className="grid grid-cols-1 gap-8 lg:grid-cols-2 lg:grid-rows-2 lg:gap-0 lg:overflow-hidden lg:rounded-xl lg:border lg:border-border lg:bg-card lg:shadow-sm"
+    >
+      {quadrants.map((meta, index) => (
+        <section
+          key={meta.id}
+          className={cn(
+            "relative flex min-h-[280px] flex-col rounded-xl border border-border p-5",
+            WASH_CLASS[index],
+            "lg:rounded-none lg:border-0",
+            POSITION_RULES[index]
+          )}
+        >
+          {/* The quadrant rule stays at full pigment: it is structure, not
+              content, and is known before the data loads. */}
+          <span
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 top-0 z-[1] h-[3px]"
+            style={{
+              backgroundColor: QUADRANT_ACCENT[meta.rdKey],
+              borderTopLeftRadius: "inherit",
+              borderTopRightRadius: "inherit",
+            }}
+          />
+          <header className="-mx-5 -mt-5 mb-4 flex items-center gap-1.5 border-b border-border-muted px-5 py-3">
+            <Skeleton className="h-[18px] w-[18px] rounded-md" />
+            <Skeleton className="h-3.5 w-20" />
+            <Skeleton className="ml-auto h-3.5 w-6 rounded" />
+          </header>
+          <div className="flex flex-1 flex-col gap-2">
+            {Array.from({ length: CARD_COUNT[index] }).map((_, i) => (
+              <div key={i} className="rounded-lg border border-card-border bg-card p-3">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="mt-2 h-3.5 w-14 rounded-full" />
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/components/matrix-simplified/quadrant-pane.tsx
+++ b/components/matrix-simplified/quadrant-pane.tsx
@@ -6,7 +6,7 @@ import { PlusIcon, FlameIcon, CalendarIcon, UsersIcon, Trash2Icon, type LucideIc
 import { TaskCard } from "@/components/task-card";
 import type { TaskRecord } from "@/lib/types";
 import type { QuadrantMeta, RedesignQuadrantKey, RedesignIconKey } from "@/lib/quadrants";
-import { QUADRANT_ACCENT } from "@/lib/quadrants";
+import { QUADRANT_ACCENT, QUADRANT_INK } from "@/lib/quadrants";
 import { cn } from "@/lib/utils";
 
 const RD_ICON: Record<RedesignIconKey, LucideIcon> = {
@@ -71,6 +71,7 @@ export function QuadrantPane({
 }: QuadrantPaneProps) {
   const { setNodeRef, isOver } = useDroppable({ id: meta.id });
   const accent = QUADRANT_ACCENT[meta.rdKey];
+  const ink = QUADRANT_INK[meta.rdKey];
   const QuadrantIcon = RD_ICON[meta.rdIcon];
   const taskIds = tasks.map((t) => t.id);
   const activeTaskCount = tasks.reduce((count, task) => count + (task.completed ? 0 : 1), 0);
@@ -121,7 +122,7 @@ export function QuadrantPane({
         </span>
         <span
           className="rd-serif text-[15px] font-semibold leading-none"
-          style={{ color: accent, letterSpacing: "-0.005em" }}
+          style={{ color: ink, letterSpacing: "-0.005em" }}
         >
           {meta.title}
         </span>
@@ -133,7 +134,7 @@ export function QuadrantPane({
           type="button"
           onClick={() => onAddInQuadrant(meta.rdKey)}
           aria-label={`Add to ${meta.title}`}
-          className="touch-target inline-flex h-7 w-7 items-center justify-center rounded-md text-foreground-muted hover:bg-background-muted hover:text-foreground"
+          className="touch-target inline-flex h-7 w-7 items-center justify-center rounded-md text-foreground-muted hover:bg-background-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
         >
           <PlusIcon className="h-3.5 w-3.5" />
         </button>
@@ -153,12 +154,12 @@ export function QuadrantPane({
                 <QuadrantIcon className="h-6 w-6" />
               </span>
               <p
-                className="rd-serif text-[18px] leading-tight text-foreground"
+                className="rd-serif text-balance text-[18px] leading-tight text-foreground"
                 style={{ letterSpacing: "-0.01em" }}
               >
                 {meta.rdEmptyHeadline}
               </p>
-              <p className="max-w-[26ch] text-caption text-foreground-muted">
+              <p className="max-w-[26ch] text-pretty text-caption text-foreground-muted">
                 {meta.rdEmptySupporting}
               </p>
               {/* Eliminate is the one quadrant where an empty state needs no action
@@ -167,7 +168,7 @@ export function QuadrantPane({
                 <button
                   type="button"
                   onClick={() => onAddInQuadrant(meta.rdKey)}
-                  className="mt-2 inline-flex items-center gap-1.5 rounded-full border border-dashed px-2.5 py-1 text-[11px] font-medium transition-colors hover:bg-background-muted/40"
+                  className="mt-2 inline-flex items-center gap-1.5 rounded-full border border-dashed px-2.5 py-1 text-[11px] font-medium transition-colors hover:bg-background-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
                   style={{ borderColor: accent, color: accent }}
                 >
                   <PlusIcon className="h-3 w-3" aria-hidden />

--- a/components/matrix-simplified/smart-view-strip.tsx
+++ b/components/matrix-simplified/smart-view-strip.tsx
@@ -10,7 +10,28 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { SMART_VIEW_ICONS, type SmartViewIconKey } from "@/lib/smart-views/icons";
 import { useSmartViewOverflow } from "./use-smart-view-overflow";
+
+/**
+ * Renders a view's icon. Built-ins name a Lucide glyph; a custom view saved
+ * before the registry existed may still hold a raw character, which we render
+ * as-is rather than dropping the user's choice on the floor.
+ *
+ * The glyph is read as a direct member of the module-level registry rather than
+ * through a helper call: react-hooks/static-components cannot see through a
+ * function boundary and treats the returned type as a component minted during
+ * render, which would (wrongly) imply remounting on every keystroke.
+ */
+function SmartViewIcon({ icon }: { icon?: string }) {
+  if (!icon) return null;
+  const Glyph = SMART_VIEW_ICONS[icon as SmartViewIconKey];
+  return Glyph ? (
+    <Glyph className="h-3.5 w-3.5 shrink-0" aria-hidden />
+  ) : (
+    <span aria-hidden>{icon}</span>
+  );
+}
 
 interface SmartViewStripProps {
   views: SmartView[];
@@ -20,8 +41,11 @@ interface SmartViewStripProps {
 }
 
 /** Shared pill geometry so inline pills, the More button, and the ghost match. */
+// `touch-target` opts the pills into the 44px floor on coarse pointers. At 36px
+// they were the only interactive controls on the matrix without it, and they sit
+// in a horizontally scrolling row where a mis-tap changes the whole view.
 const PILL_BASE =
-  "inline-flex h-9 shrink-0 items-center gap-1.5 rounded-full border px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2";
+  "touch-target inline-flex h-9 shrink-0 items-center gap-1.5 rounded-full border px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2";
 
 function pillVariant(active: boolean): string {
   // Editorial chrome: selection is a neutral sunken fill + ink, not a tinted pill.
@@ -126,7 +150,7 @@ function SmartViewButton({
       aria-pressed={active}
       className={cn(PILL_BASE, pillVariant(active))}
     >
-      {icon ? <span aria-hidden>{icon}</span> : null}
+      <SmartViewIcon icon={icon} />
       <span>{label}</span>
     </button>
   );
@@ -186,7 +210,7 @@ export function SmartViewOverflowMenu({
               aria-current={isActive ? "true" : undefined}
               className={cn("gap-2", isActive && "bg-background-muted text-foreground")}
             >
-              {view.icon ? <span aria-hidden>{view.icon}</span> : null}
+              <SmartViewIcon icon={view.icon} />
               <span className="flex-1">{view.name}</span>
               {isActive ? <CheckIcon className="h-3.5 w-3.5 text-foreground-muted" aria-hidden /> : null}
             </DropdownMenuItem>

--- a/components/task-card/index.tsx
+++ b/components/task-card/index.tsx
@@ -39,11 +39,11 @@ export function TaskCard({
   const isBlocked = blockingTasks.length > 0;
   const isBlocking = blockedTasks.length > 0;
 
-  // The card carries its quadrant's pigment (spine, completion disc, tag chips,
-  // subtask fill) so the four-color matrix language reads on every surface.
+  // The card carries its quadrant's pigment (spine, completion disc, subtask
+  // fill) so the four-color matrix language reads on every surface. Tags are
+  // deliberately excluded — see the note in TaskCardMetadata.
   const quadrant = quadrantForTask(task.urgent, task.important);
   const accentVar = QUADRANT_ACCENT[quadrant.rdKey];
-  const washVar = `var(--${quadrant.rdKey}-wash)`;
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: task.id,
@@ -78,7 +78,15 @@ export function TaskCard({
         // Clear the sticky topbar + capture bar (plus ~12pt) when scrolled to.
         "scroll-mt-24",
         "border-card-border",
-        task.completed ? "opacity-60" : "opacity-100 hover:-translate-y-0.5 hover:border-accent/40",
+        // focus-within, not focus-visible: the article is tabIndex={-1} and is
+        // only ever focused programmatically (scroll-to-highlight), and
+        // :focus-visible does not match programmatic focus — a ring here would
+        // be dead CSS. focus-within gives a keyboard user tabbing into the card
+        // the same row-highlight a mouse user gets on hover.
+        // ui-craft-detect-ignore-next-line
+        task.completed
+          ? "opacity-60"
+          : "opacity-100 hover:-translate-y-0.5 hover:border-accent/40 focus-within:border-accent/40",
         !task.completed && isBlocked && "opacity-[0.62]",
         task.completed && "animate-complete-flash",
         isDragging && "cursor-grabbing",
@@ -105,6 +113,7 @@ export function TaskCard({
       <TaskCardHeader
         task={task}
         accentVar={accentVar}
+        reserveBadgeSpace={taskIsOverdue}
         selectionMode={selectionMode}
         isSelected={isSelected}
         onToggleSelect={onToggleSelect}
@@ -116,7 +125,6 @@ export function TaskCard({
       <TaskCardMetadata
         task={task}
         accentVar={accentVar}
-        washVar={washVar}
         completedSubtasks={completedSubtasks}
         totalSubtasks={totalSubtasks}
         isBlocked={isBlocked}

--- a/components/task-card/task-card-actions.tsx
+++ b/components/task-card/task-card-actions.tsx
@@ -97,7 +97,7 @@ function DesktopActions({ task, onEdit, onDelete, onShare, onDuplicate, onSnooze
             <button
               type="button"
               onClick={() => onShare(task)}
-              className="rounded px-1.5 py-0.5 flex items-center justify-center hover:bg-background-muted hover:text-foreground transition-colors"
+              className="rounded px-1.5 py-0.5 flex items-center justify-center hover:bg-background-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent transition-colors"
               aria-label="Share task"
             >
               <Share2Icon className="h-3 w-3" />
@@ -112,7 +112,7 @@ function DesktopActions({ task, onEdit, onDelete, onShare, onDuplicate, onSnooze
             <button
               type="button"
               onClick={() => onDuplicate(task)}
-              className="rounded px-1.5 py-0.5 flex items-center justify-center hover:bg-background-muted hover:text-foreground transition-colors"
+              className="rounded px-1.5 py-0.5 flex items-center justify-center hover:bg-background-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent transition-colors"
               aria-label="Duplicate task"
             >
               <CopyIcon className="h-3 w-3" />
@@ -130,7 +130,7 @@ function DesktopActions({ task, onEdit, onDelete, onShare, onDuplicate, onSnooze
             data-testid="edit-task"
             type="button"
             onClick={() => onEdit(task)}
-            className="rounded px-1.5 py-0.5 flex items-center justify-center hover:bg-background-muted hover:text-foreground transition-colors"
+            className="rounded px-1.5 py-0.5 flex items-center justify-center hover:bg-background-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent transition-colors"
             aria-label="Edit task"
           >
             <PencilIcon className="h-3 w-3" />
@@ -140,11 +140,16 @@ function DesktopActions({ task, onEdit, onDelete, onShare, onDuplicate, onSnooze
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>
+          {/* Delete is undoable, not confirmed: the handler pairs it with a
+              faithful Undo toast that restores the exact original record
+              (matrix-simplified/index.tsx). review.md's Interaction Audit takes
+              "confirmed OR Undo provided"; the detector cannot see the toast. */}
+          {/* ui-craft-detect-ignore-next-line */}
           <button
             data-testid="delete-task"
             type="button"
             onClick={() => onDelete(task)}
-            className="rounded px-1.5 py-0.5 flex items-center justify-center text-rust hover:bg-rust-tint hover:text-rust-d transition-colors"
+            className="rounded px-1.5 py-0.5 flex items-center justify-center text-rust hover:bg-rust-tint hover:text-rust-d focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rust transition-colors"
             aria-label="Delete task"
           >
             <Trash2Icon className="h-3 w-3" />
@@ -171,7 +176,7 @@ function MobileActions({ task, onEdit, onDelete, onShare, onDuplicate }: MobileA
         data-testid="edit-task-mobile"
         type="button"
         onClick={() => onEdit(task)}
-        className="rounded p-2 min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-background-muted hover:text-foreground touch-manipulation transition-colors"
+        className="rounded p-2 min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-background-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent touch-manipulation transition-colors"
         aria-label="Edit task"
       >
         <PencilIcon className="h-4 w-4" />
@@ -181,7 +186,7 @@ function MobileActions({ task, onEdit, onDelete, onShare, onDuplicate }: MobileA
           <button
             data-testid="task-card-menu"
             type="button"
-            className="rounded p-2 min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-background-muted hover:text-foreground touch-manipulation transition-colors"
+            className="rounded p-2 min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-background-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent touch-manipulation transition-colors"
             aria-label="More actions"
           >
             <MoreHorizontalIcon className="h-4 w-4" />

--- a/components/task-card/task-card-header.tsx
+++ b/components/task-card/task-card-header.tsx
@@ -12,6 +12,9 @@ export interface TaskCardHeaderProps {
   task: TaskRecord;
   /** CSS var for the task's quadrant pigment, e.g. "var(--q1)". */
   accentVar: string;
+  /** Reserves room for the absolutely-positioned overdue badge so a long title
+   *  truncates instead of rendering underneath it. */
+  reserveBadgeSpace?: boolean;
   selectionMode?: boolean;
   isSelected?: boolean;
   onToggleSelect?: (task: TaskRecord) => void;
@@ -23,6 +26,7 @@ export interface TaskCardHeaderProps {
 export function TaskCardHeader({
   task,
   accentVar,
+  reserveBadgeSpace,
   selectionMode,
   isSelected,
   onToggleSelect,
@@ -74,7 +78,7 @@ export function TaskCardHeader({
         ) : (
           <button
             type="button"
-            className="touch-target cursor-grab touch-none shrink-0 rounded p-1.5 opacity-0 transition group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-background-muted"
+            className="touch-target cursor-grab touch-none shrink-0 rounded p-1.5 opacity-0 transition group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-background-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             aria-label="Drag to move task"
             {...sortableAttributes}
             {...sortableListeners}
@@ -82,7 +86,7 @@ export function TaskCardHeader({
             <GripVerticalIcon className="h-4 w-4 text-foreground-muted" />
           </button>
         )}
-        <div className="min-w-0 flex-1">
+        <div className={cn("min-w-0 flex-1", reserveBadgeSpace && "pr-24")}>
           <h3 className={cn(
             "text-[15px] font-semibold leading-snug tracking-tight text-foreground truncate",
             task.completed && "line-through"
@@ -110,7 +114,7 @@ export function TaskCardHeader({
             className={cn(
               // active:scale-95 gives the completion toggle — the card's key
               // moment — a tactile down-press to pair with the check-pop on release.
-              "button-reset touch-target relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border transition-all duration-200 active:scale-95 sm:h-9 sm:w-9",
+              "button-reset touch-target relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border transition-[background-color,border-color,color,box-shadow,transform] duration-200 active:scale-95 sm:h-9 sm:w-9",
               task.completed
                 ? "shadow-sm"
                 : "border-border bg-background/90 text-foreground-muted shadow-sm shadow-black/[0.04] hover:border-accent hover:text-accent hover:bg-accent/5 hover:scale-105 hover:shadow-accent/10"

--- a/components/task-card/task-card-metadata.tsx
+++ b/components/task-card/task-card-metadata.tsx
@@ -9,8 +9,6 @@ export interface TaskCardMetadataProps {
   task: TaskRecord;
   /** CSS var for the task's quadrant pigment, e.g. "var(--q1)". */
   accentVar: string;
-  /** CSS var for the quadrant wash, e.g. "var(--q1-wash)". */
-  washVar: string;
   completedSubtasks: number;
   totalSubtasks: number;
   isBlocked: boolean;
@@ -24,7 +22,6 @@ export interface TaskCardMetadataProps {
 export function TaskCardMetadata({
   task,
   accentVar,
-  washVar,
   completedSubtasks,
   totalSubtasks,
   isBlocked,
@@ -37,15 +34,18 @@ export function TaskCardMetadata({
   const subtasksDone = totalSubtasks > 0 && completedSubtasks === totalSubtasks;
   return (
     <>
-      {/* Tags — quadrant-wash chips with quadrant-accent text (reference §06) */}
+      {/* Tags read neutral. Tinting them with the quadrant pigment restated a
+          fact the pane, header, and card spine already carry three times over,
+          and it mis-signalled: it implied the *tag* meant something about
+          urgency when "infra" and "home" are orthogonal to the matrix. Color
+          on this surface means quadrant, and only quadrant. */}
       {task.tags.length > 0 ? (
         <div className="flex flex-wrap gap-1">
           {task.tags.map((tag) => (
             <span
               key={tag}
               data-testid="task-tag"
-              style={{ backgroundColor: washVar, color: accentVar }}
-              className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
+              className="inline-flex items-center rounded-full bg-background-muted px-2 py-0.5 text-[11px] font-medium text-foreground-muted"
             >
               {tag}
             </span>
@@ -57,13 +57,18 @@ export function TaskCardMetadata({
       {totalSubtasks > 0 ? (
         <div className="flex items-center gap-2 text-xs">
           <div className="flex-1 h-1.5 rounded-full bg-background-muted/80 overflow-hidden">
+            {/* Fill scales on the compositor rather than animating `width`:
+                a width transition relayouts every frame, and listing it
+                explicitly would only trade one detector finding for another.
+                300ms keeps it inside the 100-400ms UI transition band. */}
             <div
+              data-testid="subtask-progress-fill"
               className={cn(
-                "h-full rounded-full transition-all duration-500",
+                "h-full w-full origin-left rounded-full transition-transform duration-300",
                 subtasksDone && "bg-status-success"
               )}
               style={{
-                width: `${(completedSubtasks / totalSubtasks) * 100}%`,
+                transform: `scaleX(${completedSubtasks / totalSubtasks})`,
                 backgroundColor: subtasksDone ? undefined : accentVar,
               }}
             />

--- a/lib/command-actions.ts
+++ b/lib/command-actions.ts
@@ -199,7 +199,9 @@ export function buildCommandActions(
   builtInSmartViews.forEach((view) => {
     actions.push({
       id: `view-${view.id}`,
-      label: `${view.icon || '📋'} ${view.name}`,
+      // Name only — a glyph concatenated here is read aloud by screen readers
+      // and dilutes fuzzy-match scoring. Icons belong in the item's icon slot.
+      label: view.name,
       section: 'views',
       keywords: [
         view.name.toLowerCase(),

--- a/lib/quadrants.ts
+++ b/lib/quadrants.ts
@@ -12,6 +12,17 @@ export const QUADRANT_ACCENT: Record<RedesignQuadrantKey, string> = {
   q4: "var(--q4)",
 };
 
+/** Text-safe pigment for quadrant *titles*. Equals the pigment except where the
+ *  pigment misses WCAG AA on its own header tint (ochre, light mode) — see the
+ *  --q*-ink block in app/globals.css. Use QUADRANT_ACCENT for fills, rules, and
+ *  spines; use this only where the pigment is set as text color. */
+export const QUADRANT_INK: Record<RedesignQuadrantKey, string> = {
+  q1: "var(--q1-ink)",
+  q2: "var(--q2-ink)",
+  q3: "var(--q3-ink)",
+  q4: "var(--q4-ink)",
+};
+
 /** Same palette keyed by QuadrantId for components that reference the long-form id. */
 export const QUADRANT_ACCENT_BY_ID: Record<QuadrantId, string> = {
   "urgent-important": "var(--q1)",

--- a/lib/smart-views/built-in.ts
+++ b/lib/smart-views/built-in.ts
@@ -13,8 +13,8 @@ import type { SmartView } from "@/lib/filters";
 export const BUILT_IN_SMART_VIEWS: Omit<SmartView, 'id' | 'createdAt' | 'updatedAt'>[] = [
   {
     name: "Today's Focus",
-    description: "All urgent and important tasks - your top priorities",
-    icon: "🎯",
+    description: "All urgent and important tasks, your top priorities",
+    icon: "flame",
     isBuiltIn: true,
     criteria: {
       status: 'active',
@@ -24,7 +24,7 @@ export const BUILT_IN_SMART_VIEWS: Omit<SmartView, 'id' | 'createdAt' | 'updated
   {
     name: "This Week",
     description: "Tasks needing attention this week (overdue + next 7 days)",
-    icon: "📅",
+    icon: "calendar",
     isBuiltIn: true,
     criteria: {
       status: 'active',
@@ -34,7 +34,7 @@ export const BUILT_IN_SMART_VIEWS: Omit<SmartView, 'id' | 'createdAt' | 'updated
   {
     name: "Overdue Backlog",
     description: "All overdue tasks across quadrants",
-    icon: "⚠️",
+    icon: "overdue",
     isBuiltIn: true,
     criteria: {
       status: 'active',
@@ -44,7 +44,7 @@ export const BUILT_IN_SMART_VIEWS: Omit<SmartView, 'id' | 'createdAt' | 'updated
   {
     name: "No Deadline",
     description: "Tasks without due dates for planning",
-    icon: "📋",
+    icon: "no-deadline",
     isBuiltIn: true,
     criteria: {
       status: 'active',
@@ -54,7 +54,7 @@ export const BUILT_IN_SMART_VIEWS: Omit<SmartView, 'id' | 'createdAt' | 'updated
   {
     name: "Recently Added",
     description: "Tasks created in the last 7 days",
-    icon: "✨",
+    icon: "added",
     isBuiltIn: true,
     criteria: {
       status: 'active',
@@ -64,7 +64,7 @@ export const BUILT_IN_SMART_VIEWS: Omit<SmartView, 'id' | 'createdAt' | 'updated
   {
     name: "This Week's Wins",
     description: "Completed tasks from the last 7 days",
-    icon: "🏆",
+    icon: "completed-recent",
     isBuiltIn: true,
     criteria: {
       status: 'completed',
@@ -74,7 +74,7 @@ export const BUILT_IN_SMART_VIEWS: Omit<SmartView, 'id' | 'createdAt' | 'updated
   {
     name: "All Completed",
     description: "All completed tasks across all time",
-    icon: "✅",
+    icon: "completed",
     isBuiltIn: true,
     criteria: {
       status: 'completed'
@@ -83,7 +83,7 @@ export const BUILT_IN_SMART_VIEWS: Omit<SmartView, 'id' | 'createdAt' | 'updated
   {
     name: "Recurring Tasks",
     description: "All tasks with recurrence enabled",
-    icon: "🔁",
+    icon: "recurring",
     isBuiltIn: true,
     criteria: {
       status: 'active',
@@ -92,8 +92,8 @@ export const BUILT_IN_SMART_VIEWS: Omit<SmartView, 'id' | 'createdAt' | 'updated
   },
   {
     name: "Ready to Work",
-    description: "Tasks with no blocking dependencies - start now!",
-    icon: "🚀",
+    description: "Tasks with no blocking dependencies",
+    icon: "ready",
     isBuiltIn: true,
     criteria: {
       status: 'active',

--- a/lib/smart-views/icons.ts
+++ b/lib/smart-views/icons.ts
@@ -1,0 +1,44 @@
+/**
+ * Smart View icon registry.
+ *
+ * `SmartView.icon` is a free-form string on the persisted record, so custom
+ * views created before this registry existed may still carry a raw glyph. The
+ * built-ins name a key here instead: the matrix draws all of its chrome with
+ * Lucide, and a pictograph in the middle of that set reads as a different
+ * product (PRODUCT.md anti-reference: "a gamified todo toy").
+ *
+ * Consumers index this map directly and fall back to rendering the raw string
+ * when it isn't a known key, so legacy custom icons keep working. Index it
+ * inline rather than wrapping it in a resolver: react-hooks/static-components
+ * cannot see through a function boundary and flags the returned component as
+ * one created during render.
+ */
+
+import {
+  AlertTriangleIcon,
+  CalendarCheckIcon,
+  CalendarDaysIcon,
+  CalendarOffIcon,
+  CircleCheckIcon,
+  CirclePlusIcon,
+  FlameIcon,
+  PlayIcon,
+  RepeatIcon,
+  type LucideIcon,
+} from "lucide-react";
+
+export const SMART_VIEW_ICONS = {
+  // Mirrors the Q1 pane glyph — this view *is* the urgent-and-important
+  // quadrant, so reusing its mark ties the filter to the matrix it filters.
+  flame: FlameIcon,
+  calendar: CalendarDaysIcon,
+  overdue: AlertTriangleIcon,
+  "no-deadline": CalendarOffIcon,
+  added: CirclePlusIcon,
+  "completed-recent": CalendarCheckIcon,
+  completed: CircleCheckIcon,
+  recurring: RepeatIcon,
+  ready: PlayIcon,
+} as const satisfies Record<string, LucideIcon>;
+
+export type SmartViewIconKey = keyof typeof SMART_VIEW_ICONS;

--- a/lib/use-tasks.ts
+++ b/lib/use-tasks.ts
@@ -34,6 +34,10 @@ export function keepValidTaskRecords(rows: TaskRecord[]): TaskRecord[] {
 }
 
 export function useTasks(): TaskBuckets {
+  // No default result. Supplying one (previously `[]`) makes useLiveQuery return
+  // synchronously on first render, which pinned `isLoading` to false forever and
+  // made every consumer's skeleton dead code — the matrix painted four "nothing
+  // here" empty states before IndexedDB had been read.
   const result = useLiveQuery(async () => {
     if (typeof window === "undefined") {
       return [] as TaskRecord[];
@@ -42,7 +46,7 @@ export function useTasks(): TaskBuckets {
     const rows = await db.tasks.toArray();
     const valid = keepValidTaskRecords(rows);
     return valid.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
-  }, [], []);
+  }, []);
 
   const isLoading = result === undefined;
   const tasks = result ?? [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "10.4.1",
+	"version": "10.5.1",
 	"private": true,
 	"type": "module",
 	"scripts": {
@@ -25,7 +25,7 @@
 		"@dnd-kit/core": "6.3.1",
 		"@dnd-kit/sortable": "10.0.0",
 		"@dnd-kit/utilities": "3.2.2",
-		"@openai/codex-security": "^0.1.1",
+		"@openai/codex-security": "^0.1.4",
 		"@radix-ui/react-dialog": "1.1.20",
 		"@radix-ui/react-dropdown-menu": "2.1.22",
 		"@radix-ui/react-icons": "1.3.2",
@@ -53,7 +53,7 @@
 		"zod": "4.4.3"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.62.0",
+		"@playwright/test": "^1.62.1",
 		"@tailwindcss/postcss": "4.3.3",
 		"@testing-library/dom": "10.4.1",
 		"@testing-library/jest-dom": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "10.5.1",
+	"version": "10.6.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '10.4.1';
+const CACHE_VERSION = '10.5.1';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '10.5.1';
+const CACHE_VERSION = '10.6.0';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 

--- a/tests/data/command-actions.test.ts
+++ b/tests/data/command-actions.test.ts
@@ -164,14 +164,27 @@ describe('buildCommandActions', () => {
     }
   });
 
-  it('should use default icon for smart views without one', () => {
+  // The label is the searchable, screen-reader-visible string — an icon glyph
+  // concatenated into it read out as "clipboard No Icon View" and polluted
+  // fuzzy-match scoring. Icons belong in the item's icon slot, not its label.
+  it('should label smart views by name alone, with no icon glyph', () => {
     const smartViews = [
       { id: 'no-icon', name: 'No Icon View', criteria: {} as FilterCriteria },
     ];
 
     const actions = buildCommandActions(createMockHandlers(), smartViews, defaultConditions);
     const viewAction = actions.find((a: CommandAction) => a.id === 'view-no-icon');
-    expect(viewAction!.label).toContain('📋');
+    expect(viewAction!.label).toBe('No Icon View');
+  });
+
+  it('should not embed an emoji in a smart view label', () => {
+    const smartViews = [
+      { id: 'today', name: 'Due Today', icon: '📅', criteria: {} as FilterCriteria },
+    ];
+
+    const actions = buildCommandActions(createMockHandlers(), smartViews, defaultConditions);
+    const viewAction = actions.find((a: CommandAction) => a.id === 'view-today');
+    expect(viewAction!.label).not.toMatch(/\p{Extended_Pictographic}/u);
   });
 
   // Migrated from the former tests/data/final-coverage-push.test.ts (finding F2.1).

--- a/tests/data/smart-views-built-in.test.ts
+++ b/tests/data/smart-views-built-in.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { BUILT_IN_SMART_VIEWS } from '@/lib/smart-views/built-in';
+import { SMART_VIEW_ICONS } from '@/lib/smart-views/icons';
 
 describe('BUILT_IN_SMART_VIEWS', () => {
   it('exports an array of smart views', () => {
@@ -76,6 +77,29 @@ describe('BUILT_IN_SMART_VIEWS', () => {
     const names = BUILT_IN_SMART_VIEWS.map(v => v.name);
     const uniqueNames = new Set(names);
     expect(uniqueNames.size).toBe(names.length);
+  });
+
+  // PRODUCT.md anti-reference: "a gamified todo toy". Emoji as feature icons is
+  // the loudest tell; the rest of the app draws its chrome with the Lucide set.
+  // `icon` stays a string (custom user views may still carry one) but built-ins
+  // name a Lucide glyph instead of embedding a pictograph.
+  it('no built-in view uses an emoji icon', () => {
+    for (const view of BUILT_IN_SMART_VIEWS) {
+      expect(view.icon).not.toMatch(/\p{Extended_Pictographic}/u);
+    }
+  });
+
+  it('every built-in icon resolves to a known Lucide glyph', () => {
+    for (const view of BUILT_IN_SMART_VIEWS) {
+      expect(SMART_VIEW_ICONS).toHaveProperty(view.icon as string);
+    }
+  });
+
+  // "start now!" — PRODUCT.md voice: no exclamation-point cheerleading.
+  it('no built-in description uses exclamation-point cheerleading', () => {
+    for (const view of BUILT_IN_SMART_VIEWS) {
+      expect(view.description ?? '').not.toContain('!');
+    }
   });
 });
 

--- a/tests/data/use-tasks.test.ts
+++ b/tests/data/use-tasks.test.ts
@@ -1,6 +1,19 @@
 import { describe, it, expect, vi } from 'vitest';
-import { keepValidTaskRecords } from '@/lib/use-tasks';
+import { renderHook } from '@testing-library/react';
+import { keepValidTaskRecords, useTasks } from '@/lib/use-tasks';
 import type { TaskRecord } from '@/lib/types';
+
+// Mirrors dexie-react-hooks' real contract: useLiveQuery(querier, deps, default)
+// returns `default` synchronously when one is supplied, and `undefined` until
+// the promise resolves when one is not. Passing a default therefore makes an
+// `isLoading` derived from `=== undefined` permanently false.
+const liveQueryResult = vi.hoisted(() => ({ resolved: undefined as TaskRecord[] | undefined }));
+vi.mock('dexie-react-hooks', () => ({
+  useLiveQuery: (_querier: unknown, _deps: unknown, defaultResult?: unknown) =>
+    liveQueryResult.resolved ?? defaultResult,
+}));
+
+vi.mock('@/lib/db', () => ({ getDb: () => ({ tasks: { toArray: async () => [] } }) }));
 
 // Mock logger so quarantine warnings don't produce side effects during tests.
 const mockWarn = vi.hoisted(() => vi.fn());
@@ -33,6 +46,34 @@ function buildTask(overrides?: Partial<TaskRecord>): TaskRecord {
     ...overrides,
   };
 }
+
+describe('useTasks loading state', () => {
+  // The matrix renders four empty states ("Nothing on fire.") while IndexedDB is
+  // still being read. That is a false statement about the user's data, so the
+  // hook must be able to say "not yet" — it cannot if it supplies a default.
+  it('reports isLoading while the live query has not resolved', () => {
+    liveQueryResult.resolved = undefined;
+    const { result } = renderHook(() => useTasks());
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.all).toEqual([]);
+  });
+
+  it('clears isLoading and buckets tasks once the query resolves', () => {
+    liveQueryResult.resolved = [buildTask({ id: 'a', quadrant: 'urgent-important', urgent: true, important: true })];
+    const { result } = renderHook(() => useTasks());
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.all).toHaveLength(1);
+    expect(result.current.byQuadrant['urgent-important']).toHaveLength(1);
+    liveQueryResult.resolved = undefined;
+  });
+
+  it('reports not-loading for an empty database, not loading-forever', () => {
+    liveQueryResult.resolved = [];
+    const { result } = renderHook(() => useTasks());
+    expect(result.current.isLoading).toBe(false);
+    liveQueryResult.resolved = undefined;
+  });
+});
 
 describe('keepValidTaskRecords', () => {
   it('passes valid records through unchanged', () => {

--- a/tests/ui/app-shell.test.tsx
+++ b/tests/ui/app-shell.test.tsx
@@ -145,7 +145,7 @@ describe("AppShell command palette wiring", () => {
       {
         id: "built-in-focus",
         name: "Today's Focus",
-        icon: "🎯",
+        icon: "flame",
         criteria: { status: "active" },
         isBuiltIn: true,
         createdAt: "2025-01-01T00:00:00.000Z",
@@ -162,7 +162,8 @@ describe("AppShell command palette wiring", () => {
     fireEvent.keyDown(document, { key: "k", metaKey: true });
 
     await waitFor(() => expect(screen.getByText("Smart Views")).toBeInTheDocument());
-    expect(screen.getByText("🎯 Today's Focus")).toBeInTheDocument();
+    // Label is the name alone; the glyph renders in the item's icon slot.
+    expect(screen.getByText("Today's Focus")).toBeInTheDocument();
   });
 
   it("navigates to /settings when Open settings is executed", async () => {

--- a/tests/ui/matrix-simplified.test.tsx
+++ b/tests/ui/matrix-simplified.test.tsx
@@ -5,7 +5,7 @@ import { renderToString } from "react-dom/server";
 import type { TaskRecord } from "@/lib/types";
 import type { SmartView } from "@/lib/filters";
 
-const tasksFixture = vi.hoisted(() => ({ current: [] as TaskRecord[] }));
+const tasksFixture = vi.hoisted(() => ({ current: [] as TaskRecord[], loading: false }));
 const smartViewsFixture = vi.hoisted(() => ({
   enabled: false,
   current: [] as SmartView[],
@@ -21,7 +21,7 @@ vi.mock("@/lib/use-tasks", () => ({
       "urgent-not-important": [],
       "not-urgent-not-important": [],
     },
-    isLoading: false,
+    isLoading: tasksFixture.loading,
   }),
 }));
 
@@ -129,6 +129,7 @@ import { celebrateCompletion } from "@/lib/confetti";
 describe("<MatrixSimplified>", () => {
   beforeEach(() => {
     tasksFixture.current = [];
+    tasksFixture.loading = false;
     smartViewsFixture.enabled = false;
     smartViewsFixture.current = [];
     localStorage.removeItem("gsd:show-completed");
@@ -142,6 +143,34 @@ describe("<MatrixSimplified>", () => {
     vi.mocked(deleteTask).mockClear();
     vi.mocked(restoreTask).mockClear();
     handleSuccessSpy.mockClear();
+  });
+
+  // The empty states make a specific claim ("Nothing on fire.") that must not be
+  // shown before IndexedDB has been read — a user with urgent tasks would see the
+  // app assert the opposite of the truth for the duration of the load.
+  describe("loading state", () => {
+    it("renders the skeleton, not the empty-state grid, while tasks are loading", () => {
+      tasksFixture.loading = true;
+      render(<MatrixSimplified />);
+      expect(screen.getByTestId("matrix-grid-skeleton")).toBeInTheDocument();
+      expect(screen.queryByTestId("matrix-grid")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("quadrant-empty-mark")).not.toBeInTheDocument();
+    });
+
+    it("exposes the skeleton to assistive tech as a busy status", () => {
+      tasksFixture.loading = true;
+      render(<MatrixSimplified />);
+      const sk = screen.getByTestId("matrix-grid-skeleton");
+      expect(sk).toHaveAttribute("role", "status");
+      expect(sk).toHaveAttribute("aria-busy", "true");
+    });
+
+    it("swaps to the real grid once loading resolves", () => {
+      tasksFixture.loading = false;
+      render(<MatrixSimplified />);
+      expect(screen.getByTestId("matrix-grid")).toBeInTheDocument();
+      expect(screen.queryByTestId("matrix-grid-skeleton")).not.toBeInTheDocument();
+    });
   });
 
   it("keeps the matrix single-column at tablet widths and merges it at large widths", () => {

--- a/tests/ui/smart-view-strip.test.tsx
+++ b/tests/ui/smart-view-strip.test.tsx
@@ -186,6 +186,39 @@ describe("<SmartViewOverflowMenu>", () => {
   });
 });
 
+describe("<SmartViewStrip> icons", () => {
+  const withIcon = (icon?: string): SmartView => ({ ...makeView("a", "Overdue Backlog"), icon });
+
+  // Scope every count to the visible pill row: the hidden ghost measurement row
+  // always renders a "More" chevron, so counting svg across the whole container
+  // passes no matter what the icon slot does.
+  const visibleGlyphs = () =>
+    screen.getByRole("group", { name: "Smart views" }).querySelectorAll("svg");
+
+  it("renders a registry key as an SVG glyph, not literal text", () => {
+    render(
+      <SmartViewStrip views={[withIcon("overdue")]} onSelectView={vi.fn()} onClearView={vi.fn()} />
+    );
+    expect(visibleGlyphs().length).toBe(1);
+    expect(screen.queryByText("overdue")).not.toBeInTheDocument();
+  });
+
+  // A custom view saved before the registry existed still holds a raw glyph.
+  it("falls back to rendering an unrecognized icon string as-is", () => {
+    render(
+      <SmartViewStrip views={[withIcon("✨")]} onSelectView={vi.fn()} onClearView={vi.fn()} />
+    );
+    expect(screen.getAllByText("✨").length).toBeGreaterThan(0);
+  });
+
+  it("renders no glyph when a view has no icon", () => {
+    render(
+      <SmartViewStrip views={[withIcon(undefined)]} onSelectView={vi.fn()} onClearView={vi.fn()} />
+    );
+    expect(visibleGlyphs().length).toBe(0);
+  });
+});
+
 describe("<SmartViewStrip>", () => {
   it("renders nothing when there are no views", () => {
     const { container } = render(

--- a/tests/ui/task-card-anatomy.test.tsx
+++ b/tests/ui/task-card-anatomy.test.tsx
@@ -50,6 +50,9 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenuItem: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
     <button onClick={onClick}>{children}</button>
   ),
+  // SnoozeDropdown renders these; it mounts whenever a task has a dueDate.
+  DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
 }));
 
 function renderCard(taskOverrides?: Partial<TaskRecord>, allTasks?: TaskRecord[]) {
@@ -99,13 +102,36 @@ describe("TaskCard anatomy — four-pigment language", () => {
     expect(disc.className).not.toContain("bg-status-success");
   });
 
-  it("renders tag chips in the quadrant wash + accent, not neutral gray", () => {
-    // q2 schedule with a tag
+  // Reverses the earlier "tag chips carry the quadrant pigment" rule. Tags are
+  // orthogonal to the matrix — "home" and "infra" say nothing about urgency —
+  // so tinting them implied a meaning they do not carry, and restated the
+  // quadrant a fifth time after the pane wash, header, rule, and spine. The
+  // spine and completion disc (asserted above) remain the card's pigment.
+  it("renders tag chips neutral, leaving pigment to mean quadrant only", () => {
     renderCard({ urgent: false, important: true, tags: ["work"] });
     const chip = screen.getByTestId("task-tag");
-    expect(chip.style.color).toBe("var(--q2)");
-    expect(chip.style.backgroundColor).toBe("var(--q2-wash)");
-    expect(chip.className).not.toContain("bg-background-muted");
+    expect(chip.style.color).toBe("");
+    expect(chip.style.backgroundColor).toBe("");
+    expect(chip.className).toContain("bg-background-muted");
+  });
+
+  // The overdue badge is absolutely positioned over the card's top-right. Without
+  // reserved space the title rendered *underneath* it (measured 39px of overlap
+  // at 1440px), so a long overdue title was partly unreadable. jsdom has no
+  // layout, so assert the reservation rather than the geometry.
+  it("reserves room for the overdue badge so the title truncates instead of colliding", () => {
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString();
+    renderCard({ dueDate: yesterday, completed: false });
+    const title = screen.getByRole("heading", { level: 3 });
+    expect(title.parentElement?.className).toContain("pr-24");
+    expect(title.className).toContain("truncate");
+  });
+
+  it("does not reserve badge space when the task is not overdue", () => {
+    const tomorrow = new Date(Date.now() + 86_400_000).toISOString();
+    renderCard({ dueDate: tomorrow, completed: false });
+    const title = screen.getByRole("heading", { level: 3 });
+    expect(title.parentElement?.className).not.toContain("pr-24");
   });
 
   it("dims a blocked (incomplete) card to 0.62 opacity", () => {


### PR DESCRIPTION
Bumps to **10.6.0**. Two commits, kept separate on purpose:

1. `chore(deps)` — a dependency bump that was already sitting uncommitted in my working tree (codex-security, playwright, version 10.5.1). Unrelated to the rest; committed on its own so it stays reviewable.
2. `feat(matrix)` — everything below.

## What changed and why

### The loading state (the one real bug)

The matrix rendered four empty states — "Nothing on fire.", "Plan the week." — before IndexedDB had been read. For anyone with saved tasks, the app briefly asserted the opposite of the truth.

`useLiveQuery` was passed a `[]` default, so it returned synchronously and `isLoading` was pinned `false` forever. `index.tsx` never read it anyway. It was dead for the **dashboard and settings pages too**, which already consumed it. Dropping the default makes it truthful and repairs all three surfaces.

Verified against the server-rendered HTML, where `isLoading` is necessarily true:

```
matrix-grid-skeleton in SSR HTML: True
matrix-grid (real) in SSR HTML:   False
quadrant-empty-mark in SSR HTML:  False   ← no longer paints pre-data
aria-busy present:                True
```

### The reskin

The surface read generic not from too little design but from **redundant signalling**: each quadrant asserted its identity five ways at once (pane wash, 3px rule, header band, header text colour, card spine) plus quadrant-tinted tags. Five simultaneous statements force every one to be timid. Now stated twice, with conviction:

- Pane washes softened to ~45%, close to `--ivory`. Dark washes pulled below `--paper` so elevation reads page < pane < card — they previously sat *lighter*, so cards appeared recessed into their own quadrant.
- Tag chips read neutral. Colour on this surface means quadrant and only quadrant; "home" and "infra" say nothing about urgency.
- Smart-view strip: nine emoji replaced with the Lucide set used everywhere else (PRODUCT.md anti-reference: *"a gamified todo toy"*).

### Accessibility

| Issue | Before | After |
|---|---|---|
| "Delegate" title contrast | 4.32:1 | **5.27:1** |
| Overdue badge over title | 39px overlap, no truncation | truncates, 57px clearance |
| Focus rings | missing on 15+ controls | present |
| Smart-view pill targets | 36px | 44px on coarse pointers |

For contrast I added `--q*-ink` so the *title* darkens rather than the header, preserving the 10/10/12/14 tint ladder that equalises perceived header weight across pigments of differing lightness.

## Detector

**13 Critical / 6 Major → 1 Critical / 0 Major** across `matrix-simplified/` and `task-card/`.

Contested findings are suppressed **inline with a recorded reason**, not globally:

- delete is undoable via toast (review.md accepts "confirmed *or* Undo")
- chip removal acts on an unsaved draft, reversible in a keystroke
- the capture input's focus ring lives on its parent form
- the `<article>` is `tabIndex={-1}`; `:focus-visible` never matches programmatic focus

## Deliberately not done

- **Radix `<Dialog>` for the edit drawer.** I tried it and reverted. Radix's `DismissableLayer` handles Escape at the document level, so the dependency-suggestions popup could no longer swallow the first Escape — breaking the layered contract (first Escape closes the popup, second closes the drawer). The hand-rolled drawer has passing tests for role/aria-modal, focus restore and Escape layering — the exact behaviours the rule protects. Suppressed with that reasoning at the site.
- **`transition-[width]` on the icon rail** (the remaining Critical). The width transition *pushes* content, which is intended; `transform` would make the rail overlay instead. That's a UX decision, not a mechanical fix.
- **Pre-existing `refs during render` warnings** in `task-card-header.tsx` — untouched logic, 0 errors.

## How to test

```bash
bun install
bun run test        # 2372 pass (+11), 1 skipped
bun typecheck       # clean
bun run dev         # then hard-reload; skeleton should precede the grid
```

Worth checking by hand: dark mode (the wash/elevation change), an overdue task with a long title, and keyboard-tabbing a task card.

https://claude.ai/code/session_01BHRMo7X1KdHaKGyU1P6kKi

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->