### PR TITLE
fix(logging): put the message in the console string, not only the object

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.4.1
+**Current version:** 11.4.2
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/lib/error-logger.ts
+++ b/lib/error-logger.ts
@@ -40,16 +40,22 @@ export function logError(error: unknown, context: ErrorContext): LoggedError {
     stack: error instanceof Error ? error.stack : undefined
   };
 
-  // In development, log to console with full context
+  // The string argument carries enough to diagnose from on its own. Console
+  // capture stringifies arguments, so passing only an object lands in a bug
+  // report as "[GSD Error] [object Object]" — which is what a reviewer of this
+  // app actually got, and why they could not diagnose a failing drag.
+  const summary =
+    `[GSD Error] ${loggedError.action}: ${loggedError.errorType}: ${loggedError.errorMessage}`;
+
   if (process.env.NODE_ENV === 'development') {
-    console.error('[GSD Error]', {
+    console.error(summary, {
       ...loggedError,
       originalError: error
     });
   } else {
     // In production, send to error tracking service
     // Example: Sentry.captureException(error, { contexts: { gsd: loggedError } });
-    console.error('[GSD Error]', {
+    console.error(summary, {
       action: loggedError.action,
       errorType: loggedError.errorType,
       errorMessage: loggedError.errorMessage,

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -172,21 +172,50 @@ function formatLog(
     ...(sanitized && Object.keys(sanitized).length > 0 ? { metadata: sanitized } : {}),
   };
 
-  // Use structured logObject for all levels for consistent output
+  // The string argument has to carry the message on its own. A structured
+  // object reads fine in devtools, which expands it — but anything that captures
+  // console output stringifies the arguments, and an object-only payload lands
+  // in a bug report as "[TASK_CRUD] [object Object]". The object still follows,
+  // so devtools loses nothing.
+  const prefix = formatLogPrefix(context, message, sanitized);
+
   switch (level) {
     case 'debug':
-      console.debug(`[${context}]`, logObject);
+      console.debug(prefix, logObject);
       break;
     case 'info':
-      console.log(`[${context}]`, logObject);
+      console.log(prefix, logObject);
       break;
     case 'warn':
-      console.warn(`[${context}]`, logObject);
+      console.warn(prefix, logObject);
       break;
     case 'error':
-      console.error(`[${context}]`, logObject);
+      console.error(prefix, logObject);
       break;
   }
+}
+
+/**
+ * Build the human-readable half of a log line: context, message, and — when an
+ * Error was supplied — its type and message, which are what make a report
+ * actionable.
+ *
+ * Takes the **sanitized** metadata, never the caller's. Error text from a remote
+ * 4xx body can echo task field names and values, and this string is the most
+ * visible part of the log line. `tests/data/sync/pb-push.test.ts` asserts a task
+ * title never reaches it.
+ */
+function formatLogPrefix(
+  context: LogContext,
+  message: string,
+  sanitized?: LogMetadata
+): string {
+  const errorType = sanitized?.errorType;
+  const errorMessage = sanitized?.errorMessage;
+  const detail = errorType || errorMessage
+    ? ` — ${[errorType, errorMessage].filter(Boolean).join(': ')}`
+    : '';
+  return `[${context}] ${message}${detail}`;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.4.1",
+	"version": "11.4.2",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/tests/data/error-logger.test.ts
+++ b/tests/data/error-logger.test.ts
@@ -111,7 +111,7 @@ describe("Error Logger module", () => {
 			logError(error, context);
 
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
-				"[GSD Error]",
+				expect.stringContaining("[GSD Error]"),
 				expect.objectContaining({
 					action: "test_action",
 					errorType: "Error",
@@ -134,7 +134,7 @@ describe("Error Logger module", () => {
 			logError(error, context);
 
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
-				"[GSD Error]",
+				expect.stringContaining("[GSD Error]"),
 				expect.objectContaining({
 					action: "test_action",
 					errorType: "Error",
@@ -391,6 +391,29 @@ describe("Error Logger module", () => {
 				expect(message.length).toBeGreaterThan(10);
 				expect(message).toMatch(/[.!]/); // Ends with punctuation
 			});
+		});
+	});
+
+	describe("capture-friendly console output", () => {
+		it("summarises action, error type, and message in the string argument", () => {
+			const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+			try {
+				logError(new TypeError("over.id is not a quadrant"), {
+					action: "move_task_to_quadrant",
+					userMessage: "Failed to move task",
+					timestamp: new Date().toISOString(),
+				});
+
+				// The reviewer of v11.2.1 got "[GSD Error] [object Object]" and had
+				// nothing to diagnose a failing drag with.
+				const [firstArg] = spy.mock.calls[0];
+				expect(firstArg).not.toContain("[object Object]");
+				expect(firstArg).toContain("move_task_to_quadrant");
+				expect(firstArg).toContain("TypeError");
+				expect(firstArg).toContain("over.id is not a quadrant");
+			} finally {
+				spy.mockRestore();
+			}
 		});
 	});
 });

--- a/tests/data/logger.test.ts
+++ b/tests/data/logger.test.ts
@@ -76,7 +76,7 @@ describe("Logger module", () => {
 
 			expect(consoleDebugSpy).toHaveBeenCalledTimes(1);
 			expect(consoleDebugSpy).toHaveBeenCalledWith(
-				"[DB]",
+				expect.stringContaining("[DB]"),
 				expect.objectContaining({
 					level: "DEBUG",
 					context: "DB",
@@ -91,7 +91,7 @@ describe("Logger module", () => {
 
 			expect(consoleLogSpy).toHaveBeenCalledTimes(1);
 			expect(consoleLogSpy).toHaveBeenCalledWith(
-				"[SYNC_ENGINE]",
+				expect.stringContaining("[SYNC_ENGINE]"),
 				expect.objectContaining({
 					level: "INFO",
 					context: "SYNC_ENGINE",
@@ -106,7 +106,7 @@ describe("Logger module", () => {
 
 			expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
 			expect(consoleWarnSpy).toHaveBeenCalledWith(
-				"[AUTH]",
+				expect.stringContaining("[AUTH]"),
 				expect.objectContaining({
 					level: "WARN",
 					context: "AUTH",
@@ -121,7 +121,7 @@ describe("Logger module", () => {
 
 			expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
-				"[TASK_CRUD]",
+				expect.stringContaining("[TASK_CRUD]"),
 				expect.objectContaining({
 					level: "ERROR",
 					context: "TASK_CRUD",
@@ -135,7 +135,7 @@ describe("Logger module", () => {
 			logger.info("timestamp check");
 
 			expect(consoleLogSpy).toHaveBeenCalledWith(
-				"[UI]",
+				expect.stringContaining("[UI]"),
 				expect.objectContaining({
 					timestamp: expect.stringMatching(
 						/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
@@ -231,7 +231,7 @@ describe("Logger module", () => {
 			logger.info("sync started", metadata);
 
 			expect(consoleLogSpy).toHaveBeenCalledWith(
-				"[SYNC_PUSH]",
+				expect.stringContaining("[SYNC_PUSH]"),
 				expect.objectContaining({
 					metadata: expect.objectContaining({
 						correlationId: "abc-123",
@@ -578,7 +578,7 @@ describe("Logger module", () => {
 			logger.error("sync failed", testError, { phase: "push" });
 
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
-				"[SYNC_ENGINE]",
+				expect.stringContaining("[SYNC_ENGINE]"),
 				expect.objectContaining({
 					level: "ERROR",
 					message: "sync failed",
@@ -597,7 +597,7 @@ describe("Logger module", () => {
 			logger.error("something went wrong");
 
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
-				"[SYNC_ENGINE]",
+				expect.stringContaining("[SYNC_ENGINE]"),
 				expect.objectContaining({
 					level: "ERROR",
 					message: "something went wrong",
@@ -612,7 +612,7 @@ describe("Logger module", () => {
 			logger.error("db failure", testError);
 
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
-				"[DB]",
+				expect.stringContaining("[DB]"),
 				expect.objectContaining({
 					metadata: expect.objectContaining({
 						errorType: "TypeError",
@@ -656,7 +656,7 @@ describe("Logger module", () => {
 			logger.error("sync issue", syncError);
 
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
-				"[SYNC_ENGINE]",
+				expect.stringContaining("[SYNC_ENGINE]"),
 				expect.objectContaining({
 					metadata: expect.objectContaining({
 						errorType: "SyncError",
@@ -808,7 +808,7 @@ describe("Logger module", () => {
 			childLogger.info("push started");
 
 			expect(consoleLogSpy).toHaveBeenCalledWith(
-				"[SYNC_PUSH]",
+				expect.stringContaining("[SYNC_PUSH]"),
 				expect.objectContaining({
 					context: "SYNC_PUSH",
 				}),
@@ -850,6 +850,37 @@ describe("Logger module", () => {
 			const counter2 = parseInt(id2.split("-")[1], 10);
 
 			expect(counter2).toBe(counter1 + 1);
+		});
+	});
+
+	describe("capture-friendly console output", () => {
+		it("puts the message in the string argument, not only the object", () => {
+			vi.stubEnv("NODE_ENV", "development");
+			createLogger("TASK_CRUD").error("Failed to toggle task completion");
+
+			// Tools that capture console output stringify the arguments, so an
+			// object-only payload renders as "[TASK_CRUD] [object Object]" and
+			// tells a bug reporter nothing.
+			const [firstArg] = consoleErrorSpy.mock.calls[0];
+			expect(firstArg).toContain("TASK_CRUD");
+			expect(firstArg).toContain("Failed to toggle task completion");
+		});
+
+		it("still passes the structured object for devtools", () => {
+			vi.stubEnv("NODE_ENV", "development");
+			createLogger("SYNC_ENGINE").error("Push failed");
+
+			const [, second] = consoleErrorSpy.mock.calls[0];
+			expect(second).toMatchObject({ context: "SYNC_ENGINE", message: "Push failed" });
+		});
+
+		it("names the error type and message when an Error is supplied", () => {
+			vi.stubEnv("NODE_ENV", "development");
+			createLogger("DB").error("Write rejected", new TypeError("bad key"));
+
+			const [firstArg] = consoleErrorSpy.mock.calls[0];
+			expect(firstArg).toContain("TypeError");
+			expect(firstArg).toContain("bad key");
 		});
 	});
 });

--- a/tests/data/notification-checker.test.ts
+++ b/tests/data/notification-checker.test.ts
@@ -369,7 +369,7 @@ describe("NotificationChecker", () => {
 
 			// Logger routes error through console.error with structured format
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
-				"[NOTIFICATIONS]",
+				expect.stringContaining("[NOTIFICATIONS]"),
 				expect.objectContaining({ message: "Error in notification checker" }),
 			);
 

--- a/tests/data/notifications/badge.test.ts
+++ b/tests/data/notifications/badge.test.ts
@@ -90,7 +90,7 @@ describe('Notification Badge', () => {
 
       // Logger routes error through console.error with structured format
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[NOTIFICATIONS]',
+        expect.stringContaining('[NOTIFICATIONS]'),
         expect.objectContaining({ message: 'Error setting app badge' })
       );
       consoleErrorSpy.mockRestore();
@@ -132,7 +132,7 @@ describe('Notification Badge', () => {
 
       // Logger routes error through console.error with structured format
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[NOTIFICATIONS]',
+        expect.stringContaining('[NOTIFICATIONS]'),
         expect.objectContaining({ message: 'Error clearing app badge' })
       );
       consoleErrorSpy.mockRestore();

--- a/tests/data/sync/pb-push.test.ts
+++ b/tests/data/sync/pb-push.test.ts
@@ -406,7 +406,7 @@ describe('pushLocalChanges LWW guard', () => {
       // should echo task field names or values that a 4xx body may include.
       expect(result.lastError).not.toContain('title');
 
-      const syncErrorLog = consoleErrorSpy.mock.calls.find((call) => call[0] === '[SYNC_ENGINE]');
+      const syncErrorLog = consoleErrorSpy.mock.calls.find((call) => String(call[0]).startsWith('[SYNC_ENGINE]'));
       expect(syncErrorLog).toBeDefined();
       const serializedLog = JSON.stringify(syncErrorLog);
       expect(serializedLog).toContain('validation_failed');


### PR DESCRIPTION
Wave D, PR 2 of 4.

## What the reviewer actually saw

```
[TASK_CRUD] [object Object]
[GSD Error]  [object Object]
```

They had nothing to diagnose the broken drag with — the bug that turned out to be `over.id as QuadrantId` (fixed in #476).

## Why it happened

`console.error('[TASK_CRUD]', logObject)` is *correct* browser practice — devtools expands the second argument. But **anything that captures console output stringifies the arguments**, so an object-only payload collapses to `[object Object]`.

I flagged this in the original triage as lower severity than the review claimed, and that still holds: it was never broken in devtools. It was broken for exactly the person trying to file a useful bug report.

## The fix

The string argument now carries context, message, and — when an `Error` was supplied — its type and message:

```
[TASK_CRUD] Failed to toggle task completion — TypeError: over.id is not a quadrant
```

The structured object still follows, so devtools loses nothing.

## Security detail

`formatLogPrefix` takes the **sanitized** metadata, never the caller's. Error text from a remote 4xx body can echo task field names and values, and this string is now the most visible part of the line.

`tests/data/sync/pb-push.test.ts` already guarded this. Its finder matched the prefix by exact equality, so I widened it to `startsWith` — which means the new prefix is now **part of what the test serializes and checks**. The guard is strictly stronger than before:

```ts
expect(serializedLog).not.toContain(leakedTaskTitle);  // still passes
```

I verified this by running the guard rather than reasoning about it.

## Test churn

11 assertions in `logger.test.ts` and 2 in `error-logger.test.ts` pinned the exact prefix literal (`"[DB]"`). They now use `expect.stringContaining`, which is what they were actually asserting.

## Verification

- 4 new tests covering the capture-friendly output, including one that asserts the summary never reads `[object Object]`
- `bun run test` — 2679 passed, 1 skipped
- typecheck / lint / shape clean

https://claude.ai/code/session_01DA4QuYKyWt5WkynEqteWJH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->