### PR TITLE
feat(matrix): tell the user a filter matched nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.4.2
+**Current version:** 11.5.0
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/components/matrix-simplified/filtered-empty.tsx
+++ b/components/matrix-simplified/filtered-empty.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { SearchXIcon } from "lucide-react";
+
+interface FilteredEmptyProps {
+  /** The search text, when the board was narrowed by search. */
+  query: string;
+  /** The active smart view's name, when one is applied. */
+  viewName?: string | null;
+  onClear: () => void;
+}
+
+/**
+ * Shown when a filter matched nothing.
+ *
+ * Without it the four quadrants fall back to their default copy — "Nothing on
+ * fire.", "Stay sharp." — which asserts something about the user's workload
+ * rather than about their search. Combined with a header count for the whole
+ * board, a filtered board read as a board that had vanished.
+ */
+export function FilteredEmpty({ query, viewName, onClear }: FilteredEmptyProps) {
+  const label = query.trim() ? `“${query.trim()}”` : viewName;
+
+  return (
+    <div
+      data-testid="filtered-empty"
+      className="col-span-full flex flex-col items-center justify-center gap-3 rounded-[20px] border border-pane-border bg-card/60 px-6 py-16 text-center"
+    >
+      <SearchXIcon className="h-6 w-6 text-foreground-muted" aria-hidden="true" />
+      <div className="space-y-1">
+        <p className="rd-serif text-xl text-foreground">No tasks match {label}</p>
+        <p className="text-sm text-foreground-muted">
+          Your tasks are still here — this view is just narrowed.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onClear}
+        className="rounded-full border border-pane-border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-background-muted"
+      >
+        {query.trim() ? "Clear search" : "Clear filter"}
+      </button>
+    </div>
+  );
+}

--- a/components/matrix-simplified/index.tsx
+++ b/components/matrix-simplified/index.tsx
@@ -20,6 +20,8 @@ import { AppShell } from "./app-shell";
 import { CaptureBar, type CapturePayload } from "./capture-bar";
 import { handleCapture, handleToggle, reportTaskMutationError } from "./task-actions";
 import { DragLayer } from "./drag-layer";
+import { FilteredEmpty } from "./filtered-empty";
+import { MatrixCaption } from "./matrix-caption";
 import { MatrixGrid } from "./matrix-grid";
 import { MatrixGridSkeleton } from "./matrix-grid-skeleton";
 import { EditDrawer, type EditDraft } from "./edit-drawer";
