### PR TITLE
test(e2e): repair the four specs that have been red on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.11.4
+**Current version:** 11.11.5
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/lib/tasks/import-export.ts
+++ b/lib/tasks/import-export.ts
@@ -149,7 +149,7 @@ async function buildBackup(): Promise<{ payload: ImportPayload; skippedCount: nu
 }
 
 /**
- * Export every user-owned store as a structured payload (envelope 2.0.0).
+ * Export every user-owned store as a structured payload (envelope 2.1.0).
  */
 export async function exportTasks(): Promise<ImportPayload> {
   return (await buildBackup()).payload;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.11.4",
+	"version": "11.11.5",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '11.11.4';
+const CACHE_VERSION = '11.11.5';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 

--- a/tests/e2e/drag-and-drop.spec.ts
+++ b/tests/e2e/drag-and-drop.spec.ts
@@ -14,6 +14,49 @@ import type { Page, Locator } from "@playwright/test";
  * whatever version the app just created, which is always the right one.
  */
 
+/** Vertical band of the drop target we need on screen to aim a pointer at it. */
+const MIN_TARGET_BAND_PX = 24;
+/** One wheel notch, large enough to cross a quadrant without overshooting the grid. */
+const SCROLL_STEP_PX = 240;
+
+/**
+ * Scrolls the drop target into range while the drag is active.
+ *
+ * The matrix is taller than a short viewport, and how tall depends on the font
+ * the host resolves — the same 1280x720 viewport fits all four quadrants on a
+ * developer machine but not on a CI runner. Rather than pin a viewport height
+ * that only holds until the next row of fields lands, bring the target into
+ * view the way a user does. @dnd-kit tracks scrolling during a drag, so the
+ * gesture does not disturb the pointer session.
+ */
+async function bringTargetIntoView(page: Page, target: Locator): Promise<void> {
+  const viewport = page.viewportSize();
+  if (!viewport) return;
+
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const box = await target.boundingBox();
+    if (!box) return;
+    const topInView = box.y + box.height - MIN_TARGET_BAND_PX > 0;
+    const bottomInView = box.y + MIN_TARGET_BAND_PX < viewport.height;
+    if (topInView && bottomInView) return;
+
+    const previousY = box.y;
+    await page.mouse.wheel(0, box.y > 0 ? SCROLL_STEP_PX : -SCROLL_STEP_PX);
+    // `html { scroll-behavior: smooth }` animates the scroll, so wait for the
+    // box to actually move instead of assuming the wheel applied synchronously.
+    try {
+      await expect
+        .poll(async () => (await target.boundingBox())?.y ?? previousY, {
+          timeout: 2000,
+          intervals: [50, 50, 100],
+        })
+        .not.toBe(previousY);
+    } catch {
+      return; // Already scrolled as far as the page allows.
+    }
+  }
+}
+
 /**
  * Perform a drag from a source handle to a target container using manual mouse events.
  * This works with @dnd-kit's PointerSensor activation constraint.
@@ -41,6 +84,7 @@ async function performDrag(page: Page, source: Locator, target: Locator) {
       await overlay.waitFor({ state: "visible", timeout: 3000 });
 
       // Re-read the target after activation because dnd-kit can change layout.
+      await bringTargetIntoView(page, target);
       const targetBox = await target.boundingBox();
       if (!targetBox) throw new Error("Could not get a bounding box for the drop target");
       const viewport = page.viewportSize();

--- a/tests/e2e/fixtures/test-fixtures.ts
+++ b/tests/e2e/fixtures/test-fixtures.ts
@@ -4,7 +4,10 @@ import { test as base } from "@playwright/test";
 // navigates while Next's development font response is still in flight.
 // 2152398850 is NS_BINDING_ABORTED; keep this fingerprint deliberately narrow
 // so missing fonts, non-local URLs, and every application error still fail.
-const FIREFOX_ABORTED_DEV_FONT = /^\[JavaScript Error: "downloadable font: download failed \(font-family: "[^"]+" style:[^ ]+ weight:[^ ]+ stretch:100 src index:0\): status=2152398850 source: http:\/\/localhost:3000\/(?:_next\/static\/media\/[a-z0-9.-]+|__nextjs_font\/[a-z0-9.-]+)\.woff2"\]$/;
+// The filename class includes `_` because Turbopack's hashed asset names carry
+// underscores (26aa48c1bdeb5547-s.p.30a_ou6vtcpon.woff2); without it this stops
+// matching and the aborted-font diagnostic fails tests again.
+const FIREFOX_ABORTED_DEV_FONT = /^\[JavaScript Error: "downloadable font: download failed \(font-family: "[^"]+" style:[^ ]+ weight:[^ ]+ stretch:100 src index:0\): status=2152398850 source: http:\/\/localhost:3000\/(?:_next\/static\/media\/[a-z0-9._-]+|__nextjs_font\/[a-z0-9._-]+)\.woff2"\]$/;
 
 function isExpectedBrowserDiagnostic(message: string): boolean {
   return FIREFOX_ABORTED_DEV_FONT.test(message);

--- a/tests/e2e/pages/matrix-page.ts
+++ b/tests/e2e/pages/matrix-page.ts
@@ -122,8 +122,17 @@ export class MatrixPage {
    */
   async addDependencyInDrawer(query: string, suggestionTitle: string): Promise<void> {
     const drawer = this.page.locator("[data-testid='edit-drawer']");
-    await drawer.locator("[data-testid='dep-search']").fill(query);
-    await drawer
+    const search = drawer.locator("[data-testid='dep-search']");
+    await search.fill(query);
+    // The popup is position: fixed and re-measures the field on scroll, so it
+    // sits wherever the field sits. "Depends on" is the last group in a drawer
+    // that scrolls internally, and Firefox and WebKit leave that field off
+    // screen after the fill — which parks the popup outside the viewport and
+    // makes it unclickable. Bring the anchor back into view first.
+    await search.scrollIntoViewIfNeeded();
+    // Portalled to document.body so the drawer's scroll container cannot clip
+    // it (#483), so this is scoped to the page rather than the drawer.
+    await this.page
       .locator("[data-testid='dep-suggestion']")
       .filter({ hasText: suggestionTitle })
       .click();

--- a/tests/e2e/settings-navigation.spec.ts
+++ b/tests/e2e/settings-navigation.spec.ts
@@ -165,7 +165,7 @@ test.describe("Settings Navigation", () => {
     for await (const chunk of stream) chunks.push(chunk as Buffer);
     const backup = JSON.parse(Buffer.concat(chunks).toString("utf8"));
 
-    expect(backup.version).toBe("2.0.0");
+    expect(backup.version).toBe("2.1.0");
     expect(backup.tasks.length).toBeGreaterThan(0);
 
     // The 232-record omission this ADR exists to fix.


### PR DESCRIPTION
`main` has been red since `4eacd21`. Four e2e failures, four unrelated causes,
none of them a product defect. Version 11.11.4 → **11.11.5**.

---

## 1. `settings-navigation` — the assertion outlived the shape

```
lib/tasks/import-export.ts:21          BACKUP_ENVELOPE_VERSION = "2.1.0"
tests/e2e/settings-navigation.spec.ts  expect(backup.version).toBe("2.0.0")
```

Trash joined the backup payload and the envelope moved to 2.1.0 without the
assertion following. The doc comment over `exportTasks` had drifted the same
way and is corrected too.

## 2. `drag-and-drop` ×2 — the matrix outgrew the viewport

```
Error: Drop target is outside the viewport
```

How tall the matrix renders depends on the font the host resolves, so the same
1280×720 viewport fits four quadrants on a developer machine and not on a CI
runner. This spec **passed locally and failed in CI at the identical viewport**,
which is also why pinning a taller viewport is not the fix — the number could
only be guessed, and would hold until the next row of fields lands.

Instead the target is scrolled into range mid-drag, the way a user does;
@dnd-kit tracks scrolling during a drag, so the gesture does not disturb the
pointer session. Verified by reproducing the condition at a 600px viewport,
well under CI's 720.

## 3. `task-dependencies` — a portal, then an anchor off screen

Two causes stacked. #483 moved the suggestion popup to a `document.body` portal
so the drawer's scroll container could not clip it — which also moved it out of
the drawer subtree the page object was searching. That fixed Chromium and
revealed the second: the popup is `position: fixed` and re-measures its anchor
on scroll, so it follows the field wherever the field sits. "Depends on" is the
last group in a drawer that scrolls internally, and on Firefox and WebKit that
left the popup parked outside the viewport:

```
- locator resolved to <button data-testid="dep-suggestion">Gather data</button>
- attempting click action
  - element is visible, enabled and stable
  - scrolling into view if needed
  - done scrolling
  - element is outside of the viewport
```

The product code is correct — `useAnchorRect` already listens with
`capture: true` so the drawer's non-bubbling scroll reaches it. The fix is to
bring the anchor back into view before clicking.

## 4. The fixture stopped recognising its own diagnostic

`FIREFOX_ABORTED_DEV_FONT` fingerprints Firefox's aborted dev-font console
error so it does not fail tests. Its filename class excluded underscores, and
Turbopack's hashed asset names carry them:

```
26aa48c1bdeb5547-s.p.30a_ou6vtcpon.woff2
                        ^
```

So a diagnostic meant to be ignored had quietly started failing tests.
Widened to match, and no wider — the status code, host, path and extension are
all still pinned.

---

## Verification

Run under CI's own configuration rather than the local default, which matters:
CI uses `workers: 1, retries: 2` while a local run defaults to 7 parallel
workers and no retries. Parallel local runs produce contention flakes that CI
does not see.

```
bunx playwright test --workers=1 --retries=2     # 293 passed
bun run test                                     # 2743 passed
bun typecheck                                    # clean
bun lint                                         # clean
```

## The one failure left

`[webkit] design-lab-isolation.spec.ts:25` fails on `indexedDbOpenCalls`
containing `__next_debug_channel` — Next's dev overlay opening IndexedDB, which
the isolation assertion counts. **It reproduces with this branch stashed**, so
it is pre-existing and untouched here. Worth its own fix: either the overlay is
disabled for that spec, or the assertion allows a dev-only channel.

https://claude.ai/code/session_01TdQk3P6pgm2FQ4dZiHsHGY
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->