### PR TITLE
fix(task-card): stop the drag grip covering the title's first character

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.7.0
+**Current version:** 11.7.1
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/components/task-card/task-card-header.tsx
+++ b/components/task-card/task-card-header.tsx
@@ -74,38 +74,24 @@ export function TaskCardHeader({
   return (
     <div className="flex items-start justify-between gap-2">
       <div className="flex items-start gap-2 min-w-0 flex-1">
-        {selectionMode ? (
-          <label className="touch-target mt-0.5 inline-flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center">
-            <input
-              type="checkbox"
-              checked={isSelected}
-              onChange={() => onToggleSelect?.(task)}
-              className="h-5 w-5 shrink-0 cursor-pointer rounded border-border text-accent focus:ring-2 focus:ring-accent focus:ring-offset-2"
-              aria-label={`Select ${task.title}`}
-            />
-          </label>
-        ) : (
-          // Floats over the card's left gutter instead of holding a column, so
-          // titles start flush. Visibility (not hit-testing) is what's gated:
-          // gating pointer-events too would be a no-op for a real mouse — you
-          // cannot reach the grip without hovering the card that reveals it —
-          // while breaking any tool that asserts actionability before moving
-          // the pointer, Playwright's `hover()` included.
-          <button
-            type="button"
-            // bg-card matters: at 24px the button overhangs the card's 16px
-            // left gutter by 8px, so a transparent grip would render on top of
-            // the title's first glyph. An opaque fill makes the overlap read as
-            // a control appearing rather than a paint bug.
-            className="task-card-grip touch-target absolute left-0 top-2.5 z-10 flex h-6 w-6 cursor-grab touch-none items-center justify-center rounded-icon bg-card opacity-0 transition-opacity hover:bg-background-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent group-hover:opacity-100 group-focus-within:opacity-100 [@media(pointer:coarse)]:static [@media(pointer:coarse)]:opacity-100"
-            aria-label="Drag to move task"
-            {...sortableAttributes}
-            {...sortableListeners}
-          >
-            <GripVerticalIcon className="h-4 w-4 text-foreground-muted" />
-          </button>
-        )}
-        <div className={cn("min-w-0 flex-1", reserveBadgeSpace && "pr-24")}>
+        <CardLeadingControl
+          task={task}
+          selectionMode={selectionMode}
+          isSelected={isSelected}
+          onToggleSelect={onToggleSelect}
+          sortableAttributes={sortableAttributes}
+          sortableListeners={sortableListeners}
+        />
+        <div
+          className={cn(
+            "min-w-0 flex-1",
+            // Clears the grip's column. The grip is absolute from the card's
+            // border and overruns the 16px card padding by 8px, so without this
+            // it lands on the title's first character.
+            !selectionMode && "pl-2",
+            reserveBadgeSpace && "pr-24"
+          )}
+        >
           <h3 className={cn(
             "text-[14.5px] font-semibold leading-[1.4] tracking-[-0.005em]",
             !onInspect && "truncate",
@@ -187,5 +173,54 @@ export function TaskCardHeader({
         <TooltipContent>{completionLabel}</TooltipContent>
       </Tooltip>
     </div>
+  );
+}
+
+/**
+ * The card's left gutter: a selection checkbox in selection mode, otherwise the
+ * drag grip.
+ */
+function CardLeadingControl({
+  task,
+  selectionMode,
+  isSelected,
+  onToggleSelect,
+  sortableAttributes,
+  sortableListeners,
+}: Pick<
+  TaskCardHeaderProps,
+  "task" | "selectionMode" | "isSelected" | "onToggleSelect" | "sortableAttributes" | "sortableListeners"
+>) {
+  return selectionMode ? (
+          <label className="touch-target mt-0.5 inline-flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center">
+            <input
+              type="checkbox"
+              checked={isSelected}
+              onChange={() => onToggleSelect?.(task)}
+              className="h-5 w-5 shrink-0 cursor-pointer rounded border-border text-accent focus:ring-2 focus:ring-accent focus:ring-offset-2"
+              aria-label={`Select ${task.title}`}
+            />
+          </label>
+        ) : (
+          // Floats over the card's left gutter instead of holding a column, so
+          // titles start flush. Visibility (not hit-testing) is what's gated:
+          // gating pointer-events too would be a no-op for a real mouse — you
+          // cannot reach the grip without hovering the card that reveals it —
+          // while breaking any tool that asserts actionability before moving
+          // the pointer, Playwright's `hover()` included.
+          <button
+            type="button"
+            // The 24px button starts at the card's left border and the card
+            // pads 16px, so it reached 8px into the text column and covered the
+            // title's leading glyph — "QA TEST 3" read as "A TEST 3". An opaque
+            // fill made that look deliberate rather than fixing it; the text
+            // column now reserves the missing 8px instead (see the wrapper).
+            className="task-card-grip touch-target absolute left-0 top-2.5 z-10 flex h-6 w-6 cursor-grab touch-none items-center justify-center rounded-icon bg-card opacity-0 transition-opacity hover:bg-background-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent group-hover:opacity-100 group-focus-within:opacity-100 [@media(pointer:coarse)]:static [@media(pointer:coarse)]:opacity-100"
+            aria-label="Drag to move task"
+            {...sortableAttributes}
+            {...sortableListeners}
+          >
+            <GripVerticalIcon className="h-4 w-4 text-foreground-muted" />
+          </button>
   );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.7.0",
+	"version": "11.7.1",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/tests/e2e/layout-overlap.spec.ts
+++ b/tests/e2e/layout-overlap.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from "./fixtures/test-fixtures";
+import { waitForAppLoad, createTaskViaCaptureBar } from "./helpers/test-helpers";
+import type { Locator } from "@playwright/test";
+
+/**
+ * Overlap regressions, measured rather than eyeballed.
+ *
+ * jsdom has no layout, so these three defects — a grip covering a glyph, a
+ * fixed bar covering a card, a dialog's actions below the fold — are invisible
+ * to the unit suite by construction. They need real boxes at a real viewport.
+ */
+async function box(locator: Locator) {
+  const rect = await locator.boundingBox();
+  if (!rect) throw new Error("Element has no bounding box");
+  return rect;
+}
+
+test.describe("Layout overlap", () => {
+  test.beforeEach(async ({ clearIndexedDB }) => {
+    // Fixture clears IndexedDB
+  });
+
+  test("the drag grip does not cover the title's first character", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await waitForAppLoad(page);
+    await createTaskViaCaptureBar(page, "QA TEST 3 !!");
+
+    const card = page.locator("[data-testid='task-card']").filter({ hasText: "QA TEST 3" });
+    await card.hover();
+
+    const grip = card.getByRole("button", { name: "Drag to move task" });
+    await expect(grip).toBeVisible();
+
+    const gripBox = await box(grip);
+    const titleBox = await box(card.locator("h3"));
+
+    // The grip used to overhang the gutter by 8px, hiding the leading glyph —
+    // "QA TEST 3" rendered as "A TEST 3".
+    expect(gripBox.x + gripBox.width).toBeLessThanOrEqual(titleBox.x + 1);
+  });
+
+  test("the mobile capture bar does not cover the last task card", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await waitForAppLoad(page);
+
+    for (let i = 1; i <= 6; i += 1) {
+      await createTaskViaCaptureBar(page, `Mobile task ${i} !!`);
+    }
+
+    const captureBar = page.getByLabel("Capture a task");
+    const lastCard = page.locator("[data-testid='task-card']").last();
+
+    // Scroll by moving to the element rather than sleeping after a wheel event.
+    await lastCard.scrollIntoViewIfNeeded();
+    await expect(lastCard).toBeVisible();
+
+    const barBox = await box(captureBar);
+    const cardBox = await box(lastCard);
+
+    // Scrolled fully down, the final card must clear the fixed bar rather than
+    // sit under it.
+    expect(cardBox.y + cardBox.height).toBeLessThanOrEqual(barBox.y + 1);
+  });
+
+  test("the share dialog's actions stay on screen at 720px height", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await waitForAppLoad(page);
+    await createTaskViaCaptureBar(page, "Share me !!");
+
+    const card = page.locator("[data-testid='task-card']").filter({ hasText: "Share me" });
+    await card.hover();
+    await card.getByRole("button", { name: "Share task" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    // Cancel anchors the action row whichever share tab is active.
+    const action = dialog.getByRole("button", { name: "Cancel" });
+    const actionBox = await box(action);
+
+    // The row must be on screen without scrolling the dialog — a primary
+    // action below the fold reads as a dialog with no way out.
+    expect(actionBox.y + actionBox.height).toBeLessThanOrEqual(720);
+  });
+});


### PR DESCRIPTION
Wave F, PR 3 of 3 — completes Wave F.

## One real defect, measured

The grip is `absolute left-0` and 24px wide; the card pads 16px. So it reached **8px into the text column** and sat on the leading glyph — `QA TEST 3` rendered as `A TEST 3` on hover.

The previous treatment gave the button an opaque `bg-card` fill *"so the overlap reads as a control appearing rather than a paint bug"* — which made it look deliberate without making it correct. The text column now reserves the missing 8px.

Measured, not eyeballed:

```
grip right edge:  258
title left edge:  251     ← 7px overlap
```

## Two claims that don't reproduce

The review also reported the mobile capture bar covering cards and the Share dialog's buttons falling below the fold at 720px. **Neither reproduces on current `main`:**

- At 390×844, scrolled to the bottom, the last card clears the fixed bar (`pb-48` is sufficient).
- At 1280×720, the Share dialog's action row is on screen (`max-h-[85vh]` keeps it in view).

Both may well have been true at v11.2.1 and fixed since. I've kept them **as regression guards rather than deleting them** — the measurements are the evidence they hold, and they'll fail loudly if that changes.

## Why e2e and not unit tests

jsdom has no layout, so overlap defects are invisible to the unit suite *by construction*. These three need real boxes at real viewports.

The repo's own `e2e-quality-gates` test then caught my first draft using `waitForTimeout` — replaced with `scrollIntoViewIfNeeded`, which waits on the actual condition.

## Verification

- `tests/e2e/layout-overlap.spec.ts` — 3 passed
- `bun run test` — 2723 passed, 1 skipped
- typecheck / lint / shape clean (extracted `CardLeadingControl` to hold the ratchet)

https://claude.ai/code/session_01DA4QuYKyWt5WkynEqteWJH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->