### PR TITLE
feat(edit-drawer): add the estimate input the Review page was missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.9.0
+**Current version:** 11.10.0
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/components/matrix-simplified/edit-draft.ts
+++ b/components/matrix-simplified/edit-draft.ts
@@ -10,4 +10,5 @@ export interface EditDraft {
   dependencies: string[];
   recurrence: RecurrenceType;
   subtasks: Subtask[];
+  estimatedMinutes?: number;
 }

--- a/components/matrix-simplified/edit-drawer-fields.tsx
+++ b/components/matrix-simplified/edit-drawer-fields.tsx
@@ -411,3 +411,38 @@ function SubtaskEntry({
     />
   );
 }
+
+/**
+ * How long the task should take.
+ *
+ * The Review page has always reported Total Estimated and Estimation Accuracy;
+ * with the timer wired to cards but no estimate input, both had nothing to
+ * measure against.
+ */
+export function EstimateField({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}): React.ReactElement {
+  return (
+    <Field label="Estimate">
+      <div className="flex items-center gap-2">
+        <input
+          data-testid="edit-estimate"
+          type="number"
+          min={1}
+          max={10080}
+          inputMode="numeric"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="—"
+          aria-label="Estimate in minutes"
+          className="w-28 rounded-lg border border-border bg-background px-3 py-2 text-[13px] text-foreground outline-none focus:border-foreground-muted focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+        />
+        <span className="text-[13px] text-foreground-muted">minutes</span>
+      </div>
+    </Field>
+  );
+}

--- a/components/matrix-simplified/edit-drawer.tsx
+++ b/components/matrix-simplified/edit-drawer.tsx
@@ -9,7 +9,7 @@ import { DrawerHint } from "@/components/ui/drawer-hint";
 import { useModalSurface } from "./use-modal-surface";
 import { useDialogFocus } from "./use-dialog-focus";
 import { useEditDraftState } from "./use-edit-draft-state";
-import { Field, QuadrantField, DueDateField, TagsField, RecurrenceField, SubtasksField } from "./edit-drawer-fields";
+import { Field, QuadrantField, DueDateField, TagsField, RecurrenceField, SubtasksField, EstimateField } from "./edit-drawer-fields";
 import { DependenciesField, findDependencyCycleError } from "./edit-drawer-dependencies";
 import type { EditDraft } from "./edit-draft";
 export type { EditDraft } from "./edit-draft";
