### PR TITLE
feat(matrix): replace static intro hero with date-anchored briefing

### DIFF
--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -28,6 +28,7 @@ import { useSmartViews } from "./use-smart-views";
 import { useTaskHighlight } from "./use-task-highlight";
 import { useMatrixWindowEvents } from "./use-matrix-window-events";
 import { MatrixIntro } from "./matrix-intro";
+import { deriveIntroStats, introDateLabel, introMessage } from "./intro-copy";
 import { TaskDetailSheet } from "./task-detail-sheet";
 
 /**
@@ -306,6 +307,13 @@ export function MatrixSimplified() {
     (count, task) => count + (!task.completed && !task.urgent && task.important ? 1 : 0),
     0
   );
+  // Intro briefing: date + state reading render only after hydration so the
+  // prerendered static export never bakes in a build-time date or an empty-board
+  // message computed before IndexedDB has loaded.
+  const introReady = mounted && !isLoading;
+  const introStats = introReady
+    ? deriveIntroStats(all, new Date().toISOString().slice(0, 10))
+    : null;
 
   // Header counts — three small inline pills, semantic colors. Overdue
   // pill is conditional on count > 0. Sits on the same baseline as the title
@@ -338,6 +346,8 @@ export function MatrixSimplified() {
         searchInputRef={searchInputRef}
       >
         <MatrixIntro
+          dateLabel={mounted ? introDateLabel(new Date()) : null}
+          message={introStats ? introMessage(introStats) : null}
           scheduleCount={isLoading ? null : activeScheduleCount}
           onFocusSchedule={() => focusQuadrant("q2")}
         />

--- a/components/matrix-simplified/intro-copy.ts
+++ b/components/matrix-simplified/intro-copy.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure copy derivation for the matrix intro briefing.
+ *
+ * The h1 date label and the one-sentence state reading live here so the copy
+ * rules stay unit-testable and MatrixIntro stays presentational. Rules are
+ * priority-ordered. The subtext never mentions Q2 (the Protect Q2 card owns
+ * that topic) and never repeats the header pills' raw counts — it interprets
+ * state the pills can't (where overdue work sits, how the day leans).
+ */
+
+import { quadrantForTask } from "@/lib/quadrants";
+import type { TaskRecord } from "@/lib/types";
+
+export interface IntroStats {
+  activeTotal: number;
+  doFirstCount: number;
+  overdueTotal: number;
+  /** Titles of quadrants holding at least one overdue task, deduped, first-seen order. */
+  overdueQuadrants: string[];
+}
+
+const DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
+  weekday: "long",
+  month: "long",
+  day: "numeric",
+});
+
+export function introDateLabel(now: Date): string {
+  return DATE_FORMAT.format(now);
+}
+
+export function deriveIntroStats(all: TaskRecord[], todayIso: string): IntroStats {
+  let activeTotal = 0;
+  let doFirstCount = 0;
+  let overdueTotal = 0;
+  const overdueQuadrants: string[] = [];
+
+  for (const task of all) {
+    if (task.completed) continue;
+    activeTotal += 1;
+    const meta = quadrantForTask(task.urgent, task.important);
+    if (meta.rdKey === "q1") doFirstCount += 1;
+    if (task.dueDate && task.dueDate < todayIso) {
+      overdueTotal += 1;
+      if (!overdueQuadrants.includes(meta.title)) {
+        overdueQuadrants.push(meta.title);
+      }
+    }
+  }
+
+  return { activeTotal, doFirstCount, overdueTotal, overdueQuadrants };
+}
+
+export function introMessage(stats: IntroStats): string {
+  if (stats.activeTotal === 0) {
+    return "The board is clear. Capture the first thing on your mind below.";
+  }
+  if (stats.overdueTotal > 0) {
+    if (stats.overdueQuadrants.length === 1) {
+      const quadrant = stats.overdueQuadrants[0];
+      if (stats.overdueTotal === 1) return `The overdue task sits in ${quadrant}.`;
+      if (stats.overdueTotal === 2) return `Both overdue tasks sit in ${quadrant}.`;
+      return `All ${stats.overdueTotal} overdue tasks sit in ${quadrant}.`;
+    }
+    return `${stats.overdueTotal} tasks are past their dates — give them a fresh decision.`;
+  }
+  if (stats.activeTotal >= 3 && stats.doFirstCount * 2 > stats.activeTotal) {
+    return "Today leans urgent: most of the list sits in Do First.";
+  }
+  return "Nothing overdue. Everything on the board is there by choice.";
+}

