### PR TITLE
feat(edit-drawer): let users author a task's subtasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.8.0
+**Current version:** 11.9.0
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/components/matrix-simplified/edit-draft.ts
+++ b/components/matrix-simplified/edit-draft.ts
@@ -1,4 +1,4 @@
-import type { RecurrenceType } from "@/lib/types";
+import type { RecurrenceType, Subtask } from "@/lib/types";
 
 export interface EditDraft {
   title: string;
@@ -9,4 +9,5 @@ export interface EditDraft {
   tags: string[];
   dependencies: string[];
   recurrence: RecurrenceType;
+  subtasks: Subtask[];
 }

--- a/components/matrix-simplified/edit-drawer-fields.tsx
+++ b/components/matrix-simplified/edit-drawer-fields.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { CalendarIcon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { quadrants, QUADRANT_ACCENT, QUADRANT_HEADER, QUADRANT_INK } from "@/lib/quadrants";
 import { DUE_PRESETS, type DuePreset } from "@/lib/due-date-presets";
-import type { RecurrenceType } from "@/lib/types";
+import type { RecurrenceType, Subtask } from "@/lib/types";
 
 // ─── Shared ────────────────────────────────────────────────────────────────
 
@@ -297,5 +297,117 @@ export function RecurrenceField({
         })}
       </div>
     </Field>
+  );
+}
+
+/**
+ * A task's checklist.
+ *
+ * Progress already rendered on the card and in the detail sheet; only the way
+ * to author the items was missing. Edits stay in the draft until Save, so
+ * ticking an item here is reversible by closing without saving.
+ */
+export function SubtasksField({
+  subtasks,
+  onAdd,
+  onToggle,
+  onRemove,
+}: {
+  subtasks: Subtask[];
+  onAdd: (title: string) => void;
+  onToggle: (id: string) => void;
+  onRemove: (id: string) => void;
+}): React.ReactElement {
+  const [entry, setEntry] = useState("");
+  const done = subtasks.filter((s) => s.completed).length;
+
+  const commit = (): void => {
+    onAdd(entry);
+    setEntry("");
+  };
+
+  return (
+    <Field label={subtasks.length ? `Subtasks · ${done}/${subtasks.length}` : "Subtasks"} as="group">
+      {subtasks.length > 0 ? (
+        <ul className="space-y-1">
+          {subtasks.map((subtask) => (
+            <SubtaskRow
+              key={subtask.id}
+              subtask={subtask}
+              onToggle={onToggle}
+              onRemove={onRemove}
+            />
+          ))}
+        </ul>
+      ) : null}
+      <SubtaskEntry value={entry} onChange={setEntry} onCommit={commit} />
+    </Field>
+  );
+}
+
+/** One checklist item: tick, label, remove. */
+function SubtaskRow({
+  subtask,
+  onToggle,
+  onRemove,
+}: {
+  subtask: Subtask;
+  onToggle: (id: string) => void;
+  onRemove: (id: string) => void;
+}): React.ReactElement {
+  return (
+    <li className="flex items-center gap-2">
+      <input
+        type="checkbox"
+        checked={subtask.completed}
+        onChange={() => onToggle(subtask.id)}
+        aria-label={subtask.title}
+        className="h-4 w-4 shrink-0 cursor-pointer rounded border-border text-accent focus:ring-2 focus:ring-accent focus:ring-offset-1"
+      />
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate text-[13px]",
+          subtask.completed ? "text-foreground-muted line-through" : "text-foreground"
+        )}
+      >
+        {subtask.title}
+      </span>
+      {/* ui-craft-detect-ignore-next-line */}
+      <button
+        type="button"
+        onClick={() => onRemove(subtask.id)}
+        aria-label={`Remove subtask ${subtask.title}`}
+        className="rounded-xs p-1 text-foreground-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+      >
+        <XIcon className="h-3 w-3" />
+      </button>
+    </li>
+  );
+}
+
+/** The "add a subtask" input. Enter commits rather than submitting the drawer. */
+function SubtaskEntry({
+  value,
+  onChange,
+  onCommit,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  onCommit: () => void;
+}): React.ReactElement {
+  return (
+    <input
+      data-testid="edit-subtask-input"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key !== "Enter") return;
+        e.preventDefault();
+        onCommit();
+      }}
+      placeholder="Add a subtask…"
+      aria-label="Add a subtask"
+      className="w-full rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground outline-none focus:border-foreground-muted focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+    />
   );
 }

--- a/components/matrix-simplified/edit-drawer.tsx
+++ b/components/matrix-simplified/edit-drawer.tsx
@@ -9,7 +9,7 @@ import { DrawerHint } from "@/components/ui/drawer-hint";
 import { useModalSurface } from "./use-modal-surface";
 import { useDialogFocus } from "./use-dialog-focus";
 import { useEditDraftState } from "./use-edit-draft-state";
