### PR TITLE
fix(dnd): resolve drop targets to quadrants instead of casting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.3.3
+**Current version:** 11.3.4
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/components/matrix-simplified/drag-layer.tsx
+++ b/components/matrix-simplified/drag-layer.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { DragOverlay } from "@dnd-kit/core";
+import type { TaskRecord } from "@/lib/types";
+
+interface DragLayerProps {
+  /** The task currently under the cursor's grip, or null when nothing is dragging. */
+  task: TaskRecord | null;
+  /** Outcome of the last drop, announced once the write has actually settled. */
+  statusMessage: string;
+}
+
+/**
+ * Everything the board renders *about* a drag rather than as part of it: the
+ * floating overlay card and the live region that reports the result.
+ *
+ * The live region is deliberately separate from dnd-kit's own announcements.
+ * dnd-kit narrates the gesture and fires the moment the pointer lifts; the write
+ * is async and can still fail. Reporting both from one place would mean either
+ * announcing success too early or staying silent about failure.
+ */
+export function DragLayer({ task, statusMessage }: DragLayerProps) {
+  return (
+    <>
+      <DragOverlay dropAnimation={null}>
+        {task ? (
+          <div
+            data-testid="drag-overlay"
+            aria-hidden="true"
+            className="max-w-sm rounded-lg border border-pane-border bg-card px-4 py-3 shadow-[var(--shadow-elevated)]"
+            style={{ cursor: "grabbing" }}
+          >
+            <p className="truncate text-small font-semibold text-foreground">{task.title}</p>
+          </div>
+        ) : null}
+      </DragOverlay>
+
+      <div role="status" aria-live="polite" data-testid="drag-status" className="sr-only">
+        {statusMessage}
+      </div>
+    </>
+  );
+}

--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useReducer, useRef, useState, useSyncExternalStore } from "react";
-import { DndContext, DragOverlay } from "@dnd-kit/core";
+import { DndContext, closestCorners } from "@dnd-kit/core";
 import { createTask, toggleCompleted, updateTask, deleteTask, restoreTask } from "@/lib/tasks";
 import { celebrateCompletion } from "@/lib/confetti";
 import { extractUrlsFromTitle, buildDescription } from "@/lib/capture-parser";
@@ -19,6 +19,7 @@ import { quadrantByRdKey, type RedesignQuadrantKey } from "@/lib/quadrants";
 import { ShareTaskDialog } from "@/components/share-task-dialog";
 import { AppShell } from "./app-shell";
 import { CaptureBar, type CapturePayload } from "./capture-bar";
+import { DragLayer } from "./drag-layer";
 import { MatrixGrid } from "./matrix-grid";
 import { MatrixGridSkeleton } from "./matrix-grid-skeleton";
 import { EditDrawer, type EditDraft } from "./edit-drawer";