--- a/components/matrix-simplified/matrix-intro.tsx
+++ b/components/matrix-simplified/matrix-intro.tsx
@@ -3,6 +3,10 @@
 import { ArrowDownRightIcon, CalendarRangeIcon } from "lucide-react";
 
 interface MatrixIntroProps {
+  /** Formatted local date for the h1; null until hydrated so the static export stays date-free. */
+  dateLabel: string | null;
+  /** One-sentence state reading from introMessage(); null while tasks load. */
+  message: string | null;
   scheduleCount: number | null;
   onFocusSchedule: () => void;
 }
@@ -13,16 +17,17 @@ function scheduleMessage(count: number): string {
   return `${count} strategic commitments need protected time.`;
 }
 
-export function MatrixIntro({ scheduleCount, onFocusSchedule }: MatrixIntroProps) {
+export function MatrixIntro({ dateLabel, message, scheduleCount, onFocusSchedule }: MatrixIntroProps) {
   return (
     <section className="mb-6 grid items-end gap-5 border-b border-border/70 pb-6 lg:grid-cols-[minmax(0,1fr)_minmax(300px,0.58fr)] lg:gap-10">
       <div>
         <p className="text-eyebrow uppercase text-foreground-muted">Today&rsquo;s matrix</p>
-        <h1 className="mt-3 max-w-[20ch] text-display font-semibold text-foreground">
-          Decide what deserves you.
+        <h1 className="mt-3 text-display font-semibold text-foreground">
+          <span className="sr-only">Today&rsquo;s matrix — </span>
+          {dateLabel ?? " "}
         </h1>
         <p className="mt-3 max-w-[58ch] text-body text-foreground-muted">
-          Hold the whole picture, then protect the work that matters before urgency chooses for you.
+          {message ?? " "}
         </p>
       </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.0.1",
+	"version": "11.1.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '11.0.1';
+const CACHE_VERSION = '11.1.0';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,6 +2,45 @@
 
 ---
 
+## In progress — 2026-08-01: Date-anchored matrix intro briefing
+
+**Branch:** `feat/matrix-intro-briefing` · **Tier:** Standard (content-only change
+to the matrix intro block: one new pure module, two component wirings, test
+updates; no new public contract). **Approved contract:** user-approved design in
+this session (date-anchored briefing direction).
+
+**Design summary:** replace the static hero copy ("Decide what deserves you." /
+"Hold the whole picture…") with a date-anchored briefing. Eyebrow stays
+"Today's matrix"; the h1 becomes the formatted local date with an sr-only
+"Today's matrix — " prefix; the subtext becomes one computed sentence from a
+priority-ordered rule set (empty board → overdue-located → overdue-scattered →
+Q1-majority → all-clear). The subtext never mentions Q2 (the Protect Q2 card
+owns that topic) and never repeats raw counts (the header pills own those).
+Hydration: `dateLabel`/`stats` props are `null` until mounted/loaded and render
+reserved blank space, keeping the static-export snapshot date-free.
+
+**Plan (TDD):**
+- [x] RED: unit tests for `intro-copy.ts` — `introDateLabel(now)` formatting and
+  `introMessage(stats)` across all rules, boundaries, and pluralization.
+  (16 tests; red confirmed via unresolved module import.)
+- [x] GREEN: implement `components/matrix-simplified/intro-copy.ts`. (16/16.)
+- [x] Wire `MatrixIntro` (dateLabel + message props, sr-only h1 prefix) and
+  `index.tsx` (compute stats from `all`); update `app-shell.test.tsx` and
+  `matrix-simplified.test.tsx` assertions, including the `renderToString`
+  hydration-safety test (server snapshot asserted date-free).
+- [x] Verify: full suite 2,513 pass / 1 skip; typecheck clean; lint 0 errors
+  (10 known warnings). Coverage: intro-copy 100%, matrix-intro 100%, index.tsx
+  90.9/86.8/85.7/92.5. Live browser (SW busted, console clean): all-clear,
+  overdue-located, and overdue-scattered states each rendered the correct
+  sentence; seeds cleaned up. Empty/Q1-majority states unit-covered only.
+- [ ] Version bump (minor), commit, push, PR.
+
+**Out of scope:** layout/spacing changes, the Protect Q2 card, design-lab
+prototype copy (historical artifact), midnight rollover re-render, About-page
+copy.
+
+---
+
 ## Done — 2026-08-01: Clarify and strengthen Q2 shortcut feedback
 
 **Branch:** `design/five-visual-directions` · **Tier:** Standard (bounded copy and

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,7 +2,7 @@
 
 ---
 
-## In progress — 2026-08-01: Date-anchored matrix intro briefing
+## Done — 2026-08-01: Date-anchored matrix intro briefing
 
 **Branch:** `feat/matrix-intro-briefing` · **Tier:** Standard (content-only change
 to the matrix intro block: one new pure module, two component wirings, test
@@ -33,7 +33,8 @@ reserved blank space, keeping the static-export snapshot date-free.
   90.9/86.8/85.7/92.5. Live browser (SW busted, console clean): all-clear,
   overdue-located, and overdue-scattered states each rendered the correct
   sentence; seeds cleaned up. Empty/Q1-majority states unit-covered only.
-- [ ] Version bump (minor), commit, push, PR.
+- [x] Version bump (11.0.1 → 11.1.0, package.json + sw.js CACHE_VERSION),
+  commit `9e46145`, pushed, PR #468.
 
 **Out of scope:** layout/spacing changes, the Protect Q2 card, design-lab
 prototype copy (historical artifact), midnight rollover re-render, About-page

--- a/tests/data/intro-copy.test.ts
+++ b/tests/data/intro-copy.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveIntroStats,
+  introDateLabel,
+  introMessage,
+  type IntroStats,
+} from "@/components/matrix-simplified/intro-copy";
+import type { TaskRecord } from "@/lib/types";
+
+function makeTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    id: overrides.id ?? `task-${Math.random().toString(36).slice(2)}`,
+    title: "Task",
+    description: "",
+    urgent: false,
+    important: false,
+    quadrant: "not-urgent-not-important",
+    completed: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    recurrence: "none",
+    tags: [],
+    subtasks: [],
+    dependencies: [],
+    notificationEnabled: false,
+    notificationSent: false,
+    ...overrides,
+  };
+}
+
+function makeStats(overrides: Partial<IntroStats> = {}): IntroStats {
+  return {
+    activeTotal: 0,
+    doFirstCount: 0,
+    overdueTotal: 0,
+    overdueQuadrants: [],
+    ...overrides,
+  };
+}
+
+const TODAY = "2026-08-01";
+
+describe("introDateLabel", () => {
+  it("formats a weekday, month, and day without the year", () => {
+    expect(introDateLabel(new Date(2026, 7, 1))).toBe("Saturday, August 1");
+  });
+
+  it("formats single-digit days without padding", () => {
+    expect(introDateLabel(new Date(2026, 0, 1))).toBe("Thursday, January 1");
+  });
+});
+
+describe("deriveIntroStats", () => {
+  it("counts only incomplete tasks as active", () => {
+    const stats = deriveIntroStats(
+      [makeTask(), makeTask(), makeTask({ completed: true })],
+      TODAY
+    );
+    expect(stats.activeTotal).toBe(2);
+  });
+
+  it("counts Do First membership from the urgent/important flags", () => {
+    const stats = deriveIntroStats(
+      [
+        makeTask({ urgent: true, important: true }),
+        makeTask({ urgent: true, important: false }),
+        makeTask({ urgent: true, important: true, completed: true }),
+      ],
+      TODAY
+    );
+    expect(stats.doFirstCount).toBe(1);
+  });
+
+  it("counts overdue as incomplete tasks due strictly before today", () => {
+    const stats = deriveIntroStats(
+      [
+        makeTask({ dueDate: "2026-07-30" }),
+        makeTask({ dueDate: TODAY }),
+        makeTask({ dueDate: "2026-07-01", completed: true }),
+        makeTask(),
+      ],
+      TODAY
+    );
+    expect(stats.overdueTotal).toBe(1);
+  });
+
+  it("collects deduped quadrant titles that hold overdue tasks", () => {
+    const stats = deriveIntroStats(
+      [
+        makeTask({ urgent: true, important: true, dueDate: "2026-07-30" }),
+        makeTask({ urgent: true, important: true, dueDate: "2026-07-29" }),
+        makeTask({ urgent: false, important: true, dueDate: "2026-07-28" }),
+      ],
+      TODAY
+    );
+    expect(stats.overdueQuadrants).toEqual(["Do First", "Schedule"]);
+  });
+});
+
+describe("introMessage", () => {
+  it("invites capture when the board has no active tasks", () => {
+    expect(introMessage(makeStats())).toBe(
+      "The board is clear. Capture the first thing on your mind below."
+    );
+  });
+
+  it("locates a single overdue task in its quadrant", () => {
+    const stats = makeStats({
+      activeTotal: 4,
+      overdueTotal: 1,
+      overdueQuadrants: ["Do First"],
+    });
+    expect(introMessage(stats)).toBe("The overdue task sits in Do First.");
+  });
+
+  it("uses 'Both' for two overdue tasks sharing a quadrant", () => {
+    const stats = makeStats({
+      activeTotal: 5,
+      overdueTotal: 2,
+      overdueQuadrants: ["Schedule"],
+    });
+    expect(introMessage(stats)).toBe("Both overdue tasks sit in Schedule.");
+  });
+
+  it("counts three or more overdue tasks sharing a quadrant", () => {
+    const stats = makeStats({
+      activeTotal: 6,
+      overdueTotal: 3,
+      overdueQuadrants: ["Do First"],
+    });
+    expect(introMessage(stats)).toBe("All 3 overdue tasks sit in Do First.");
+  });
+
+  it("asks for a fresh decision when overdue tasks are scattered", () => {
+    const stats = makeStats({
+      activeTotal: 6,
+      overdueTotal: 2,
+      overdueQuadrants: ["Do First", "Eliminate"],
+    });
+    expect(introMessage(stats)).toBe(
+      "2 tasks are past their dates — give them a fresh decision."
+    );
+  });
+
+  it("prefers the overdue message over the urgency-lean message", () => {
+    const stats = makeStats({
+      activeTotal: 5,
+      doFirstCount: 4,
+      overdueTotal: 1,
+      overdueQuadrants: ["Do First"],
+    });
+    expect(introMessage(stats)).toBe("The overdue task sits in Do First.");
+  });
+
+  it("names the urgency lean when Do First holds the majority", () => {
+    const stats = makeStats({ activeTotal: 5, doFirstCount: 3 });
+    expect(introMessage(stats)).toBe(
+      "Today leans urgent: most of the list sits in Do First."
+    );
+  });
+
+  it("does not call an exact half a majority", () => {
+    const stats = makeStats({ activeTotal: 4, doFirstCount: 2 });
+    expect(introMessage(stats)).toBe(
+      "Nothing overdue. Everything on the board is there by choice."
+    );
+  });
+
+  it("skips the urgency lean on boards smaller than three tasks", () => {
+    const stats = makeStats({ activeTotal: 2, doFirstCount: 2 });
+    expect(introMessage(stats)).toBe(
+      "Nothing overdue. Everything on the board is there by choice."
+    );
+  });
+
+  it("falls back to the calm all-clear reading", () => {
+    const stats = makeStats({ activeTotal: 3, doFirstCount: 1 });
+    expect(introMessage(stats)).toBe(
+      "Nothing overdue. Everything on the board is there by choice."
+    );
+  });
+});

--- a/tests/ui/app-shell.test.tsx
+++ b/tests/ui/app-shell.test.tsx
@@ -91,13 +91,13 @@ describe("AppShell command palette wiring", () => {
   it("lets matrix content own the page heading while retaining a compact shell label", () => {
     render(
       <AppShell title="GSD Matrix" titleAsLabel>
-        <h1>Decide what deserves you.</h1>
+        <h1>Saturday, August 1</h1>
       </AppShell>
     );
 
     expect(screen.getByText("GSD Matrix").tagName).toBe("P");
     expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
-    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Decide what deserves you.");
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Saturday, August 1");
   });
 
   it("accepts a matrix-only main width and mobile clearance contract", () => {

--- a/tests/ui/matrix-simplified.test.tsx
+++ b/tests/ui/matrix-simplified.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderToString } from "react-dom/server";
+import { introDateLabel } from "@/components/matrix-simplified/intro-copy";
 import type { TaskRecord } from "@/lib/types";
 import type { SmartView } from "@/lib/filters";
 
@@ -260,15 +261,41 @@ describe("<MatrixSimplified>", () => {
   it("renders 'GSD Matrix' title", () => {
     render(<MatrixSimplified />);
     expect(screen.getByTestId("topbar-title")).toHaveTextContent("GSD Matrix");
-    expect(screen.getByRole("heading", { level: 1, name: /decide what deserves you/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: /today.s matrix/i })).toBeInTheDocument();
     expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+  });
+
+  it("shows today's date as the page heading once hydrated", () => {
+    render(<MatrixSimplified />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      introDateLabel(new Date())
+    );
   });
 
   it("keeps the static-export server snapshot hydration-safe", () => {
     const html = renderToString(<MatrixSimplified />);
     expect(html).toContain("GSD Matrix");
-    expect(html).toContain("Decide what deserves you.");
+    expect(html).toContain("Today’s matrix —");
+    expect(html).not.toContain(introDateLabel(new Date()));
     expect(html).toContain("Capture a task");
+  });
+
+  it("reads the board state in the intro briefing", () => {
+    tasksFixture.current = [
+      makeTask({ id: "od1", urgent: true, important: true, dueDate: "2000-01-01" }),
+      makeTask({ id: "od2", urgent: true, important: true, dueDate: "2000-01-02" }),
+      makeTask({ id: "q4" }),
+    ];
+    render(<MatrixSimplified />);
+
+    expect(screen.getByText("Both overdue tasks sit in Do First.")).toBeInTheDocument();
+  });
+
+  it("does not publish a board reading while tasks are loading", () => {
+    tasksFixture.loading = true;
+    render(<MatrixSimplified />);
+
+    expect(screen.queryByText(/the board is clear/i)).not.toBeInTheDocument();
   });
 
   it("reports active Schedule work from the full task set", () => {


### PR DESCRIPTION
## What changed

Replaces the matrix page's static hero copy ("Decide what deserves you." / "Hold the whole picture…") with a **date-anchored briefing**:

- **H1** is now the formatted local date (e.g. "Saturday, August 1") with an sr-only "Today's matrix — " prefix so screen-reader heading navigation still announces the page name.
- **Subtext** is one computed sentence from a priority-ordered rule set in a new pure module (`components/matrix-simplified/intro-copy.ts`): empty board → overdue located in one quadrant → overdue scattered → Do First majority → all clear.
- `public/sw.js` CACHE_VERSION and `package.json` bumped to **11.1.0** so installed PWA clients bust their page caches and pick up the new chunk.

## Why

The static aphorism read identically every day on a daily-use surface and sat closer to marketing copy than PRODUCT.md's "plain and direct" voice. The briefing changes with the board by construction and interprets state the header pills can't (the pills own raw counts; the Protect Q2 card owns the Q2 topic — the subtext deliberately overlaps with neither).

## How to test

1. `bun run test -- tests/data/intro-copy.test.ts tests/ui/matrix-simplified.test.tsx tests/ui/app-shell.test.tsx`
2. `bun dev`, open `/`, bust the SW cache, and confirm the h1 shows today's date and the subtext matches your board state (seed overdue tasks to cycle the rules).

## Verification

- Full suite 2,513 pass / 1 skip · typecheck clean · lint 0 errors (10 known warnings)
- Coverage: intro-copy 100%, matrix-intro 100%, index.tsx ≥85% all dimensions
- Live browser (SW busted, console clean): all-clear, overdue-located, and overdue-scattered states each rendered the correct sentence; hydration-safety test asserts the server snapshot stays date-free

https://claude.ai/code/session_01G65F4vmF8joqaRBLnpd4sH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->