### PR TITLE
fix(palette): name quadrants properly and make the data actions act

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.6.0
+**Current version:** 11.6.1
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/components/command-palette/task-item.tsx
+++ b/components/command-palette/task-item.tsx
@@ -2,6 +2,7 @@
 
 import { Command } from "cmdk";
 import { CheckIcon } from "lucide-react";
+import { quadrants } from "@/lib/quadrants";
 import { cn } from "@/lib/utils";
 import type { TaskRecord } from "@/lib/types";
 
@@ -23,10 +24,9 @@ const quadrantStyles = {
  * Renders a single task item in the command palette
  */
 export function TaskItem({ task, onSelect }: TaskItemProps) {
-  const quadrantLabel = task.quadrant
-    .split("-")
-    .map((w) => w[0].toUpperCase())
-    .join("");
+  // The board's own name for the quadrant. Initials of the raw id read as
+  // "UI" and "NUNI" — an encoding of the database value, not a label.
+  const quadrantLabel = quadrants.find((q) => q.id === task.quadrant)?.title ?? task.quadrant;
 
   return (
     <Command.Item

--- a/components/settings-page/settings-body.tsx
+++ b/components/settings-page/settings-body.tsx
@@ -4,7 +4,7 @@ import { lazy, Suspense, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
-import { exportToJsonWithReport } from "@/lib/tasks";
+import { downloadBackup } from "@/lib/backup-download";
 import { createLogger } from "@/lib/logger";
 import type { TaskRecord } from "@/lib/types";
 
@@ -68,14 +68,8 @@ export function SettingsBody({
     // No `finally`: the React Compiler can't yet optimize a component with a
     // try/finally, so the exporting reset is duplicated across both paths.
     try {
-      const { json, skippedCount } = await exportToJsonWithReport();
-      const blob = new Blob([json], { type: "application/json" });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = `gsd-tasks-${new Date().toISOString()}.json`;
-      link.click();
-      URL.revokeObjectURL(url);
+      const { ok, skippedCount } = await downloadBackup();
+      if (!ok) throw new Error("Export failed");
       if (skippedCount > 0) {
         // Never let a corrupt record silently vanish from the user's backup.
         toast.warning(

--- a/lib/backup-download.ts
+++ b/lib/backup-download.ts
@@ -1,0 +1,59 @@
+import { toast } from "sonner";
+
+import { exportToJsonWithReport } from "@/lib/tasks";
+import { createLogger } from "@/lib/logger";
+
+const logger = createLogger("UI");
+
+export interface BackupDownloadResult {
+  ok: boolean;
+  /** Records excluded from the file as unreadable. Never silently dropped. */
+  skippedCount: number;
+}
+
+/**
+ * Write the backup to a file the user receives.
+ *
+ * Shared by Settings and the command palette so "Export tasks as JSON" performs
+ * the same act from either surface — the palette entry previously only navigated
+ * to Settings, which is not what the label promises.
+ */
+/**
+ * Download the backup and report the outcome to the user.
+ *
+ * Callers that have no UI of their own (the command palette) get the same
+ * feedback Settings gives, including the partial-export warning — a skipped
+ * record must never vanish quietly from someone's only copy of their data.
+ */
+export async function runBackupExport(): Promise<boolean> {
+  const { ok, skippedCount } = await downloadBackup();
+  if (!ok) {
+    toast.error("Failed to export tasks");
+    return false;
+  }
+  if (skippedCount > 0) {
+    toast.warning(
+      `Exported, but ${skippedCount} unreadable task${skippedCount === 1 ? "" : "s"} could not be included.`,
+    );
+    return true;
+  }
+  toast.success("Tasks exported");
+  return true;
+}
+
+export async function downloadBackup(): Promise<BackupDownloadResult> {
+  try {
+    const { json, skippedCount } = await exportToJsonWithReport();
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `gsd-tasks-${new Date().toISOString()}.json`;
+    link.click();
+    URL.revokeObjectURL(url);
+    return { ok: true, skippedCount };
+  } catch (error) {
+    logger.error("Export failed", error instanceof Error ? error : undefined);
+    return { ok: false, skippedCount: 0 };
+  }
+}

--- a/lib/use-shell-command-handlers.ts
+++ b/lib/use-shell-command-handlers.ts
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useTheme } from "next-themes";
+import { runBackupExport } from "@/lib/backup-download";
 import type { CommandActionHandlers } from "@/lib/command-actions";
 import type { FilterCriteria } from "@/lib/filters";
 import type { RedesignQuadrantKey } from "@/lib/quadrants";
@@ -85,11 +86,16 @@ export function useShellCommandHandlers(): ShellCommandResult {
       const current = theme === "system" ? resolvedTheme : theme;
       setTheme(current === "dark" ? "light" : "dark");
     },
+    // The label says "Export tasks as JSON", so it exports. Navigating to
+    // Settings — and to the Appearance tab at that — was not what it promised.
     onExportTasks: async () => {
-      router.push("/settings");
+      await runBackupExport();
     },
+    // Import needs the merge/replace confirmation that lives on the Data
+    // section, so this lands the user on that control rather than performing a
+    // destructive write straight from the palette.
     onImportTasks: () => {
-      router.push("/settings");
+      router.push("/settings#data");
     },
     onOpenSettings: () => router.push("/settings"),
     onOpenHelp: () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.6.0",
+	"version": "11.6.1",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/tests/data/use-shell-command-handlers.test.ts
+++ b/tests/data/use-shell-command-handlers.test.ts
@@ -22,6 +22,16 @@ vi.mock("next-themes", () => ({
   useTheme: () => themeState,
 }));
 
+const downloadBackupMock = vi.fn();
+const runBackupExportMock = vi.fn();
+vi.mock("@/lib/backup-download", () => ({
+  downloadBackup: (...a: unknown[]) => downloadBackupMock(...a),
+  runBackupExport: (...a: unknown[]) => runBackupExportMock(...a),
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}));
+
 function navigateTo(pathname: string) {
   window.history.pushState({}, "", pathname);
 }
@@ -134,9 +144,10 @@ describe("useShellCommandHandlers", () => {
     expect(setThemeMock).toHaveBeenCalledWith("dark");
   });
 
-  it("routes export, import, settings, dashboard, matrix and archive actions", async () => {
+  it("routes the navigation actions", async () => {
     const { result } = renderHook(() => useShellCommandHandlers());
-    await result.current.handlers.onExportTasks();
+    // Export is deliberately absent: it performs the export rather than
+    // navigating, and import now lands on the Data section it needs.
     result.current.handlers.onImportTasks();
     result.current.handlers.onOpenSettings();
     result.current.handlers.onViewDashboard();
@@ -144,8 +155,7 @@ describe("useShellCommandHandlers", () => {
     result.current.handlers.onViewArchive();
 
     expect(pushMock.mock.calls.map((c) => c[0])).toEqual([
-      "/settings",
-      "/settings",
+      "/settings#data",
       "/settings",
       "/dashboard",
       "/",
@@ -189,6 +199,30 @@ describe("useShellCommandHandlers", () => {
       isSyncEnabled: false,
       selectionMode: false,
       hasSelection: false,
+    });
+  });
+
+  describe("data actions actually act", () => {
+    it("exports rather than navigating to Settings", async () => {
+      runBackupExportMock.mockResolvedValue(true);
+      const { result } = renderHook(() => useShellCommandHandlers());
+
+      await result.current.handlers.onExportTasks();
+
+      // The palette entry reads "Export tasks as JSON". It used to open
+      // Settings on the Appearance tab.
+      expect(runBackupExportMock).toHaveBeenCalled();
+      expect(pushMock).not.toHaveBeenCalled();
+    });
+
+    it("lands import on the Data section, not the default tab", () => {
+      const { result } = renderHook(() => useShellCommandHandlers());
+
+      result.current.handlers.onImportTasks();
+
+      // Import needs the merge/replace confirmation that lives there, so this
+      // routes to the control rather than writing straight from the palette.
+      expect(pushMock).toHaveBeenCalledWith("/settings#data");
     });
   });
 });

--- a/tests/ui/command-palette.test.tsx
+++ b/tests/ui/command-palette.test.tsx
@@ -86,10 +86,8 @@ describe('Command Palette Components', () => {
       expect(screen.getByText('Buy groceries')).toBeInTheDocument();
     });
 
-    it('renders quadrant badge', () => {
-      const task = createMockTask({
-        quadrant: 'urgent-important',
-      });
+    it('names the quadrant the way the board does', () => {
+      const task = createMockTask({ quadrant: 'urgent-important' });
 
       render(
         <CommandWrapper>
@@ -97,8 +95,22 @@ describe('Command Palette Components', () => {
         </CommandWrapper>
       );
 
-      // urgent-important => "UI" (first letter of each word uppercased)
-      expect(screen.getByText('UI')).toBeInTheDocument();
+      // Initials of the raw id produced "UI" here and "NUNI" for Q4 — an
+      // encoding of the database value rather than a label anyone recognises.
+      expect(screen.getByText('Do First')).toBeInTheDocument();
+    });
+
+    it('does not render initials of the raw quadrant id', () => {
+      const task = createMockTask({ quadrant: 'not-urgent-not-important' });
+
+      render(
+        <CommandWrapper>
+          <TaskItem task={task} onSelect={vi.fn()} />
+        </CommandWrapper>
+      );
+
+      expect(screen.queryByText('NUNI')).not.toBeInTheDocument();
+      expect(screen.getByText('Eliminate')).toBeInTheDocument();
     });
 
     it('renders tags', () => {


### PR DESCRIPTION
Wave F, PR 1 of 3.

## Two ways the palette described itself inaccurately

**1. Quadrant badges read as `UI`, `NUI`, `UNI`, `NUNI`.**

```ts
task.quadrant.split("-").map(w => w[0].toUpperCase()).join("")
// "not-urgent-not-important" → "NUNI"
```

An encoding of the database value, not a label. Now shows the board's own name (`Do First`, `Eliminate`) so the palette teaches nothing new to learn.

**2. Export and Import both just navigated.**

Both called `router.push("/settings")` — which lands on **Appearance**. Not the export, not even the Data section.

- **Export now exports**, sharing one implementation (`runBackupExport`) with the Settings button so the two surfaces can't drift, including the partial-export warning.
- **Import routes to `/settings#data`**, where the merge/replace confirmation lives. Firing a destructive write straight from a palette entry would be worse than a navigation, not better — so this fixes the "not even the `#data` anchor" half and leaves the confirmation intact.

## Verification

Live run:

> The task shown is 'Q4 — eliminate' with a quadrant badge that reads **'Eliminate'** (the full board name, not initials).

Console clean.

- Badge tests written red-first; one now asserts `NUNI` is *absent*
- 2 new handler tests (export acts and doesn't navigate; import lands on `#data`)
- `bun run test` — 2717 passed, 1 skipped
- typecheck / lint / shape clean

https://claude.ai/code/session_01DA4QuYKyWt5WkynEqteWJH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->