### PR TITLE
feat(matrix): collapse completed tasks behind a per-quadrant disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.6.1
+**Current version:** 11.7.0
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/components/matrix-simplified/quadrant-pane.tsx
+++ b/components/matrix-simplified/quadrant-pane.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+import { ChevronRightIcon } from "lucide-react";
 import { useDroppable } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { PlusIcon, FlameIcon, CalendarIcon, UsersIcon, Trash2Icon, type LucideIcon } from "lucide-react";
@@ -55,7 +57,16 @@ export function QuadrantPane({
   const header = QUADRANT_HEADER[meta.rdKey];
   const QuadrantIcon = RD_ICON[meta.rdIcon];
   const taskIds = tasks.map((t) => t.id);
-  const activeTaskCount = tasks.reduce((count, task) => count + (task.completed ? 0 : 1), 0);
+  // Completed work is separated rather than interleaved. Show-completed used to
+  // inject every finished card inline, growing the board past 8,000px and
+  // pushing the active tasks — the whole point of the quadrant — off screen.
+  const activeTasks = tasks.filter((task) => !task.completed);
+  const completedTasks = tasks.filter((task) => task.completed);
+  const activeTaskCount = activeTasks.length;
+  const [showCompletedHere, setShowCompletedHere] = useState(false);
+  const cardHandlers: CardHandlers = {
+    onEdit, onInspect, onDelete, onShare, onToggleComplete, highlightedTaskId, onTaskRef,
+  };
   return (
     <section data-testid={`quadrant-${meta.rdKey}`}
       data-drop-active={isOver ? "true" : undefined}
@@ -111,7 +122,7 @@ export function QuadrantPane({
 
       <SortableContext id={meta.id} items={taskIds} strategy={verticalListSortingStrategy}>
         <div className="flex flex-1 flex-col gap-2 px-4 pb-4 pt-1">
-          {tasks.length === 0 ? (
+          {activeTasks.length === 0 && completedTasks.length === 0 ? (
             <div className="my-auto flex flex-col items-center gap-2 py-4 text-center">
               {/* Reassuring mark: one icon in ink-3 on a 60pt sunken tile — never a
                   colorful illustration (reference §09). */}
@@ -146,23 +157,94 @@ export function QuadrantPane({
               ) : null}
             </div>
           ) : (
-            tasks.map((task) => (
-              <TaskCard
-                key={task.id}
-                task={task}
-                allTasks={allTasks}
-                onEdit={onEdit}
-                onInspect={onInspect}
-                onDelete={onDelete}
-                onShare={onShare}
-                onToggleComplete={onToggleComplete}
-                isHighlighted={task.id === highlightedTaskId}
-                taskRef={(element) => onTaskRef?.(task.id, element)}
-              />
-            ))
+            <TaskCardList tasks={activeTasks} allTasks={allTasks} handlers={cardHandlers} />
           )}
+
+          <CompletedDisclosure
+            tasks={completedTasks}
+            allTasks={allTasks}
+            open={showCompletedHere}
+            onToggle={() => setShowCompletedHere((open) => !open)}
+            handlers={cardHandlers}
+          />
         </div>
       </SortableContext>
     </section>
+  );
+}
+
+/**
+ * Finished work in this quadrant, collapsed by default.
+ *
+ * Nothing is hidden permanently — Show-completed asked for these, and one click
+ * returns them. What changes is that they no longer bury the active tasks the
+ * quadrant exists to surface.
+ */
+function CompletedDisclosure({
+  tasks,
+  allTasks,
+  open,
+  onToggle,
+  handlers,
+}: {
+  tasks: TaskRecord[];
+  allTasks: TaskRecord[];
+  open: boolean;
+  onToggle: () => void;
+  handlers: CardHandlers;
+}) {
+  if (tasks.length === 0) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        className="mt-1 inline-flex w-fit items-center gap-1.5 rounded-full px-2 py-1 text-caption font-medium text-foreground-muted transition-colors hover:bg-background-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+      >
+        <ChevronRightIcon
+          className={cn("h-3.5 w-3.5 transition-transform", open && "rotate-90")}
+          aria-hidden="true"
+        />
+        {tasks.length} done
+      </button>
+      {open ? <TaskCardList tasks={tasks} allTasks={allTasks} handlers={handlers} /> : null}
+    </>
+  );
+}
+
+type CardHandlers = Pick<
+  QuadrantPaneProps,
+  "onEdit" | "onInspect" | "onDelete" | "onShare" | "onToggleComplete" | "highlightedTaskId" | "onTaskRef"
+>;
+
+/** A run of task cards. Shared by the active list and the completed disclosure. */
+function TaskCardList({
+  tasks,
+  allTasks,
+  handlers,
+}: {
+  tasks: TaskRecord[];
+  allTasks: TaskRecord[];
+  handlers: CardHandlers;
+}) {
+  return (
+    <>
+      {tasks.map((task) => (
+        <TaskCard
+          key={task.id}
+          task={task}
+          allTasks={allTasks}
+          onEdit={handlers.onEdit}
+          onInspect={handlers.onInspect}
+          onDelete={handlers.onDelete}
+          onShare={handlers.onShare}
+          onToggleComplete={handlers.onToggleComplete}
+          isHighlighted={task.id === handlers.highlightedTaskId}
+          taskRef={(element) => handlers.onTaskRef?.(task.id, element)}
+        />
+      ))}
+    </>
   );
 }

--- a/components/task-card/task-card-header.tsx
+++ b/components/task-card/task-card-header.tsx
@@ -107,9 +107,12 @@ export function TaskCardHeader({
         )}
         <div className={cn("min-w-0 flex-1", reserveBadgeSpace && "pr-24")}>
           <h3 className={cn(
-            "text-[14.5px] font-semibold leading-[1.4] tracking-[-0.005em] text-foreground",
+            "text-[14.5px] font-semibold leading-[1.4] tracking-[-0.005em]",
             !onInspect && "truncate",
-            task.completed && "line-through"
+            // Strike-through alone leaves the title at full contrast; in dark
+            // mode that makes a completed card read as an active one. The
+            // recede is what carries the state.
+            task.completed ? "text-foreground-muted line-through" : "text-foreground"
           )}>
             {onInspect ? (
               <button

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.6.1",
+	"version": "11.7.0",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/tests/e2e/task-crud.spec.ts
+++ b/tests/e2e/task-crud.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "./fixtures/test-fixtures";
 import { MatrixPage } from "./pages/matrix-page";
-import { waitForAppLoad } from "./helpers/test-helpers";
+import { waitForAppLoad, createTaskViaCaptureBar } from "./helpers/test-helpers";
 
 test.describe("Task CRUD Operations", () => {
   let matrixPage: MatrixPage;
@@ -103,5 +103,38 @@ test.describe("Task CRUD Operations", () => {
     await expect(page.locator("[data-testid='task-card']").filter({ hasText: "First task" })).toBeVisible();
     await expect(page.locator("[data-testid='task-card']").filter({ hasText: "Second task" })).toBeVisible();
     await expect(page.locator("[data-testid='task-card']").filter({ hasText: "Third task" })).toBeVisible();
+  });
+});
+
+test.describe("Completed tasks stay collapsed", () => {
+  test.beforeEach(async ({ clearIndexedDB }) => {
+    // Fixture clears IndexedDB
+  });
+
+  /**
+   * Show-completed used to inject every finished card inline, growing the board
+   * past 8,000px and pushing active work off screen. The cards are still
+   * reachable — one click — they just no longer bury the quadrant's point.
+   */
+  test("show-completed reveals a disclosure, not a wall of cards", async ({ page }) => {
+    await waitForAppLoad(page);
+    await createTaskViaCaptureBar(page, "Finish me !!");
+    await createTaskViaCaptureBar(page, "Still open !!");
+
+    const q1 = page.locator("[data-testid='quadrant-q1']");
+    const target = q1.locator("[data-testid='task-card']").filter({ hasText: "Finish me" });
+    await target.getByRole("button", { name: /mark as complete/i }).click();
+
+    await page.evaluate(() => localStorage.setItem("gsd:show-completed", "true"));
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await waitForAppLoad(page);
+
+    const disclosure = q1.getByRole("button", { name: /1 done/i });
+    await expect(disclosure).toBeVisible();
+    await expect(q1.locator("[data-testid='task-card']").filter({ hasText: "Finish me" })).toHaveCount(0);
+    await expect(q1.locator("[data-testid='task-card']").filter({ hasText: "Still open" })).toBeVisible();
+
+    await disclosure.click();
+    await expect(q1.locator("[data-testid='task-card']").filter({ hasText: "Finish me" })).toBeVisible();
   });
 });

--- a/tests/ui/matrix-simplified.test.tsx
+++ b/tests/ui/matrix-simplified.test.tsx
@@ -164,6 +164,17 @@ import { MatrixSimplified } from "@/components/matrix-simplified";
 import { createTask, toggleCompleted, updateTask, deleteTask, restoreTask } from "@/lib/tasks";
 import { celebrateCompletion } from "@/lib/confetti";
 
+/**
+ * Completed tasks now live behind a per-quadrant "N done" disclosure, so tests
+ * that assert on them have to open it first — the same click a user makes.
+ */
+async function revealCompleted() {
+  const toggles = screen.queryAllByRole("button", { name: /\d+ done/i });
+  for (const toggle of toggles) {
+    await userEvent.click(toggle);
+  }
+}
+
 describe("<MatrixSimplified>", () => {
   beforeEach(() => {
     tasksFixture.current = [];
@@ -251,6 +262,7 @@ describe("<MatrixSimplified>", () => {
       localStorage.setItem("gsd:show-completed", "true");
       tasksFixture.current = [makeTask({ id: "b", title: "Done bravo", completed: true })];
       render(<MatrixSimplified />);
+      await revealCompleted();
 
       await user.click(screen.getByRole("button", { name: /mark as incomplete/i }));
 
@@ -314,6 +326,7 @@ describe("<MatrixSimplified>", () => {
       localStorage.setItem("gsd:show-completed", "true");
       tasksFixture.current = [makeTask({ id: "b", title: "Done bravo", completed: true })];
       render(<MatrixSimplified />);
+      await revealCompleted();
 
       await user.click(screen.getByRole("button", { name: /mark as incomplete/i }));
 
@@ -735,10 +748,11 @@ describe("<MatrixSimplified>", () => {
 
     await user.click(await screen.findByRole("button", { name: /all completed/i }));
 
-    await waitFor(() => {
-      expect(screen.queryByText("Active alpha")).not.toBeInTheDocument();
-      expect(screen.getByText("Done bravo")).toBeInTheDocument();
-    });
+    await waitFor(() =>
+      expect(screen.queryByText("Active alpha")).not.toBeInTheDocument()
+    );
+    await revealCompleted();
+    expect(screen.getByText("Done bravo")).toBeInTheDocument();
   });
 
   describe("show-completed preference", () => {
@@ -752,7 +766,7 @@ describe("<MatrixSimplified>", () => {
       expect(screen.queryByText("Done bravo")).not.toBeInTheDocument();
     });
 
-    it("shows completed tasks when 'gsd:show-completed' is true", () => {
+    it("shows completed tasks when 'gsd:show-completed' is true", async () => {
       localStorage.setItem("gsd:show-completed", "true");
       tasksFixture.current = [
         makeTask({ id: "a", title: "Active alpha", completed: false }),
@@ -760,6 +774,9 @@ describe("<MatrixSimplified>", () => {
       ];
       render(<MatrixSimplified />);
       expect(screen.getByText("Active alpha")).toBeInTheDocument();
+
+      // Behind the "N done" disclosure now, so it takes the click a user makes.
+      await revealCompleted();
       expect(screen.getByText("Done bravo")).toBeInTheDocument();
     });
 
@@ -779,8 +796,10 @@ describe("<MatrixSimplified>", () => {
       });
 
       await waitFor(() =>
-        expect(screen.getByText("Done bravo")).toBeInTheDocument(),
+        expect(screen.getByRole("button", { name: /1 done/i })).toBeInTheDocument(),
       );
+      await revealCompleted();
+      expect(screen.getByText("Done bravo")).toBeInTheDocument();
     });
 
     it("opens the share dialog with the target task when its share button is clicked", async () => {

--- a/tests/ui/quadrant-completed-disclosure.test.tsx
+++ b/tests/ui/quadrant-completed-disclosure.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { QuadrantPane } from "@/components/matrix-simplified/quadrant-pane";
+import { quadrantForTask } from "@/lib/quadrants";
+import { createMockTask } from "@/tests/fixtures";
+import type { TaskRecord } from "@/lib/types";
+
+function renderPane(tasks: TaskRecord[]) {
+  return render(
+    <QuadrantPane
+      meta={quadrantForTask(true, true)}
+      tasks={tasks}
+      allTasks={tasks}
+      onEdit={vi.fn()}
+      onToggleComplete={vi.fn()}
+      onDelete={vi.fn()}
+      onShare={vi.fn()}
+      onAddInQuadrant={vi.fn()}
+    />
+  );
+}
+
+const active = createMockTask({ id: "a", title: "Still to do", urgent: true, important: true });
+const done1 = createMockTask({ id: "d1", title: "Finished one", urgent: true, important: true, completed: true });
+const done2 = createMockTask({ id: "d2", title: "Finished two", urgent: true, important: true, completed: true });
+
+describe("QuadrantPane completed disclosure", () => {
+  it("keeps completed tasks collapsed so they cannot bury the active ones", () => {
+    renderPane([active, done1, done2]);
+
+    // Show-completed used to inject every completed card inline, growing the
+    // board to ~8,000px and pushing active work off screen.
+    expect(screen.getByText("Still to do")).toBeInTheDocument();
+    expect(screen.queryByText("Finished one")).not.toBeInTheDocument();
+  });
+
+  it("says how many are hidden", () => {
+    renderPane([active, done1, done2]);
+    expect(screen.getByRole("button", { name: /2 done/i })).toBeInTheDocument();
+  });
+
+  it("reveals them on request", async () => {
+    const user = userEvent.setup();
+    renderPane([active, done1, done2]);
+
+    await user.click(screen.getByRole("button", { name: /2 done/i }));
+
+    // Nothing is hidden permanently — Show-completed asked for these.
+    expect(screen.getByText("Finished one")).toBeInTheDocument();
+    expect(screen.getByText("Finished two")).toBeInTheDocument();
+  });
+
+  it("shows no disclosure when nothing is completed", () => {
+    renderPane([active]);
+    expect(screen.queryByRole("button", { name: /done/i })).not.toBeInTheDocument();
+  });
+
+  it("does not treat a quadrant of only completed tasks as empty", () => {
+    renderPane([done1, done2]);
+
+    // "Nothing on fire." would be a claim about the user's workload; the truth
+    // is that everything here is finished.
+    expect(screen.queryByTestId("quadrant-empty-mark")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /2 done/i })).toBeInTheDocument();
+  });
+});

--- a/tests/ui/task-card-states.test.tsx
+++ b/tests/ui/task-card-states.test.tsx
@@ -262,4 +262,14 @@ describe("TaskCard states", () => {
     expect(screen.getByTestId("task-card")).toHaveClass("opacity-100");
     expect(screen.getByTestId("task-card")).not.toHaveClass("opacity-[0.55]");
   });
+
+  it("dims a completed title, not just strikes it", () => {
+    const { container } = renderTaskCard({ id: "done", title: "Finished", completed: true });
+
+    // Strike-through alone leaves the title at full contrast, which in dark
+    // mode makes a completed card near-indistinguishable from an active one.
+    const heading = container.querySelector("h3");
+    expect(heading?.className).toContain("line-through");
+    expect(heading?.className).toContain("text-foreground-muted");
+  });
 });


### PR DESCRIPTION
Wave F, PR 2 of 3.

## The problem

Show-completed injected **every finished card inline** — 51 extra cards on a real board, a page around **8,000px** tall, and the active tasks pushed off screen.

## The change

Completed work sits behind a **`N done`** toggle per quadrant, closed by default.

**Nothing is hidden permanently.** Show-completed asked for these cards; one click returns them. What changes is that they stop burying the work that's still open.

## Two things that fell out of it

**A quadrant of only completed tasks is no longer "empty."** It used to render *"Nothing on fire."* — a claim about the user's workload that's false when the truth is everything there is finished.

**Completed titles now recede, not just strike.** Strike-through alone left them at `text-foreground`, which in dark mode made a completed card read as an active one — the exact complaint in the review.

## Deviation from the review's wording

The review suggested defaulting the disclosure to *"the last 7 days"*. I collapsed **all** completed tasks in the quadrant instead. Filtering to 7 days would silently drop tasks between 7 and 30 days old — after the disclosure but before auto-archive picks them up — and quietly hiding data the user explicitly asked to see is the class of bug I've spent this session removing. Collapsing everything solves the 8,000px problem completely without dropping anything.

## Verification

New Playwright spec (the Stagehand runner extracted before client-side nav settled, and this is regression-worthy):

```
show-completed reveals a disclosure, not a wall of cards — 1 passed
```

It completes a task, enables the preference, reloads, and asserts the quadrant shows `1 done`, the completed card is absent, the active card isn't, and clicking reveals it.

- 5 new unit tests, 1 new e2e, 3 existing matrix tests updated for the new interaction
- `bun run test` — 2723 passed, 1 skipped
- typecheck / lint / shape clean

## Refactor

Extracted `TaskCardList` (shared by the active list and the disclosure, so they can't drift) and `CompletedDisclosure`. Shape ratchet back at its prior maximums.

https://claude.ai/code/session_01DA4QuYKyWt5WkynEqteWJH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->