@@ -148,7 +150,13 @@ export function MatrixSimplified() {
   const { smartViewsEnabled, smartViews, activeSmartView, applySmartViewById, clearSmartView } =
     useSmartViews(clearSearch);
 
-  const { visibleTasks, total, completed, overdue } = deriveMatrixView({
+  // The empty state offers one way back, so it clears whichever filter is on.
+  const handleClearFilter = () => {
+    clearSearch();
+    clearSmartView();
+  };
+
+  const { visibleTasks, total, completed, overdue, isFiltered, matchCount } = deriveMatrixView({
     all,
     showCompleted,
     smartViewsEnabled,
@@ -300,25 +308,6 @@ export function MatrixSimplified() {
     ? deriveIntroStats(all, new Date().toISOString().slice(0, 10))
     : null;
 
-  // Header counts — three small inline pills, semantic colors. Overdue
-  // pill is conditional on count > 0. Sits on the same baseline as the title
-  // (the topbar wraps the caption slot in a flex row).
-  const caption = (
-    <>
-      <span className="inline-flex items-center rounded-full bg-background-muted px-2 py-0.5 text-[11px] font-medium tabular-nums text-foreground">
-        {mounted ? `${total - completed} active` : " "}
-      </span>
-      <span className="inline-flex items-center rounded-full bg-status-success-muted px-2 py-0.5 text-[11px] font-medium tabular-nums text-status-success-ink">
-        {mounted ? `${completed} done` : " "}
-      </span>
-      {mounted && overdue > 0 ? (
-        <span className="inline-flex items-center rounded-full bg-status-overdue-muted px-2 py-0.5 text-[11px] font-medium tabular-nums text-status-overdue-ink">
-          {overdue} overdue
-        </span>
-    ) : null}
-    </>
-  );
-
   return (
     <DndContext
       sensors={sensors}
@@ -335,7 +324,14 @@ export function MatrixSimplified() {
         title="GSD Matrix"
         titleAsLabel
         mainClassName="max-w-[1540px] pb-48 md:pb-6"
-        caption={caption}
+        caption={
+          <MatrixCaption
+            active={total - completed}
+            completed={completed}
+            overdue={overdue}
+            mounted={mounted}
+          />
+        }
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         searchInputRef={searchInputRef}
@@ -364,6 +360,12 @@ export function MatrixSimplified() {
         ) : null}
         {isLoading ? (
           <MatrixGridSkeleton />
+        ) : isFiltered && matchCount === 0 ? (
+          <FilteredEmpty
+            query={searchQuery}
+            viewName={activeSmartView?.name}
+            onClear={handleClearFilter}
+          />
         ) : (
           <MatrixGrid
             tasks={visibleTasks}

--- a/components/matrix-simplified/matrix-caption.tsx
+++ b/components/matrix-simplified/matrix-caption.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+interface MatrixCaptionProps {
+  active: number;
+  completed: number;
+  overdue: number;
+  /** False until hydration, so the static export doesn't ship a count. */
+  mounted: boolean;
+}
+
+/**
+ * The three header pills.
+ *
+ * These describe whatever is currently on screen, filter included. Reporting the
+ * whole database here while the board showed a filtered subset is what made a
+ * narrowed board read as a broken one.
+ */
+export function MatrixCaption({ active, completed, overdue, mounted }: MatrixCaptionProps) {
+  return (
+    <>
+      <span className="inline-flex items-center rounded-full bg-background-muted px-2 py-0.5 text-[11px] font-medium tabular-nums text-foreground">
+        {mounted ? `${active} active` : " "}
+      </span>
+      <span className="inline-flex items-center rounded-full bg-status-success-muted px-2 py-0.5 text-[11px] font-medium tabular-nums text-status-success-ink">
+        {mounted ? `${completed} done` : " "}
+      </span>
+      {mounted && overdue > 0 ? (
+        <span className="inline-flex items-center rounded-full bg-status-overdue-muted px-2 py-0.5 text-[11px] font-medium tabular-nums text-status-overdue-ink">
+          {overdue} overdue
+        </span>
+      ) : null}
+    </>
+  );
+}

--- a/components/matrix-simplified/matrix-view.ts
+++ b/components/matrix-simplified/matrix-view.ts
@@ -40,6 +40,24 @@ export interface MatrixView {
   total: number;
   completed: number;
   overdue: number;
+  /** True when a search query or smart view is narrowing the board. */
+  isFiltered: boolean;
+  /** How many tasks survived the filter. Zero means "no matches", not "no tasks". */
+  matchCount: number;
+}
+
+/** Tally the header figures for whichever set is actually on screen. */
+function tally(tasks: TaskRecord[]): { total: number; completed: number; overdue: number } {
+  const todayIso = new Date().toISOString().slice(0, 10);
+  let completed = 0;
+  let overdue = 0;
+
+  for (const task of tasks) {
+    if (task.completed) completed += 1;
+    else if (task.dueDate && task.dueDate < todayIso) overdue += 1;
+  }
+
+  return { total: tasks.length, completed, overdue };
 }
 
 /**
@@ -48,6 +66,10 @@ export interface MatrixView {
  * Base set: an active smart view (when the feature is enabled) filters the full
  * task set; otherwise the base is all tasks when "show completed" is on, or just
  * the active (incomplete) tasks. The search query is applied last.
+ *
+ * The counts describe what is on screen, not what is in the database. A header
+ * reading "5 active" above a board showing nothing is how a filtered board comes
+ * to look broken rather than filtered.
  */
 export function deriveMatrixView({
   all,
@@ -56,21 +78,7 @@ export function deriveMatrixView({
   activeSmartView,
   searchQuery,
 }: MatrixViewInput): MatrixView {
-  const todayIso = new Date().toISOString().slice(0, 10);
-  let completed = 0;
-  let overdue = 0;
-  const activeTasks: TaskRecord[] = [];
-
-  for (const task of all) {
-    if (task.completed) {
-      completed += 1;
-    } else {
-      activeTasks.push(task);
-      if (task.dueDate && task.dueDate < todayIso) {
-        overdue += 1;
-      }
-    }
-  }
+  const activeTasks = all.filter((task) => !task.completed);
 
   const effectiveSmartView = smartViewsEnabled ? activeSmartView : null;
   const base = effectiveSmartView ? all : showCompleted ? all : activeTasks;
@@ -78,10 +86,14 @@ export function deriveMatrixView({
     ? applyFilters(base, effectiveSmartView.criteria, all)
     : base;
 
+  const visibleTasks = filterTasks(smartViewTasks, searchQuery);
+  const isFiltered = Boolean(effectiveSmartView) || searchQuery.trim().length > 0;
+  const counted = isFiltered ? visibleTasks : all;
+
   return {
-    visibleTasks: filterTasks(smartViewTasks, searchQuery),
-    total: all.length,
-    completed,
-    overdue,
+    visibleTasks,
+    ...tally(counted),
+    isFiltered,
+    matchCount: visibleTasks.length,
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.4.2",
+	"version": "11.5.0",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/tests/data/matrix-view.test.ts
+++ b/tests/data/matrix-view.test.ts
@@ -125,4 +125,69 @@ describe("deriveMatrixView", () => {
     });
     expect(view.visibleTasks.map((t) => t.id)).toEqual(["active"]);
   });
+
+  describe("filter awareness", () => {
+    it("reports no filter when nothing narrows the board", () => {
+      const view = deriveMatrixView({
+        all: [active, done, overdue],
+        showCompleted: false,
+        smartViewsEnabled: false,
+        activeSmartView: null,
+        searchQuery: "",
+      });
+      expect(view.isFiltered).toBe(false);
+      expect(view.matchCount).toBe(2);
+    });
+
+    it("reports a filter and its match count while searching", () => {
+      const view = deriveMatrixView({
+        all: [active, done, overdue],
+        showCompleted: false,
+        smartViewsEnabled: false,
+        activeSmartView: null,
+        searchQuery: "alpha",
+      });
+      expect(view.isFiltered).toBe(true);
+      expect(view.matchCount).toBe(1);
+    });
+
+    it("counts only what the filter matched, not the whole board", () => {
+      // The header read "5 active" beside an apparently empty board, which is
+      // what made a filtered board look broken rather than filtered.
+      const view = deriveMatrixView({
+        all: [active, done, overdue],
+        showCompleted: false,
+        smartViewsEnabled: false,
+        activeSmartView: null,
+        searchQuery: "alpha",
+      });
+      expect(view.total).toBe(1);
+      expect(view.completed).toBe(0);
+      expect(view.overdue).toBe(0);
+    });
+
+    it("reports zero matches for a query nothing satisfies", () => {
+      const view = deriveMatrixView({
+        all: [active, done, overdue],
+        showCompleted: false,
+        smartViewsEnabled: false,
+        activeSmartView: null,
+        searchQuery: "nothing-matches-this",
+      });
+      expect(view.isFiltered).toBe(true);
+      expect(view.matchCount).toBe(0);
+      expect(view.total).toBe(0);
+    });
+
+    it("treats an active smart view as a filter", () => {
+      const view = deriveMatrixView({
+        all: [active, done, overdue],
+        showCompleted: false,
+        smartViewsEnabled: true,
+        activeSmartView: completedView,
+        searchQuery: "",
+      });
+      expect(view.isFiltered).toBe(true);
+    });
+  });
 });

--- a/tests/ui/matrix-simplified.test.tsx
+++ b/tests/ui/matrix-simplified.test.tsx
@@ -131,18 +131,23 @@ vi.mock("@/components/matrix-simplified/app-shell", () => ({
   AppShell: ({
     title,
     titleAsLabel,
+    caption,
     searchQuery,
     onSearchChange,
     children,
   }: {
     title: string;
     titleAsLabel?: boolean;
+    caption?: React.ReactNode;
     searchQuery?: string;
     onSearchChange?: (value: string) => void;
     children: React.ReactNode;
   }) => (
     <div>
       {titleAsLabel ? <p data-testid="topbar-title">{title}</p> : <h1>{title}</h1>}
+      {/* The header counts live here. Dropping them from the stub hid whether
+          they describe the filtered board or the whole database. */}
+      {caption ? <div data-testid="topbar-caption">{caption}</div> : null}
       {onSearchChange ? (
         <input
           aria-label="Shell search"
@@ -848,6 +853,60 @@ describe("<MatrixSimplified>", () => {
       const undoAction = handleSuccessSpy.mock.calls[0][1] as () => Promise<void>;
       await undoAction();
       expect(restoreTask).toHaveBeenCalledWith(expect.objectContaining({ id: "del-1" }));
+    });
+  });
+
+  describe("filtered empty state", () => {
+    it("says nothing matched instead of showing the quadrant empty copy", async () => {
+      tasksFixture.current = [
+        makeTask({ id: "a", title: "Active alpha" }),
+        makeTask({ id: "b", title: "Active bravo" }),
+      ];
+      render(<MatrixSimplified />);
+
+      await userEvent.type(screen.getByLabelText("Shell search"), "zzz-no-match");
+
+      // Previously each quadrant kept its default copy ("Nothing on fire.")
+      // while the header still read "2 active", so the board looked as if it
+      // had vanished rather than been filtered.
+      await waitFor(() =>
+        expect(screen.getByTestId("filtered-empty")).toBeInTheDocument()
+      );
+      expect(screen.getByTestId("filtered-empty")).toHaveTextContent("zzz-no-match");
+      expect(screen.queryByText("Nothing on fire.")).not.toBeInTheDocument();
+    });
+
+    it("offers a way back to the full board", async () => {
+      const user = userEvent.setup();
+      tasksFixture.current = [makeTask({ id: "a", title: "Active alpha" })];
+      render(<MatrixSimplified />);
+
+      await user.type(screen.getByLabelText("Shell search"), "zzz-no-match");
+      await waitFor(() => expect(screen.getByTestId("filtered-empty")).toBeInTheDocument());
+
+      await user.click(screen.getByRole("button", { name: /clear (search|filter)/i }));
+
+      await waitFor(() => expect(screen.queryByTestId("filtered-empty")).not.toBeInTheDocument());
+      expect(screen.getByText("Active alpha")).toBeInTheDocument();
+    });
+
+    it("keeps the quadrant empty copy when the board is genuinely empty", () => {
+      tasksFixture.current = [];
+      render(<MatrixSimplified />);
+
+      expect(screen.queryByTestId("filtered-empty")).not.toBeInTheDocument();
+    });
+
+    it("reports the match count in the header while filtering", async () => {
+      tasksFixture.current = [
+        makeTask({ id: "a", title: "Active alpha" }),
+        makeTask({ id: "b", title: "Active bravo" }),
+      ];
+      render(<MatrixSimplified />);
+
+      await userEvent.type(screen.getByLabelText("Shell search"), "alpha");
+
+      await waitFor(() => expect(screen.getByText("1 active")).toBeInTheDocument());
     });
   });
 });


### PR DESCRIPTION
Wave D, PR 3 of 4.

## The contradiction

Search for something with no matches and the board showed:

- each quadrant's **default** empty copy — *"Nothing on fire."*, *"Stay sharp."*
- a header still reading **"5 active"**

Two halves of one screen disagreeing. It read as *the board vanished*, not *the board is filtered*.

## One idea, two changes

**What the screen says should describe what the screen shows.**

1. **Header counts tally the visible set**, not the whole database. Searching one task now reads `1 active`, not `5 active`.
2. **A filter that matches nothing gets its own panel** — names the term, says the tasks are still there, and offers one control that clears whichever filter is active (search or smart view).

The quadrant copy is untouched for a genuinely empty board: *"Nothing on fire."* is a true statement about an empty Q1 and a false one about an unmatched search.

## Verification

Live headless run — searching `zzzznomatch`:

> A paragraph with 'No tasks match' followed by the search term in quotes... 'Your tasks are still here — this view is just narrowed.'... a 'Clear search' button. The four quadrants are not visible.

The screenshot shows the header reading **`0 active` / `0 done`** — before this, it would have said `4 active` beside an empty board. Console clean.

## Test note worth flagging

The `AppShell` stub in `matrix-simplified.test.tsx` silently dropped the `caption` prop, so **no test could see the header counts at all**. The stub now renders it — which is what let the count assertion become meaningful rather than vacuous.

## Refactor the ratchet required

`index.tsx` complexity 19 → 21 and function length 269 → 277. Extracted `MatrixCaption`; both are back at their prior maximums.

- 5 new data tests, 4 new UI tests
- `bun run test` — 2688 passed, 1 skipped
- typecheck / lint / shape clean

https://claude.ai/code/session_01DA4QuYKyWt5WkynEqteWJH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->