@@ -163,7 +164,8 @@ async function handleToggle(task: TaskRecord, completedNext: boolean): Promise<v
 export function MatrixSimplified() {
   const { all, isLoading } = useTasks();
   const { handleError, handleSuccess } = useErrorHandlerWithUndo();
-  const { sensors, activeId, handleDragStart, handleDragEnd } = useDragAndDrop(handleError);
+  const { sensors, activeId, statusMessage, announcements, handleDragStart, handleDragEnd } =
+    useDragAndDrop(handleError);
 
   useAutoArchive();
   useNotificationChecker();
@@ -365,7 +367,17 @@ export function MatrixSimplified() {
   );
 
   return (
-    <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+    <DndContext
+      sensors={sensors}
+      // Cards and quadrant panes are both droppables. The default
+      // rectIntersection favours whichever rect overlaps, which made pointer
+      // drops depend on exactly where the cursor landed; closestCorners picks
+      // the nearest target consistently and the handler resolves it either way.
+      collisionDetection={closestCorners}
+      accessibility={{ announcements }}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
       <AppShell
         title="GSD Matrix"
         titleAsLabel
@@ -446,18 +458,7 @@ export function MatrixSimplified() {
         onSubmit={handleEditSubmit}
       />
 
-      <DragOverlay dropAnimation={null}>
-        {activeDragTask ? (
-          <div
-            data-testid="drag-overlay"
-            aria-hidden="true"
-            className="max-w-sm rounded-lg border border-pane-border bg-card px-4 py-3 shadow-[var(--shadow-elevated)]"
-            style={{ cursor: "grabbing" }}
-          >
-            <p className="truncate text-small font-semibold text-foreground">{activeDragTask.title}</p>
-          </div>
-        ) : null}
-      </DragOverlay>
+      <DragLayer task={activeDragTask} statusMessage={statusMessage} />
     </DndContext>
   );
 }

--- a/components/matrix-simplified/quadrant-pane.tsx
+++ b/components/matrix-simplified/quadrant-pane.tsx
@@ -45,6 +45,9 @@ export function QuadrantPane({
   onTaskRef,
   sectionRef,
 }: QuadrantPaneProps) {
+  // `meta.id` names both the droppable and the SortableContext below. The
+  // SortableContext id is load-bearing: a card dropped onto another card
+  // resolves its target quadrant through its container, since `over` is the card.
   const { setNodeRef, isOver } = useDroppable({ id: meta.id });
   const accent = QUADRANT_ACCENT[meta.rdKey];
   const ink = QUADRANT_INK[meta.rdKey];
@@ -106,7 +109,7 @@ export function QuadrantPane({
         </button>
       </header>
 
-      <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>
+      <SortableContext id={meta.id} items={taskIds} strategy={verticalListSortingStrategy}>
         <div className="flex flex-1 flex-col gap-2 px-4 pb-4 pt-1">
           {tasks.length === 0 ? (
             <div className="my-auto flex flex-col items-center gap-2 py-4 text-center">

--- a/lib/dnd-drop-target.ts
+++ b/lib/dnd-drop-target.ts
@@ -1,0 +1,35 @@
+import type { Active, Over } from "@dnd-kit/core";
+
+import { quadrantOrder, quadrants } from "@/lib/quadrants";
+import type { QuadrantId } from "@/lib/types";
+
+function isQuadrantId(value: unknown): value is QuadrantId {
+  return typeof value === "string" && (quadrantOrder as string[]).includes(value);
+}
+
+/** The SortableContext a draggable belongs to — the quadrant pane it sits in. */
+export function containerOf(node: Active | Over | null): QuadrantId | null {
+  const containerId = node?.data.current?.sortable?.containerId;
+  return isQuadrantId(containerId) ? containerId : null;
+}
+
+/**
+ * Resolve a drop target to the quadrant it belongs to.
+ *
+ * Two kinds of droppable overlap on this board: the quadrant panes and the task
+ * cards inside them, since every card registers itself through `useSortable`.
+ * Keyboard dragging resolves `over` to a neighbouring *card*, so treating
+ * `over.id` as a quadrant id silently handed a task id to the write and every
+ * keyboard drop failed. Cards resolve through their sortable container instead.
+ *
+ * Returns null when the target is neither — not a failure, just not a drop target.
+ */
+export function resolveDropQuadrant(over: Over | null): QuadrantId | null {
+  if (!over) return null;
+  if (isQuadrantId(over.id)) return over.id;
+  return containerOf(over);
+}
+
+export function quadrantTitle(id: QuadrantId): string {
+  return quadrants.find((quadrant) => quadrant.id === id)?.title ?? id;
+}

--- a/lib/use-drag-and-drop.ts
+++ b/lib/use-drag-and-drop.ts
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { useSensors, useSensor, PointerSensor, TouchSensor, KeyboardSensor, DragStartEvent, DragEndEvent } from "@dnd-kit/core";
+import type { Announcements } from "@dnd-kit/core";
 import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
-import type { QuadrantId } from "@/lib/types";
 import { moveTaskToQuadrant } from "@/lib/tasks";
+import { containerOf, quadrantTitle, resolveDropQuadrant } from "@/lib/dnd-drop-target";
 import { DND_CONFIG } from "@/lib/constants";
 import { ErrorActions, ErrorMessages } from "@/lib/error-logger";
 
@@ -21,20 +22,33 @@ export type DragErrorHandler = (
 ) => void;
 
 /**
- * Custom hook for drag-and-drop functionality in MatrixBoard
- * Configures sensors and provides drag handler with error handling
+ * dnd-kit's default `onDragEnd` announcement claims the item was "dropped over"
+ * the target the moment the gesture ends — before the write has resolved, and
+ * regardless of whether it succeeds. These report intent only; the outcome is
+ * announced separately once it is actually known.
  */
-export function useDragAndDrop(onError: DragErrorHandler) {
-  const [activeId, setActiveId] = useState<string | null>(null);
+const DRAG_ANNOUNCEMENTS: Announcements = {
+  onDragStart: ({ active }) => `Picked up task ${active.id}.`,
+  onDragOver: ({ over }) => {
+    const quadrant = resolveDropQuadrant(over);
+    return quadrant ? `Over ${quadrantTitle(quadrant)}.` : "Not over a quadrant.";
+  },
+  onDragEnd: ({ over }) => {
+    const quadrant = resolveDropQuadrant(over);
+    return quadrant ? `Dropped over ${quadrantTitle(quadrant)}. Moving…` : "Drop cancelled.";
+  },
+  onDragCancel: () => "Drag cancelled. Task returned to its quadrant.",
+};
 
-  // Configure sensors for drag-and-drop (mouse + touch + keyboard).
-  // KeyboardSensor makes the drag handle operable without a pointer (WCAG 2.1.1);
-  // sortableKeyboardCoordinates drives arrow-key movement within the sortable list.
-  const sensors = useSensors(
+/**
+ * Mouse, touch, and keyboard sensors. The KeyboardSensor makes the drag handle
+ * operable without a pointer (WCAG 2.1.1); sortableKeyboardCoordinates drives
+ * arrow-key movement within the sortable list.
+ */
+function useDragSensors() {
+  return useSensors(
     useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: DND_CONFIG.POINTER_DISTANCE,
-      },
+      activationConstraint: { distance: DND_CONFIG.POINTER_DISTANCE },
     }),
     useSensor(TouchSensor, {
       activationConstraint: {
@@ -42,16 +56,27 @@ export function useDragAndDrop(onError: DragErrorHandler) {
         tolerance: DND_CONFIG.TOUCH_TOLERANCE,
       },
     }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    })
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
+}
+
+/**
+ * Custom hook for drag-and-drop functionality in MatrixBoard
+ * Configures sensors and provides drag handler with error handling
+ */
+export function useDragAndDrop(onError: DragErrorHandler) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+  // Announced after the write settles, so assistive tech never hears "moved"
+  // for a move that threw. Rendered into an sr-only live region by the board.
+  const [statusMessage, setStatusMessage] = useState("");
+  const sensors = useDragSensors();
 
   /**
    * Track which task is being dragged for DragOverlay
    */
   const handleDragStart = (event: DragStartEvent) => {
     setActiveId(event.active.id as string);
+    setStatusMessage("");
   };
 
   /**
@@ -65,12 +90,18 @@ export function useDragAndDrop(onError: DragErrorHandler) {
       return;
     }
 
+    const targetQuadrant = resolveDropQuadrant(over);
+    if (!targetQuadrant || containerOf(active) === targetQuadrant) {
+      return;
+    }
+
     const taskId = active.id as string;
-    const targetQuadrant = over.id as QuadrantId;
 
     try {
       await moveTaskToQuadrant(taskId, targetQuadrant);
+      setStatusMessage(`Task moved to ${quadrantTitle(targetQuadrant)}.`);
     } catch (error) {
+      setStatusMessage(ErrorMessages.TASK_MOVE_FAILED);
       onError(error, {
         action: ErrorActions.MOVE_TASK,
         taskId,
@@ -84,6 +115,8 @@ export function useDragAndDrop(onError: DragErrorHandler) {
   return {
     sensors,
     activeId,
+    statusMessage,
+    announcements: DRAG_ANNOUNCEMENTS,
     handleDragStart,
     handleDragEnd,
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.3.3",
+	"version": "11.3.4",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/tests/data/use-drag-and-drop.test.ts
+++ b/tests/data/use-drag-and-drop.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { useDragAndDrop } from "@/lib/use-drag-and-drop";
 import { moveTaskToQuadrant } from "@/lib/tasks";
 import { ErrorActions, ErrorMessages } from "@/lib/error-logger";
@@ -97,6 +97,123 @@ describe("useDragAndDrop", () => {
 
     expect(moveTaskToQuadrant).not.toHaveBeenCalled();
     expect(mockOnError).not.toHaveBeenCalled();
+  });
+
+  // The defect this suite missed: dropping on a *different* card. `over.id` was
+  // cast straight to a QuadrantId, so the write got a task id and threw. Cards
+  // are droppables (useSortable), so every keyboard drag lands here.
+  it("resolves the quadrant from a card drop target", async () => {
+    const { result } = renderHook(() => useDragAndDrop(mockOnError));
+
+    const mockEvent: DragEndEvent = {
+      active: { id: "task-1", data: { current: {} } },
+      over: {
+        id: "task-2",
+        data: { current: { sortable: { containerId: "not-urgent-important", index: 0, items: [] } } },
+      },
+      delta: { x: 0, y: 0 },
+      activatorEvent: new KeyboardEvent("keydown"),
+      collisions: null,
+    } as unknown as DragEndEvent;
+
+    await result.current.handleDragEnd(mockEvent);
+
+    expect(moveTaskToQuadrant).toHaveBeenCalledWith("task-1", "not-urgent-important");
+    expect(mockOnError).not.toHaveBeenCalled();
+  });
+
+  it("ignores a drop target that resolves to no quadrant", async () => {
+    const { result } = renderHook(() => useDragAndDrop(mockOnError));
+
+    const mockEvent: DragEndEvent = {
+      active: { id: "task-1", data: { current: {} } },
+      over: { id: "some-unrelated-droppable", data: { current: {} } },
+      delta: { x: 0, y: 0 },
+      activatorEvent: new MouseEvent("mousedown"),
+      collisions: null,
+    } as unknown as DragEndEvent;
+
+    await result.current.handleDragEnd(mockEvent);
+
+    // Not a failure — just not a drop target. No write, no error toast.
+    expect(moveTaskToQuadrant).not.toHaveBeenCalled();
+    expect(mockOnError).not.toHaveBeenCalled();
+  });
+
+  it("does not move when the card is already in the target quadrant", async () => {
+    const { result } = renderHook(() => useDragAndDrop(mockOnError));
+
+    const mockEvent: DragEndEvent = {
+      active: {
+        id: "task-1",
+        data: { current: { sortable: { containerId: "urgent-important", index: 0, items: [] } } },
+      },
+      over: {
+        id: "task-2",
+        data: { current: { sortable: { containerId: "urgent-important", index: 1, items: [] } } },
+      },
+      delta: { x: 0, y: 0 },
+      activatorEvent: new KeyboardEvent("keydown"),
+      collisions: null,
+    } as unknown as DragEndEvent;
+
+    await result.current.handleDragEnd(mockEvent);
+
+    expect(moveTaskToQuadrant).not.toHaveBeenCalled();
+    expect(mockOnError).not.toHaveBeenCalled();
+  });
+
+  it("announces the drop as pending, never as succeeded", () => {
+    const { result } = renderHook(() => useDragAndDrop(mockOnError));
+
+    const message = result.current.announcements.onDragEnd?.({
+      active: { id: "task-1", data: { current: {} } },
+      over: { id: "not-urgent-important", data: { current: {} } },
+    } as never);
+
+    // The write hasn't run yet, so this must not claim the move happened.
+    expect(message).toMatch(/moving/i);
+    expect(message).not.toMatch(/moved/i);
+  });
+
+  it("reports the settled outcome only after the write resolves", async () => {
+    const { result } = renderHook(() => useDragAndDrop(mockOnError));
+    expect(result.current.statusMessage).toBe("");
+
+    const mockEvent: DragEndEvent = {
+      active: { id: "task-1", data: { current: {} } },
+      over: { id: "not-urgent-important", data: { current: {} } },
+      delta: { x: 0, y: 0 },
+      activatorEvent: new KeyboardEvent("keydown"),
+      collisions: null,
+    } as unknown as DragEndEvent;
+
+    await act(async () => {
+      await result.current.handleDragEnd(mockEvent);
+    });
+
+    expect(result.current.statusMessage).toMatch(/moved to Schedule/i);
+  });
+
+  it("announces failure rather than success when the move rejects", async () => {
+    vi.mocked(moveTaskToQuadrant).mockRejectedValueOnce(new Error("Move failed"));
+    const { result } = renderHook(() => useDragAndDrop(mockOnError));
+
+    const mockEvent: DragEndEvent = {
+      active: { id: "task-1", data: { current: {} } },
+      over: { id: "not-urgent-important", data: { current: {} } },
+      delta: { x: 0, y: 0 },
+      activatorEvent: new KeyboardEvent("keydown"),
+      collisions: null,
+    } as unknown as DragEndEvent;
+
+    await act(async () => {
+      await result.current.handleDragEnd(mockEvent);
+    });
+
+    // A screen-reader user was previously told the drop succeeded here.
+    expect(result.current.statusMessage).not.toMatch(/moved to/i);
+    expect(result.current.statusMessage).toBe(ErrorMessages.TASK_MOVE_FAILED);
   });
 
   it("calls onError when move fails", async () => {

--- a/tests/e2e/drag-and-drop.spec.ts
+++ b/tests/e2e/drag-and-drop.spec.ts
@@ -291,3 +291,93 @@ test.describe("Drag and Drop Between Quadrants", () => {
     await expect(movedTask).toContainText("project-x");
   });
 });
+
+/**
+ * Lift a card with the keyboard and step until the drag is genuinely over a
+ * quadrant other than its own, then drop.
+ *
+ * A single arrow press often resolves to the source's *own* pane, which is a
+ * legitimate no-op — so a fixed number of presses makes the test order-dependent.
+ * Steps against dnd-kit's own announcement, which names the quadrant under the
+ * cursor, and asserts we actually crossed before committing the drop.
+ */
+async function keyboardDragOut(page: Page, dragHandle: Locator) {
+  const overOtherQuadrant = page.getByText(/Over (Do First|Schedule|Delegate)\./);
+
+  await dragHandle.focus();
+  await page.keyboard.press("Space");
+  await expect(page.locator("[data-testid='drag-overlay']")).toBeVisible();
+
+  for (let press = 0; press < 5; press += 1) {
+    await page.keyboard.press("ArrowUp");
+    if (await overOtherQuadrant.count()) break;
+  }
+  await expect(overOtherQuadrant.first()).toBeVisible();
+
+  await page.keyboard.press("Space");
+}
+
+test.describe("Keyboard drag between quadrants", () => {
+  test.beforeEach(async ({ clearIndexedDB }) => {
+    // Fixture clears IndexedDB
+  });
+
+  /**
+   * Regression: the drop handler cast `over.id` straight to a QuadrantId. Task
+   * cards are droppables too (useSortable), so arrow-key movement resolved
+   * `over` to a neighbouring *card* and the write received a task id — every
+   * keyboard drop failed with "Failed to move task. Please try again."
+   *
+   * Only a real keyboard sequence exercises this; pointer drags usually land on
+   * the pane rect and mask it.
+   */
+  test("keyboard drag moves a task into the target quadrant", async ({ page }) => {
+    await waitForAppLoad(page);
+
+    // Every quadrant needs an occupant: sortableKeyboardCoordinates traverses
+    // between registered droppables, and the failure mode under test is landing
+    // on a *card* rather than a pane.
+    await createTaskViaCaptureBar(page, "Q1 anchor !!");
+    await createTaskViaCaptureBar(page, "Q2 anchor *");
+    await createTaskViaCaptureBar(page, "Q3 anchor !");
+    await createTaskViaCaptureBar(page, "Keyboard move me");
+
+    const q4 = page.locator("[data-testid='quadrant-q4']");
+    const taskInQ4 = q4.locator("[data-testid='task-card']").filter({ hasText: "Keyboard move me" });
+    await expect(taskInQ4).toBeVisible();
+
+    // Lift with Space, traverse with an arrow, drop with Space — the documented
+    // dnd-kit keyboard contract.
+    const dragHandle = taskInQ4.locator("button[aria-label='Drag to move task']");
+    await keyboardDragOut(page, dragHandle);
+
+    // Before the fix this threw and the card stayed put.
+    await expect(taskInQ4).toHaveCount(0, { timeout: 5000 });
+    await expect(page.getByText("Failed to move task")).toHaveCount(0);
+
+    const movedCard = page
+      .locator("[data-testid='task-card']")
+      .filter({ hasText: "Keyboard move me" });
+    await expect(movedCard).toBeVisible();
+  });
+
+  test("keyboard drag reports the settled outcome to assistive tech", async ({ page }) => {
+    await waitForAppLoad(page);
+    await createTaskViaCaptureBar(page, "Q1 anchor !!");
+    await createTaskViaCaptureBar(page, "Q2 anchor *");
+    await createTaskViaCaptureBar(page, "Announce me");
+
+    const q4 = page.locator("[data-testid='quadrant-q4']");
+    const card = q4.locator("[data-testid='task-card']").filter({ hasText: "Announce me" });
+    await expect(card).toBeVisible();
+
+    await keyboardDragOut(page, card.locator("button[aria-label='Drag to move task']"));
+
+    // The status region reports the result only after the write resolves, so a
+    // screen-reader user is never told "moved" for a move that failed.
+    await expect(page.locator("[data-testid='drag-status']")).toHaveText(
+      /Task moved to (Do First|Schedule|Delegate)\./,
+      { timeout: 5000 }
+    );
+  });
+});


### PR DESCRIPTION
Wave B of the v11.2.1 review remediation — the one genuinely broken interaction. Spec: `tasks/spec-review-remediation-wave-a-b.md`.

## Root cause

The review reported "keyboard drop fails with *Failed to move task*". The cause wasn't the handler — it was a **type cast**:

```ts
const targetQuadrant = over.id as QuadrantId;   // over.id is often a *task* id
```

Three things combined:

1. Every task card is a droppable (`useSortable` in `task-card/index.tsx`).
2. `DndContext` declared **no `collisionDetection`**, so it defaulted to `rectIntersection` across *all* droppables — cards included.
3. `sortableKeyboardCoordinates` moves between sortables, so arrow keys resolve `over` to a neighbouring **card**.

So `moveTaskToQuadrant(taskId, "<another task id>")` threw. `as QuadrantId` silenced the compiler at precisely the line where the assumption breaks.

This also explains the unreliable *pointer* drags the review couldn't complete: whether a drop worked depended on whether the cursor happened to overlap a card or the pane.

## The fix

- `resolveDropQuadrant()` — a drop target is a quadrant if its id is one, otherwise the quadrant of the `SortableContext` it belongs to. Anything else resolves to `null` and is ignored rather than attempted; landing on a non-target isn't a failure.
- Gave each `SortableContext` its quadrant's id, so cards can resolve their container.
- Added explicit `collisionDetection={closestCorners}` — consistent nearest-target picking instead of overlap roulette.
- No casts: ids are validated against `quadrantOrder`.

## Accessibility

dnd-kit announced `"dropped over droppable area"` the instant the gesture ended — **before** the async write, and regardless of outcome. A screen-reader user was told the move succeeded when it had just thrown.

Now dnd-kit reports intent (`"Dropped over Schedule. Moving…"`) and a separate `role="status"` region reports the settled result (`"Task moved to Schedule."` / the failure message) once it's actually known.

## Why the old tests missed it

`use-drag-and-drop.test.ts` covered dropping on **self** (early return) but never on a **different card** — the exact untested path where the defect lived. That case is now covered, plus same-quadrant no-op and unresolvable targets.

## Verification

**The new e2e tests were confirmed to fail against the pre-fix code** — I reverted the resolution line and re-ran; both failed, then passed again once restored. Stable across `--repeat-each=3`.

- `bun run test:e2e -g "Drag and Drop|Keyboard drag"` — 6 passed
- `bun run test` — 2657 passed, 1 skipped
- `bun typecheck` / `bun lint` / `bun run quality:shape` — clean

A useful diagnostic surfaced along the way: my first e2e attempt failed because a single `ArrowUp` from a card resolves to the card's **own** pane — a legitimate no-op. The helper now steps until dnd-kit announces a *different* quadrant, which is both more honest and non-flaky.

## Refactors the shape ratchet required

Adding this pushed `matrix-simplified/index.tsx` over the 400-line `max-lines` budget (which is 0 and one-way). Extracted `DragLayer` (overlay + live region) and `lib/dnd-drop-target.ts` (pure resolution). The ratchet's `max-lines-per-function` maximum came **down** 269 → 265.

## Known gap, not fixed here

Keyboard drag can only reach quadrants that dnd-kit can traverse to; an **empty** quadrant is hard to reach because `sortableKeyboardCoordinates` navigates between registered droppables. Out of scope for this fix — worth its own issue.

https://claude.ai/code/session_01DA4QuYKyWt5WkynEqteWJH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->