### PR TITLE
feat(backup): export and restore every user-owned store

### DIFF
--- a/.claude/rules/archive-tombstone.md
+++ b/.claude/rules/archive-tombstone.md
@@ -38,6 +38,7 @@ Sync had no awareness of `archivedTasks`. Archiving deleted the task locally but
 | `applyRemoteRecords` | `lib/sync/pb-pull.ts` | Archive guard, un-archives on a newer edit |
 | `applyRemoteChange` | `lib/sync/pb-sync-engine.ts` | Same guard, realtime path |
 | Migration v15 | `lib/db.ts` | Deletes only duplicates that stay archivable |
+| `applyArchivedTasks` | `lib/tasks/import-export.ts` | Idempotent `put`; live copy wins on a contradictory payload; absent key ≠ delete |
 
 Adding a writer? Add it to this table and give it a test for each rule that applies.
 
@@ -47,4 +48,6 @@ Adding a writer? Add it to this table and give it a test for each rule that appl
 - **`bulkAdd` inside a transaction is all-or-nothing.** One duplicate key aborts the entire batch, which turns a single bad row into a permanent feature outage.
 - **Byte comparison does not identify resurrected rows.** Sync normalizes fields on the round trip. Measured against the affected dataset, content comparison matched zero of 167 duplicates.
 - **`archivedTasks` is never synced.** The remote copy is deleted when the task is archived, so undoing a permanent delete enqueues nothing.
+- **An absent key in a backup is not an instruction to delete.** A `1.0.0` export carries no `archivedTasks`, so replace-mode import must leave the archive alone rather than read the silence as "empty". Distinguish a missing key from an empty array (ADR 0014).
+- **`taskRecordSchema` is `.strict()` and declares no `archivedAt`.** Validating archived rows with it rejects every one of them — silently, since callers skip invalid records rather than throw. Use `archivedTaskRecordSchema`.
 - **Verifying against one dataset proves less than it looks.** The production data that exposed this bug held no counterexamples to the absolute-tombstone version. A real-data check passed while the rule was still wrong. Reason about the invariant, then measure.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.3.4