@@ -257,14 +257,7 @@ function EditDrawerBody({
             onChange={(u, i) => { draft.setUrgent(u); draft.setImportant(i); }}
           />
 
-          <RecurrenceField recurrence={draft.recurrence} onChange={draft.setRecurrence} />
-
-          <SubtasksField
-            subtasks={draft.subtasks}
-            onAdd={draft.addSubtask}
-            onToggle={draft.toggleSubtask}
-            onRemove={draft.removeSubtask}
-          />
+          <TaskDetailFields draft={draft} />
 
           <SchedulingAndLinksFields
             draft={draft}
@@ -325,6 +318,24 @@ function handleTagKeyDown(
   if (event.key === "Backspace" && !draft.tagInput && draft.tags.length) {
     draft.setTags(draft.tags.slice(0, -1));
   }
+}
+
+/** Repeat, checklist, and estimate — the fields describing the work itself. */
+function TaskDetailFields({ draft }: { draft: ReturnType<typeof useEditDraftState> }) {
+  return (
+    <>
+      <RecurrenceField recurrence={draft.recurrence} onChange={draft.setRecurrence} />
+
+      <SubtasksField
+        subtasks={draft.subtasks}
+        onAdd={draft.addSubtask}
+        onToggle={draft.toggleSubtask}
+        onRemove={draft.removeSubtask}
+      />
+
+      <EstimateField value={draft.estimateInput} onChange={draft.setEstimateInput} />
+    </>
+  );
 }
 
 /** Due date, tags, and dependencies — the fields that relate a task to others. */

--- a/components/matrix-simplified/use-edit-draft-state.ts
+++ b/components/matrix-simplified/use-edit-draft-state.ts
@@ -55,6 +55,8 @@ export interface EditDraftState {
   addSubtask: (title: string) => void;
   toggleSubtask: (id: string) => void;
   removeSubtask: (id: string) => void;
+  estimateInput: string;
+  setEstimateInput: (v: string) => void;
   toDraft: () => EditDraft;
 }
 
@@ -70,11 +72,62 @@ function subtaskActions(setSubtasks: Dispatch<SetStateAction<Subtask[]>>) {
   };
 }
 
+/**
+ * Minutes, or undefined for "no estimate".
+ *
+ * An empty field must not become 0 — the Review page averages estimates, and a
+ * zero would drag Estimation Accuracy down for every task nobody estimated.
+ */
+function parseEstimate(raw: string): number | undefined {
+  const value = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
 /** Append a subtask, ignoring blank input. Ids are generated locally until save. */
 function appendSubtask(subtasks: Subtask[], rawTitle: string): Subtask[] {
   const title = rawTitle.trim();
   if (!title) return subtasks;
   return [...subtasks, { id: generateId(), title, completed: false }];
+}
+
+/**
+ * The fields that describe the work itself: how often it repeats, what it
+ * breaks into, and how long it should take.
+ *
+ * Split from the core fields so the drawer's state hook stops growing every
+ * time a field is added — the reason the shape ratchet caught the last three.
+ */
+function useDetailDraftFields(
+  task: TaskRecord | null | undefined,
+  initialDraft: Partial<EditDraft> | undefined
+) {
+  const [recurrence, setRecurrence] = useState<RecurrenceType>(() =>
+    task ? task.recurrence ?? "none" : initialDraft?.recurrence ?? "none"
+  );
+  const [subtasks, setSubtasks] = useState<Subtask[]>(() =>
+    task ? task.subtasks ?? [] : initialDraft?.subtasks ?? []
+  );
+  // Held as a string so an emptied field means "no estimate" rather than 0.
+  const [estimateInput, setEstimateInput] = useState<string>(() =>
+    String(task?.estimatedMinutes ?? initialDraft?.estimatedMinutes ?? "")
+  );
+
+  return {
+    recurrence,
+    setRecurrence,
+    subtasks,
+    ...subtaskActions(setSubtasks),
+    estimateInput,
+    setEstimateInput,
+  };
+}
+
+/** Tags come from the task in edit mode and the seeded draft in create mode. */
+function seedTags(
+  task: TaskRecord | null | undefined,
+  initialDraft: Partial<EditDraft> | undefined
+): string[] {
+  return task ? task.tags ?? [] : initialDraft?.tags ?? [];
 }
 
 /** Normalise and append a tag, ignoring blanks and duplicates. */
@@ -124,17 +177,12 @@ export function useEditDraftState(
     task ? classifyExistingCustomDate(task.dueDate) : undefined
   );
   const [showCustomDateInput, setShowCustomDateInput] = useState(false);
-  const [tags, setTags] = useState<string[]>(() => (task ? task.tags ?? [] : initialDraft?.tags ?? []));
+  const [tags, setTags] = useState<string[]>(() => seedTags(task, initialDraft));
   const [tagInput, setTagInput] = useState("");
   const [dependencies, setDependencies] = useState<string[]>(() =>
     task ? task.dependencies ?? [] : initialDraft?.dependencies ?? []
   );
-  const [recurrence, setRecurrence] = useState<RecurrenceType>(() =>
-    task ? task.recurrence ?? "none" : initialDraft?.recurrence ?? "none"
-  );
-  const [subtasks, setSubtasks] = useState<Subtask[]>(() =>
-    task ? task.subtasks ?? [] : initialDraft?.subtasks ?? []
-  );
+  const detail = useDetailDraftFields(task, initialDraft);
 
   useAutofocusTitle(titleRef);
 
@@ -151,8 +199,9 @@ export function useEditDraftState(
     dueDate: resolveDueDate(customDate, duePreset),
     tags,
     dependencies,
-    recurrence,
-    subtasks,
+    recurrence: detail.recurrence,
+    subtasks: detail.subtasks,
+    estimatedMinutes: parseEstimate(detail.estimateInput),
   });
 
   return {
@@ -167,9 +216,7 @@ export function useEditDraftState(
     tagInput, setTagInput,
     addTag,
     dependencies, setDependencies,
-    recurrence, setRecurrence,
-    subtasks,
-    ...subtaskActions(setSubtasks),
+    ...detail,
     toDraft,
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.9.0",
+	"version": "11.10.0",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/tests/ui/edit-drawer-estimate.test.tsx
+++ b/tests/ui/edit-drawer-estimate.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { EditDrawer } from "@/components/matrix-simplified/edit-drawer";
+import type { TaskRecord } from "@/lib/types";
+
+const baseTask = {
+  id: "t1",
+  title: "Draft the proposal",
+  description: "",
+  urgent: false,
+  important: true,
+  quadrant: "not-urgent-important",
+  completed: false,
+  recurrence: "none",
+  tags: [],
+  subtasks: [],
+  dependencies: [],
+  notificationEnabled: false,
+  notificationSent: false,
+  createdAt: "2026-04-26T00:00:00.000Z",
+  updatedAt: "2026-04-26T00:00:00.000Z",
+} as TaskRecord;
+
+describe("<EditDrawer> estimate", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  it("submits the entered estimate", async () => {
+    const onSubmit = vi.fn();
+    render(<EditDrawer open task={baseTask} onClose={vi.fn()} onSubmit={onSubmit} />);
+
+    // The Review page reports Total Estimated and Estimation Accuracy; without
+    // this field there was no way to give either a number.
+    await user.type(screen.getByLabelText(/estimate/i), "90");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ estimatedMinutes: 90 }),
+      "t1"
+    );
+  });
+
+  it("seeds from the task being edited", () => {
+    render(
+      <EditDrawer
+        open
+        task={{ ...baseTask, estimatedMinutes: 45 }}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText(/estimate/i)).toHaveValue(45);
+  });
+
+  it("submits no estimate when the field is left blank", async () => {
+    const onSubmit = vi.fn();
+    render(<EditDrawer open task={baseTask} onClose={vi.fn()} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ estimatedMinutes: undefined }),
+      "t1"
+    );
+  });
+
+  it("clears an estimate when the field is emptied", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <EditDrawer
+        open
+        task={{ ...baseTask, estimatedMinutes: 45 }}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    );
+
+    await user.clear(screen.getByLabelText(/estimate/i));
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ estimatedMinutes: undefined }),
+      "t1"
+    );
+  });
+});


