### PR TITLE
fix: resolve the console errors surfaced after the 11.11.0 deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.11.0
+**Current version:** 11.11.1
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.11.1
+**Current version:** 11.11.2
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.11.2
+**Current version:** 11.11.3
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.11.3
+**Current version:** 11.11.4
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -176,7 +176,7 @@ default-src 'self';
 script-src 'self';
 script-src-attr 'none';
 style-src 'self';
-style-src-elem 'self';
+style-src-elem 'self' 'unsafe-inline';
 style-src-attr 'unsafe-inline';
 img-src 'self' data: blob:;
 font-src 'self' data:;
@@ -190,10 +190,22 @@ form-action 'self' https://accounts.google.com https://github.com;
 > stable style blocks into hashed same-origin assets before deployment.
 > `style-src-attr 'unsafe-inline'` remains narrowly scoped to React's dynamic
 > style attributes (virtualized positioning, chart dimensions, and drag
-> transforms). The remaining runtime style elements from pinned Sonner and
-> next-themes releases are allowlisted by exact hashes and guarded by the
-> production browser smoke test; executable inline script and script
-> attributes are denied.
+> transforms). Executable inline script and script attributes are denied, and
+> the production browser smoke test guards the script directives.
+>
+> `style-src-elem` allows `'unsafe-inline'` because the scroll lock that
+> `@radix-ui/react-dialog` applies through `react-remove-scroll` cannot be
+> hash-pinned. That library interpolates the measured scrollbar width into the
+> stylesheet it injects, so the text differs across platforms and zoom levels —
+> a hash computed on one machine fails on another. Enforcing hashes here did
+> not harden the app; it silently broke every modal, leaving the page scrollable
+> behind open dialogs. A hash in the directive also makes `'unsafe-inline'`
+> inert, so the two cannot coexist.
+>
+> The residual risk is bounded: an attacker who could inject a style element
+> already needs the HTML injection that `script-src 'self'` denies, and
+> `style-src-attr 'unsafe-inline'` was already permitted. Script execution,
+> `base-uri`, `form-action`, and `connect-src` remain locked down.
 
 #### 2. X-Frame-Options
 ```

--- a/cloudfront/response-headers-policy.json
+++ b/cloudfront/response-headers-policy.json
@@ -16,7 +16,7 @@
     },
     "ContentSecurityPolicy": {
       "Override": true,
-      "ContentSecurityPolicy": "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self' 'report-sample' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' 'sha256-StEaX+se6YS7pqjzrzMIA0KaX9zF/8zAhvQXZAe5epY=' 'sha256-skqujXORqzxt1aE0NNXxujEanPTX6raoqSscTV/Ww/Y='; style-src-attr 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.vinny.io https://accounts.google.com https://github.com https://*.ingest.us.sentry.io; frame-ancestors 'none'; base-uri 'none'; form-action 'self' https://accounts.google.com https://github.com; object-src 'none'; manifest-src 'self'; worker-src 'self' blob:;"
+      "ContentSecurityPolicy": "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.vinny.io https://accounts.google.com https://github.com https://*.ingest.us.sentry.io; frame-ancestors 'none'; base-uri 'none'; form-action 'self' https://accounts.google.com https://github.com; object-src 'none'; manifest-src 'self'; worker-src 'self' blob:;"
     },
     "ContentTypeOptions": {
       "Override": true

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -39,7 +39,7 @@
 		# allowlist did not cover.
 		Permissions-Policy           "accelerometer=(), autoplay=(), bluetooth=(), browsing-topics=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), hid=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), serial=(), usb=()"
 
-		Content-Security-Policy      "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self' 'report-sample' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' 'sha256-StEaX+se6YS7pqjzrzMIA0KaX9zF/8zAhvQXZAe5epY=' 'sha256-skqujXORqzxt1aE0NNXxujEanPTX6raoqSscTV/Ww/Y='; style-src-attr 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self' https://accounts.google.com https://github.com; object-src 'none'; manifest-src 'self'; worker-src 'self';"
+		Content-Security-Policy      "default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src-attr 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self' https://accounts.google.com https://github.com; object-src 'none'; manifest-src 'self'; worker-src 'self';"
 
 		# Hide server / upstream framework banners.
 		-Server

--- a/docs/audits/ACTION-CHECKLIST-2026-08-12.md
+++ b/docs/audits/ACTION-CHECKLIST-2026-08-12.md
@@ -1,0 +1,137 @@
+# GSD Task Manager — Action Checklist
+
+Derived from the review of **web app v11.2.1** on **12 Aug 2026**. Full findings and repro steps: `/home/user/gsd-review/index.html`
+
+Effort estimates assume you're working solo in a codebase you know. Phases are ordered by risk retired per hour spent — Phase 0 is a single afternoon and clears everything that can cost a user data or trust.
+
+---
+
+## Phase 0 — Ship this week (an afternoon)
+
+Three fixes, no new surface area, all of them close a hole where the app either loses data or misrepresents itself.
+
+- [ ] **Stop sync toasts from preempting the Undo toast.** Give actionable toasts their own lane and queue status toasts instead of replacing them. *Today a delete during a pending sync becomes permanent while the UI still shows Undo — verified gone from both `tasks` and `archivedTasks`.* · **P0** · hours
+- [ ] **Include every store in JSON export** — archived tasks, preferences, smart views, archive + notification settings, behind a version field. *Export currently writes 59 of 291 records.* · **P0** · hours
+- [ ] **Make import handle archived records** on both merge and replace paths. · **P0** · hours
+- [ ] **Fix the "Local storage · 59 tasks" figure** in Settings → Data & Storage to include archived tasks. *Understates the real footprint ~4×, two rows above "Reset everything".* · **P1** · <1 hour
+- [ ] **Reconcile the About page with what ships.** Cut or badge the **Recurring Tasks** and **Subtasks** feature cards. · **P1** · <1 hour
+- [ ] **Hide the Review page's Time Tracking panel** until estimates and timers have inputs. *Currently renders Total Tracked / Total Estimated / Estimation Accuracy / Running Timers with no way to enter any of it.* · **P1** · <1 hour
+- [ ] **Hide the "Recurring Tasks" smart view** while recurrence has no UI. *It can only ever be empty.* · **P1** · <1 hour
+- [ ] **Correct the Help drawer:** `Shift+N` is documented as opening "the full composer" but focuses the capture bar, and the drawer claims recurring tasks spawn next instances. · **P2** · <1 hour
+
+---
+
+## Phase 1 — Broken things (2–3 days)
+
+- [ ] **Fix the keyboard drag drop handler.** Space lifts the card, an arrow previews it over the target quadrant, drop fails with "Failed to move task. Please try again." — reproducible in every direction, on blocked and unblocked tasks. · **P1** · half day
+- [ ] **Log real error objects.** `[TASK_CRUD] [object Object]` and `[GSD Error] [object Object]` gave me nothing to diagnose the above with. Serialize name/message/stack/context. · **P2** · 1 hour
+- [ ] **Gate the dnd-kit success announcement on the write resolving.** A screen-reader user is currently told "dropped over droppable area…" when the move silently failed. · **P1** · 1 hour
+- [ ] **Manually verify pointer drag** on trackpad and touch. I could not complete a cross-quadrant pointer drag in automated testing (8px activation threshold + pointer sensor); drag is the headline interaction on the landing page, so confirm it by hand. · **P1** · 1 hour
+- [ ] **Fix the stale `Blocking N` badge.** It counts all dependency edges, not open ones, so a blocker keeps its badge after the dependent task is completed — which also skews the "Ready to Work" view. · **P1** · 2 hours
+- [ ] **Add complete-undo** ("Task completed · Undo"), reusing the delete toast pattern. *Highest relief-per-line-of-code item in the review: completion is the most frequent action, its checkbox sits inches from delete, and recovery today means enabling Show-completed and scrolling an 8,000px board.* · **P1** · 2 hours
+- [ ] **Portal the Depends-on dropdown** with collision detection, and add arrow-key selection. *At 1280×720 the suggestion list renders behind the sticky Save footer and is un-clickable — the field is unusable until you zoom out.* · **P1** · half day
+- [ ] **Audit other in-drawer popovers** for the same footer clipping. · **P2** · 1 hour
+- [ ] **Lock body scroll while the edit drawer is open** (`overscroll-behavior: contain`), and check the drawer doesn't re-derive form state on scroll — I lost an in-progress title edit once during that interaction. · **P1** · 2 hours
+- [ ] **Add a filtered-empty state.** Zero search results currently shows each quadrant's default empty copy ("Nothing on fire. / Stay sharp.") while the header still reads "5 active" — it looks like the board vanished. Add "No tasks match X", a result count, and a Clear chip. · **P1** · half day
+- [ ] **Reflect the active filter in the header counts.** · **P2** · 1 hour
+
+---
+
+## Phase 2 — Polish (2–3 days)
+
+- [ ] **Fix the palette quadrant badges** rendering as `UI` and `NUNI`. Use the quadrant name or Q1–Q4 with its colour dot. · **P2** · 1 hour
+- [ ] **Make palette actions act.** "Export tasks as JSON" / "Import tasks from JSON" currently just open Settings at the Appearance tab — not the export, not even the `#data` anchor. · **P2** · 2 hours
+- [ ] **Strip a leading `#` in search** so `#qa` matches the `qa` tag. Users type the syntax the capture bar taught them. · **P2** · 1 hour
+- [ ] **Make tag chips on cards clickable** to filter by that tag. · **P2** · 2 hours
+- [ ] **Stop the drag handle clipping the title's first character** on hover ("QA TEST 3" → "A TEST 3"). Reserve the gutter in the card grid. · **P2** · 1 hour
+- [ ] **Collapse completed tasks** into a per-quadrant "12 done this week ▸" disclosure, default to the last 7 days. *Show-completed currently injects 51 cards and grows the page to ~8,000px, while quadrant counts still show active only.* · **P2** · half day
+- [ ] **Strike or dim completed titles in the matrix**, consistent with the archive. In dark mode a completed card is nearly indistinguishable from an active one. · **P2** · 1 hour
+- [ ] **Fix the mobile capture bar** covering task cards. Either let it scroll away behind a floating "+", or pin it with the header and add matching scroll padding. · **P2** · half day
+- [ ] **Reconcile the Review streak.** "Streak 0 days" sits above a dot strip showing five of the last seven days filled. Either label it or fix the calculation. · **P2** · 2 hours
+- [ ] **Wire up notification permission.** Settings shows "Push notifications · on" and a 15-minute default while "Browser permission · Not set" — reminders are silently off. Add an inline "Enable in browser" trigger and mark the toggle inactive until granted. · **P2** · half day
+- [ ] **Enrich the task detail panel.** It shows title, tags and an Edit button; add created/completed dates, due date, dependency list, and complete/move actions so it isn't just a stop on the way to Edit. · **P2** · half day
+- [ ] **Fix the Share modal's buttons** falling below the fold at 720px viewport height. · **P2** · 1 hour
+- [ ] **Align version numbers** across surfaces (app footer v11.2.1 vs README 11.3.0). · **P2** · <1 hour
+
+---
+
+## Phase 3 — Structural safety (3–4 days)
+
+- [ ] **Build a trash with 30-day retention.** Soft-delete instead of depending on a toast — the archive store already proves the pattern. This is what makes deletion structurally safe rather than timing-dependent. · **P0-adjacent** · 2–3 days
+- [ ] **Add a backup nudge** — "your last export was N days ago" — given that clearing browser data erases everything. · half day
+- [ ] **Add Settings → "Copy diagnostics"** dumping recent errors, version, and store counts, so bug reports from a no-analytics app are actionable. · half day
+- [ ] **Test JSON import properly** — merge and replace paths, plus a deliberately malformed file. *I skipped this to avoid risking your live data; it's the other half of the backup story.* · half day
+- [ ] **Test true offline behaviour** with the network severed, not just service-worker presence. · 2 hours
+
+---
+
+## Phase 4 — Close the claimed-vs-shipped gap (1–2 weeks)
+
+Nearly half the task schema has no user-facing control. These are the fields already modelled and, in two cases, already advertised.
+
+- [ ] **Recurrence UI** — daily / weekly / monthly. Already claimed on the About page, already in the schema, already has a smart view waiting for it. · 3–4 days
+- [ ] **Subtasks / checklist UI** with progress shown on the card. Also already claimed on About. · 3–4 days
+- [ ] **Estimate + timer controls**, so the Review page's Time Tracking panel has real data. · 3–4 days
+- [ ] **Due times, not just dates.** "file taxes tomorrow at 3pm" currently keeps the words and drops the time. · 1–2 days
+- [ ] **Snooze UI** (`snoozedUntil` already exists). · 1 day
+- [ ] **Per-task reminders** in the composer (`notifyBefore`, `notificationEnabled` already exist). · 1–2 days
+
+---
+
+## Phase 5 — Workflow depth (2–3 weeks)
+
+- [ ] **Multi-select and bulk actions.** The README notes batch ops were retired in v11; re-tagging or triaging 232 archived items is impossible today. · 3–4 days
+- [ ] **Archive overhaul:** search, tag filter, "archived on" grouping, virtualised scrolling, and a single control set — the card controls (drag handle, mark-incomplete, edit, delete) currently overlap the archive's own Restore/Delete in the same corner. Promote Archive into the sidebar under Review. · 2–3 days
+- [ ] **Deduplicate archived tasks** (the same Medium article appears twice) or at least surface likely duplicates. · 1 day
+- [ ] **Natural-language dates in capture** — "tomorrow 3pm", "every Monday". The parser already handles `!`, `*` and `#`; dates are the obvious next token. · 3–4 days
+- [ ] **Manual ordering within a quadrant.** There's no answer to "what first?" inside Do First. · 2 days
+- [ ] **WIP limits / overload nudge** — "Do First has 12 items" is exactly the coaching this framework exists to give. · 2 days
+- [ ] **User-defined smart views.** The `smartViews` store exists and is empty; there's no create-view UI. · 3–4 days
+- [ ] **Tag management** — rename, merge, delete, colour. Your data already has `todo` (4/7) alongside `todos` (8/8). · 2–3 days
+- [ ] **Task templates** for repeating checklists like the weekly review. · 2–3 days
+- [ ] **Reconsider the unmarked-capture default.** A bare task previews as **Eliminate — "Noise. Stop doing these."** It's philosophically consistent, but it means the fastest path through the app files work into the quadrant that means "don't do this". Consider defaulting to Schedule, or an "Unsorted" inbox strip that must be triaged. *Product decision, but the one default I'd change.* · 1–2 days
+
+---
+
+## Phase 6 — Differentiators worth exploring
+
+Where GSD could become the only app of its kind rather than the nicest Eisenhower app.
+
+- [ ] **Make the Review page actionable.** It asks "What can leave the list?" and then offers no way to drop, reschedule, or delegate anything. A guided weekly triage — step through overdue, stale and Eliminate items and act inline — would be the strongest feature in the product, and no competitor does it well. · **Top pick** · 1–2 weeks
+- [ ] **A time surface for Schedule.** An entire quadrant is about protecting time with no calendar view or ICS feed. Even a read-only week strip would land the promise. · 1–2 weeks
+- [ ] **Staleness detection** — "created 74 days ago, never touched" is the most honest Eliminate signal available, and `createdAt` is already there. · 3–4 days
+- [ ] **Deep links to tasks.** Share only copies text; a URL would make tasks referenceable from notes and email. · 2–3 days
+- [ ] **Lean into link triage.** Most of your 287 tasks carry a URL and tags like `readme`, `todo`, `video` — in practice GSD is being used as much as a read-it-later tool as a task manager. Auto-fetch page title / favicon / reading time, a reading view, and a browser extension or share-target would fit the observed behaviour better than another priority field. · 1–2 weeks
+- [ ] **Sync conflict resolution UI**, already listed as future work in the MCP README. · 1 week
+- [ ] **Markdown rendering in descriptions.** The field is a multiline textarea labelled "details, links, context" and URLs autolink, so people will write markdown — `**bold**` currently renders literally on cards and in palette snippets. · 1–2 days
+
+---
+
+## Phase 7 — Landing page (1–2 days)
+
+gsdtaskmanager.com is well built and undersells the product. Every link tested resolved; nothing is broken.
+
+- [ ] **Name the depth that already ships.** Dependencies with cycle prevention, ten smart views, the Review analytics, keyboard-first navigation and the self-managing archive are all live and all absent from the page. Dependencies in a free personal task app is genuinely uncommon and isn't mentioned once.
+- [ ] **Show the first 60 seconds.** A short captioned walkthrough of typing `!!` and watching it route would convert better than another privacy paragraph — the capture bar is the best demo you have.
+- [ ] **Move MCP's prerequisite next to its CTA.** It requires sync plus OAuth, a constraint that only appears in the FAQ.
+- [ ] **Add proof.** No testimonials, counts, or comparison against other Eisenhower or local-first apps. Even "built and used daily by its author since 2025" is proof.
+- [ ] **State the local-data risk plainly.** The README warns that clearing browser data erases tasks; the page frames export as freedom, never as insurance. (Do this *after* export is complete — Phase 0.)
+- [ ] **Disambiguate the Mac badge**, which points at the universal App Store listing rather than a distinct Mac storefront URL.
+- [ ] **Decide what to do about recurrence and subtasks in marketing** once Phase 4 lands — right now the landing page is narrower than the product and the About page is broader than it.
+
+---
+
+## Suggested sequence
+
+| Order | Phase | Elapsed | Why here |
+|---|---|---|---|
+| 1 | Phase 0 | An afternoon | Retires every finding that can cost data or trust |
+| 2 | Phase 1 | 2–3 days | Fixes things that are simply broken |
+| 3 | Phase 3 | 3–4 days | Makes deletion structurally safe, not timing-dependent |
+| 4 | Phase 2 | 2–3 days | Removes the "is this broken?" moments |
+| 5 | Phase 4 | 1–2 weeks | Closes the claimed-vs-shipped gap |
+| 6 | Phase 7 | 1–2 days | Market the product you now actually have |
+| 7 | Phase 5 | 2–3 weeks | Workflow depth |
+| 8 | Phase 6 | Ongoing | Pick one — the actionable Review is the strongest |
+
+**Totals:** 8 items in Phase 0, 11 in Phase 1, 13 in Phase 2, 5 in Phase 3, 6 in Phase 4, 10 in Phase 5, 7 in Phase 6, 7 in Phase 7 — **67 items**.