-import { Field, QuadrantField, DueDateField, TagsField, RecurrenceField } from "./edit-drawer-fields";
+import { Field, QuadrantField, DueDateField, TagsField, RecurrenceField, SubtasksField } from "./edit-drawer-fields";
 import { DependenciesField, findDependencyCycleError } from "./edit-drawer-dependencies";
 import type { EditDraft } from "./edit-draft";
 export type { EditDraft } from "./edit-draft";
@@ -258,6 +258,13 @@ function EditDrawerBody({
           />
 
           <RecurrenceField recurrence={draft.recurrence} onChange={draft.setRecurrence} />
+
+          <SubtasksField
+            subtasks={draft.subtasks}
+            onAdd={draft.addSubtask}
+            onToggle={draft.toggleSubtask}
+            onRemove={draft.removeSubtask}
+          />
 
           <SchedulingAndLinksFields
             draft={draft}

--- a/components/matrix-simplified/use-edit-draft-state.ts
+++ b/components/matrix-simplified/use-edit-draft-state.ts
@@ -1,10 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { RefObject } from "react";
-import type { RecurrenceType, TaskRecord } from "@/lib/types";
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import type { RecurrenceType, Subtask, TaskRecord } from "@/lib/types";
 import { resolveDuePreset, type DuePreset } from "@/lib/due-date-presets";
 import { UI_TIMING } from "@/lib/constants/ui";
+import { generateId } from "@/lib/id-generator";
 import type { EditDraft } from "./edit-draft";
 
 function classifyExistingDate(iso: string | undefined): DuePreset {
@@ -50,15 +51,32 @@ export interface EditDraftState {
   setDependencies: (v: string[]) => void;
   recurrence: RecurrenceType;
   setRecurrence: (v: RecurrenceType) => void;
+  subtasks: Subtask[];
+  addSubtask: (title: string) => void;
+  toggleSubtask: (id: string) => void;
+  removeSubtask: (id: string) => void;
   toDraft: () => EditDraft;
 }
 
-/**
- * Owns all form-field state for EditDrawer. Field values are seeded once from
- * the task (edit mode) or initialDraft (create mode) via lazy useState
- * initializers. EditDrawer remounts this hook (via a `key` on the task id) when
- * the selected task changes, so no effect is needed to re-sync from props.
- */
+/** The three ways a draft's checklist changes. */
+function subtaskActions(setSubtasks: Dispatch<SetStateAction<Subtask[]>>) {
+  return {
+    addSubtask: (title: string) => setSubtasks((current) => appendSubtask(current, title)),
+    toggleSubtask: (id: string) =>
+      setSubtasks((current) =>
+        current.map((s) => (s.id === id ? { ...s, completed: !s.completed } : s))
+      ),
+    removeSubtask: (id: string) => setSubtasks((current) => current.filter((s) => s.id !== id)),
+  };
+}
+
+/** Append a subtask, ignoring blank input. Ids are generated locally until save. */
+function appendSubtask(subtasks: Subtask[], rawTitle: string): Subtask[] {
+  const title = rawTitle.trim();
+  if (!title) return subtasks;
+  return [...subtasks, { id: generateId(), title, completed: false }];
+}
+
 /** Normalise and append a tag, ignoring blanks and duplicates. */
 function appendTag(tags: string[], raw: string): string[] {
   const value = raw.trim().toLowerCase().replace(/^#/, "");
@@ -80,6 +98,12 @@ function resolveDueDate(customDate: string | undefined, duePreset: DuePreset): s
   return rawDate ? new Date(`${rawDate}T00:00:00`).toISOString() : undefined;
 }
 
+/**
+ * Owns all form-field state for EditDrawer. Field values are seeded once from
+ * the task (edit mode) or initialDraft (create mode) via lazy useState
+ * initializers. EditDrawer remounts this hook (via a `key` on the task id) when
+ * the selected task changes, so no effect is needed to re-sync from props.
+ */
 export function useEditDraftState(
   task: TaskRecord | null | undefined,
   initialDraft: Partial<EditDraft> | undefined,
@@ -108,6 +132,9 @@ export function useEditDraftState(
   const [recurrence, setRecurrence] = useState<RecurrenceType>(() =>
     task ? task.recurrence ?? "none" : initialDraft?.recurrence ?? "none"
   );
+  const [subtasks, setSubtasks] = useState<Subtask[]>(() =>
+    task ? task.subtasks ?? [] : initialDraft?.subtasks ?? []
+  );
 
   useAutofocusTitle(titleRef);
 
@@ -116,19 +143,17 @@ export function useEditDraftState(
     setTagInput("");
   };
 
-  const toDraft = (): EditDraft => {
-    const dueDate = resolveDueDate(customDate, duePreset);
-    return {
-      title: title.trim(),
-      description: description.trim(),
-      urgent,
-      important,
-      dueDate,
-      tags,
-      dependencies,
-      recurrence,
-    };
-  };
+  const toDraft = (): EditDraft => ({
+    title: title.trim(),
+    description: description.trim(),
+    urgent,
+    important,
+    dueDate: resolveDueDate(customDate, duePreset),
+    tags,
+    dependencies,
+    recurrence,
+    subtasks,
+  });
 
   return {
     title, setTitle,
@@ -143,6 +168,8 @@ export function useEditDraftState(
     addTag,
     dependencies, setDependencies,
     recurrence, setRecurrence,
+    subtasks,
+    ...subtaskActions(setSubtasks),
     toDraft,
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.8.0",
+	"version": "11.9.0",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/tests/ui/edit-drawer-subtasks.test.tsx
+++ b/tests/ui/edit-drawer-subtasks.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { EditDrawer } from "@/components/matrix-simplified/edit-drawer";
+import type { TaskRecord } from "@/lib/types";
+
+const baseTask = {
+  id: "t1",
+  title: "Ship the release",
+  description: "",
+  urgent: true,
+  important: true,
+  quadrant: "urgent-important",
+  completed: false,
+  recurrence: "none",
+  tags: [],
+  subtasks: [],
+  dependencies: [],
+  notificationEnabled: false,
+  notificationSent: false,
+  createdAt: "2026-04-26T00:00:00.000Z",
+  updatedAt: "2026-04-26T00:00:00.000Z",
+} as TaskRecord;
+
+describe("<EditDrawer> subtasks", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  it("adds a subtask and submits it", async () => {
+    const onSubmit = vi.fn();
+    render(<EditDrawer open task={baseTask} onClose={vi.fn()} onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/add a subtask/i), "Write the changelog{Enter}");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subtasks: [expect.objectContaining({ title: "Write the changelog", completed: false })],
+      }),
+      "t1"
+    );
+  });
+
+  it("shows existing subtasks with their completion state", () => {
+    render(
+      <EditDrawer
+        open
+        task={{
+          ...baseTask,
+          subtasks: [
+            { id: "s1", title: "Already done", completed: true },
+            { id: "s2", title: "Still open", completed: false },
+          ],
+        }}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("checkbox", { name: /already done/i })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: /still open/i })).not.toBeChecked();
+  });
+
+  it("toggles a subtask's completion", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <EditDrawer
+        open
+        task={{ ...baseTask, subtasks: [{ id: "s1", title: "Tick me", completed: false }] }}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    );
+
+    await user.click(screen.getByRole("checkbox", { name: /tick me/i }));
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subtasks: [expect.objectContaining({ id: "s1", completed: true })],
+      }),
+      "t1"
+    );
+  });
+
+  it("removes a subtask", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <EditDrawer
+        open
+        task={{ ...baseTask, subtasks: [{ id: "s1", title: "Drop me", completed: false }] }}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /remove subtask drop me/i }));
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ subtasks: [] }),
+      "t1"
+    );
+  });
+
+  it("ignores an empty subtask", async () => {
+    const onSubmit = vi.fn();
+    render(<EditDrawer open task={baseTask} onClose={vi.fn()} onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/add a subtask/i), "   {Enter}");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ subtasks: [] }),
+      "t1"
+    );
+  });
+});


### PR DESCRIPTION
Wave G, PR 3 of 5.

## The gap

Subtasks were the other capability the About page advertised and the app couldn't reach:

- Schema modelled them ✅
- Card showed `2/3` progress ✅
- Detail sheet listed them ✅
- Import and sync carried them ✅
- **Any way to write one** ❌

## The change

A **Subtasks** field in the composer: type and press Enter to add, tick to complete, X to remove, with a `done/total` count in the label.

Enter is swallowed so it commits the item rather than submitting the drawer — the same reason the tag input does it.

Edits stay in the draft until Save, so ticking an item is reversible by closing without saving. That matches how tags and dependencies already behave, rather than inventing a third convention.

## Verification

Live run:

> a 'SUBTASKS' group field that contains a textbox labeled 'Add a subtask'

- 5 tests written red-first: add and submit, existing items render with their state, toggle, remove, and blank input is ignored
- `bun run test` — 2732 passed, 1 skipped
- typecheck / lint / shape clean

Extracted `SubtaskRow`, `SubtaskEntry`, and `subtaskActions` to hold the ratchet.

https://claude.ai/code/session_01DA4QuYKyWt5WkynEqteWJH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->