### PR TITLE
feat(matrix): offer an undo when a task is completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.4.0
+**Current version:** 11.4.1
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -2,23 +2,23 @@
 
 import { useCallback, useEffect, useReducer, useRef, useState, useSyncExternalStore } from "react";
 import { DndContext, closestCorners } from "@dnd-kit/core";
-import { createTask, toggleCompleted, updateTask, deleteTask, restoreTask } from "@/lib/tasks";
-import { celebrateCompletion } from "@/lib/confetti";
+import { createTask, updateTask, deleteTask, restoreTask } from "@/lib/tasks";
 import { extractUrlsFromTitle, buildDescription } from "@/lib/capture-parser";
 import { toast } from "sonner";
+import { TOAST_DURATION } from "@/lib/constants";
 import { useTasks } from "@/lib/use-tasks";
 import { useErrorHandlerWithUndo } from "@/lib/use-error-handler";
-import { ErrorActions, logError } from "@/lib/error-logger";
+import { ErrorActions } from "@/lib/error-logger";
 import { useDragAndDrop } from "@/lib/use-drag-and-drop";
 import { useAutoArchive } from "@/lib/use-auto-archive";
 import { useNotificationChecker } from "@/lib/use-notification-checker";
-import { TOAST_DURATION } from "@/lib/constants";
 import { SHOW_COMPLETED_EVENT, readShowCompleted } from "@/lib/preferences/show-completed";
 import type { TaskDraft, TaskRecord } from "@/lib/types";
 import { quadrantByRdKey, type RedesignQuadrantKey } from "@/lib/quadrants";
 import { ShareTaskDialog } from "@/components/share-task-dialog";
 import { AppShell } from "./app-shell";
 import { CaptureBar, type CapturePayload } from "./capture-bar";
+import { handleCapture, handleToggle, reportTaskMutationError } from "./task-actions";
 import { DragLayer } from "./drag-layer";
 import { MatrixGrid } from "./matrix-grid";
 import { MatrixGridSkeleton } from "./matrix-grid-skeleton";
@@ -93,21 +93,6 @@ const initialOverlayState: OverlayState = {
   sharingTask: null,
 };
 
-function reportTaskMutationError(
-  error: unknown,
-  action: string,
-  userMessage: string,
-  taskId?: string
-): void {
-  logError(error, {
-    action,
-    taskId,
-    userMessage,
-    timestamp: new Date().toISOString(),
-  });
-  toast.error(userMessage, { duration: TOAST_DURATION.LONG });
-}
-
 function overlayReducer(state: OverlayState, action: OverlayAction): OverlayState {
   switch (action.type) {
     case "openEdit":
@@ -126,38 +111,6 @@ function overlayReducer(state: OverlayState, action: OverlayAction): OverlayStat
       return { ...state, sharingTask: action.task };
     case "closeShare":
       return { ...state, sharingTask: null };
-  }
-}
-
-// Pure capture/toggle handlers — they close over no component state, so they
-// live at module scope (stable identity for memoized children).
-async function handleCapture({ title, urgent, important, tags }: CapturePayload): Promise<void> {
-  try {
-    const { cleanTitle, urls } = extractUrlsFromTitle(title);
-    await createTask({
-      title: cleanTitle,
-      description: buildDescription("", urls),
-      urgent,
-      important,
-      tags: tags.length > 0 ? tags : undefined,
-    });
-    toast.success("Task added", { duration: TOAST_DURATION.SHORT });
-  } catch (error) {
-    reportTaskMutationError(error, ErrorActions.CREATE_TASK, "Failed to create task");
-  }
-}
-
-async function handleToggle(task: TaskRecord, completedNext: boolean): Promise<void> {
-  try {
-    await toggleCompleted(task.id, completedNext);
-    if (completedNext) celebrateCompletion();
-  } catch (error) {
-    reportTaskMutationError(
-      error,
-      ErrorActions.TOGGLE_TASK,
-      "Failed to update task",
-      task.id
-    );
   }
 }
 