### PR DESCRIPTION
Wave G, PR 4 of 5.

## The gap

The Review page reports four figures. Two of them had nothing to measure:

| Figure | Source | Status before |
|---|---|---|
| Total Tracked | `TaskTimer`, wired to cards | working |
| Running Timers | same | working |
| **Total Estimated** | `estimatedMinutes` | **no way to set it** |
| **Estimation Accuracy** | tracked ÷ estimated | **permanently blank** |

This is the item my original triage found the review had **overstated** — it claimed "estimate + timer controls" were missing and budgeted 3–4 days. The timer was already shipped; only the estimate field was absent, which made this about a day.

## One decision worth noting

The value is held as a **string**, not a number, so an emptied field means *"no estimate"* rather than `0`.

The Review page averages estimates. A zero would drag Estimation Accuracy down for every task nobody bothered to estimate — turning an absent value into a wrong one.

## Verification

Live run:

> REPEAT (with Never, Daily, Weekly, Monthly buttons), SUBTASKS (with an input textbox), and **ESTIMATE (with a spinbutton for minutes)** — all visible together

- 4 tests red-first: submits the value, seeds from the task, blank submits `undefined`, clearing an existing estimate submits `undefined`
- `bun run test` — 2736 passed, 1 skipped
- typecheck / lint / shape clean

## Refactor

The draft hook grew a field in each of the last three PRs. Its detail fields — recurrence, subtasks, estimate — now live in `useDetailDraftFields`, so the next field goes there without touching the core hook.

https://claude.ai/code/session_01DA4QuYKyWt5WkynEqteWJH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->