### PR TITLE
feat: restore the surfaces withheld while recurrence had no UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.10.0
+**Current version:** 11.10.1
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/components/about/features-section.tsx
+++ b/components/about/features-section.tsx
@@ -65,7 +65,6 @@ const features: Feature[] = [
     title: "Recurring Tasks",
     description:
       "Daily standup prep. Weekly reviews. Monthly goals. Set once, repeat automatically.",
-    badge: "Coming soon",
   },
   {
     icon: Tags,
@@ -78,7 +77,6 @@ const features: Feature[] = [
     title: "Subtasks",
     description:
       "Break complex work into steps. Track progress with a checklist.",
-    badge: "Coming soon",
   },
   {
     icon: Smartphone,

--- a/components/matrix-simplified/help-drawer.tsx
+++ b/components/matrix-simplified/help-drawer.tsx
@@ -136,7 +136,7 @@ export function HelpDrawer({ open, onClose }: HelpDrawerProps) {
 
           <Section label="Editing, completing, and drag-drop">
             <p style={bodyStyle}>
-              <strong>Complete</strong>: tap the checkbox on any task card.
+              <strong>Complete</strong>: tap the checkbox on any task card. Recurring tasks automatically spawn the next instance.
             </p>
             <p style={bodyStyle}>
               <strong>Edit</strong>: hover a task card and click the pencil to open the composer pre-filled with that

--- a/lib/smart-views/built-in.ts
+++ b/lib/smart-views/built-in.ts
@@ -80,11 +80,16 @@ export const BUILT_IN_SMART_VIEWS: Omit<SmartView, 'id' | 'createdAt' | 'updated
       status: 'completed'
     }
   },
-  // "Recurring Tasks" is withheld until the composer can set `recurrence`.
-  // The engine works — completing a recurring task spawns the next instance —
-  // but no UI can turn recurrence on, so for a UI-only user the view can only
-  // ever be empty. Restore it alongside the recurrence authoring UI; the
-  // criteria shape is preserved in git history.
+  {
+    name: "Recurring Tasks",
+    description: "All tasks with recurrence enabled",
+    icon: "recurring",
+    isBuiltIn: true,
+    criteria: {
+      status: 'active',
+      recurrence: ['daily', 'weekly', 'monthly']
+    }
+  },
   {
     name: "Ready to Work",
     description: "Tasks with no blocking dependencies",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.10.0",
+	"version": "11.10.1",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/tests/data/filters.test.ts
+++ b/tests/data/filters.test.ts
@@ -348,6 +348,7 @@ describe("Filter utilities", () => {
         "Recently Added",
         "This Week's Wins",
         "All Completed",
+        "Recurring Tasks",
         "Ready to Work",
       ];
 
@@ -373,11 +374,10 @@ describe("Filter utilities", () => {
       expect(view?.criteria.dueThisWeek).toBe(true);
     });
 
-    // Withheld until the composer can set `recurrence` — see
-    // lib/smart-views/built-in.ts. Restore with the recurrence authoring UI.
-    it("should not ship a Recurring Tasks view while recurrence is unauthorable", () => {
+    it("should have Recurring Tasks view", () => {
       const view = BUILT_IN_SMART_VIEWS.find(v => v.name === "Recurring Tasks");
-      expect(view).toBeUndefined();
+      expect(view).toBeDefined();
+      expect(view?.criteria.recurrence).toEqual(["daily", "weekly", "monthly"]);
     });
 
     it("should have No Deadline view", () => {

--- a/tests/data/smart-views-built-in.test.ts
+++ b/tests/data/smart-views-built-in.test.ts
@@ -66,13 +66,11 @@ describe('BUILT_IN_SMART_VIEWS', () => {
     expect(thisWeeksWins?.criteria.status).toBe('completed');
   });
 
-  // Withheld until the edit drawer can set `recurrence`. The recurrence engine
-  // works (toggle.ts spawns the next instance on completion), but nothing in the
-  // UI can turn it on, so this view can only ever be empty for a UI-only user.
-  // Restore it with the recurrence authoring UI.
-  it('omits the Recurring Tasks view while recurrence has no authoring UI', () => {
+  it('includes Recurring Tasks view', () => {
     const recurring = BUILT_IN_SMART_VIEWS.find(v => v.name === 'Recurring Tasks');
-    expect(recurring).toBeUndefined();
+    expect(recurring).toBeDefined();
+    expect(recurring?.criteria.recurrence).toEqual(['daily', 'weekly', 'monthly']);
+    expect(recurring?.criteria.status).toBe('active');
   });
 
   it('all views have unique names', () => {

--- a/tests/ui/about-copy.test.tsx
+++ b/tests/ui/about-copy.test.tsx
@@ -17,28 +17,21 @@ describe("about-page privacy copy", () => {
 });
 
 describe("about-page shipped-feature claims", () => {
-  // Recurrence and subtasks are modelled, rendered read-only on the card and in
-  // the detail sheet, and fully implemented in the data layer — but no UI can
-  // author either one. Advertising them as available oversells the product.
-  // Asserting on the heading's accessible name, not just its text, so the
-  // caveat reaches screen-reader users along with everyone else.
-  it("should_mark_recurring_tasks_as_not_yet_available", () => {
+  // Recurrence and subtasks were badged "Coming soon" while the schema and the
+  // engine existed but no UI could reach them. Both are authorable now, so the
+  // page can claim them plainly again.
+  it("should_claim_recurring_tasks_without_a_caveat", () => {
     render(<FeaturesSection />);
-    expect(
-      screen.getByRole("heading", { name: /Recurring Tasks\s+Coming soon/i })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Recurring Tasks" })).toBeInTheDocument();
   });
 
-  it("should_mark_subtasks_as_not_yet_available", () => {
+  it("should_claim_subtasks_without_a_caveat", () => {
     render(<FeaturesSection />);
-    expect(
-      screen.getByRole("heading", { name: /Subtasks\s+Coming soon/i })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Subtasks" })).toBeInTheDocument();
   });
 
-  it("should_not_badge_shipped_features", () => {
-    render(<FeaturesSection />);
-    const card = screen.getByRole("heading", { name: "Eisenhower Matrix" }).closest("div");
-    expect(card?.textContent).not.toMatch(/coming soon/i);
+  it("should_not_badge_any_feature_as_coming_soon", () => {
+    const { container } = render(<FeaturesSection />);
+    expect(container.textContent).not.toMatch(/coming soon/i);
   });
 });

--- a/tests/ui/help-drawer.test.tsx
+++ b/tests/ui/help-drawer.test.tsx
@@ -91,10 +91,8 @@ describe("HelpDrawer", () => {
     await waitFor(() => expect(screen.getByRole("main")).toHaveFocus());
   });
 
-  it("does not describe recurrence while no UI can set it", () => {
+  it("documents recurrence now that the composer can set it", () => {
     render(<HelpDrawer open onClose={vi.fn()} />);
-    // The recurrence engine works, but nothing in the app can turn it on, so
-    // documenting it sends readers looking for a control that isn't there.
-    expect(document.body.textContent).not.toMatch(/recurring tasks automatically/i);
+    expect(document.body.textContent).toMatch(/recurring tasks automatically/i);
   });
 });


### PR DESCRIPTION
Wave G, PR 5 of 5 — **completes Waves A–G.**

## Closing the loop

#475 withheld three surfaces because the capabilities were built but unreachable:

| Withheld in #475 | Restored here |
|---|---|
| About cards badged "Coming soon" | badges removed |
| Built-in **Recurring Tasks** smart view hidden | back, original criteria |
| Help drawer's recurrence sentence cut | back |

The composer can now author recurrence (#490), subtasks (#491), and an estimate (#492), so every claim is true again.

The Help sentence is worth a note: it was **always accurate** — `toggle.ts` really did spawn the next instance, with e2e coverage. I removed it on narrower grounds, that it sent readers hunting for a control that didn't exist. Now it does.

## Tests reverted, not deleted

The four tests asserting absence are reverted to their original assertions. The git history shows the withholding was temporary and conditional rather than a decision someone later undid without knowing why.

## Verification

Live run against `/about`:

> The 'Recurring Tasks' card... with no badge visible. The 'Subtasks' card... with no badge visible. Neither card displays a 'Coming soon' badge anywhere on the page.

- `bun run test` — 2736 passed, 1 skipped
- typecheck / lint / shape clean

https://claude.ai/code/session_01DA4QuYKyWt5WkynEqteWJH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->