### PR TITLE
chore(release): 11.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.10.1
+**Current version:** 11.11.0
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.10.1",
+	"version": "11.11.0",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '11.6.0';
+const CACHE_VERSION = '11.11.0';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 


### PR DESCRIPTION
Version bump closing the review remediation — PRs #473–#494.

> Branch is still named `chore/release-12.0.0` from the first draft of this PR. Cosmetic only — the branch is squashed and deleted on merge.

## Why minor

Everything user-facing is **additive**. Recurrence, subtasks, estimates, and trash are new capabilities rather than replacements, and the backup envelope at `2.1.0` is a **superset** — every existing `1.0.0` backup still imports unchanged.

## Two things to know at deploy time

Neither changes the version's shape, but both are worth knowing before you roll forward:

| | |
|---|---|
| **IndexedDB schema → v16** | One-way. A v16 database will not open in an older build. **Take a backup from the deployed build first** — that's the rollback. |
| **Delete is now soft** | Tasks move to trash for 30 days rather than being destroyed. The Undo toast still works; it's no longer the only route back. |

## Also in this commit

The service-worker cache version was stale at `11.6.0`. It's stamped from `.build-info.json`, which only regenerates during a build, so it drifted across the release PRs. Restamped to `11.11.0` so the cache boundary matches the release.

## What shipped under this version

Seven waves, 18 code changes:

- **Data loss** — full-fidelity versioned backup (ADR 0014), trash with retention (ADR 0015)
- **Broken** — drag-and-drop target resolution, dependency popup clipping, blocking badge
- **Honesty** — storage figure, filtered-empty state, palette badges and actions, About claims
- **Features** — recurrence, subtasks, and estimate authoring, all previously modelled but unreachable

ADRs: `docs/adr/0014-versioned-backup-envelope.md`, `docs/adr/0015-trash-with-retention.md`.

## Verification

- `bun run test` — 2736 passed, 1 skipped
- `bun typecheck` / `bun lint` / `bun run quality:shape` — all clean

`action-checklist.md` is deliberately left untracked — it's the source report for this work, not part of the release.

https://claude.ai/code/session_01DA4QuYKyWt5WkynEqteWJH