### PR TITLE
feat(edit-drawer): let users set a task's recurrence

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.7.2
+**Current version:** 11.8.0
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/components/matrix-simplified/edit-draft.ts
+++ b/components/matrix-simplified/edit-draft.ts
@@ -1,3 +1,5 @@
+import type { RecurrenceType } from "@/lib/types";
+
 export interface EditDraft {
   title: string;
   description: string;
@@ -6,4 +8,5 @@ export interface EditDraft {
   dueDate?: string;
   tags: string[];
   dependencies: string[];
+  recurrence: RecurrenceType;
 }

--- a/components/matrix-simplified/edit-drawer-fields.tsx
+++ b/components/matrix-simplified/edit-drawer-fields.tsx
@@ -5,6 +5,7 @@ import { CalendarIcon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { quadrants, QUADRANT_ACCENT, QUADRANT_HEADER, QUADRANT_INK } from "@/lib/quadrants";
 import { DUE_PRESETS, type DuePreset } from "@/lib/due-date-presets";
+import type { RecurrenceType } from "@/lib/types";
 
 // ─── Shared ────────────────────────────────────────────────────────────────
 
@@ -245,6 +246,55 @@ export function TagsField({ tags, tagInput, onTagInputChange, onAddTag, onRemove
           // an offset ring would draw outside the field it belongs to.
           className="min-w-[80px] flex-1 rounded-xs border-0 bg-transparent text-[13px] text-foreground outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent"
         />
+      </div>
+    </Field>
+  );
+}
+
+const RECURRENCE_OPTIONS: { value: RecurrenceType; label: string }[] = [
+  { value: "none", label: "Never" },
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+  { value: "monthly", label: "Monthly" },
+];
+
+/**
+ * How often the task comes back.
+ *
+ * The recurrence engine has always worked — completing a recurring task spawns
+ * the next instance — but nothing in the app could turn it on, so the About
+ * page advertised a feature no user could reach.
+ */
+export function RecurrenceField({
+  recurrence,
+  onChange,
+}: {
+  recurrence: RecurrenceType;
+  onChange: (value: RecurrenceType) => void;
+}): React.ReactElement {
+  return (
+    <Field label="Repeat" as="group">
+      <div className="flex flex-wrap gap-1.5">
+        {RECURRENCE_OPTIONS.map((option) => {
+          const active = option.value === recurrence;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              data-testid={`edit-recurrence-${option.value}`}
+              onClick={() => onChange(option.value)}
+              aria-pressed={active}
+              className={cn(
+                "rounded-full border px-3 py-1.5 text-[13px] font-medium transition-colors",
+                active
+                  ? "border-accent bg-accent/10 text-accent"
+                  : "border-border text-foreground-muted hover:bg-background-muted"
+              )}
+            >
+              {option.label}
+            </button>
+          );
+        })}
       </div>
     </Field>
   );

--- a/components/matrix-simplified/edit-drawer.tsx
+++ b/components/matrix-simplified/edit-drawer.tsx
@@ -9,7 +9,7 @@ import { DrawerHint } from "@/components/ui/drawer-hint";
 import { useModalSurface } from "./use-modal-surface";
 import { useDialogFocus } from "./use-dialog-focus";
 import { useEditDraftState } from "./use-edit-draft-state";
-import { Field, QuadrantField, DueDateField, TagsField } from "./edit-drawer-fields";
+import { Field, QuadrantField, DueDateField, TagsField, RecurrenceField } from "./edit-drawer-fields";
 import { DependenciesField, findDependencyCycleError } from "./edit-drawer-dependencies";
 import type { EditDraft } from "./edit-draft";
 export type { EditDraft } from "./edit-draft";
@@ -256,6 +256,8 @@ function EditDrawerBody({
             important={draft.important}
             onChange={(u, i) => { draft.setUrgent(u); draft.setImportant(i); }}
           />
+
+          <RecurrenceField recurrence={draft.recurrence} onChange={draft.setRecurrence} />
 
           <SchedulingAndLinksFields
             draft={draft}

--- a/components/matrix-simplified/use-edit-draft-state.ts
+++ b/components/matrix-simplified/use-edit-draft-state.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import type { RefObject } from "react";
-import type { TaskRecord } from "@/lib/types";
+import type { RecurrenceType, TaskRecord } from "@/lib/types";
 import { resolveDuePreset, type DuePreset } from "@/lib/due-date-presets";
 import { UI_TIMING } from "@/lib/constants/ui";
 import type { EditDraft } from "./edit-draft";
@@ -48,6 +48,8 @@ export interface EditDraftState {
   addTag: () => void;
   dependencies: string[];
   setDependencies: (v: string[]) => void;
+  recurrence: RecurrenceType;
+  setRecurrence: (v: RecurrenceType) => void;
   toDraft: () => EditDraft;
 }
 
@@ -57,6 +59,27 @@ export interface EditDraftState {
  * initializers. EditDrawer remounts this hook (via a `key` on the task id) when
  * the selected task changes, so no effect is needed to re-sync from props.
  */
+/** Normalise and append a tag, ignoring blanks and duplicates. */
+function appendTag(tags: string[], raw: string): string[] {
+  const value = raw.trim().toLowerCase().replace(/^#/, "");
+  if (!value || tags.includes(value)) return tags;
+  return [...tags, value];
+}
+
+/** Move focus to the title field shortly after the drawer mounts. */
+function useAutofocusTitle(titleRef: RefObject<HTMLInputElement | null>): void {
+  useEffect(() => {
+    const timer = setTimeout(() => titleRef.current?.focus(), UI_TIMING.FOCUS_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [titleRef]);
+}
+
+/** Resolve the picked preset (or custom date) into an ISO due date. */
+function resolveDueDate(customDate: string | undefined, duePreset: DuePreset): string | undefined {
+  const rawDate = customDate ?? resolveDuePreset(duePreset);
+  return rawDate ? new Date(`${rawDate}T00:00:00`).toISOString() : undefined;
+}
+
 export function useEditDraftState(
   task: TaskRecord | null | undefined,
   initialDraft: Partial<EditDraft> | undefined,
@@ -82,26 +105,19 @@ export function useEditDraftState(
   const [dependencies, setDependencies] = useState<string[]>(() =>
     task ? task.dependencies ?? [] : initialDraft?.dependencies ?? []
   );
+  const [recurrence, setRecurrence] = useState<RecurrenceType>(() =>
+    task ? task.recurrence ?? "none" : initialDraft?.recurrence ?? "none"
+  );
 
-  // Move focus to the title field shortly after the drawer mounts.
-  useEffect(() => {
-    const timer = setTimeout(() => titleRef.current?.focus(), UI_TIMING.FOCUS_DELAY_MS);
-    return () => clearTimeout(timer);
-  }, [titleRef]);
+  useAutofocusTitle(titleRef);
 
   const addTag = (): void => {
-    const v = tagInput.trim().toLowerCase().replace(/^#/, "");
-    if (!v || tags.includes(v)) {
-      setTagInput("");
-      return;
-    }
-    setTags([...tags, v]);
+    setTags(appendTag(tags, tagInput));
     setTagInput("");
   };
 
   const toDraft = (): EditDraft => {
-    const rawDate = customDate ?? resolveDuePreset(duePreset);
-    const dueDate = rawDate ? new Date(`${rawDate}T00:00:00`).toISOString() : undefined;
+    const dueDate = resolveDueDate(customDate, duePreset);
     return {
       title: title.trim(),
       description: description.trim(),
@@ -110,6 +126,7 @@ export function useEditDraftState(
       dueDate,
       tags,
       dependencies,
+      recurrence,
     };
   };
 
@@ -125,6 +142,7 @@ export function useEditDraftState(
     tagInput, setTagInput,
     addTag,
     dependencies, setDependencies,
+    recurrence, setRecurrence,
     toDraft,
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.7.2",
+	"version": "11.8.0",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/tests/ui/edit-drawer-recurrence.test.tsx
+++ b/tests/ui/edit-drawer-recurrence.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { EditDrawer } from "@/components/matrix-simplified/edit-drawer";
+import type { TaskRecord } from "@/lib/types";
+
+const baseTask = {
+  id: "t1",
+  title: "Weekly review",
+  description: "",
+  urgent: false,
+  important: true,
+  quadrant: "not-urgent-important",
+  completed: false,
+  recurrence: "none",
+  tags: [],
+  subtasks: [],
+  dependencies: [],
+  notificationEnabled: false,
+  notificationSent: false,
+  createdAt: "2026-04-26T00:00:00.000Z",
+  updatedAt: "2026-04-26T00:00:00.000Z",
+} as TaskRecord;
+
+describe("<EditDrawer> recurrence", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("offers the recurrence options the schema supports", () => {
+    render(<EditDrawer open task={baseTask} onClose={vi.fn()} onSubmit={vi.fn()} />);
+
+    // The engine already spawns the next instance on completion; only the way
+    // to turn it on was missing.
+    expect(screen.getByRole("group", { name: /repeat/i })).toBeInTheDocument();
+    for (const label of ["Never", "Daily", "Weekly", "Monthly"]) {
+      expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it("submits the chosen recurrence", async () => {
+    const onSubmit = vi.fn();
+    render(<EditDrawer open task={baseTask} onClose={vi.fn()} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: "Weekly" }));
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ recurrence: "weekly" }),
+      "t1"
+    );
+  });
+
+  it("seeds from the task being edited", () => {
+    render(
+      <EditDrawer
+        open
+        task={{ ...baseTask, recurrence: "monthly" }}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Monthly" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
+
+  it("defaults a new task to no recurrence", async () => {
+    const onSubmit = vi.fn();
+    render(<EditDrawer open task={null} onClose={vi.fn()} onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/title/i), "One-off task");
+    await user.click(screen.getByRole("button", { name: /create task/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ recurrence: "none" }),
+      undefined
+    );
+  });
+});


### PR DESCRIPTION
Wave G, PR 2 of 5.

## The gap this closes

Recurrence was **fully built and completely unreachable**:

| Layer | Status |
|---|---|
| Schema (`recurrence` on `TaskRecord`) | shipped |
| Card badge | shipped |
| Detail-sheet row | shipped |
| **Engine** — completing a recurring task spawns the next instance | shipped, e2e-covered |
| Built-in smart view | written |
| Advertised on the About page | yes |
| **Any way to turn it on** | **none** |

That's why #475 badged the About card "Coming soon" — the app was promising something no user could reach.

## The change

A **Repeat** field in the composer: Never / Daily / Weekly / Monthly. Seeded from the task being edited, defaulting to Never for a new one.

The value rides the existing `EditDraft` through to `createTask` and `updateTask`, which already handled `recurrence` — nothing downstream needed touching.

## Verification

Live run:

> The task edit drawer is open and displays a **REPEAT** field with four button options: Never, Daily, Weekly, and Monthly.

- 4 new tests written red-first: options render, the choice is submitted, an existing value seeds the control, and a new task defaults to `none`
- `bun run test` — 2727 passed, 1 skipped
- typecheck / lint / shape clean

The ratchet needed `useAutofocusTitle`, `resolveDueDate`, and `appendTag` extracted from `useEditDraftState` — the first dividend of #489's decomposition landing first.

https://claude.ai/code/session_01DA4QuYKyWt5WkynEqteWJH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->