+**Current version:** 11.4.0
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/components/import-dialog.tsx
+++ b/components/import-dialog.tsx
@@ -109,7 +109,7 @@ export function ImportDialog({ open, onOpenChange, fileContents, existingTaskCou
               <div className="flex-1">
                 <h3 className="font-semibold text-foreground">Merge Tasks</h3>
                 <p className="mt-1 text-sm text-foreground-muted">
-                  Keep your existing tasks and add the imported tasks. Duplicate IDs will be regenerated to avoid conflicts.
+                  Keep your existing tasks and add the imported ones, archive included. Duplicate IDs are regenerated to avoid conflicts, and your settings stay as they are.
                 </p>
                 <p className="mt-2 text-xs font-medium text-olive-d">
                   ✓ Safe - No data loss
@@ -130,9 +130,9 @@ export function ImportDialog({ open, onOpenChange, fileContents, existingTaskCou
                 <RefreshCwIcon className="h-5 w-5" />
               </div>
               <div className="flex-1">
-                <h3 className="font-semibold text-foreground">Replace All Tasks</h3>
+                <h3 className="font-semibold text-foreground">Replace Everything</h3>
                 <p className="mt-1 text-sm text-foreground-muted">
-                  Delete all existing tasks and replace them with the imported tasks. This action cannot be undone.
+                  Restore this backup over your current data — tasks, archive, and settings. This action cannot be undone.
                 </p>
                 <div className="mt-2 flex items-center gap-1 text-xs font-medium text-rust-d">
                   <AlertTriangleIcon className="h-3 w-3" />

--- a/docs/adr/0014-versioned-backup-envelope.md
+++ b/docs/adr/0014-versioned-backup-envelope.md
@@ -1,0 +1,149 @@
+# 0014 — Versioned backup envelope
+
+| Field | Value |
+|---|---|
+| Date | 2026-08-12 |
+| Status | Accepted |
+| Deciders | Vinny Carpenter |
+
+## Context
+
+JSON export is the only way data leaves this app. There is no server copy by default,
+and the README warns that clearing browser data erases everything. Export *is* the
+backup story.
+
+It was exporting one of ten Dexie stores.
+
+`exportTasks()` read `db.tasks` and nothing else. On a live dataset that was 59 of 291
+records — the other 232 sat in `archivedTasks` and were absent from every backup any
+user had ever taken. Import mirrored the omission: it wrote `db.tasks` inside a
+transaction scoped to `[db.tasks, db.syncQueue]`, so restoring a backup silently
+discarded the archive.
+
+Four stores of user-authored settings were missing too: `smartViews`,
+`notificationSettings`, `archiveSettings`, `appPreferences`.
+
+The failure is quiet in both directions. Nothing warns at export time that most of the
+data is being left behind, and nothing warns at import time that the archive is gone. A
+user restoring after a browser-data wipe discovers the loss only when they go looking
+for something archived.
+
+## Decision
+
+**The backup envelope carries every user-owned store, behind a version field, and the
+importer accepts both the old and new shapes.**
+
+### Envelope shape
+
+Top-level keys mirror the Dexie table names, and v2 is a structural *superset* of v1:
+
+```jsonc
+{
+  "version": "2.0.0",
+  "exportedAt": "2026-08-12T22:00:00.000Z",
+  "tasks":            [ /* TaskRecord */ ],
+  "archivedTasks":    [ /* TaskRecord + archivedAt */ ],
+  "smartViews":       [ /* SmartView (custom only) */ ],
+  "notificationSettings": { /* singleton */ },
+  "archiveSettings":      { /* singleton */ },
+  "appPreferences":       { /* singleton */ }
+}
+```
+
+Because every new key is optional, one parser reads both versions: a v1 payload is
+simply a v2 payload with the new keys absent. No branching on `version` is required to
+*read* a backup. The field is bumped anyway, so the format can be identified and so a
+future change has somewhere to signal from.
+
+### What is in, and what is deliberately out
+
+| Store | Exported | Why |
+|---|---|---|
+| `tasks` | yes | The user's work |
+| `archivedTasks` | yes | Also the user's work; the largest omission |
+| `smartViews` | yes | Custom views only — built-ins are computed at read time from `BUILT_IN_SMART_VIEWS`, never persisted |
+| `notificationSettings` | yes | User-authored configuration |
+| `archiveSettings` | yes | User-authored configuration |
+| `appPreferences` | yes | User-authored configuration |
+| `syncQueue` | **no** | Pending operations belonging to *this* device |
+| `syncMetadata` | **no** | Holds `email`, `userId`, `deviceId`, `provider`, `localTaskOwnerUserId` |
+| `deviceInfo` | **no** | Device identity |
+| `syncHistory` | **no** | This device's operational log |
+
+Excluding `syncMetadata` is a **privacy requirement, not tidiness**. A backup is a file
+users email themselves and drop in cloud storage; it must not carry an account identity
+that binds the file to a PocketBase user. Auth tokens are not at risk — the PocketBase
+SDK keeps those in `localStorage`, outside IndexedDB entirely — but the account PII is.
+
+Restoring a backup therefore never changes who you are signed in as, which device you
+are, or what is queued to sync. It restores your data, not your session.
+
+### Import semantics
+
+Replace and merge answer different questions, so they get different scopes:
+
+| | Replace — *"restore this backup"* | Merge — *"add these to what I have"* |
+|---|---|---|
+| `tasks` | Cleared and rewritten | Added; colliding ids regenerated, references remapped |
+| `archivedTasks` | Cleared and rewritten | Added only when the id is absent from **both** task tables |
+| `smartViews` | Cleared and rewritten | Added when the id is absent |
+| Settings singletons | Applied when present | **Untouched** |
+
+Settings are a restore-path concern. Someone merging a file is combining task lists, not
+adopting another device's notification schedule, so merge leaves local configuration
+alone.
+
+### Tombstone compliance
+
+`archivedTasks` is a conditional tombstone (ADR 0013), and import becomes a new writer to
+it. Three of the four rules bind here:
+
+- **Rule 1 (one table at a time).** Import runs as a single Dexie transaction across
+  `tasks`, `archivedTasks`, `smartViews`, the three settings tables, and `syncQueue`. A
+  payload that lists the same id in both `tasks` and `archivedTasks` is self-contradictory;
+  the live copy wins, the archived duplicate is dropped, and the count is reported rather
+  than swallowed.
+- **Rule 3 (idempotent, never regress).** Archived writes use `put`, never `add`, so a
+  re-import cannot throw a `ConstraintError` and abort the shared transaction.
+- **Rule 4 (a shared id is not proof of resurrection).** Replace-mode import legitimately
+  places a live task under a previously archived id. This was already true and is why the
+  rule exists; the writer table records it.
+
+`archivedTasks` is never synced, so archived rows enqueue nothing.
+
+## Consequences
+
+**Easier.** Backups are actually backups. A restore after a browser-data wipe returns the
+archive and the user's settings, not just the live board. Wave E's trash store slots into
+the same envelope additively.
+
+**Harder.** Export now reads six stores instead of one, so it is slower and the file is
+larger — on the measured dataset, roughly 5× the records. The Data section is a deliberate
+navigation rather than a hot path, so this is an acceptable trade.
+
+A new `archivedTaskRecordSchema` is required. `taskRecordSchema` is `.strict()` and does
+not declare `archivedAt`, so validating archived records against it would reject **every
+one of them** and silently drop the entire archive from the backup — reproducing the bug
+this ADR exists to fix, in a form that looks like it works.
+
+**Out of scope.** Selective restore (choosing which stores to apply), backup encryption,
+and any change to what syncs. Old app versions reading a v2 file degrade gracefully: the
+import schema strips unknown keys, so they import the tasks and ignore the rest.
+
+## Alternatives considered
+
+**A nested `stores: { … }` map.** Cleaner conceptually, but it makes v1 a different shape
+rather than a subset, forcing version branching in the parser and a migration path for
+every existing backup file. Rejected: the flat shape buys backward compatibility for free.
+
+**Exporting every table.** Simplest rule to state — "back up the database" — but it puts
+account PII and this device's sync cursor into a file users share, and restoring it onto a
+second device would corrupt that device's sync state. Rejected on privacy and correctness.
+
+**Leaving export alone and telling users to rely on cloud sync.** Sync is optional, off by
+default, and the product's central claim is that it works without a server. A backup story
+that requires an account contradicts the premise. Rejected.
+
+**A separate archive-only export.** Two files, two restore steps, and a user who takes one
+and not the other. Rejected: the failure mode is the same silent partial backup, just
+harder to notice.

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -87,11 +87,48 @@ export const storedTaskRecordSchema = taskDraftSchema
 	})
 	.strip();
 
-export const importPayloadSchema = z.object({
-	tasks: z.array(storedTaskRecordSchema),
-	exportedAt: z.iso.datetime({ offset: true }),
-	version: z.string(),
+/**
+ * An archived task is a task record plus the moment it was archived.
+ *
+ * `archivedAt` is declared in no other schema, and `taskRecordSchema` is
+ * `.strict()` — so validating archived rows with the plain record schema rejects
+ * every one of them. That failure is silent (records are skipped, not thrown),
+ * which is exactly how the archive stayed out of backups in the first place.
+ */
+export const archivedTaskRecordSchema = taskRecordSchema
+	.extend({ archivedAt: z.iso.datetime({ offset: true }).optional() })
+	.strict();
+
+/** Lenient counterpart for reading archived rows back in. */
+export const storedArchivedTaskRecordSchema = storedTaskRecordSchema
+	.extend({ archivedAt: z.iso.datetime({ offset: true }).optional() })
+	.strip();
+
+export const archiveSettingsSchema = z.object({
+	id: z.literal("settings").default("settings"),
+	enabled: z.boolean(),
+	archiveAfterDays: z.union([z.literal(30), z.literal(60), z.literal(90)]),
 });
+
+export const appPreferencesSchema = z.object({
+	id: z.literal("preferences").default("preferences"),
+	pinnedSmartViewIds: z.array(z.string()).default([]),
+	maxPinnedViews: z.number().int().min(0),
+	smartViewsEnabled: z.boolean(),
+});
+
+/** Custom smart views only — built-ins are derived at read time, never stored. */
+export const smartViewSchema = z.object({
+	id: z.string().min(1),
+	name: z.string().min(1),
+	description: z.string().optional(),
+	icon: z.string().optional(),
+	criteria: z.record(z.string(), z.unknown()),
+	isBuiltIn: z.boolean().default(false),
+	createdAt: z.iso.datetime({ offset: true }),
+	updatedAt: z.iso.datetime({ offset: true }),
+});
+
 
 export const notificationSettingsSchema = z.object({
 	id: z.literal("settings").default("settings"),
@@ -102,4 +139,21 @@ export const notificationSettingsSchema = z.object({
 	quietHoursEnd: z.string().optional(), // HH:mm format
 	permissionAsked: z.boolean().default(false),
 	updatedAt: z.iso.datetime({ offset: true }),
+});
+
+/**
+ * Backup envelope (ADR 0014). Version 2.0.0 is a structural superset of 1.0.0 —
+ * every store beyond `tasks` is optional, so one parser reads both and a legacy
+ * export needs no migration. An absent key means "this backup says nothing about
+ * that store", which is different from an empty array.
+ */
+export const importPayloadSchema = z.object({
+	tasks: z.array(storedTaskRecordSchema),
+	exportedAt: z.iso.datetime({ offset: true }),
+	version: z.string(),
+	archivedTasks: z.array(storedArchivedTaskRecordSchema).optional(),
+	smartViews: z.array(smartViewSchema).optional(),
+	notificationSettings: notificationSettingsSchema.optional(),
+	archiveSettings: archiveSettingsSchema.optional(),
+	appPreferences: appPreferencesSchema.optional(),
 });

--- a/lib/tasks/import-export.ts
+++ b/lib/tasks/import-export.ts
@@ -1,7 +1,7 @@
 import { getDb } from "@/lib/db";
 import { generateId } from "@/lib/id-generator";
 import { createLogger } from "@/lib/logger";
-import { importPayloadSchema, taskRecordSchema } from "@/lib/schema";
+import { archivedTaskRecordSchema, importPayloadSchema, taskRecordSchema } from "@/lib/schema";
 import type { ImportPayload, TaskRecord } from "@/lib/types";
 import type { SyncQueue } from "@/lib/sync/queue";
 import { isoNow } from "@/lib/utils";
@@ -11,6 +11,9 @@ const MAX_IMPORT_TASKS = 10_000;
 
 /** Maximum raw JSON string size (10 MB) to prevent memory exhaustion */
 const MAX_IMPORT_SIZE_BYTES = 10 * 1024 * 1024;
+
+/** Envelope version written by this build. See docs/adr/0014. */
+const BACKUP_ENVELOPE_VERSION = "2.0.0";
 
 function getUtf8ByteLength(value: string): number {
   return new TextEncoder().encode(value).byteLength;
@@ -48,16 +51,81 @@ async function collectExportableTasks(): Promise<{ tasks: TaskRecord[]; skippedC
   return { tasks: normalized, skippedCount };
 }
 
-function toPayload(tasks: TaskRecord[]): ImportPayload {
-  return { tasks, exportedAt: isoNow(), version: "1.0.0" } satisfies ImportPayload;
+/**
+ * Read the archive, keeping only rows that pass the archived-record schema.
+ *
+ * Deliberately NOT `taskRecordSchema`: that schema is `.strict()` and declares no
+ * `archivedAt`, so every archived row would fail and be counted as corrupt —
+ * producing an empty archive in the backup that looks like an empty archive on
+ * disk. See ADR 0014.
+ */
+async function collectExportableArchive(): Promise<{ tasks: TaskRecord[]; skippedCount: number }> {
+  const db = getDb();
+  const archived = await db.archivedTasks.toArray();
+  const normalized: TaskRecord[] = [];
+  let skippedCount = 0;
+  for (const task of archived) {
+    const result = archivedTaskRecordSchema.safeParse(task);
+    if (result.success) {
+      normalized.push(result.data as TaskRecord);
+    } else {
+      skippedCount++;
+      logger.warn('Skipping corrupt archived task during export', { taskId: task.id });
+    }
+  }
+  return { tasks: normalized, skippedCount };
 }
 
 /**
- * Export all tasks as a structured payload
+ * Collect every user-owned store for a backup.
+ *
+ * Device-local and account-identifying stores are excluded by omission rather
+ * than by filtering: `syncMetadata` carries email / userId / deviceId, and a
+ * backup is a file people mail themselves. See ADR 0014 for the full table.
+ */
+async function collectUserOwnedStores() {
+  const db = getDb();
+  const [smartViews, notificationSettings, archiveSettings, appPreferences] = await Promise.all([
+    db.smartViews.toArray(),
+    db.notificationSettings.get("settings"),
+    db.archiveSettings.get("settings"),
+    db.appPreferences.get("preferences"),
+  ]);
+  return { smartViews, notificationSettings, archiveSettings, appPreferences };
+}
+
+/**
+ * Build the backup envelope once, reporting how many records were unreadable.
+ *
+ * Single source for both `exportTasks` and `exportToJsonWithReport`, so the file
+ * a user downloads can never contain less than the API says it does.
+ */
+async function buildBackup(): Promise<{ payload: ImportPayload; skippedCount: number }> {
+  const [live, archive, stores] = await Promise.all([
+    collectExportableTasks(),
+    collectExportableArchive(),
+    collectUserOwnedStores(),
+  ]);
+
+  const payload: ImportPayload = {
+    version: BACKUP_ENVELOPE_VERSION,
+    exportedAt: isoNow(),
+    tasks: live.tasks,
+    archivedTasks: archive.tasks,
+    smartViews: stores.smartViews as ImportPayload["smartViews"],
+    ...(stores.notificationSettings ? { notificationSettings: stores.notificationSettings } : {}),
+    ...(stores.archiveSettings ? { archiveSettings: stores.archiveSettings } : {}),
+    ...(stores.appPreferences ? { appPreferences: stores.appPreferences } : {}),
+  };
+
+  return { payload, skippedCount: live.skippedCount + archive.skippedCount };
+}
+
+/**
+ * Export every user-owned store as a structured payload (envelope 2.0.0).
  */
 export async function exportTasks(): Promise<ImportPayload> {
-  const { tasks } = await collectExportableTasks();
-  return toPayload(tasks);
+  return (await buildBackup()).payload;
 }
 
 /**
@@ -143,6 +211,107 @@ async function resolveSyncDeps(): Promise<{ syncEnabled: boolean; queue: SyncQue
 }
 
 /**
+ * Write the archive, upholding the ADR 0013 tombstone rules.
+ *
+ * Rule 1 — an id lives in `tasks` or `archivedTasks`, never both. A payload
+ * listing an id in both is self-contradictory; the live copy wins and the
+ * archived duplicate is dropped, because resurrecting a tombstone over live work
+ * loses data while dropping a redundant tombstone does not.
+ *
+ * Rule 3 — `put`, never `add`, so a re-import cannot raise a ConstraintError and
+ * abort the surrounding transaction.
+ *
+ * Returns the number of archived records dropped, so the caller can report it
+ * rather than swallow it.
+ */
+async function applyArchivedTasks(
+  archivedTasks: TaskRecord[] | undefined,
+  mode: "replace" | "merge"
+): Promise<number> {
+  // Silence is not an instruction to delete: a 1.0.0 backup says nothing about
+  // the archive, so replace must leave it alone.
+  if (!archivedTasks) return 0;
+
+  const db = getDb();
+  if (mode === "replace") await db.archivedTasks.clear();
+
+  const liveIds = new Set((await db.tasks.toCollection().primaryKeys()) as string[]);
+  const existingArchivedIds =
+    mode === "merge"
+      ? new Set((await db.archivedTasks.toCollection().primaryKeys()) as string[])
+      : new Set<string>();
+
+  let dropped = 0;
+  for (const task of archivedTasks) {
+    if (liveIds.has(task.id)) {
+      dropped++;
+      continue;
+    }
+    if (existingArchivedIds.has(task.id)) continue;
+    await db.archivedTasks.put(task);
+  }
+  return dropped;
+}
+
+async function applySmartViews(
+  smartViews: ImportPayload["smartViews"],
+  mode: "replace" | "merge"
+): Promise<void> {
+  if (!smartViews) return;
+  const db = getDb();
+  if (mode === "replace") await db.smartViews.clear();
+  for (const view of smartViews) {
+    await db.smartViews.put(view as never);
+  }
+}
+
+/** Settings singletons, applied on the restore path only. */
+async function applySettings(parsed: ImportPayload): Promise<void> {
+  const db = getDb();
+  if (parsed.notificationSettings) await db.notificationSettings.put(parsed.notificationSettings);
+  if (parsed.archiveSettings) await db.archiveSettings.put(parsed.archiveSettings);
+  if (parsed.appPreferences) await db.appPreferences.put(parsed.appPreferences);
+}
+
+/** Every table a restore writes. A narrower scope would let a partial restore commit. */
+function importTransactionTables(db: ReturnType<typeof getDb>) {
+  return [
+    db.tasks,
+    db.archivedTasks,
+    db.smartViews,
+    db.notificationSettings,
+    db.archiveSettings,
+    db.appPreferences,
+    db.syncQueue,
+  ];
+}
+
+/** Write the live-task table, returning what sync needs to hear about. */
+async function applyTasks(
+  tasks: TaskRecord[],
+  mode: "replace" | "merge"
+): Promise<{ created: TaskRecord[]; deletedIds: string[] }> {
+  const db = getDb();
+
+  if (mode === "replace") {
+    const existingIds = new Set((await db.tasks.toCollection().primaryKeys()) as string[]);
+    const importedIds = new Set(tasks.map(t => t.id));
+    const deletedIds = [...existingIds].filter(id => !importedIds.has(id));
+
+    await db.tasks.clear();
+    await db.tasks.bulkAdd(tasks);
+    return { created: tasks, deletedIds };
+  }
+
+  const existingTasks = await db.tasks.toArray();
+  const existingIds = new Set(existingTasks.map(t => t.id));
+  const { tasks: regeneratedTasks, idMap } = regenerateConflictingIds(tasks, existingIds);
+  const tasksToImport = remapTaskReferences(regeneratedTasks, idMap);
+  await db.tasks.bulkAdd(tasksToImport);
+  return { created: tasksToImport, deletedIds: [] };
+}
+
+/**
  * Import tasks from a payload with merge or replace mode
  */
 export async function importTasks(payload: ImportPayload, mode: "replace" | "merge" = "replace"): Promise<void> {
@@ -161,34 +330,35 @@ export async function importTasks(payload: ImportPayload, mode: "replace" | "mer
 
   let tasksToCreate: TaskRecord[] = [];
   let taskIdsToDelete: string[] = [];
+  let droppedArchivedCount = 0;
 
-  await db.transaction("rw", [db.tasks, db.syncQueue], async () => {
-    if (mode === "replace") {
-      const existingIds = new Set(
-        (await db.tasks.toCollection().primaryKeys()) as string[],
-      );
-      const importedIds = new Set(parsed.tasks.map(t => t.id));
-      taskIdsToDelete = [...existingIds].filter(id => !importedIds.has(id));
+  await db.transaction(
+    "rw",
+    importTransactionTables(db),
+    async () => {
+      ({ created: tasksToCreate, deletedIds: taskIdsToDelete } = await applyTasks(parsed.tasks, mode));
 
-      await db.tasks.clear();
-      await db.tasks.bulkAdd(parsed.tasks);
-      tasksToCreate = parsed.tasks;
-    } else {
-      const existingTasks = await db.tasks.toArray();
-      const existingIds = new Set(existingTasks.map(t => t.id));
-      const { tasks: regeneratedTasks, idMap } = regenerateConflictingIds(parsed.tasks, existingIds);
-      const tasksToImport = remapTaskReferences(regeneratedTasks, idMap);
-      await db.tasks.bulkAdd(tasksToImport);
-      tasksToCreate = tasksToImport;
-    }
+      droppedArchivedCount = await applyArchivedTasks(parsed.archivedTasks, mode);
+      await applySmartViews(parsed.smartViews, mode);
+      // Settings belong to the restore path: merging combines task lists, it
+      // does not adopt another device's configuration.
+      if (mode === "replace") await applySettings(parsed);
 
-    if (syncEnabled) {
-      await Promise.all([
-        ...taskIdsToDelete.map((id) => queue.enqueue('delete', id, null)),
-        ...tasksToCreate.map((task) => queue.enqueue('create', task.id, task)),
-      ]);
-    }
-  });
+      if (syncEnabled) {
+        // Archived rows are never synced — the remote copy is deleted when a
+        // task is archived (ADR 0013).
+        await Promise.all([
+          ...taskIdsToDelete.map((id) => queue.enqueue('delete', id, null)),
+          ...tasksToCreate.map((task) => queue.enqueue('create', task.id, task)),
+        ]);
+      }
+    });
+
+  if (droppedArchivedCount > 0) {
+    logger.warn('Dropped archived records that were also present as live tasks', {
+      count: droppedArchivedCount,
+    });
+  }
 
   if (syncEnabled) {
     scheduleSyncAfterChange();
@@ -221,8 +391,11 @@ export async function importFromJson(raw: string, mode: "replace" | "merge" = "r
  * Use this when you need to tell the user that some records were unreadable.
  */
 export async function exportToJsonWithReport(): Promise<ExportReport> {
-  const { tasks, skippedCount } = await collectExportableTasks();
-  return { json: JSON.stringify(toPayload(tasks), null, 2), skippedCount };
+  // Shares buildBackup with exportTasks: this is the path the Settings "Export
+  // tasks" button uses, so anything it omits is omitted from every backup a user
+  // actually takes.
+  const { payload, skippedCount } = await buildBackup();
+  return { json: JSON.stringify(payload, null, 2), skippedCount };
 }
 
 /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -63,10 +63,34 @@ export interface TaskDraft {
   estimatedMinutes?: number; // Estimated time to complete task
 }
 
+/**
+ * Backup envelope — see docs/adr/0014-versioned-backup-envelope.md.
+ *
+ * Everything past `tasks` is optional so that a 1.0.0 payload parses unchanged.
+ * An absent key means the backup says nothing about that store, which import
+ * treats differently from an empty array: silence leaves the store alone.
+ */
 export interface ImportPayload {
   tasks: TaskRecord[];
   exportedAt: string;
   version: string;
+  archivedTasks?: TaskRecord[];
+  smartViews?: SmartViewRecord[];
+  notificationSettings?: NotificationSettings;
+  archiveSettings?: ArchiveSettings;
+  appPreferences?: AppPreferences;
+}
+
+/** Shape of a stored (custom) smart view as it appears in a backup. */
+export interface SmartViewRecord {
+  id: string;
+  name: string;
+  description?: string;
+  icon?: string;
+  criteria: Record<string, unknown>;
+  isBuiltIn: boolean;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface NotificationSettings {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.3.4",
+	"version": "11.4.0",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/tasks/spec-review-remediation-wave-a-b.md
+++ b/tasks/spec-review-remediation-wave-a-b.md
@@ -149,6 +149,74 @@ blocked state.
 
 ---
 
+---
+
+## W-C1 · Backup omits five of six user-owned stores
+
+**Status:** approved 2026-08-12. ADR: `docs/adr/0014-versioned-backup-envelope.md`.
+
+**Problem.** `exportTasks()` reads only `db.tasks` (`lib/tasks/import-export.ts:36`), and
+`importTasks()` writes inside a transaction scoped to `[db.tasks, db.syncQueue]`. Five
+user-owned stores never reach a backup: `archivedTasks`, `smartViews`,
+`notificationSettings`, `archiveSettings`, `appPreferences`. On the reviewed dataset that
+was 59 of 291 records. Export is the only way data leaves this app.
+
+**Inputs/Outputs.** Envelope `2.0.0`, keys mirroring table names, structurally a superset
+of `1.0.0` so one parser reads both. Device-local and account-identifying stores stay out —
+see the ADR's table.
+
+**Constraints.**
+- **`archivedAt` is in no schema.** `taskRecordSchema` is `.strict()`, so validating
+  archived records with it drops every one of them. A dedicated `archivedTaskRecordSchema`
+  is required. This is the single highest-risk detail in the change.
+- **`syncMetadata` must never be exported** — it holds `email`, `userId`, `deviceId`,
+  `localTaskOwnerUserId`. Privacy requirement.
+- Import is a new writer to `archivedTasks`: one transaction, `put` not `add`, no older
+  snapshot overwriting a newer one. Register it in `.claude/rules/archive-tombstone.md`.
+- `archivedTasks` is never synced — archived rows enqueue nothing.
+- Import keeps `.strip()` leniency; export keeps `.strict()`.
+
+**Edge cases.**
+- v1 payload (tasks only) → imports exactly as today; absent stores are left untouched.
+- Same id in both `tasks` and `archivedTasks` in the payload → live wins, archived
+  duplicate dropped, count reported (never silently swallowed).
+- Merge mode → archived rows added only when the id is absent from both tables; settings
+  untouched.
+- Empty `archivedTasks` → round-trips as an empty array, not a missing key.
+- A corrupt record in any store → skipped and counted, never aborting the whole backup.
+
+**Acceptance criteria.**
+1. Export of 4 live + 3 archived + settings produces an envelope containing all of them.
+2. Round-trip through replace mode restores every store byte-for-byte.
+3. A `1.0.0` payload still imports its tasks, and leaves other stores untouched.
+4. `syncMetadata`, `syncQueue`, `deviceInfo`, `syncHistory` never appear in output.
+5. Archived records survive export with `archivedAt` intact.
+6. A payload listing one id as both live and archived imports the live copy only, and
+   reports one dropped record.
+7. Merge mode leaves local settings unchanged.
+8. Replace-mode import runs in one transaction spanning every table it writes.
+
+**Test stubs.**
+```
+tests/data/import-export.test.ts (or export-full-fidelity.test.ts)
+  export
+    should_include_archived_tasks_with_archivedAt
+    should_include_smart_views_and_settings
+    should_never_include_sync_metadata_or_device_stores
+    should_emit_empty_arrays_rather_than_missing_keys
+  import v1 compatibility
+    should_import_tasks_from_a_1_0_0_payload
+    should_leave_other_stores_untouched_for_v1
+  import replace
+    should_restore_every_store
+    should_drop_archived_duplicate_when_id_is_also_live
+  import merge
+    should_add_archived_only_when_id_absent_from_both_tables
+    should_not_overwrite_local_settings
+```
+
+---
+
 ## Out of scope
 
 - Toast lanes / sync-toast preemption — could not be reproduced from code; the undo closure

--- a/tests/data/backup-envelope.test.ts
+++ b/tests/data/backup-envelope.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it, beforeEach } from "vitest";
+
+import { exportTasks, importTasks } from "@/lib/tasks";
+import { getDb } from "@/lib/db";
+import { createMockTask } from "@/tests/fixtures";
+import type { TaskRecord } from "@/lib/types";
+
+/**
+ * Full-fidelity backup coverage (ADR 0014).
+ *
+ * Export is the only way data leaves this app, so a store missing from the
+ * envelope is a store the user can never get back.
+ */
+
+function archived(id: string, archivedAt = "2026-01-01T00:00:00.000Z"): TaskRecord {
+  return { ...createMockTask({ id, title: `Archived ${id}`, completed: true }), archivedAt };
+}
+
+async function seedEveryStore() {
+  const db = getDb();
+  await db.tasks.bulkPut([
+    createMockTask({ id: "live-1", title: "Live one" }),
+    createMockTask({ id: "live-2", title: "Live two" }),
+  ]);
+  await db.archivedTasks.bulkPut([archived("arch-1"), archived("arch-2"), archived("arch-3")]);
+  await db.smartViews.put({
+    id: "custom-1",
+    name: "My view",
+    criteria: { status: "active" },
+    isBuiltIn: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  });
+  await db.notificationSettings.put({
+    id: "settings",
+    enabled: true,
+    defaultReminder: 45,
+    soundEnabled: false,
+    permissionAsked: true,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  });
+  await db.archiveSettings.put({ id: "settings", enabled: true, archiveAfterDays: 60 });
+  await db.appPreferences.put({
+    id: "preferences",
+    pinnedSmartViewIds: ["custom-1"],
+    maxPinnedViews: 5,
+    smartViewsEnabled: true,
+  });
+}
+
+async function clearEveryStore() {
+  const db = getDb();
+  await Promise.all([
+    db.tasks.clear(),
+    db.archivedTasks.clear(),
+    db.smartViews.clear(),
+    db.notificationSettings.clear(),
+    db.archiveSettings.clear(),
+    db.appPreferences.clear(),
+    db.syncQueue.clear(),
+  ]);
+}
+
+describe("Backup envelope", () => {
+  beforeEach(async () => {
+    await getDb();
+    await clearEveryStore();
+  });
+
+  describe("export", () => {
+    it("should_include_archived_tasks_with_archivedAt", async () => {
+      await seedEveryStore();
+      const payload = await exportTasks();
+
+      expect(payload.archivedTasks).toHaveLength(3);
+      // taskRecordSchema is .strict() and declares no archivedAt — validating
+      // archived rows with it would drop every one of them.
+      expect(payload.archivedTasks?.[0]?.archivedAt).toBe("2026-01-01T00:00:00.000Z");
+    });
+
+    it("should_include_smart_views_and_settings", async () => {
+      await seedEveryStore();
+      const payload = await exportTasks();
+
+      expect(payload.smartViews).toHaveLength(1);
+      expect(payload.notificationSettings?.defaultReminder).toBe(45);
+      expect(payload.archiveSettings?.archiveAfterDays).toBe(60);
+      expect(payload.appPreferences?.smartViewsEnabled).toBe(true);
+    });
+
+    it("should_announce_the_new_envelope_version", async () => {
+      await seedEveryStore();
+      expect((await exportTasks()).version).toBe("2.0.0");
+    });
+
+    it("should_never_include_device_local_or_account_stores", async () => {
+      await seedEveryStore();
+      const serialized = JSON.stringify(await exportTasks());
+
+      // syncMetadata carries email / userId / deviceId. A backup is a file people
+      // email themselves; it must not bind that file to an account.
+      for (const forbidden of ["syncMetadata", "syncQueue", "deviceInfo", "syncHistory"]) {
+        expect(serialized).not.toContain(forbidden);
+      }
+    });
+
+    it("should_emit_empty_arrays_rather_than_missing_keys", async () => {
+      const payload = await exportTasks();
+      expect(payload.tasks).toEqual([]);
+      expect(payload.archivedTasks).toEqual([]);
+      expect(payload.smartViews).toEqual([]);
+    });
+  });
+
+  describe("import — 1.0.0 compatibility", () => {
+    it("should_import_tasks_from_a_1_0_0_payload", async () => {
+      const db = getDb();
+      await importTasks(
+        {
+          version: "1.0.0",
+          exportedAt: "2026-01-01T00:00:00.000Z",
+          tasks: [createMockTask({ id: "legacy-1", title: "Legacy task" })],
+        },
+        "replace"
+      );
+
+      expect(await db.tasks.count()).toBe(1);
+    });
+
+    it("should_leave_other_stores_untouched_for_a_1_0_0_payload", async () => {
+      const db = getDb();
+      await seedEveryStore();
+
+      await importTasks(
+        {
+          version: "1.0.0",
+          exportedAt: "2026-01-01T00:00:00.000Z",
+          tasks: [createMockTask({ id: "legacy-1", title: "Legacy task" })],
+        },
+        "replace"
+      );
+
+      // A v1 backup says nothing about the archive, so replace must not read
+      // that silence as "delete it".
+      expect(await db.archivedTasks.count()).toBe(3);
+      expect(await db.archiveSettings.get("settings")).toBeDefined();
+    });
+  });
+
+  describe("import — replace", () => {
+    it("should_restore_every_store", async () => {
+      const db = getDb();
+      await seedEveryStore();
+      const backup = await exportTasks();
+
+      await clearEveryStore();
+      await importTasks(backup, "replace");
+
+      expect(await db.tasks.count()).toBe(2);
+      expect(await db.archivedTasks.count()).toBe(3);
+      expect(await db.smartViews.count()).toBe(1);
+      expect((await db.notificationSettings.get("settings"))?.defaultReminder).toBe(45);
+      expect((await db.archiveSettings.get("settings"))?.archiveAfterDays).toBe(60);
+      expect((await db.appPreferences.get("preferences"))?.maxPinnedViews).toBe(5);
+    });
+
+    it("should_preserve_archivedAt_through_a_round_trip", async () => {
+      const db = getDb();
+      await seedEveryStore();
+      const backup = await exportTasks();
+
+      await clearEveryStore();
+      await importTasks(backup, "replace");
+
+      expect((await db.archivedTasks.get("arch-1"))?.archivedAt).toBe(
+        "2026-01-01T00:00:00.000Z"
+      );
+    });
+
+    it("should_drop_the_archived_duplicate_when_an_id_is_also_live", async () => {
+      const db = getDb();
+
+      // Self-contradictory payload: ADR 0013 rule 1 says an id lives in one
+      // table or the other, never both.
+      await importTasks(
+        {
+          version: "2.0.0",
+          exportedAt: "2026-01-01T00:00:00.000Z",
+          tasks: [createMockTask({ id: "shared", title: "Live wins" })],
+          archivedTasks: [archived("shared")],
+        },
+        "replace"
+      );
+
+      expect(await db.tasks.get("shared")).toBeDefined();
+      expect(await db.archivedTasks.get("shared")).toBeUndefined();
+    });
+  });
+
+  describe("import — merge", () => {
+    it("should_add_archived_only_when_the_id_is_absent_from_both_tables", async () => {
+      const db = getDb();
+      await db.tasks.put(createMockTask({ id: "already-live", title: "Existing live" }));
+      await db.archivedTasks.put(archived("already-archived"));
+
+      await importTasks(
+        {
+          version: "2.0.0",
+          exportedAt: "2026-01-01T00:00:00.000Z",
+          tasks: [],
+          archivedTasks: [archived("already-live"), archived("already-archived"), archived("fresh")],
+        },
+        "merge"
+      );
+
+      expect(await db.archivedTasks.get("fresh")).toBeDefined();
+      // Would have resurrected a tombstone over live data.
+      expect(await db.archivedTasks.get("already-live")).toBeUndefined();
+      expect(await db.tasks.get("already-live")).toBeDefined();
+      expect(await db.archivedTasks.count()).toBe(2);
+    });
+
+    it("should_not_overwrite_local_settings", async () => {
+      const db = getDb();
+      await seedEveryStore();
+
+      await importTasks(
+        {
+          version: "2.0.0",
+          exportedAt: "2026-01-01T00:00:00.000Z",
+          tasks: [],
+          archiveSettings: { id: "settings", enabled: false, archiveAfterDays: 30 },
+        },
+        "merge"
+      );
+
+      // Merge combines task lists; it does not adopt another device's config.
+      expect((await db.archiveSettings.get("settings"))?.archiveAfterDays).toBe(60);
+    });
+  });
+});

--- a/tests/data/tasks/import-export.test.ts
+++ b/tests/data/tasks/import-export.test.ts
@@ -101,6 +101,24 @@ describe('Task Import/Export Operations', () => {
           primaryKeys: vi.fn().mockResolvedValue([]),
         })),
       },
+      // Every user-owned store the 2.0.0 envelope carries (ADR 0014). Defaults
+      // are empty so existing task-only assertions keep their meaning.
+      archivedTasks: {
+        toArray: vi.fn().mockResolvedValue([]),
+        clear: vi.fn(),
+        put: vi.fn(),
+        toCollection: vi.fn(() => ({
+          primaryKeys: vi.fn().mockResolvedValue([]),
+        })),
+      },
+      smartViews: {
+        toArray: vi.fn().mockResolvedValue([]),
+        clear: vi.fn(),
+        put: vi.fn(),
+      },
+      notificationSettings: { get: vi.fn().mockResolvedValue(undefined), put: vi.fn() },
+      archiveSettings: { get: vi.fn().mockResolvedValue(undefined), put: vi.fn() },
+      appPreferences: { get: vi.fn().mockResolvedValue(undefined), put: vi.fn() },
       syncQueue: {
         add: vi.fn(),
         clear: vi.fn(),
@@ -124,7 +142,7 @@ describe('Task Import/Export Operations', () => {
       expect(result).toHaveProperty('exportedAt');
       expect(result).toHaveProperty('version');
       expect(result.tasks).toHaveLength(2);
-      expect(result.version).toBe('1.0.0');
+      expect(result.version).toBe('2.0.0');
     });
 
     it('should validate tasks with schema', async () => {
@@ -156,7 +174,7 @@ describe('Task Import/Export Operations', () => {
       const result = await exportTasks();
 
       expect(result.tasks).toEqual([]);
-      expect(result.version).toBe('1.0.0');
+      expect(result.version).toBe('2.0.0');
     });
 
     it('should skip invalid tasks instead of aborting the whole export', async () => {
@@ -328,9 +346,19 @@ describe('Task Import/Export Operations', () => {
 
       await importTasks(validPayload, 'replace');
 
+      // Scoped across every table a restore writes — a narrower scope would let
+      // a partial restore commit (ADR 0014).
       expect(mockDb.transaction).toHaveBeenCalledWith(
         'rw',
-        [mockDb.tasks, mockDb.syncQueue],
+        [
+          mockDb.tasks,
+          mockDb.archivedTasks,
+          mockDb.smartViews,
+          mockDb.notificationSettings,
+          mockDb.archiveSettings,
+          mockDb.appPreferences,
+          mockDb.syncQueue,
+        ],
         expect.any(Function)
       );
     });
@@ -419,7 +447,7 @@ describe('Task Import/Export Operations', () => {
 
       expect(parsed).toHaveProperty('tasks');
       expect(parsed.tasks).toHaveLength(2);
-      expect(parsed.version).toBe('1.0.0');
+      expect(parsed.version).toBe('2.0.0');
     });
 
     it('should format with indentation', async () => {

--- a/tests/e2e/data-management.spec.ts
+++ b/tests/e2e/data-management.spec.ts
@@ -209,4 +209,90 @@ test.describe("Data Management — Import", () => {
 
     await expect(page.getByText("2 tasks", { exact: true })).toBeVisible();
   });
+
+  /**
+   * The restore half of ADR 0014. Before it, a v2 backup's archive was dropped
+   * on import, so a user who wiped their browser got their board back and lost
+   * everything they had ever archived.
+   */
+  test("replace-mode restore brings the archive back", async ({ page }) => {
+    await matrixPage.createTask("Task before restore");
+    await gotoDataSection(matrixPage);
+
+    const now = "2026-01-01T00:00:00.000Z";
+    const archivedRecord = {
+      id: "restored-archive-1",
+      title: "Restored from the archive",
+      description: "",
+      urgent: false,
+      important: false,
+      quadrant: "not-urgent-not-important",
+      completed: true,
+      createdAt: now,
+      updatedAt: now,
+      archivedAt: now,
+      recurrence: "none",
+      tags: [],
+      subtasks: [],
+      dependencies: [],
+      notificationEnabled: false,
+      notificationSent: false,
+    };
+
+    const backup = JSON.stringify({
+      version: "2.0.0",
+      exportedAt: now,
+      tasks: [{ ...archivedRecord, id: "restored-live-1", title: "Restored live task", completed: false, archivedAt: undefined }],
+      archivedTasks: [archivedRecord],
+      archiveSettings: { id: "settings", enabled: true, archiveAfterDays: 90 },
+    });
+
+    const fileChooserPromise = page.waitForEvent("filechooser");
+    await page.getByRole("button", { name: /import/i }).click();
+    await (await fileChooserPromise).setFiles({
+      name: "full-backup.json",
+      mimeType: "application/json",
+      buffer: Buffer.from(backup),
+    });
+
+    const dialog = page.getByRole("dialog", { name: /import tasks/i });
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await dialog.getByRole("button", { name: /replace everything/i }).click();
+    await expect(dialog).toBeHidden();
+
+    // The archive is restored into its own store, not the board.
+    const archived = await page.evaluate(() => {
+      return new Promise<unknown[]>((resolve, reject) => {
+        const req = indexedDB.open("GsdTaskManager");
+        req.onsuccess = () => {
+          const db = req.result;
+          const store = db.transaction("archivedTasks", "readonly").objectStore("archivedTasks");
+          const all = store.getAll();
+          all.onsuccess = () => { db.close(); resolve(all.result); };
+          all.onerror = () => { db.close(); reject(all.error); };
+        };
+        req.onerror = () => reject(req.error);
+      });
+    });
+
+    expect(archived).toHaveLength(1);
+    expect((archived[0] as { title: string }).title).toBe("Restored from the archive");
+    expect((archived[0] as { archivedAt: string }).archivedAt).toBe(now);
+
+    // Settings ride along on the restore path.
+    const archiveDays = await page.evaluate(() => {
+      return new Promise<number | undefined>((resolve, reject) => {
+        const req = indexedDB.open("GsdTaskManager");
+        req.onsuccess = () => {
+          const db = req.result;
+          const get = db.transaction("archiveSettings", "readonly")
+            .objectStore("archiveSettings").get("settings");
+          get.onsuccess = () => { db.close(); resolve(get.result?.archiveAfterDays); };
+          get.onerror = () => { db.close(); reject(get.error); };
+        };
+        req.onerror = () => reject(req.error);
+      });
+    });
+    expect(archiveDays).toBe(90);
+  });
 });

--- a/tests/e2e/settings-navigation.spec.ts
+++ b/tests/e2e/settings-navigation.spec.ts
@@ -110,4 +110,73 @@ test.describe("Settings Navigation", () => {
 
     expect(download.suggestedFilename()).toMatch(/^gsd-tasks-.*\.json$/);
   });
+
+  /**
+   * The backup is the only copy of this data that leaves the app, so what
+   * matters is the *contents* of the file the user actually receives — not that
+   * a download fired. Before ADR 0014 this file held 1 of 6 user-owned stores.
+   */
+  test("exported backup carries every user-owned store and no account data", async ({ page }) => {
+    await matrixPage.createTask("Live task for backup");
+
+    // Archived tasks live in their own store and can't be created from the UI.
+    await page.evaluate(() => {
+      return new Promise<void>((resolve, reject) => {
+        const req = indexedDB.open("GsdTaskManager");
+        req.onsuccess = () => {
+          const db = req.result;
+          const tx = db.transaction("archivedTasks", "readwrite");
+          const now = new Date().toISOString();
+          tx.objectStore("archivedTasks").put({
+            id: "e2e-archived-1",
+            title: "Archived task for backup",
+            description: "",
+            urgent: false,
+            important: false,
+            quadrant: "not-urgent-not-important",
+            completed: true,
+            createdAt: now,
+            updatedAt: now,
+            archivedAt: now,
+            recurrence: "none",
+            tags: [],
+            subtasks: [],
+            dependencies: [],
+            notificationEnabled: false,
+            notificationSent: false,
+            timeSpent: 0,
+            timeEntries: [],
+          });
+          tx.oncomplete = () => { db.close(); resolve(); };
+          tx.onerror = () => { db.close(); reject(tx.error); };
+        };
+        req.onerror = () => reject(req.error);
+      });
+    });
+
+    await matrixPage.openSettings();
+    await page.locator("aside.lg\\:block").getByRole("button", { name: "Data & Storage" }).click();
+    await expect(page.locator("main h2", { hasText: "Data & Storage" })).toBeVisible();
+
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: /Export tasks/ }).click();
+    const stream = await (await downloadPromise).createReadStream();
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) chunks.push(chunk as Buffer);
+    const backup = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+
+    expect(backup.version).toBe("2.0.0");
+    expect(backup.tasks.length).toBeGreaterThan(0);
+
+    // The 232-record omission this ADR exists to fix.
+    expect(backup.archivedTasks).toHaveLength(1);
+    expect(backup.archivedTasks[0].archivedAt).toBeTruthy();
+
+    // syncMetadata carries email / userId / deviceId. A backup must not bind
+    // the file to an account.
+    const serialized = JSON.stringify(backup);
+    for (const forbidden of ["syncMetadata", "deviceInfo", "syncHistory", "syncQueue"]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
 });

--- a/tests/ui/import-dialog.test.tsx
+++ b/tests/ui/import-dialog.test.tsx
@@ -97,8 +97,10 @@ describe("ImportDialog", () => {
   it("renders replace option button", () => {
     render(<ImportDialog {...defaultProps} />);
 
-    expect(screen.getByText("Replace All Tasks")).toBeInTheDocument();
-    expect(screen.getByText(/delete all existing tasks/i)).toBeInTheDocument();
+    expect(screen.getByText("Replace Everything")).toBeInTheDocument();
+    // Replace restores the whole backup, not just the task list (ADR 0014), so
+    // the copy has to name what else it overwrites.
+    expect(screen.getByText(/tasks, archive, and settings/i)).toBeInTheDocument();
     expect(screen.getByText(/warning - deletes 5 existing/i)).toBeInTheDocument();
   });
 
@@ -123,7 +125,7 @@ describe("ImportDialog", () => {
     const user = userEvent.setup();
     render(<ImportDialog {...defaultProps} />);
 
-    await user.click(screen.getByText("Replace All Tasks"));
+    await user.click(screen.getByText("Replace Everything"));
 
     await waitFor(() => {
       expect(mockImportFromJson).toHaveBeenCalledWith(validJsonContent, "replace");
@@ -145,7 +147,7 @@ describe("ImportDialog", () => {
     const user = userEvent.setup();
     render(<ImportDialog {...defaultProps} />);
 
-    await user.click(screen.getByText("Replace All Tasks"));
+    await user.click(screen.getByText("Replace Everything"));
 
     await waitFor(() => {
       expect(mockOnImportComplete).toHaveBeenCalled();
@@ -171,7 +173,7 @@ describe("ImportDialog", () => {
     render(<ImportDialog {...defaultProps} />);
 
     const mergeButton = screen.getByText("Merge Tasks").closest("button");
-    const replaceButton = screen.getByText("Replace All Tasks").closest("button");
+    const replaceButton = screen.getByText("Replace Everything").closest("button");
     const cancelButton = screen.getByRole("button", { name: /cancel/i });
 
     await user.click(mergeButton!);


### PR DESCRIPTION
Wave C — the P0 data-loss item from the v11.2.1 review. ADR: `docs/adr/0014-versioned-backup-envelope.md`.

## The problem

`exportTasks()` read `db.tasks` and nothing else. **A backup held 59 of 291 records.**

| Store | Before | After |
|---|---|---|
| `tasks` | exported | exported |
| `archivedTasks` | **missing** (232 records) | exported |
| `smartViews` | **missing** | exported |
| `notificationSettings` | **missing** | exported |
| `archiveSettings` | **missing** | exported |
| `appPreferences` | **missing** | exported |

Import mirrored the omission — its transaction was scoped to `[tasks, syncQueue]` — so restoring a backup silently discarded the archive too. There is no server copy by default; export *is* the backup story.

## Envelope 2.0.0

Keys mirror the Dexie table names, and every new key is optional — which makes 2.0.0 a structural **superset** of 1.0.0. One parser reads both, and no existing backup file needs migrating.

## What's deliberately excluded, and why it matters

`syncMetadata`, `syncQueue`, `deviceInfo`, `syncHistory` stay out.

`syncMetadata` holds `email`, `userId`, `deviceId`, and `localTaskOwnerUserId`. A backup is a file people mail themselves and drop in cloud storage — it must not bind that file to a PocketBase account. **This is a privacy requirement, not tidiness.** (Auth tokens were never at risk; the PB SDK keeps those in `localStorage`, outside IndexedDB.) Restoring a backup never changes who you're signed in as.

## The subtle part — and the trap this could have fallen into

`archivedAt` is declared in **no schema**, and `taskRecordSchema` is `.strict()`.

Validating archived rows with it rejects **every single one** — and rejects them *silently*, because the export path skips invalid records rather than throwing. A naive implementation would have shipped an export that produced an empty archive looking exactly like a genuinely empty archive: the original bug, wearing the fix's clothes.

Hence `archivedTaskRecordSchema`. This is recorded in `.claude/rules/archive-tombstone.md` so the next person doesn't rediscover it.

## Tombstone compliance (ADR 0013)

Import becomes a new writer to `archivedTasks`, now registered in the rule's writer table:

- **One transaction** across all seven tables it touches — a narrower scope would let a partial restore commit.
- **`put`, not `add`** — a re-import can't raise `ConstraintError` and abort the shared transaction.
- **Live wins on a contradictory payload.** An id listed as both live and archived drops the archived copy and reports the count; resurrecting a tombstone over live work loses data, dropping a redundant tombstone doesn't.
- **An absent key is not a delete.** A 1.0.0 backup says nothing about the archive, so replace leaves it alone rather than reading silence as "empty".

## Import semantics

| | Replace — *"restore this backup"* | Merge — *"add these to what I have"* |
|---|---|---|
| `tasks` | cleared and rewritten | added; colliding ids regenerated |
| `archivedTasks` | cleared and rewritten | added only when absent from **both** tables |
| Settings | applied | **untouched** |

Merging combines task lists; it doesn't adopt another device's notification schedule. Dialog copy updated to say so.

## Verification

**Real browser, real download, real restore** — not just `fake-indexeddb`:

- `exported backup carries every user-owned store and no account data` — parses the actual downloaded file, asserts `archivedTasks[0].archivedAt` survives and no account store appears
- `replace-mode restore brings the archive back` — uploads a v2 backup through the dialog, then reads IndexedDB to confirm the archive and settings landed

Results: 21/21 e2e passing across data-management + settings · `bun run test` 2669 passed, 1 skipped (12 new unit tests) · typecheck / lint clean · shape ratchet **tightened** (113 → 112 violations).

## Sets up Wave E

Trash slots into this envelope additively — `deletedTasks` becomes another optional key, no second breaking bump. That ordering was the reason Wave C went first.

https://claude.ai/code/session_01DA4QuYKyWt5WkynEqteWJH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->