### PR TITLE
fix(edit-drawer): free the dependency popup from the scroll container

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.5.0
+**Current version:** 11.5.1
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/components/matrix-simplified/edit-drawer-dependencies.tsx
+++ b/components/matrix-simplified/edit-drawer-dependencies.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useId, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { XIcon } from "lucide-react";
 import type { TaskRecord } from "@/lib/types";
 import { wouldCreateCircularDependency } from "@/lib/dependencies";
 import { SCHEMA_LIMITS } from "@/lib/constants/schema";
 import { Field } from "./edit-drawer-fields";
+import { useSuggestionCombobox } from "./use-suggestion-combobox";
 
 const MAX_SUGGESTIONS = 8;
 
@@ -51,6 +53,30 @@ export function DependenciesField({
   const inputRef = useRef<HTMLInputElement>(null);
   const limitNoteId = useId();
   const errorId = useId();
+  const listboxId = useId();
+  const optionId = (index: number) => `${listboxId}-option-${index}`;
+
+  const matches = matchingCandidates(query, taskId, dependencies, allTasks);
+
+  const pick = (id: string) => {
+    onChange([...dependencies, id]);
+    setQuery("");
+    setOpen(false);
+    combobox.resetActive();
+    // Picking removes the focused suggestion button from the DOM;
+    // return focus to the input so keyboard users keep their place.
+    inputRef.current?.focus();
+  };
+
+  const combobox = useSuggestionCombobox(open && query.trim().length > 0, {
+    count: matches.length,
+    onPick: (index) => {
+      const picked = matches[index];
+      if (picked) pick(picked.id);
+    },
+    onDismiss: () => setOpen(false),
+  });
+  const { activeIndex, anchorRect, anchorRef } = combobox;
 
   // Ghost IDs (no local record) render no chip but stay in `dependencies`.
   const chips = dependencies
@@ -69,27 +95,14 @@ export function DependenciesField({
           if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setOpen(false);
         }}
       >
-        <div className="flex flex-wrap items-center gap-1.5 rounded-lg border border-border bg-background p-2">
-          {chips.map((t) => (
-            <span
-              key={t.id}
-              data-testid="dep-chip"
-              className="inline-flex items-center gap-1 rounded bg-background-muted px-2 py-0.5 text-[11.5px] font-medium text-foreground-muted"
-            >
-              {t.title}
-              {/* Unsaved-draft chip removal, same as the tag chips: reversible
-                  by re-searching, and nothing is written until Save. */}
-              {/* ui-craft-detect-ignore-next-line */}
-              <button
-                type="button"
-                onClick={() => onChange(dependencies.filter((id) => id !== t.id))}
-                aria-label={`Remove dependency ${t.title}`}
-                className="rounded-xs hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-              >
-                <XIcon className="h-3 w-3" />
-              </button>
-            </span>
-          ))}
+        <div
+          ref={anchorRef}
+          className="flex flex-wrap items-center gap-1.5 rounded-lg border border-border bg-background p-2"
+        >
+          <DependencyChips
+            chips={chips}
+            onRemove={(id) => onChange(dependencies.filter((depId) => depId !== id))}
+          />
           <input
             data-testid="dep-search"
             ref={inputRef}
@@ -98,19 +111,17 @@ export function DependenciesField({
             onChange={(e) => {
               setQuery(e.target.value);
               setOpen(true);
+              combobox.resetActive();
             }}
             onFocus={() => setOpen(true)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") e.preventDefault();
-              // Escape dismisses the suggestion popup only; a second Escape
-              // (popup closed) bubbles to the drawer's window listener as usual.
-              if (e.key === "Escape" && suggestionsVisible) {
-                e.stopPropagation();
-                setOpen(false);
-              }
-            }}
+            onKeyDown={combobox.onKeyDown}
             placeholder={chips.length ? "" : "Search tasks this one depends on…"}
             aria-label="Search tasks to add as a dependency"
+            role="combobox"
+            aria-expanded={suggestionsVisible}
+            aria-controls={suggestionsVisible ? listboxId : undefined}
+            aria-activedescendant={activeIndex >= 0 ? optionId(activeIndex) : undefined}
+            aria-autocomplete="list"
             aria-invalid={error ? true : undefined}
             aria-describedby={describedBy}
             className="min-w-[80px] flex-1 rounded-xs border-0 bg-transparent text-[13px] text-foreground outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent disabled:cursor-not-allowed"
@@ -122,16 +133,32 @@ export function DependenciesField({
           taskId={taskId}
           dependencies={dependencies}
           allTasks={allTasks}
-          onPick={(id) => {
-            onChange([...dependencies, id]);
-            setQuery("");
-            setOpen(false);
-            // Picking removes the focused suggestion button from the DOM;
-            // return focus to the input so keyboard users keep their place.
-            inputRef.current?.focus();
-          }}
+          anchorRect={anchorRect}
+          activeIndex={activeIndex}
+          listboxId={listboxId}
+          optionId={optionId}
+          onPick={pick}
         />
       </div>
+      <FieldNotes atLimit={atLimit} limitNoteId={limitNoteId} error={error} errorId={errorId} />
+    </Field>
+  );
+}
+
+/** The limit caption and validation error that sit under the field. */
+function FieldNotes({
+  atLimit,
+  limitNoteId,
+  error,
+  errorId,
+}: {
+  atLimit: boolean;
+  limitNoteId: string;
+  error?: string | null;
+  errorId: string;
+}): React.ReactElement {
+  return (
+    <>
       {atLimit ? (
         <p id={limitNoteId} className="text-[11.5px] text-foreground-muted">
           Dependency limit reached ({SCHEMA_LIMITS.MAX_DEPENDENCIES}).
@@ -142,7 +169,41 @@ export function DependenciesField({
           {error}
         </p>
       ) : null}
-    </Field>
+    </>
+  );
+}
+
+/** Selected dependencies, each removable while the draft is unsaved. */
+function DependencyChips({
+  chips,
+  onRemove,
+}: {
+  chips: TaskRecord[];
+  onRemove: (id: string) => void;
+}): React.ReactElement {
+  return (
+    <>
+      {chips.map((t) => (
+        <span
+          key={t.id}
+          data-testid="dep-chip"
+          className="inline-flex items-center gap-1 rounded bg-background-muted px-2 py-0.5 text-[11.5px] font-medium text-foreground-muted"
+        >
+          {t.title}
+          {/* Unsaved-draft chip removal, same as the tag chips: reversible by
+              re-searching, and nothing is written until Save. */}
+          {/* ui-craft-detect-ignore-next-line */}
+          <button
+            type="button"
+            onClick={() => onRemove(t.id)}
+            aria-label={`Remove dependency ${t.title}`}
+            className="rounded-xs hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            <XIcon className="h-3 w-3" />
+          </button>
+        </span>
+      ))}
+    </>
   );
 }
 
@@ -159,12 +220,61 @@ function isCandidate(
   return true;
 }
 
+/** The suggestion list, shared by the popup and the keyboard handler. */
+function matchingCandidates(
+  query: string,
+  taskId: string | undefined,
+  dependencies: string[],
+  allTasks: TaskRecord[]
+): TaskRecord[] {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) return [];
+  return allTasks
+    .filter((t) => isCandidate(t, taskId, dependencies, allTasks))
+    .filter((t) => t.title.toLowerCase().includes(trimmed))
+    .slice(0, MAX_SUGGESTIONS);
+}
+
+/** Vertical gap between the field and its popup, in px. */
+const POPUP_OFFSET = 4;
+/** Rough popup height used to decide whether to flip above the field. */
+const POPUP_MAX_HEIGHT = 280;
+
+/**
+ * Position the popup against the viewport, flipping above the anchor when the
+ * space below cannot hold it.
+ *
+ * `fixed` rather than `absolute` because the popup is portalled out of the
+ * drawer: it has no positioned ancestor to measure against any more, and the
+ * viewport is exactly the frame collision should be judged in.
+ */
+function popupStyle(anchor: DOMRect | null): React.CSSProperties {
+  if (!anchor) return { display: "none" };
+
+  const spaceBelow = window.innerHeight - anchor.bottom;
+  const flipUp = spaceBelow < POPUP_MAX_HEIGHT && anchor.top > spaceBelow;
+
+  return {
+    position: "fixed",
+    left: anchor.left,
+    width: anchor.width,
+    maxHeight: POPUP_MAX_HEIGHT,
+    ...(flipUp
+      ? { bottom: window.innerHeight - anchor.top + POPUP_OFFSET }
+      : { top: anchor.bottom + POPUP_OFFSET }),
+  };
+}
+
 function Suggestions({
   open,
   query,
   taskId,
   dependencies,
   allTasks,
+  anchorRect,
+  activeIndex,
+  listboxId,
+  optionId,
   onPick,
 }: {
   open: boolean;
@@ -172,30 +282,46 @@ function Suggestions({
   taskId?: string;
   dependencies: string[];
   allTasks: TaskRecord[];
+  anchorRect: DOMRect | null;
+  activeIndex: number;
+  listboxId: string;
+  optionId: (index: number) => string;
   onPick: (id: string) => void;
 }): React.ReactElement | null {
   const trimmed = query.trim().toLowerCase();
   if (!open || !trimmed) return null;
 
-  const matches = allTasks
-    .filter((t) => isCandidate(t, taskId, dependencies, allTasks))
-    .filter((t) => t.title.toLowerCase().includes(trimmed))
-    .slice(0, MAX_SUGGESTIONS);
+  const matches = matchingCandidates(query, taskId, dependencies, allTasks);
 
-  return (
-    <div className="absolute z-10 mt-1 w-full overflow-hidden rounded-lg border border-border bg-card shadow-lg">
+  // Portalled to the body because the drawer's scrolling container
+  // (`overflow-auto`) clips absolutely-positioned descendants. The list was cut
+  // off behind the sticky Save footer and unclickable at 1280x720 — clipping
+  // that no z-index can undo, because the pixels are never painted.
+  return createPortal(
+    <div
+      id={listboxId}
+      role="listbox"
+      aria-label="Matching tasks"
+      style={popupStyle(anchorRect)}
+      className="z-[70] overflow-y-auto overflow-x-hidden rounded-lg border border-border bg-card shadow-lg"
+    >
       {matches.length > 0 ? (
-        matches.map((t) => (
+        matches.map((t, index) => (
           <button
             key={t.id}
             type="button"
+            role="option"
+            id={optionId(index)}
+            aria-selected={index === activeIndex}
             data-testid="dep-suggestion"
             // Keep the search input focused through pointer activation. WebKit
             // can report a null blur relatedTarget before click otherwise,
             // unmounting the option before it can commit the selection.
             onPointerDown={(event) => event.preventDefault()}
             onClick={() => onPick(t.id)}
-            className="block w-full truncate px-3 py-2 text-left text-[13px] text-foreground hover:bg-background-muted"
+            className={`block w-full truncate px-3 py-2 text-left text-[13px] text-foreground hover:bg-background-muted ${
+              index === activeIndex ? "bg-background-muted" : ""
+            }`}
           >
             {t.title}
           </button>
@@ -203,6 +329,7 @@ function Suggestions({
       ) : (
         <p className="px-3 py-2 text-[12.5px] text-foreground-muted">No matching tasks.</p>
       )}
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/components/matrix-simplified/edit-drawer.tsx
+++ b/components/matrix-simplified/edit-drawer.tsx
@@ -6,6 +6,7 @@ import type { TaskRecord } from "@/lib/types";
 import { quadrants, QUADRANT_ACCENT, QUADRANT_INK } from "@/lib/quadrants";
 import { cn } from "@/lib/utils";
 import { DrawerHint } from "@/components/ui/drawer-hint";
+import { useModalSurface } from "./use-modal-surface";
 import { useDialogFocus } from "./use-dialog-focus";
 import { useEditDraftState } from "./use-edit-draft-state";
 import { Field, QuadrantField, DueDateField, TagsField } from "./edit-drawer-fields";
@@ -44,6 +45,8 @@ export function EditDrawer({ open, task, initialDraft, allTasks, onClose, onSubm
 
 function EditDrawerForm({ task, initialDraft, allTasks = [], onClose, onSubmit }: EditDrawerFormProps): React.ReactElement {
   const titleRef = useRef<HTMLInputElement>(null);
+  const modalSurface = useModalSurface(onClose);
+
   const drawerRef = useRef<HTMLFormElement>(null);
   const draft = useEditDraftState(task, initialDraft, titleRef);
   const trapKeyDown = useDialogFocus(true, drawerRef);
@@ -92,7 +95,7 @@ function EditDrawerForm({ task, initialDraft, allTasks = [], onClose, onSubmit }
   // closes the drawer. See .ui-craft/decisions.md (2026-07-31).
   return (
     <div
-      onClick={onClose}
+      {...modalSurface}
       role="presentation"
       // ui-craft-detect-ignore-next-line
       className="fixed inset-0 z-[60] flex justify-end bg-[var(--backdrop)] animate-drawer-overlay"
@@ -126,7 +129,7 @@ function EditDrawerForm({ task, initialDraft, allTasks = [], onClose, onSubmit }
           </button>
         </header>
 
-        <div className="flex flex-1 flex-col gap-5 overflow-auto px-5 py-5">
+        <div className="flex flex-1 flex-col gap-5 overflow-auto overscroll-contain px-5 py-5">
           <input
             data-testid="edit-title"
             ref={titleRef}
@@ -187,6 +190,27 @@ function EditDrawerForm({ task, initialDraft, allTasks = [], onClose, onSubmit }
           />
         </div>
 
+        <DrawerFooter
+          onClose={onClose}
+          canSave={Boolean(draft.title.trim())}
+          isCreateMode={isCreateMode}
+        />
+      </form>
+    </div>
+  );
+}
+
+/** The sticky action bar. Split out to keep the drawer body readable. */
+function DrawerFooter({
+  onClose,
+  canSave,
+  isCreateMode,
+}: {
+  onClose: () => void;
+  canSave: boolean;
+  isCreateMode: boolean;
+}) {
+  return (
         <footer className="flex items-center gap-2.5 border-t border-border/60 bg-background px-5 py-3.5">
           <DrawerHint />
           <div className="flex-1" />
@@ -200,7 +224,7 @@ function EditDrawerForm({ task, initialDraft, allTasks = [], onClose, onSubmit }
           <button
             data-testid="save-task"
             type="submit"
-            disabled={!draft.title.trim()}
+            disabled={!canSave}
             className={cn(
               "inline-flex items-center gap-1.5 rounded-lg bg-foreground px-3.5 py-1.5 text-[13px] font-medium text-background",
               "hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-40"
@@ -210,7 +234,5 @@ function EditDrawerForm({ task, initialDraft, allTasks = [], onClose, onSubmit }
             {isCreateMode ? "Create task" : "Save changes"}
           </button>
         </footer>
-      </form>
-    </div>
   );
 }

--- a/components/matrix-simplified/use-modal-surface.ts
+++ b/components/matrix-simplified/use-modal-surface.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Behaviour shared by any hand-rolled modal surface: the page behind is frozen,
+ * and the backdrop dismisses only when the gesture *began* there.
+ *
+ * Both exist for the same reason. Scrolling past the end of the drawer otherwise
+ * chains to the document and moves the page underneath — dragging the anchored
+ * field out from under a viewport-positioned popup, and making a drag-release
+ * land somewhere the user never intended. A plain backdrop `onClick` then reads
+ * that release as a dismissal and silently discards an in-progress edit.
+ */
+export function useModalSurface(onClose: () => void) {
+  const startedOnBackdrop = useRef(false);
+
+  useEffect(() => {
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, []);
+
+  return {
+    onMouseDown: (event: React.MouseEvent<HTMLElement>) => {
+      startedOnBackdrop.current = event.target === event.currentTarget;
+    },
+    onClick: (event: React.MouseEvent<HTMLElement>) => {
+      if (event.target === event.currentTarget && startedOnBackdrop.current) onClose();
+    },
+  };
+}

--- a/components/matrix-simplified/use-suggestion-combobox.ts
+++ b/components/matrix-simplified/use-suggestion-combobox.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+interface SuggestionComboboxOptions {
+  /** How many suggestions are currently listed. Wrapping is modulo this. */
+  count: number;
+  onPick: (index: number) => void;
+  onDismiss: () => void;
+}
+
+export interface SuggestionCombobox {
+  activeIndex: number;
+  resetActive: () => void;
+  anchorRect: DOMRect | null;
+  anchorRef: React.RefObject<HTMLDivElement | null>;
+  onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
+}
+
+/**
+ * Track an element's viewport rect while `active`.
+ *
+ * Needed because the popup is portalled out of the drawer to escape its
+ * `overflow-auto` clipping — once portalled it has no positioned ancestor left
+ * to follow, so it has to be told where the field went. `capture: true` is
+ * load-bearing: the drawer's scroll container does not bubble scroll to window.
+ */
+function useAnchorRect(active: boolean, revision: number) {
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const measure = () => setAnchorRect(anchorRef.current?.getBoundingClientRect() ?? null);
+    measure();
+    window.addEventListener("scroll", measure, true);
+    window.addEventListener("resize", measure);
+    return () => {
+      window.removeEventListener("scroll", measure, true);
+      window.removeEventListener("resize", measure);
+    };
+  }, [active, revision]);
+
+  return { anchorRef, anchorRect };
+}
+
+/** Next highlighted index for an arrow key, wrapping at both ends. */
+function nextIndex(key: string, current: number, count: number): number {
+  if (key === "ArrowDown") return (current + 1) % count;
+  return current <= 0 ? count - 1 : current - 1;
+}
+
+/** Keyboard and positioning behaviour for a suggestion popup anchored to a field. */
+export function useSuggestionCombobox(
+  open: boolean,
+  { count, onPick, onDismiss }: SuggestionComboboxOptions
+): SuggestionCombobox {
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const { anchorRef, anchorRect } = useAnchorRect(open, count);
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (event.key === "Enter") {
+      // Always swallowed: this field sits inside a form, and Enter here must
+      // never submit it.
+      event.preventDefault();
+      if (activeIndex >= 0) onPick(activeIndex);
+      return;
+    }
+    if (count > 0 && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
+      event.preventDefault();
+      setActiveIndex((index) => nextIndex(event.key, index, count));
+      return;
+    }
+    // Escape dismisses the popup only; a second Escape (popup closed) bubbles to
+    // the drawer's own listener as usual.
+    if (event.key === "Escape" && open) {
+      event.stopPropagation();
+      setActiveIndex(-1);
+      onDismiss();
+    }
+  };
+
+  return {
+    activeIndex,
+    resetActive: () => setActiveIndex(-1),
+    anchorRect,
+    anchorRef,
+    onKeyDown,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.5.0",
+	"version": "11.5.1",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/tests/ui/edit-drawer-dependencies.test.tsx
+++ b/tests/ui/edit-drawer-dependencies.test.tsx
@@ -248,4 +248,89 @@ describe("findDependencyCycleError", () => {
     const tasks = [makeTask({ id: "a", title: "Alpha" }), makeTask({ id: "b", title: "Beta" })];
     expect(findDependencyCycleError("b", ["a", "ghost-1"], tasks)).toBeNull();
   });
+
+  describe("popup escapes the drawer's scroll container", () => {
+    it("should_render_suggestions_outside_the_scrolling_ancestor", async () => {
+      // The drawer body is `overflow-auto`, which CLIPS absolutely-positioned
+      // descendants — the list was cut off behind the sticky Save footer and
+      // could not be clicked at 1280x720. z-index cannot fix clipping; the
+      // popup has to leave the container entirely.
+      const { container } = render(
+        <div style={{ overflow: "auto" }} data-testid="scroll-container">
+          <DependenciesField
+            taskId="z"
+            dependencies={[]}
+            allTasks={[makeTask({ id: "a", title: "Alpha" })]}
+            onChange={vi.fn()}
+          />
+        </div>
+      );
+
+      await userEvent.type(screen.getByTestId("dep-search"), "Alp");
+
+      const suggestion = await screen.findByTestId("dep-suggestion");
+      expect(suggestion).toBeInTheDocument();
+      expect(container.contains(suggestion)).toBe(false);
+    });
+  });
+
+  describe("keyboard selection", () => {
+    it("should_pick_the_highlighted_suggestion_with_arrow_keys_and_enter", async () => {
+      const onChange = vi.fn();
+      render(
+        <DependenciesField
+          taskId="z"
+          dependencies={[]}
+          allTasks={[
+            makeTask({ id: "a", title: "Alpha one" }),
+            makeTask({ id: "b", title: "Alpha two" }),
+          ]}
+          onChange={onChange}
+        />
+      );
+
+      await userEvent.type(screen.getByTestId("dep-search"), "Alpha");
+      await userEvent.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+
+      expect(onChange).toHaveBeenCalledWith(["b"]);
+    });
+
+    it("should_pick_the_first_suggestion_on_a_single_arrow_down", async () => {
+      const onChange = vi.fn();
+      render(
+        <DependenciesField
+          taskId="z"
+          dependencies={[]}
+          allTasks={[
+            makeTask({ id: "a", title: "Alpha one" }),
+            makeTask({ id: "b", title: "Alpha two" }),
+          ]}
+          onChange={onChange}
+        />
+      );
+
+      await userEvent.type(screen.getByTestId("dep-search"), "Alpha");
+      await userEvent.keyboard("{ArrowDown}{Enter}");
+
+      expect(onChange).toHaveBeenCalledWith(["a"]);
+    });
+
+    it("should_expose_the_listbox_relationship_to_assistive_tech", async () => {
+      render(
+        <DependenciesField
+          taskId="z"
+          dependencies={[]}
+          allTasks={[makeTask({ id: "a", title: "Alpha one" })]}
+          onChange={vi.fn()}
+        />
+      );
+
+      const input = screen.getByTestId("dep-search");
+      await userEvent.type(input, "Alpha");
+
+      expect(input).toHaveAttribute("role", "combobox");
+      expect(input).toHaveAttribute("aria-expanded", "true");
+      expect(await screen.findByRole("listbox")).toBeInTheDocument();
+    });
+  });
 });

--- a/tests/ui/edit-drawer.test.tsx
+++ b/tests/ui/edit-drawer.test.tsx
@@ -314,4 +314,59 @@ describe("<EditDrawer>", () => {
       expect(onClose).toHaveBeenCalled();
     });
   });
+
+  describe("scroll containment and accidental dismissal", () => {
+    function renderDrawer(props: { onClose?: () => void } = {}) {
+      return render(
+        <EditDrawer
+          open
+          task={mockTask}
+          onClose={props.onClose ?? vi.fn()}
+          onSubmit={vi.fn()}
+        />
+      );
+    }
+
+    it("locks body scroll while open and restores it on close", () => {
+      const { unmount } = renderDrawer();
+      expect(document.body.style.overflow).toBe("hidden");
+
+      unmount();
+      expect(document.body.style.overflow).not.toBe("hidden");
+    });
+
+    it("contains overscroll so the page behind does not move", () => {
+      renderDrawer();
+      const scroller = screen
+        .getByTestId("edit-drawer")
+        .querySelector(".overflow-auto, .overflow-y-auto");
+      expect(scroller?.className).toContain("overscroll-contain");
+    });
+
+    it("does not close when a drag starts inside the form and ends on the backdrop", async () => {
+      const onClose = vi.fn();
+      renderDrawer({ onClose });
+
+      const form = screen.getByTestId("edit-drawer");
+      const backdrop = form.parentElement as HTMLElement;
+
+      // Selecting text or dragging a scrollbar routinely releases outside the
+      // form. Treating that as "dismiss" throws away an in-progress edit.
+      fireEvent.mouseDown(form);
+      fireEvent.click(backdrop);
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("still closes on a genuine backdrop click", () => {
+      const onClose = vi.fn();
+      renderDrawer({ onClose });
+
+      const backdrop = screen.getByTestId("edit-drawer").parentElement as HTMLElement;
+      fireEvent.mouseDown(backdrop);
+      fireEvent.click(backdrop);
+
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Wave D, PR 4 of 4 — completes Wave D.

## The bug

At 1280×720 the **Depends on** suggestion list rendered behind the sticky Save footer and couldn't be clicked. The field was unusable without zooming out — a shipped feature nobody could reach.

## It's clipping, not stacking

The drawer body is `overflow-auto`. An absolutely-positioned **descendant of a scroll container is clipped at its edge** — the pixels are never painted, so no z-index can rescue it.

The popup is now portalled to `document.body` and positioned against the viewport, flipping above the field when the space below can't hold it.

Being portalled means it has no positioned ancestor left to follow, so the anchor's rect is tracked and re-measured on scroll/resize. **The scroll listener uses `capture: true`** — the drawer's own scroll container doesn't bubble scroll to the window, so a bubbling listener would never fire.

## Keyboard

Arrow keys move through suggestions, Enter commits the highlighted one, with `combobox`/`listbox` roles and `aria-activedescendant` so the highlight is *reported*, not just drawn.

## Two related fixes

- `overscroll-contain` on the drawer's scroller + the page frozen while open, so scrolling past the end no longer drags the field out from under the popup.
- **The backdrop now dismisses only when the gesture *began* there.** Selecting text or dragging the scrollbar routinely releases outside the form, and a plain `onClick` read that as a dismissal — silently discarding an in-progress edit.

That last one is the likeliest explanation for the review's *"I lost an in-progress title edit once during that interaction."* I checked the alternative first: the draft is seeded lazily and only remounts on task-id change, so it cannot "re-derive on scroll" as the review speculated.

## Verification

Live run at 1280×720 — the screenshot shows `Q2 — schedule` **fully visible**, flipped above the field to clear the footer:

> a listbox labeled 'Matching tasks' with one visible option 'Q2 — schedule'. The listbox appears to be fully visible and not clipped or hidden behind the Save footer.

Console clean.

- 7 new tests, including one that renders the field inside an `overflow: auto` ancestor and asserts the popup escapes it
- `bun run test` — 2696 passed, 1 skipped
- typecheck / lint / shape clean

## Refactors the ratchet required

Extracted `useSuggestionCombobox` (keyboard + anchor tracking), `useModalSurface` (scroll lock + backdrop guard), `DependencyChips`, `FieldNotes`, and `DrawerFooter`. All budgets back at or below their prior maximums.

https://claude.ai/code/session_01DA4QuYKyWt5WkynEqteWJH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->