### PR TITLE
fix(about): stop advertising features that have no way in

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.3.2
+**Current version:** 11.3.3
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/components/about/feature-card.tsx
+++ b/components/about/feature-card.tsx
@@ -5,10 +5,12 @@ interface FeatureCardProps {
   icon: LucideIcon;
   title: string;
   description: string;
+  /** Set when the capability is built but has no way to reach it yet. */
+  badge?: string;
   className?: string;
 }
 
-export function FeatureCard({ icon: Icon, title, description, className }: FeatureCardProps) {
+export function FeatureCard({ icon: Icon, title, description, badge, className }: FeatureCardProps) {
   return (
     <div className={cn(
       "rounded-[24px] border border-border/70 bg-card/95 p-6 transition-colors duration-200",
@@ -18,8 +20,18 @@ export function FeatureCard({ icon: Icon, title, description, className }: Featu
       <div className="mb-4 grid h-9 w-9 place-items-center rounded-lg bg-accent/10">
         <Icon className="h-4 w-4 text-accent" aria-hidden="true" />
       </div>
-      <h3 className="mb-2 text-xl font-semibold tracking-tight text-foreground">
+      <h3 className="mb-2 flex flex-wrap items-center gap-2 text-xl font-semibold tracking-tight text-foreground">
         {title}
+        {/* Explicit space: JSX drops newline whitespace between expressions, and
+            without it the accessible name runs together as "SubtasksComing soon". */}
+        {badge ? " " : null}
+        {badge ? (
+          // Deliberately quiet: this marks an absence, so it must not compete
+          // with the shipped features around it.
+          <span className="rounded-full border border-border/70 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-foreground-muted">
+            {badge}
+          </span>
+        ) : null}
       </h3>
       <p className="text-sm text-foreground-muted leading-relaxed">{description}</p>
     </div>

--- a/components/about/features-section.tsx
+++ b/components/about/features-section.tsx
@@ -18,6 +18,13 @@ interface Feature {
   icon: LucideIcon;
   title: string;
   description: string;
+  /**
+   * Marks a capability that is modelled and implemented but has no way in yet.
+   * Recurrence and subtasks both render read-only on the card and in the detail
+   * sheet, and recurrence even spawns its next instance on completion — but the
+   * composer can author neither, so listing them unbadged oversells the product.
+   */
+  badge?: string;
 }
 
 // First three are hero features (Eisenhower Matrix, Privacy First, MCP Server) —
@@ -58,6 +65,7 @@ const features: Feature[] = [
     title: "Recurring Tasks",
     description:
       "Daily standup prep. Weekly reviews. Monthly goals. Set once, repeat automatically.",
+    badge: "Coming soon",
   },
   {
     icon: Tags,
@@ -70,6 +78,7 @@ const features: Feature[] = [
     title: "Subtasks",
     description:
       "Break complex work into steps. Track progress with a checklist.",
+    badge: "Coming soon",
   },
   {
     icon: Smartphone,
@@ -117,6 +126,7 @@ export function FeaturesSection() {
                   icon={feature.icon}
                   title={feature.title}
                   description={feature.description}
+                  badge={feature.badge}
                   className={lgSpan}
                 />
               );

--- a/components/matrix-simplified/help-drawer.tsx
+++ b/components/matrix-simplified/help-drawer.tsx
@@ -136,7 +136,7 @@ export function HelpDrawer({ open, onClose }: HelpDrawerProps) {
 
           <Section label="Editing, completing, and drag-drop">
             <p style={bodyStyle}>
-              <strong>Complete</strong>: tap the checkbox on any task card. Recurring tasks automatically spawn the next instance.
+              <strong>Complete</strong>: tap the checkbox on any task card.
             </p>
             <p style={bodyStyle}>
               <strong>Edit</strong>: hover a task card and click the pencil to open the composer pre-filled with that

--- a/lib/smart-views/built-in.ts
+++ b/lib/smart-views/built-in.ts
@@ -80,16 +80,11 @@ export const BUILT_IN_SMART_VIEWS: Omit<SmartView, 'id' | 'createdAt' | 'updated
       status: 'completed'
     }
   },
-  {
-    name: "Recurring Tasks",
-    description: "All tasks with recurrence enabled",
-    icon: "recurring",
-    isBuiltIn: true,
-    criteria: {
-      status: 'active',
-      recurrence: ['daily', 'weekly', 'monthly']
-    }
-  },
+  // "Recurring Tasks" is withheld until the composer can set `recurrence`.
+  // The engine works — completing a recurring task spawns the next instance —
+  // but no UI can turn recurrence on, so for a UI-only user the view can only
+  // ever be empty. Restore it alongside the recurrence authoring UI; the
+  // criteria shape is preserved in git history.
   {
     name: "Ready to Work",
     description: "Tasks with no blocking dependencies",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.3.2",
+	"version": "11.3.3",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/tests/data/filters.test.ts
+++ b/tests/data/filters.test.ts
@@ -348,7 +348,6 @@ describe("Filter utilities", () => {
         "Recently Added",
         "This Week's Wins",
         "All Completed",
-        "Recurring Tasks",
         "Ready to Work",
       ];
 
@@ -374,10 +373,11 @@ describe("Filter utilities", () => {
       expect(view?.criteria.dueThisWeek).toBe(true);
     });
 
-    it("should have Recurring Tasks view", () => {
+    // Withheld until the composer can set `recurrence` — see
+    // lib/smart-views/built-in.ts. Restore with the recurrence authoring UI.
+    it("should not ship a Recurring Tasks view while recurrence is unauthorable", () => {
       const view = BUILT_IN_SMART_VIEWS.find(v => v.name === "Recurring Tasks");
-      expect(view).toBeDefined();
-      expect(view?.criteria.recurrence).toEqual(["daily", "weekly", "monthly"]);
+      expect(view).toBeUndefined();
     });
 
     it("should have No Deadline view", () => {

--- a/tests/data/smart-views-built-in.test.ts
+++ b/tests/data/smart-views-built-in.test.ts
@@ -66,11 +66,13 @@ describe('BUILT_IN_SMART_VIEWS', () => {
     expect(thisWeeksWins?.criteria.status).toBe('completed');
   });
 
-  it('includes Recurring Tasks view', () => {
+  // Withheld until the edit drawer can set `recurrence`. The recurrence engine
+  // works (toggle.ts spawns the next instance on completion), but nothing in the
+  // UI can turn it on, so this view can only ever be empty for a UI-only user.
+  // Restore it with the recurrence authoring UI.
+  it('omits the Recurring Tasks view while recurrence has no authoring UI', () => {
     const recurring = BUILT_IN_SMART_VIEWS.find(v => v.name === 'Recurring Tasks');
-    expect(recurring).toBeDefined();
-    expect(recurring?.criteria.recurrence).toEqual(['daily', 'weekly', 'monthly']);
-    expect(recurring?.criteria.status).toBe('active');
+    expect(recurring).toBeUndefined();
   });
 
   it('all views have unique names', () => {

--- a/tests/ui/about-copy.test.tsx
+++ b/tests/ui/about-copy.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import { FeaturesSection } from "@/components/about/features-section";
 import { McpSection } from "@/components/about/mcp-section";
@@ -13,5 +13,32 @@ describe("about-page privacy copy", () => {
   it("should_not_reference_stale_encryption_passphrase", () => {
     const { container } = render(<McpSection />);
     expect(container.textContent).not.toMatch(/ENCRYPTION_PASSPHRASE/);
+  });
+});
+
+describe("about-page shipped-feature claims", () => {
+  // Recurrence and subtasks are modelled, rendered read-only on the card and in
+  // the detail sheet, and fully implemented in the data layer — but no UI can
+  // author either one. Advertising them as available oversells the product.
+  // Asserting on the heading's accessible name, not just its text, so the
+  // caveat reaches screen-reader users along with everyone else.
+  it("should_mark_recurring_tasks_as_not_yet_available", () => {
+    render(<FeaturesSection />);
+    expect(
+      screen.getByRole("heading", { name: /Recurring Tasks\s+Coming soon/i })
+    ).toBeInTheDocument();
+  });
+
+  it("should_mark_subtasks_as_not_yet_available", () => {
+    render(<FeaturesSection />);
+    expect(
+      screen.getByRole("heading", { name: /Subtasks\s+Coming soon/i })
+    ).toBeInTheDocument();
+  });
+
+  it("should_not_badge_shipped_features", () => {
+    render(<FeaturesSection />);
+    const card = screen.getByRole("heading", { name: "Eisenhower Matrix" }).closest("div");
+    expect(card?.textContent).not.toMatch(/coming soon/i);
   });
 });

--- a/tests/ui/help-drawer.test.tsx
+++ b/tests/ui/help-drawer.test.tsx
@@ -90,4 +90,11 @@ describe("HelpDrawer", () => {
     await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
     await waitFor(() => expect(screen.getByRole("main")).toHaveFocus());
   });
+
+  it("does not describe recurrence while no UI can set it", () => {
+    render(<HelpDrawer open onClose={vi.fn()} />);
+    // The recurrence engine works, but nothing in the app can turn it on, so
+    // documenting it sends readers looking for a control that isn't there.
+    expect(document.body.textContent).not.toMatch(/recurring tasks automatically/i);
+  });
 });


### PR DESCRIPTION
Wave A PR3 of the v11.2.1 review remediation. Spec: `tasks/spec-review-remediation-wave-a-b.md`.

## The gap

Recurrence and subtasks are **built but unreachable**:

| Layer | Recurrence | Subtasks |
|---|---|---|
| Schema (`lib/schema.ts`) | yes | yes |
| Data layer | yes — `toggle.ts` spawns the next instance | yes |
| Rendered read-only (card, detail sheet) | yes | yes |
| **Authoring UI (composer)** | **no** | **no** |
| Advertised on About | yes | yes |

A visitor reads the About page, adopts the app, and finds no way to do either.

## What changed

- **About** — both cards badged `Coming soon`. Kept rather than deleted: the capabilities are real and land in Wave G, where the badges come off.
- **Smart views** — the built-in `Recurring Tasks` view is withheld. Nothing in the UI can set recurrence, so for a UI-only user it can only ever be empty.
- **Help drawer** — the recurrence sentence is removed.

## Correcting the review on the Help drawer

The review said the drawer "claims recurring tasks spawn next instances" as though that were false. **It isn't.** `lib/tasks/crud/toggle.ts:56` calls `createAndQueueRecurringInstance`, and `tests/e2e/recurring-tasks.spec.ts` covers the behavior end to end.

Removed on narrower grounds: the sentence documents behavior no user can trigger, so it sends readers hunting for a control that doesn't exist. It comes back with the authoring UI.

**`Shift+N` help text is deliberately untouched** — the review flagged it as wrong, but `capture-bar.tsx:80` really does open the full composer.

## Accessibility detail

The badge sits inside the `<h3>`, so it joins the heading's accessible name. Without an explicit space that computes as `"SubtasksComing soon"` — one run-on token to a screen reader. Added `{badge ? " " : null}`; the tests now assert on the accessible name rather than raw text, so the caveat is guaranteed to reach assistive tech.

## Verification

Live headless run against `/about`:

> The 'Recurring Tasks' card shows a 'COMING SOON' badge next to its heading. The 'Subtasks' card also shows a 'COMING SOON' badge... none of these other cards display a 'Coming soon' badge.

Console clean — 0 errors, 0 warnings, 0 failed requests.

- `bun run test` — 2651 passed, 1 skipped
- `bun typecheck` / `bun lint` / `bun run quality:shape` — clean

**Visual dimension not captured**: the About screenshot stayed pinned at the hero across three attempts, so the badge is DOM-verified but unphotographed. Styling is a muted pill (hairline border, `text-foreground-muted`, no pigment) — Inkwell-conformant by construction, but worth a glance on review.

## Follow-up when Wave G lands

Remove both badges, restore the `Recurring Tasks` built-in view (criteria preserved in git history), restore the Help sentence, and revert the four tests that assert their absence.

https://claude.ai/code/session_01DA4QuYKyWt5WkynEqteWJH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->