@@ -417,7 +370,9 @@ export function MatrixSimplified() {
             allTasks={all}
             onEdit={handleEditOpen}
             onInspect={handleInspectOpen}
-            onToggleComplete={handleToggle}
+            onToggleComplete={(task, completedNext) =>
+              handleToggle(task, completedNext, handleSuccess)
+            }
             onDelete={handleDelete}
             onShare={handleShareOpen}
             onAddInQuadrant={handleAddInQuadrant}

--- a/components/matrix-simplified/task-actions.ts
+++ b/components/matrix-simplified/task-actions.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import { toast } from "sonner";
+
+import { createTask, toggleCompleted, deleteTask } from "@/lib/tasks";
+import { celebrateCompletion } from "@/lib/confetti";
+import { extractUrlsFromTitle, buildDescription } from "@/lib/capture-parser";
+import { ErrorActions, logError } from "@/lib/error-logger";
+import { TOAST_DURATION } from "@/lib/constants";
+import type { TaskRecord } from "@/lib/types";
+
+import type { CapturePayload } from "./capture-bar";
+
+export function reportTaskMutationError(
+  error: unknown,
+  action: string,
+  userMessage: string,
+  taskId?: string
+): void {
+  logError(error, {
+    action,
+    taskId,
+    userMessage,
+    timestamp: new Date().toISOString(),
+  });
+  toast.error(userMessage, { duration: TOAST_DURATION.LONG });
+}
+
+// Pure capture/toggle handlers — they close over no component state, so they
+// live at module scope (stable identity for memoized children).
+export async function handleCapture({ title, urgent, important, tags }: CapturePayload): Promise<void> {
+  try {
+    const { cleanTitle, urls } = extractUrlsFromTitle(title);
+    await createTask({
+      title: cleanTitle,
+      description: buildDescription("", urls),
+      urgent,
+      important,
+      tags: tags.length > 0 ? tags : undefined,
+    });
+    toast.success("Task added", { duration: TOAST_DURATION.SHORT });
+  } catch (error) {
+    reportTaskMutationError(error, ErrorActions.CREATE_TASK, "Failed to create task");
+  }
+}
+
+/**
+ * Toggle completion, offering an Undo on the completing direction only.
+ *
+ * Completion is the most frequent action in the app and its checkbox sits
+ * inches from delete, which has had an Undo since forever. Un-completing needs
+ * none — it is already the reversal.
+ *
+ * A recurring completion spawns the next instance, so undo removes that too;
+ * reversing only the completion would leave an orphan on the board.
+ */
+export async function handleToggle(
+  task: TaskRecord,
+  completedNext: boolean,
+  offerUndo: (message: string, undo: () => Promise<void>) => void
+): Promise<void> {
+  try {
+    const { recurringInstance } = await toggleCompleted(task.id, completedNext);
+    if (!completedNext) return;
+
+    celebrateCompletion();
+    offerUndo("Task completed", async () => {
+      await toggleCompleted(task.id, false);
+      if (recurringInstance) await deleteTask(recurringInstance.id);
+    });
+  } catch (error) {
+    reportTaskMutationError(
+      error,
+      ErrorActions.TOGGLE_TASK,
+      "Failed to update task",
+      task.id
+    );
+  }
+}
+

--- a/lib/tasks/crud/toggle.ts
+++ b/lib/tasks/crud/toggle.ts
@@ -31,19 +31,32 @@ async function withCompletionLock<T>(
 }
 
 /**
+ * Outcome of a completion toggle.
+ *
+ * `recurringInstance` is the task spawned by completing a recurring task. Undo
+ * needs it: reversing only the completion would leave the next instance behind
+ * as an orphan, so the caller receives the id rather than having to guess it
+ * from `parentTaskId` (which every instance in a chain shares).
+ */
+export interface ToggleCompletedResult {
+  task: TaskRecord;
+  recurringInstance: TaskRecord | null;
+}
+
+/**
  * Toggle task completion status, handling recurring task creation
  */
 export async function toggleCompleted(
   id: string,
   completed: boolean
-): Promise<TaskRecord> {
+): Promise<ToggleCompletedResult> {
   return withCompletionLock(id, () => toggleCompletedTransaction(id, completed));
 }
 
 async function toggleCompletedTransaction(
   id: string,
   completed: boolean
-): Promise<TaskRecord> {
+): Promise<ToggleCompletedResult> {
   try {
     const db = getDb();
     const result = await runTaskSyncTransaction(async ({ syncEnabled, enqueue }) => {
@@ -80,7 +93,7 @@ async function toggleCompletedTransaction(
       completed,
       title: nextRecord.title,
     });
-    return nextRecord;
+    return { task: nextRecord, recurringInstance };
   } catch (error) {
     logger.error(
       "Failed to toggle task completion",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.4.0",
+	"version": "11.4.1",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/tests/data/tasks.test.ts
+++ b/tests/data/tasks.test.ts
@@ -189,7 +189,7 @@ describe("Task CRUD operations", () => {
 
       // Wait a bit to ensure different timestamp
       await new Promise(resolve => setTimeout(resolve, 10));
-      const updated = await toggleCompleted(task.id, true);
+      const { task: updated } = await toggleCompleted(task.id, true);
 
       expect(updated.completed).toBe(true);
       expect(updated.updatedAt).not.toBe(task.updatedAt);
@@ -199,7 +199,7 @@ describe("Task CRUD operations", () => {
       const task = await createTask(createSampleTask());
       await toggleCompleted(task.id, true);
 
-      const updated = await toggleCompleted(task.id, false);
+      const { task: updated } = await toggleCompleted(task.id, false);
 
       expect(updated.completed).toBe(false);
     });

--- a/tests/data/tasks/crud-side-effects.test.ts
+++ b/tests/data/tasks/crud-side-effects.test.ts
@@ -106,6 +106,35 @@ describe("task crud side effects (real DB)", () => {
     expect(instances).toHaveLength(1);
   });
 
+  describe("toggleCompleted result", () => {
+    it("reports the spawned instance so a caller can undo the whole completion", async () => {
+      const db = getDb();
+      await db.tasks.put(createMockTask({
+        id: "recurring-2",
+        recurrence: "daily",
+        dueDate: "2026-07-10T12:00:00.000Z",
+      }));
+
+      const result = await toggleCompleted("recurring-2", true);
+
+      // Undo has to remove the next instance too; without the id it would
+      // un-complete the task and leave an orphan behind.
+      expect(result.task.completed).toBe(true);
+      expect(result.recurringInstance).not.toBeNull();
+      expect(await db.tasks.get(result.recurringInstance!.id)).toBeDefined();
+    });
+
+    it("reports no instance for a non-recurring completion", async () => {
+      const db = getDb();
+      await db.tasks.put(createMockTask({ id: "plain-1" }));
+
+      const result = await toggleCompleted("plain-1", true);
+
+      expect(result.task.completed).toBe(true);
+      expect(result.recurringInstance).toBeNull();
+    });
+  });
+
   describe("snoozeTask", () => {
     it("sets snoozedUntil and persists it for a positive duration", async () => {
       const db = getDb();

--- a/tests/data/tasks/crud.test.ts
+++ b/tests/data/tasks/crud.test.ts
@@ -417,7 +417,7 @@ describe('Task CRUD Operations', () => {
       mockDb.tasks.get.mockResolvedValue(existing);
       mockDb.tasks.put.mockResolvedValue(undefined);
 
-      const result = await toggleCompleted('task-1', true);
+      const { task: result } = await toggleCompleted('task-1', true);
 
       expect(result.completed).toBe(true);
       expect(result.completedAt).toBeDefined();
@@ -438,7 +438,7 @@ describe('Task CRUD Operations', () => {
       mockDb.tasks.get.mockResolvedValue(existing);
       mockDb.tasks.put.mockResolvedValue(undefined);
 
-      const result = await toggleCompleted('task-1', false);
+      const { task: result } = await toggleCompleted('task-1', false);
 
       expect(result.completed).toBe(false);
       expect(result.completedAt).toBeUndefined();

--- a/tests/ui/matrix-simplified.test.tsx
+++ b/tests/ui/matrix-simplified.test.tsx
@@ -50,7 +50,9 @@ function makeTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
 
 vi.mock("@/lib/tasks", () => ({
   createTask: vi.fn().mockResolvedValue(undefined),
-  toggleCompleted: vi.fn().mockResolvedValue(undefined),
+  // Returns { task, recurringInstance } so callers can undo the whole
+  // completion, including the instance a recurring task spawns.
+  toggleCompleted: vi.fn().mockResolvedValue({ task: null, recurringInstance: null }),
   updateTask: vi.fn().mockResolvedValue(undefined),
   deleteTask: vi.fn().mockResolvedValue(undefined),
   restoreTask: vi.fn().mockResolvedValue(undefined),
@@ -170,7 +172,7 @@ describe("<MatrixSimplified>", () => {
     }
     vi.mocked(createTask).mockReset().mockResolvedValue(undefined);
     vi.mocked(celebrateCompletion).mockClear();
-    vi.mocked(toggleCompleted).mockReset().mockResolvedValue(undefined);
+    vi.mocked(toggleCompleted).mockReset().mockResolvedValue({ task: null, recurringInstance: null });
     vi.mocked(updateTask).mockReset().mockResolvedValue(undefined);
     vi.mocked(deleteTask).mockReset().mockResolvedValue(undefined);
     vi.mocked(restoreTask).mockReset().mockResolvedValue(undefined);
@@ -249,6 +251,69 @@ describe("<MatrixSimplified>", () => {
 
       await waitFor(() => expect(toggleCompleted).toHaveBeenCalledWith("b", false));
       expect(celebrateCompletion).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("completion undo", () => {
+    it("offers an undo when a task is completed", async () => {
+      const user = userEvent.setup();
+      tasksFixture.current = [makeTask({ id: "a", title: "Active alpha", completed: false })];
+      render(<MatrixSimplified />);
+
+      await user.click(screen.getByRole("button", { name: /mark as complete/i }));
+
+      // Completion is the most frequent action and its checkbox sits inches
+      // from delete, which has had an Undo since forever.
+      await waitFor(() =>
+        expect(handleSuccessSpy).toHaveBeenCalledWith(
+          "Task completed",
+          expect.any(Function)
+        )
+      );
+    });
+
+    it("un-completes the task when the undo runs", async () => {
+      const user = userEvent.setup();
+      tasksFixture.current = [makeTask({ id: "a", title: "Active alpha", completed: false })];
+      render(<MatrixSimplified />);
+
+      await user.click(screen.getByRole("button", { name: /mark as complete/i }));
+      await waitFor(() => expect(handleSuccessSpy).toHaveBeenCalled());
+
+      vi.mocked(toggleCompleted).mockClear();
+      await handleSuccessSpy.mock.calls[0][1]();
+
+      expect(toggleCompleted).toHaveBeenCalledWith("a", false);
+    });
+
+    it("removes the spawned next instance when undoing a recurring completion", async () => {
+      const user = userEvent.setup();
+      vi.mocked(toggleCompleted).mockResolvedValueOnce({
+        task: makeTask({ id: "r", completed: true }),
+        recurringInstance: makeTask({ id: "r-next", completed: false }),
+      });
+      tasksFixture.current = [makeTask({ id: "r", title: "Recurring task", completed: false })];
+      render(<MatrixSimplified />);
+
+      await user.click(screen.getByRole("button", { name: /mark as complete/i }));
+      await waitFor(() => expect(handleSuccessSpy).toHaveBeenCalled());
+
+      await handleSuccessSpy.mock.calls[0][1]();
+
+      // Undoing only the completion would leave the next instance orphaned.
+      expect(deleteTask).toHaveBeenCalledWith("r-next");
+    });
+
+    it("does not offer an undo when un-completing", async () => {
+      const user = userEvent.setup();
+      localStorage.setItem("gsd:show-completed", "true");
+      tasksFixture.current = [makeTask({ id: "b", title: "Done bravo", completed: true })];
+      render(<MatrixSimplified />);
+
+      await user.click(screen.getByRole("button", { name: /mark as incomplete/i }));
+
+      await waitFor(() => expect(toggleCompleted).toHaveBeenCalledWith("b", false));
+      expect(handleSuccessSpy).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Wave D, PR 1 of 4. The review called this "the highest relief-per-line-of-code item".

## Why

Delete has always been undoable. **Complete was not** — despite being the most frequent action in the app, with its checkbox sitting inches from delete. Recovery meant enabling Show-completed and scrolling a board that grows past 8,000px once 51 completed cards appear.

## The non-obvious part: recurring tasks

Completing a recurring task **spawns the next instance**. Undoing only the completion would leave that instance orphaned on the board — a fresh duplicate the user never asked for.

The caller can't infer which task was spawned: `parentTaskId` points at the original ancestor, so every instance in a chain shares it. So `toggleCompleted` now reports it:

```ts
// before
Promise<TaskRecord>
// after
Promise<{ task: TaskRecord; recurringInstance: TaskRecord | null }>
```

Undo then reverses the completion *and* deletes the spawned instance.

Only one caller existed in the web app. MCP's `complete_task` goes through PocketBase directly and is unaffected.

## Scope

Undo is offered on the **completing** direction only — un-completing is already the reversal, so a toast there would be noise.

## Refactor the ratchet required

Adding the handler pushed `matrix-simplified/index.tsx` past the 400-line `max-lines` budget (which is 0 and one-way). The capture and toggle handlers moved to `task-actions.ts` — they close over no component state, so they were already module-scope and didn't belong in the component file. `max-lines-per-function` came down 269 → 267.

## Verification

Live headless run:

> After clicking a task's checkbox, a toast appears... displays **'Task completed'** and includes an **'Undo' button** next to it.

Console clean — 0 errors, 0 warnings.

- 4 new UI tests (undo offered, undo un-completes, undo removes the spawned instance, no undo when un-completing)
- 2 new data tests on the result shape
- `bun run test` — 2675 passed, 1 skipped
- typecheck / lint / shape ratchet clean

https://claude.ai/code/session_01DA4QuYKyWt5WkynEqteWJH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->