--- a/lib/sync/pb-auth.ts
+++ b/lib/sync/pb-auth.ts
@@ -75,8 +75,18 @@ export function openOAuthPopup(provider: OAuthProvider): Window | null {
 }
 
 function closeOAuthPopup(popupWindow?: Window | null): void {
+  // A provider that serves Cross-Origin-Opener-Policy: same-origin — accounts.google.com
+  // does — swaps the browsing context group when the popup navigates to it, severing this
+  // handle. The browser then reports the popup as closed and refuses close(), logging a
+  // COOP violation for a call that could not have done anything. Such a popup closes
+  // itself from its own final page, so skipping the call loses no cleanup. Providers that
+  // send no COOP, such as GitHub, keep the handle live and are still closed here.
+  if (!popupWindow || popupWindow.closed) {
+    return;
+  }
+
   try {
-    popupWindow?.close?.();
+    popupWindow.close?.();
   } catch {
     // Some mobile browsers do not allow closing OAuth browser contexts — expected, not an error.
     logger.debug("Could not close OAuth popup window — expected on some mobile browsers");

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-import "./.next/dev/types/root-params.d.ts";
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.11.0",
+	"version": "11.11.1",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.11.2",
+	"version": "11.11.3",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.11.1",
+	"version": "11.11.2",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.11.3",
+	"version": "11.11.4",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '11.11.1';
+const CACHE_VERSION = '11.11.2';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,12 +1,20 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '11.11.0';
+const CACHE_VERSION = '11.11.1';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 
 importScripts('./sw-cache-logic.js');
 
 const CACHE_NAMES = getCacheNames(CACHE_VERSION, IMMUTABLE_CACHE_VERSION);
+
+// Page responses carry `Vary: Accept` from the CloudFront agent-discovery
+// function, which content-negotiates /path against /path.md. cache.addAll()
+// stores its requests without an Accept header, so a real navigation
+// (Accept: text/html,...) can never match those entries under default Vary
+// rules — every offline page lookup misses. We key the page cache by URL
+// alone, storing only the HTML variant, so ignoring Vary is safe here.
+const PAGE_MATCH_OPTIONS = { ignoreVary: true };
 
 const PRECACHE_PAGES = [
 	"/",
@@ -136,7 +144,7 @@ self.addEventListener("fetch", (event) => {
 					return response;
 				})
 				.catch(() => {
-					return caches.match(pageRequest).then((cached) => {
+					return caches.match(pageRequest, PAGE_MATCH_OPTIONS).then((cached) => {
 						if (cached) return cached;
 
 						const url = new URL(pageRequest.url);
@@ -145,8 +153,12 @@ self.addEventListener("fetch", (event) => {
 							: url.pathname + "/";
 
 						return caches
-							.match(altPath)
-							.then((altCached) => altCached || caches.match("/"));
+							.match(altPath, PAGE_MATCH_OPTIONS)
+							.then(
+								(altCached) =>
+									altCached || caches.match("/", PAGE_MATCH_OPTIONS),
+							)
+							.then((fallback) => fallback || offlineDocumentResponse());
 					});
 				}),
 		);
@@ -194,11 +206,35 @@ self.addEventListener("fetch", (event) => {
 					return response;
 				})
 				.catch(() => {
-					return caches.match(request);
+					return caches
+						.match(request)
+						.then((fallback) => fallback || offlineAssetResponse());
 				});
 		}),
 	);
 });
+
+// respondWith() must never receive undefined. The browser reports that as
+// "Failed to convert value to 'Response'" and fails the request as a network
+// error, which for a navigation means a blank error page rather than a miss.
+function offlineDocumentResponse() {
+	return new Response(
+		"<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">" +
+			'<meta name="viewport" content="width=device-width,initial-scale=1">' +
+			"<title>Offline</title></head><body><h1>You are offline</h1>" +
+			"<p>This page has not been saved for offline use. " +
+			"Reconnect and try again.</p></body></html>",
+		{
+			status: 503,
+			statusText: "Offline",
+			headers: { "content-type": "text/html; charset=utf-8" },
+		},
+	);
+}
+
+function offlineAssetResponse() {
+	return new Response("", { status: 504, statusText: "Offline" });
+}
 
 function createSafePageRequest(request, safeUrl) {
 	const headers = new Headers();

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '11.11.2';
+const CACHE_VERSION = '11.11.3';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '11.11.3';
+const CACHE_VERSION = '11.11.4';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 

--- a/tasks/spec-review-remediation-wave-a-b.md
+++ b/tasks/spec-review-remediation-wave-a-b.md
@@ -1,7 +1,7 @@
 # Spec — Review Remediation, Waves A & B
 
 **Status:** Approved 2026-08-12
-**Source:** `action-checklist.md`, derived from the external review of web app v11.2.1
+**Source:** `docs/audits/ACTION-CHECKLIST-2026-08-12.md`, derived from the external review of web app v11.2.1
 **Tier:** Non-trivial (coordinated changes across four subsystems)
 
 Claims in the source checklist were verified against the code before this spec was

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -38,7 +38,7 @@ now shipped.**
 
 - **Done:** Waves A–G complete. Suite at 2736 passed. Dexie v16, backup envelope 2.1.0.
 - **Next:** nothing outstanding from the user's selections. Unselected items from
-  `action-checklist.md` remain available — search/tag ergonomics (Phase 2), backup nudge
+  `docs/audits/ACTION-CHECKLIST-2026-08-12.md` remain available — search/tag ergonomics (Phase 2), backup nudge
   and copy-diagnostics (Phase 3), due times / per-task reminders (Phase 4), and all of
   Phases 5–7.
 - **Blockers:** none.
@@ -141,7 +141,7 @@ genuinely empty one. Recorded in `.claude/rules/archive-tombstone.md`.
 
 ## Done — 2026-08-12: Review remediation, Waves A & B (v11.3.1 → v11.3.4)
 
-Spec: `tasks/spec-review-remediation-wave-a-b.md`. Source: `action-checklist.md`, derived
+Spec: `tasks/spec-review-remediation-wave-a-b.md`. Source: `docs/audits/ACTION-CHECKLIST-2026-08-12.md`, derived
 from an external review of deployed v11.2.1.
 
 - [x] #473 `fix(deps)` — Blocking badge counts only open dependents (`getUncompletedBlockedTasks`)

--- a/tests/data/csp-static-export.test.ts
+++ b/tests/data/csp-static-export.test.ts
@@ -49,6 +49,12 @@ describe("static export CSP hardening", () => {
     expect(cloudFrontCsp).toContain("style-src-attr 'unsafe-inline'");
     expect(caddy).toContain("script-src 'self'");
     expect(caddy).not.toMatch(/script-src[^;]*'unsafe-inline'/);
+    // Both deployments must agree, or the Docker build reintroduces the bug.
+    for (const csp of [cloudFrontCsp, caddy]) {
+      const styleSrcElem = csp.match(/style-src-elem[^;]*/)?.[0] ?? "";
+      expect(styleSrcElem).toContain("'unsafe-inline'");
+      expect(styleSrcElem).not.toContain("sha256-");
+    }
     expect(layout).toContain('process.env.NODE_ENV === "development"');
     expect(readFileSync("components/theme-provider.tsx", "utf8")).toContain(
       'scriptProps={{ src: "/theme-init.js" }}',

--- a/tests/data/security-headers-policy.test.ts
+++ b/tests/data/security-headers-policy.test.ts
@@ -22,4 +22,22 @@ describe("CloudFront response headers policy", () => {
 		expect(csp).toContain("style-src-elem 'self'");
 		expect(csp).toContain("frame-ancestors 'none'");
 	});
+
+	it("lets Radix inject its scroll-lock stylesheet", () => {
+		const policyPath = resolve(
+			__dirname,
+			"../../cloudfront/response-headers-policy.json",
+		);
+		const policy = JSON.parse(readFileSync(policyPath, "utf-8"));
+		const csp =
+			policy.SecurityHeadersConfig.ContentSecurityPolicy.ContentSecurityPolicy;
+		const styleSrcElem = csp.match(/style-src-elem[^;]*/)?.[0] ?? "";
+
+		// react-remove-scroll interpolates the measured scrollbar width into the
+		// stylesheet it injects, so its text differs per device and cannot be
+		// hash-pinned. A hash in this directive would also make 'unsafe-inline'
+		// a no-op, so the two cannot coexist.
+		expect(styleSrcElem).toContain("'unsafe-inline'");
+		expect(styleSrcElem).not.toContain("sha256-");
+	});
 });

--- a/tests/data/service-worker-offline.test.ts
+++ b/tests/data/service-worker-offline.test.ts
@@ -1,0 +1,226 @@
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+import { resolve } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+type WorkerListener = (event: Record<string, unknown>) => void;
+
+interface StoredEntry {
+	request: Request;
+	response: Response;
+}
+
+interface MatchOptions {
+	ignoreVary?: boolean;
+}
+
+const ORIGIN = "https://gsd.test";
+
+// CloudFront's agent-discovery response function appends `Accept` to Vary so
+// that /path and /path.md can be content-negotiated. Page responses therefore
+// carry this header in production; runtime assets do not.
+const PAGE_VARY = "Accept-Encoding, Accept";
+
+const NAVIGATION_ACCEPT =
+	"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8";
+
+/**
+ * Cache entry matching that honours Vary the way the browser Cache API does:
+ * for every header named in the stored response's Vary, the incoming request's
+ * value must equal the value on the request that was stored alongside it.
+ */
+function entryMatches(
+	entry: StoredEntry,
+	request: Request,
+	options?: MatchOptions,
+): boolean {
+	if (entry.request.url !== request.url) {
+		return false;
+	}
+	if (options?.ignoreVary) {
+		return true;
+	}
+	const vary = entry.response.headers.get("vary");
+	if (!vary) {
+		return true;
+	}
+	return vary
+		.split(",")
+		.map((header) => header.trim().toLowerCase())
+		.every(
+			(header) =>
+				entry.request.headers.get(header) === request.headers.get(header),
+		);
+}
+
+function toRequest(input: Request | string): Request {
+	return typeof input === "string"
+		? new Request(new URL(input, `${ORIGIN}/`).href)
+		: input;
+}
+
+function createCache(entries: StoredEntry[]) {
+	return {
+		addAll: vi.fn().mockResolvedValue(undefined),
+		put: vi.fn().mockResolvedValue(undefined),
+		keys: vi.fn().mockResolvedValue(entries.map((entry) => entry.request)),
+		delete: vi.fn().mockResolvedValue(true),
+		match: vi.fn(async (input: Request | string, options?: MatchOptions) => {
+			const request = toRequest(input);
+			return entries.find((entry) => entryMatches(entry, request, options))
+				?.response;
+		}),
+	};
+}
+
+interface Harness {
+	listeners: Map<string, WorkerListener>;
+	fetchMock: ReturnType<typeof vi.fn>;
+	respond: (request: Request) => Promise<unknown>;
+}
+
+/**
+ * Boots public/sw.js against a cache that already holds the precached pages,
+ * exactly as it exists in production: stored by cache.addAll() (so the stored
+ * request carries no Accept header) with a Vary: Accept response.
+ */
+function createHarness(entries: StoredEntry[]): Harness {
+	const listeners = new Map<string, WorkerListener>();
+	const cache = createCache(entries);
+	const cacheStorage = {
+		open: vi.fn().mockResolvedValue(cache),
+		keys: vi.fn().mockResolvedValue([]),
+		delete: vi.fn().mockResolvedValue(true),
+		match: cache.match,
+	};
+	// Offline: every network request rejects, as fetch() does with no network.
+	const fetchMock = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+	const clients = {
+		claim: vi.fn().mockResolvedValue(undefined),
+		matchAll: vi.fn().mockResolvedValue([]),
+		openWindow: vi.fn(),
+	};
+	const self = {
+		location: { origin: ORIGIN },
+		registration: { scope: `${ORIGIN}/`, showNotification: vi.fn() },
+		navigator: {},
+		clients,
+		skipWaiting: vi.fn().mockResolvedValue(undefined),
+		addEventListener: (type: string, listener: WorkerListener) => {
+			listeners.set(type, listener);
+		},
+	};
+
+	const context = vm.createContext({
+		URL,
+		URLSearchParams,
+		Request,
+		Response,
+		Headers,
+		Promise,
+		console,
+		caches: cacheStorage,
+		clients,
+		fetch: fetchMock,
+		importScripts: vi.fn(),
+		self,
+	});
+	vm.runInContext(
+		readFileSync(resolve(__dirname, "../../public/sw-cache-logic.js"), "utf8"),
+		context,
+	);
+	vm.runInContext(
+		readFileSync(resolve(__dirname, "../../public/sw.js"), "utf8"),
+		context,
+	);
+
+	const respond = (request: Request) => {
+		let responsePromise: Promise<unknown> | undefined;
+		listeners.get("fetch")?.({
+			request,
+			respondWith: (promise: Promise<unknown>) => {
+				responsePromise = promise;
+			},
+		});
+		return Promise.resolve(responsePromise);
+	};
+
+	return { listeners, fetchMock, respond };
+}
+
+function precachedPage(path: string, body: string): StoredEntry {
+	return {
+		// cache.addAll() stores a request with no Accept header.
+		request: new Request(`${ORIGIN}${path}`),
+		response: new Response(body, {
+			status: 200,
+			headers: { vary: PAGE_VARY, "content-type": "text/html" },
+		}),
+	};
+}
+
+function navigationRequest(path: string): Request {
+	const request = new Request(`${ORIGIN}${path}`, {
+		headers: { accept: NAVIGATION_ACCEPT },
+	});
+	Object.defineProperty(request, "mode", { value: "navigate" });
+	return request;
+}
+
+describe("service worker offline fallback", () => {
+	it("serves the precached page when the network is unavailable", async () => {
+		const harness = createHarness([
+			precachedPage("/", "<!doctype html>ROOT"),
+			precachedPage("/dashboard/", "<!doctype html>DASHBOARD"),
+		]);
+
+		const response = await harness.respond(navigationRequest("/dashboard/"));
+
+		expect(response).toBeInstanceOf(Response);
+		await expect((response as Response).text()).resolves.toContain("DASHBOARD");
+	});
+
+	it("resolves with a Response when a page is not cached at all", async () => {
+		const harness = createHarness([]);
+
+		const response = await harness.respond(navigationRequest("/dashboard/"));
+
+		// respondWith(undefined) throws "Failed to convert value to 'Response'"
+		// and turns the navigation into a hard network error.
+		expect(response).toBeInstanceOf(Response);
+	});
+
+	it("resolves with a Response when a hashed asset is not cached", async () => {
+		const harness = createHarness([]);
+
+		const response = await harness.respond(
+			new Request(`${ORIGIN}/_next/static/chunks/main-abc123.js`),
+		);
+
+		expect(response).toBeInstanceOf(Response);
+	});
+
+	it("resolves with a Response when a runtime asset is not cached", async () => {
+		const harness = createHarness([]);
+
+		const response = await harness.respond(
+			new Request(`${ORIGIN}/icons/icon-192.png`),
+		);
+
+		expect(response).toBeInstanceOf(Response);
+	});
+
+	it("still prefers the network response when the network is available", async () => {
+		const harness = createHarness([
+			precachedPage("/dashboard/", "<!doctype html>STALE"),
+		]);
+		harness.fetchMock.mockResolvedValue(
+			new Response("<!doctype html>FRESH", { status: 200 }),
+		);
+
+		const response = await harness.respond(navigationRequest("/dashboard/"));
+
+		expect(response).toBeInstanceOf(Response);
+		await expect((response as Response).text()).resolves.toContain("FRESH");
+	});
+});

--- a/tests/data/sync/pb-auth.test.ts
+++ b/tests/data/sync/pb-auth.test.ts
@@ -115,6 +115,26 @@ describe('PocketBase Auth', () => {
       expect(close).toHaveBeenCalledOnce();
     });
 
+    it('should not close a popup the browser already reports as closed', async () => {
+      mockAuthWithOAuth2.mockResolvedValue({
+        record: { id: 'user-123', email: 'test@example.com' },
+      });
+      const close = vi.fn();
+      // accounts.google.com serves Cross-Origin-Opener-Policy: same-origin, which
+      // swaps the browsing context group and severs our handle. Chrome then reports
+      // the popup as closed and refuses close(), logging a COOP violation for a call
+      // that could never have done anything.
+      const popupWindow = {
+        closed: true,
+        location: { href: '' },
+        close,
+      } as unknown as Window;
+
+      await loginWithProvider('google', { popupWindow });
+
+      expect(close).not.toHaveBeenCalled();
+    });
+
     it('should cancel the PocketBase request when OAuth times out', async () => {
       vi.useFakeTimers();
       try {


### PR DESCRIPTION
Three defects, all found by working backwards from the production console after
the 11.11.0 deploy. None was introduced by that release; the deploy made them
visible. Version 11.11.0 → **11.11.3**.

---

## 1. Service worker: offline page cache was unreachable

```
The FetchEvent for "https://gsd.vinny.dev/" resulted in a network error response
sw.js:1 Uncaught (in promise) TypeError: Failed to convert value to 'Response'.
```

Page responses carry `Vary: Accept-Encoding, Accept` from the CloudFront
agent-discovery function that content-negotiates `/path` against `/path.md`.
`cache.addAll()` stores its requests **without** an `Accept` header, so a real
navigation sending `Accept: text/html,...` could never match those entries.

Measured on production before writing the fix:

```
match_plain_slash     = MISS      ← the SW's last-resort fallback
match_html_accept     = MISS      ← a real navigation request
match_html_ignoreVary = HIT 200   ← same request, Vary ignored
```

Only HTML was affected. The page cache was written on every navigation and read
back never, so **offline mode did not work at all**. Both fallback chains also
bottomed out in a bare `caches.match()`, and `respondWith(undefined)` is
reported as *"Failed to convert value to 'Response'"* and fails the request as a
hard network error.

**Fix:** match the page cache with `{ ignoreVary: true }` (it is keyed by URL and
only ever holds the HTML variant), and terminate both chains in a real `Response`.

## 2. CSP: modal scroll lock was blocked

`@radix-ui/react-dialog` → `react-remove-scroll` → `react-style-singleton`
injects a stylesheet to lock background scroll. `style-src-elem` blocked it, so
**the page scrolled behind every open modal**. Confirmed on production:

```
dialog open = true
body overflow while open = auto scroll     ← not locked
scroll-lock <style> tags = 3, live = 1     ← CSP killed the rest
```

The hashes could not be extended. `react-remove-scroll-bar` interpolates the
measured scrollbar width into the stylesheet:

```js
gap: Math.max(0, windowWidth - documentWidth + offsets[2] - offsets[0])
```

The text differs per device — `0px` on macOS overlay scrollbars, `15px`/`17px`
elsewhere — so a hash computed on one machine fails on another. A hash in the
directive also makes `'unsafe-inline'` inert, so the two cannot coexist.

**Fix:** `style-src-elem 'self' 'unsafe-inline'`, applied to both CloudFront and
the Docker Caddyfile, reasoning recorded in `SECURITY.md`. Script execution,
`base-uri`, `form-action`, and `connect-src` unchanged; `style-src-attr
'unsafe-inline'` was already permitted.

## 3. OAuth popup: a close call the browser always refuses

```
Cross-Origin-Opener-Policy policy would block the window.close call.
```

`accounts.google.com` serves `Cross-Origin-Opener-Policy: same-origin`. When the
popup navigates there the browsing context group is swapped and our handle is
severed — before the user types anything. Reproduced without credentials by
driving a `COOP: same-origin` document from an opener carrying our own
`same-origin-allow-popups` header:

```
before cross-origin nav : {closed: false, reachable: true}
after  cross-origin nav : {closed: true,  reachable: false}
popup self-close        : hadOpener=false closedAfterSelfClose=true
```

So cleanup was never broken — a severed popup closes itself from its own final
page, which is what PocketBase's redirect does. `closeOAuthPopup` was firing
`close()` at a window that had already reported itself closed.

**Fix:** guard the call on the `closed` flag. GitHub's authorize endpoint sends
no COOP, so that handle stays live and is still closed; the existing test
covering that path is unchanged.

---

## How to test locally

```
bun run test          # 2743 passed
bun typecheck         # clean
bun lint              # clean
bun run build && bun run test:csp
```

The service-worker tests boot `public/sw.js` in a `vm` context against a cache
mock modelling the Cache API's real `Vary` semantics, so they reproduce the
production miss rather than a mock's opinion of it. Before the fix, requesting
`/dashboard/` offline fell through and served the **root page**.

The CSP change was verified against the real static export served with the real
policy: one live `cssRules` entry, `body` overflow computing to `hidden`, no
reported violations.

## Post-deploy verification

- **Offline:** `Vary: Accept` only exists on CloudFront, so this cannot be
  confirmed on a dev server. Tick **Offline** in DevTools and navigate to
  `/dashboard/` — it should render the app, not an error page.
- **Modals:** open any dialog and confirm the background no longer scrolls.
- **OAuth:** sign in with Google and confirm the COOP line is gone. An A/B
  harness could not reproduce Chrome's warning text on loopback origins, so
  fix 3 removing that console line is inferred from the mechanism rather than
  observed, and this is the check that settles it.

## Known gap, deliberately not addressed

`scripts/verify-production-csp.cjs` only loads the page; it never opens a
dialog, which is why fix 2 shipped in the first place. The new unit tests pin
the directive, but extending that smoke test to exercise a modal would be a
stronger guard.

The remaining console noise (`content.js`, `detectCompetitors.js`, Google
Analytics, DoubleClick, Facebook, Apollo DevTools) comes from a browser
extension running tracker-detection probes, not from this app.

https://claude.ai/code/session_01TdQk3P6pgm2FQ4dZiHsHGY