### PR TITLE
fix(security): remediate comprehensive audit findings

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -5,8 +5,6 @@ name: Publish Docker Image
 #
 #   push to main      -> :edge and :sha-<short>   (moving + immutable "latest commit")
 #   push tag vX.Y.Z   -> :X.Y.Z, :X.Y, :latest    (release)
-#   workflow_dispatch -> build only by default (dry_run), or push when dry_run=false
-#
 # GHCR auth uses the built-in GITHUB_TOKEN. Docker Hub is published only when the
 # DOCKERHUB_USERNAME / DOCKERHUB_TOKEN repo secrets are configured, so the workflow
 # stays correct even if those secrets are absent.
@@ -17,12 +15,6 @@ on:
       - main
     tags:
       - 'v*.*.*'
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Dry run (build only, do not push)'
-        type: boolean
-        default: true
 
 permissions:
   contents: read
@@ -46,8 +38,6 @@ jobs:
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           REPO: ${{ github.repository }}
-          EVENT: ${{ github.event_name }}
-          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           # Registries: GHCR always; Docker Hub only when its secret is configured.
           IMAGES="ghcr.io/${REPO}"
@@ -58,12 +48,7 @@ jobs:
             echo "dockerhub_enabled=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # Push on every trigger except an explicit dry-run dispatch.
-          if [ "$EVENT" = "workflow_dispatch" ] && [ "$DRY_RUN" = "true" ]; then
-            echo "push_enabled=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "push_enabled=true" >> "$GITHUB_OUTPUT"
-          fi
+          echo "push_enabled=true" >> "$GITHUB_OUTPUT"
 
           {
             echo "images<<EOF"
@@ -144,11 +129,7 @@ jobs:
         run: |
           {
             echo "### Docker image"
-            if [ "${{ steps.cfg.outputs.push_enabled }}" = "true" ]; then
-              echo "Pushed the following tags:"
-            else
-              echo "Dry run — built but did not push. Tags that would have been pushed:"
-            fi
+            echo "Pushed the following tags:"
             echo '```'
             echo "${{ steps.meta.outputs.tags }}"
             echo '```'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.11.5
+**Current version:** 11.11.10
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -40,6 +40,7 @@ if [ "$TASKS_TABLE_EXISTS" != "1" ]; then
     mkdir -p "$MIGRATIONS_DIR"
     cp /pb_fresh_migrations/1781000000_encrypt_existing_tasks.js "$MIGRATIONS_DIR/"
     cp /pb_migrations/1781100000_harden_task_encryption_cleanup.js "$MIGRATIONS_DIR/"
+    cp /pb_migrations/1781200000_reencrypt_invalid_prefixed_task_fields.js "$MIGRATIONS_DIR/"
 fi
 
 echo "[gsd] Applying PocketBase migrations..."

--- a/docker/pb_hooks/encryption-core.js
+++ b/docker/pb_hooks/encryption-core.js
@@ -11,6 +11,26 @@ function isEncrypted(v) {
   return typeof v === "string" && v.indexOf(PREFIX) === 0;
 }
 
+function isValidCiphertext(value, decipherFn, json = false) {
+  if (!isEncrypted(value) || typeof decipherFn !== "function") return false;
+  try {
+    const plaintext = decipherFn(value.slice(PREFIX.length));
+    if (json) JSON.parse(plaintext);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function serializableJson(value) {
+  try {
+    JSON.parse(value);
+    return value;
+  } catch {
+    return JSON.stringify(value);
+  }
+}
+
 function requireValidKey(key) {
   if (typeof key !== "string" || key.length !== 32) {
     throw new Error("GSD_TASKS_ENC_KEY must be a 32-character AES-256 key (fail-closed)");
@@ -39,18 +59,18 @@ function jsonFieldString(record, field) {
   return JSON.stringify(raw);
 }
 
-function encryptRecord(record, cipherFn) {
+function encryptRecord(record, cipherFn, decipherFn) {
   for (const f of ENCRYPTED_TEXT_FIELDS) {
     const v = record.get(f);
-    if (v === null || v === undefined || v === "" || isEncrypted(v)) continue;
+    if (v === null || v === undefined || v === "" || isValidCiphertext(v, decipherFn)) continue;
     record.set(f, PREFIX + cipherFn(String(v)));
   }
   for (const f of ENCRYPTED_JSON_FIELDS) {
     const raw = record.get(f);
     if (raw === null || raw === undefined) continue;
     const asString = jsonFieldString(record, f);
-    if (isEncrypted(asString)) continue;
-    record.set(f, PREFIX + cipherFn(asString));
+    if (isValidCiphertext(asString, decipherFn, true)) continue;
+    record.set(f, PREFIX + cipherFn(serializableJson(asString)));
   }
 }
 
@@ -74,6 +94,7 @@ module.exports = {
   ENCRYPTED_TEXT_FIELDS,
   ENCRYPTED_JSON_FIELDS,
   isEncrypted,
+  isValidCiphertext,
   requireValidKey,
   jsonFieldString,
   encryptRecord,

--- a/docker/pb_hooks/tasks_encryption.pb.js
+++ b/docker/pb_hooks/tasks_encryption.pb.js
@@ -8,7 +8,11 @@ onRecordCreate((e) => {
   const core = require(`${__hooks}/encryption-core.js`);
   const key = $os.getenv("GSD_TASKS_ENC_KEY");
   core.requireValidKey(key);
-  core.encryptRecord(e.record, (s) => $security.encrypt(s, key));
+  core.encryptRecord(
+    e.record,
+    (s) => $security.encrypt(s, key),
+    (s) => $security.decrypt(s, key),
+  );
   e.next();
 }, "tasks");
 
@@ -17,7 +21,11 @@ onRecordUpdate((e) => {
   const core = require(`${__hooks}/encryption-core.js`);
   const key = $os.getenv("GSD_TASKS_ENC_KEY");
   core.requireValidKey(key);
-  core.encryptRecord(e.record, (s) => $security.encrypt(s, key));
+  core.encryptRecord(
+    e.record,
+    (s) => $security.encrypt(s, key),
+    (s) => $security.decrypt(s, key),
+  );
   e.next();
 }, "tasks");
 

--- a/docker/pb_migrations/1781200000_reencrypt_invalid_prefixed_task_fields.js
+++ b/docker/pb_migrations/1781200000_reencrypt_invalid_prefixed_task_fields.js
@@ -1,0 +1,74 @@
+/// <reference path="../pb_data/types.d.ts" />
+// Forward-only remediation for rows whose user-supplied content starts with the
+// encryption marker but is not authenticated ciphertext. Historical migrations
+// remain immutable because deployed databases record their filenames.
+migrate((app) => {
+  const PREFIX = "enc:v1:";
+  const TEXT = ["title", "description"];
+  const JSONF = ["tags", "subtasks", "time_entries"];
+  const key = $os.getenv("GSD_TASKS_ENC_KEY");
+  if (typeof key !== "string" || key.length !== 32) {
+    throw new Error("GSD_TASKS_ENC_KEY must be a 32-character AES-256 key");
+  }
+
+  const table = new DynamicModel({ count: 0 });
+  app.db()
+    .newQuery("SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name = 'tasks'")
+    .one(table);
+  if (table.count === 0) return;
+
+  const isValidCiphertext = (value, requireJson) => {
+    if (typeof value !== "string" || value.indexOf(PREFIX) !== 0) return false;
+    try {
+      const plaintext = $security.decrypt(value.slice(PREFIX.length), key);
+      if (requireJson) JSON.parse(plaintext);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const jsonInput = (record, field) => {
+    const raw = record.get(field);
+    let value = typeof raw === "string" ? raw : record.getString(field);
+    if (typeof value !== "string" || value === "") value = JSON.stringify(raw);
+    try {
+      const parsed = JSON.parse(value);
+      if (typeof parsed === "string") value = parsed;
+    } catch {
+      // Array/object JSON text is already the desired encryption input.
+    }
+    try {
+      JSON.parse(value);
+      return value;
+    } catch {
+      return JSON.stringify(value);
+    }
+  };
+
+  const records = app.findAllRecords("tasks");
+  for (const record of records) {
+    const assignments = [];
+    const params = { id: record.getString("id") };
+    for (const field of TEXT) {
+      const value = record.get(field);
+      if (value === null || value === undefined || value === "" || isValidCiphertext(value, false)) continue;
+      params[field] = PREFIX + $security.encrypt(String(value), key);
+      assignments.push(field + " = {:" + field + "}");
+    }
+    for (const field of JSONF) {
+      const raw = record.get(field);
+      if (raw === null || raw === undefined) continue;
+      const value = jsonInput(record, field);
+      if (isValidCiphertext(value, true)) continue;
+      params[field] = PREFIX + $security.encrypt(value, key);
+      assignments.push(field + " = {:" + field + "}");
+    }
+    if (assignments.length === 0) continue;
+    app.db()
+      .newQuery("UPDATE tasks SET " + assignments.join(", ") + " WHERE id = {:id}")
+      .bind(params)
+      .execute();
+  }
+}, (_app) => {
+  // Down migration intentionally does not decrypt data.
+});

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -126,13 +126,39 @@ export const appPreferencesSchema = z.object({
 	smartViewsEnabled: z.boolean(),
 });
 
+/** Runtime validation for filters persisted in custom smart views and backups. */
+export const filterCriteriaSchema = z.object({
+	quadrants: z.array(quadrantIdSchema).optional(),
+	status: z.enum(["all", "active", "completed"]).optional(),
+	tags: z.array(z.string()).optional(),
+	dueDateRange: z.object({
+		start: z.string().optional(),
+		end: z.string().optional(),
+	}).strict().optional(),
+	// Legacy custom views may retain this unused pre-filter shape. Preserve it
+	// with a bounded runtime type rather than admitting arbitrary criteria.
+	dueDate: z.object({
+		mode: z.string(),
+		days: z.number().int().nonnegative().optional(),
+	}).strict().optional(),
+	overdue: z.boolean().optional(),
+	dueToday: z.boolean().optional(),
+	dueThisWeek: z.boolean().optional(),
+	noDueDate: z.boolean().optional(),
+	recurrence: z.array(recurrenceTypeSchema).optional(),
+	recentlyAdded: z.boolean().optional(),
+	recentlyCompleted: z.boolean().optional(),
+	readyToWork: z.boolean().optional(),
+	searchQuery: z.string().optional(),
+}).strict();
+
 /** Custom smart views only — built-ins are derived at read time, never stored. */
 export const smartViewSchema = z.object({
 	id: z.string().min(1),
 	name: z.string().min(1),
 	description: z.string().optional(),
 	icon: z.string().optional(),
-	criteria: z.record(z.string(), z.unknown()),
+	criteria: filterCriteriaSchema,
 	isBuiltIn: z.boolean().default(false),
 	createdAt: z.iso.datetime({ offset: true }),
 	updatedAt: z.iso.datetime({ offset: true }),

--- a/lib/smart-views.ts
+++ b/lib/smart-views.ts
@@ -1,6 +1,7 @@
 import { nanoid } from "nanoid";
 import { getDb } from "@/lib/db";
 import { BUILT_IN_SMART_VIEWS, type SmartView } from "@/lib/filters";
+import { smartViewSchema } from "@/lib/schema";
 import type { AppPreferences } from "@/lib/types";
 import { isoNow } from "@/lib/utils";
 import { SMART_VIEWS_CONFIG } from "@/lib/constants";
@@ -18,12 +19,23 @@ const DEFAULT_APP_PREFERENCES: AppPreferences = {
   smartViewsEnabled: false,
 };
 
+function parseSmartView(view: unknown): SmartView {
+  return smartViewSchema.parse(view) as SmartView;
+}
+
+function parseStoredSmartView(view: unknown): SmartView | undefined {
+  const parsed = smartViewSchema.safeParse(view);
+  return parsed.success ? parsed.data as SmartView : undefined;
+}
+
 /**
  * Get all Smart Views (built-in + custom)
  */
 export async function getSmartViews(): Promise<SmartView[]> {
   const db = getDb();
-  const customViews = await db.smartViews.toArray();
+  const customViews = (await db.smartViews.toArray())
+    .map(parseStoredSmartView)
+    .filter((view): view is SmartView => view !== undefined);
 
   // Convert built-in views to full SmartView objects
   const builtInViews: SmartView[] = BUILT_IN_SMART_VIEWS.map(view => ({
@@ -49,7 +61,8 @@ export async function getSmartView(id: string): Promise<SmartView | undefined> {
 
   // Otherwise, fetch from database
   const db = getDb();
-  return db.smartViews.get(id);
+  const stored = await db.smartViews.get(id);
+  return stored ? parseStoredSmartView(stored) : undefined;
 }
 
 /**
@@ -69,8 +82,9 @@ export async function createSmartView(
     updatedAt: now
   };
 
-  await db.smartViews.add(newView);
-  return newView;
+  const validated = parseSmartView(newView);
+  await db.smartViews.add(validated);
+  return validated;
 }
 
 /**
@@ -97,8 +111,9 @@ export async function updateSmartView(
     updatedAt: isoNow()
   };
 
-  await db.smartViews.put(updated);
-  return updated;
+  const validated = parseSmartView(updated);
+  await db.smartViews.put(validated);
+  return validated;
 }
 
 /**

--- a/lib/smart-views/types.ts
+++ b/lib/smart-views/types.ts
@@ -9,6 +9,11 @@ export interface FilterCriteria {
     start?: string;
     end?: string;
   };
+  /** @deprecated Retained only for legacy persisted smart views. */
+  dueDate?: {
+    mode: string;
+    days?: number;
+  };
   overdue?: boolean;
   dueToday?: boolean;
   dueThisWeek?: boolean;

--- a/lib/sync/pb-pull.ts
+++ b/lib/sync/pb-pull.ts
@@ -53,14 +53,17 @@ async function applyPreparedRecord(
   const { record, remoteTask } = prepared;
   const archived = await db.archivedTasks.get(remoteTask.id);
   if (archived && !isRemoteNewerThanArchive(remoteTask.updatedAt, archived.archivedAt)) return 0;
+  const deleted = await db.deletedTasks.get(remoteTask.id);
+  if (deleted && !isRemoteNewerThanArchive(remoteTask.updatedAt, deleted.deletedAt)) return 0;
 
   const localTask = await db.tasks.get(remoteTask.id);
   const merged = localTask ? pocketBaseToTaskRecord(record, localTask) : remoteTask;
   if (!merged) return 0;
   const remoteWins = !localTask ||
     new Date(merged.updatedAt).getTime() > new Date(localTask.updatedAt).getTime();
-  if (archived) await db.archivedTasks.delete(remoteTask.id);
   if (!remoteWins) return 0;
+  if (archived) await db.archivedTasks.delete(remoteTask.id);
+  if (deleted) await db.deletedTasks.delete(remoteTask.id);
   if (localTask) await db.tasks.put(merged);
   else await db.tasks.add(merged);
   return 1;
@@ -78,7 +81,7 @@ async function applyRemoteRecords(records: RecordModel[]): Promise<{
   const acceptedRecords = prepareRemoteRecords(records);
   let pulledCount = 0;
   const appliedRecords: PreparedRemoteRecord[] = [];
-  await db.transaction('rw', [db.tasks, db.archivedTasks], async () => {
+  await db.transaction('rw', [db.tasks, db.archivedTasks, db.deletedTasks], async () => {
     for (const prepared of acceptedRecords) {
       // react-doctor-disable-next-line react-doctor/async-await-in-loop -- one atomic Dexie transaction preserves tombstone/live invariants
       const applied = await applyPreparedRecord(db, prepared);

--- a/lib/sync/pb-sync-engine.ts
+++ b/lib/sync/pb-sync-engine.ts
@@ -65,10 +65,15 @@ export async function applyRemoteChange(
     return;
   }
 
-  await db.transaction('rw', [db.tasks, db.archivedTasks], async () => {
+  await db.transaction('rw', [db.tasks, db.archivedTasks, db.deletedTasks], async () => {
     const archived = await db.archivedTasks.get(remoteTask.id);
     if (archived && !isRemoteNewerThanArchive(remoteTask.updatedAt, archived.archivedAt)) {
       logger.debug('Realtime change skipped: task is archived locally', { taskId: remoteTask.id });
+      return;
+    }
+    const deleted = await db.deletedTasks.get(remoteTask.id);
+    if (deleted && !isRemoteNewerThanArchive(remoteTask.updatedAt, deleted.deletedAt)) {
+      logger.debug('Realtime change skipped: task is deleted locally', { taskId: remoteTask.id });
       return;
     }
     const localTask = await db.tasks.get(remoteTask.id);
@@ -78,6 +83,7 @@ export async function applyRemoteChange(
     const mergedTask = localTask ? pocketBaseToTaskRecord(record, localTask) : remoteTask;
     if (!mergedTask) return;
     if (archived) await db.archivedTasks.delete(remoteTask.id);
+    if (deleted) await db.deletedTasks.delete(remoteTask.id);
     await db.tasks.put(mergedTask);
     logger.debug(`Realtime ${action} applied`, { taskId: mergedTask.id });
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.11.5",
+	"version": "11.11.10",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '11.11.5';
+const CACHE_VERSION = '11.11.11';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 

--- a/scripts/verify-pb-encryption.sh
+++ b/scripts/verify-pb-encryption.sh
@@ -44,6 +44,7 @@ FRESH_MIGRATIONS="$WORK/fresh-migrations"
 mkdir -p "$FRESH_MIGRATIONS"
 cp docker/pb_fresh_migrations/1781000000_encrypt_existing_tasks.js "$FRESH_MIGRATIONS/"
 cp docker/pb_migrations/1781100000_harden_task_encryption_cleanup.js "$FRESH_MIGRATIONS/"
+cp docker/pb_migrations/1781200000_reencrypt_invalid_prefixed_task_fields.js "$FRESH_MIGRATIONS/"
 
 echo "1) initialize and start PocketBase with production hooks/migrations"
 "$PB_BIN" superuser upsert "$ADMIN_EMAIL" "$ADMIN_PASS" --dir="$WORK" >/dev/null

--- a/tests/data/pipeline-workflows.test.ts
+++ b/tests/data/pipeline-workflows.test.ts
@@ -6,6 +6,15 @@ function readWorkflow(path: string): string {
 }
 
 describe("pipeline workflows", () => {
+  it('only publishes Docker images from reviewed push and tag refs', () => {
+    const workflow = readWorkflow('.github/workflows/publish-docker.yml');
+
+    expect(workflow).toContain('push:');
+    expect(workflow).not.toContain('workflow_dispatch:');
+    expect(workflow).not.toContain('dry_run');
+    expect(workflow).not.toContain('github.event_name');
+  });
+
   it("reconciles risk labels instead of accumulating stale tiers", () => {
     const workflow = readWorkflow(".github/workflows/apply-risk-label.yml");
     const invalidTierIndex = workflow.indexOf("if (!tier) {");

--- a/tests/data/security-hardening-scripts.test.ts
+++ b/tests/data/security-hardening-scripts.test.ts
@@ -155,6 +155,9 @@ describe('security hardening scripts and workflows', () => {
     const followupMigration = readRepoFile(
       'docker/pb_migrations/1781100000_harden_task_encryption_cleanup.js'
     );
+    const prefixRepairMigration = readRepoFile(
+      'docker/pb_migrations/1781200000_reencrypt_invalid_prefixed_task_fields.js'
+    );
 
     expect(rootPackage.scripts['test:system:pocketbase']).toBeDefined();
     expect(workflow).toContain('test:system:pocketbase');
@@ -176,8 +179,11 @@ describe('security hardening scripts and workflows', () => {
     expect(entrypoint).toContain('--automigrate=false');
     expect(entrypoint).toContain('TASKS_TABLE_EXISTS');
     expect(entrypoint).toContain('/pb_fresh_migrations/1781000000_encrypt_existing_tasks.js');
+    expect(entrypoint).toContain('1781200000_reencrypt_invalid_prefixed_task_fields.js');
     expect(followupMigration).toContain('records.length > 0');
     expect(followupMigration).toContain('$security.decrypt');
+    expect(prefixRepairMigration).toContain('isValidCiphertext');
+    expect(prefixRepairMigration).toContain('$security.decrypt');
     expect(createHash('sha256').update(shippedMigration).digest('hex')).toBe(
       '4bad51a41488c9f5fca0d0f8665ee6c594f6f4af82b7075d752607f3baa71ae5'
     );

--- a/tests/data/smart-views.test.ts
+++ b/tests/data/smart-views.test.ts
@@ -90,6 +90,22 @@ describe('Smart Views', () => {
         });
       });
     });
+
+    it('skips persisted views with malformed criteria instead of returning a crashable filter', async () => {
+      const db = getDb();
+      await db.smartViews.add({
+        id: 'malformed-view',
+        name: 'Malformed',
+        criteria: { searchQuery: {} },
+        isBuiltIn: false,
+        createdAt: '2025-01-15T12:00:00.000Z',
+        updatedAt: '2025-01-15T12:00:00.000Z',
+      } as never);
+
+      const views = await getSmartViews();
+
+      expect(views.find((view) => view.id === 'malformed-view')).toBeUndefined();
+    });
   });
 
   describe('getSmartView', () => {
@@ -126,6 +142,13 @@ describe('Smart Views', () => {
   });
 
   describe('createSmartView', () => {
+    it('rejects malformed criteria from direct runtime callers', async () => {
+      await expect(createSmartView({
+        name: 'Malformed',
+        criteria: { searchQuery: {} },
+      } as never)).rejects.toThrow();
+    });
+
     it('should create new custom smart view', async () => {
       const newView = await createSmartView({
         name: 'High Priority',

--- a/tests/data/sync/pb-pull.test.ts
+++ b/tests/data/sync/pb-pull.test.ts
@@ -167,6 +167,7 @@ describe('pullRemoteChanges archive guard', () => {
     const db = getDb();
     await db.tasks.clear();
     await db.archivedTasks.clear();
+    await db.deletedTasks.clear();
     await db.syncQueue.clear();
     fetchRemoteTaskIndexMock.mockResolvedValue({ index: new Map(), fetchSucceeded: true });
   });
@@ -194,6 +195,50 @@ describe('pullRemoteChanges archive guard', () => {
     expect(maxObservedTimestamp).toBeNull();
     await expect(db.tasks.get('archived-task')).resolves.toBeUndefined();
     await expect(db.archivedTasks.count()).resolves.toBe(1);
+  });
+
+  it('does not resurrect a task that is deleted locally after the remote edit', async () => {
+    const db = getDb();
+    await db.deletedTasks.add({
+      ...makeTask('deleted-task'),
+      deletedAt: '2026-05-21T00:00:00.000Z',
+    });
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({
+        getFullList: vi.fn(async () => [pbRecord('deleted-task', '2026-05-20T00:00:00.000Z')]),
+      }),
+    });
+
+    const { pulledCount } = await pullRemoteChanges(null);
+
+    expect(pulledCount).toBe(0);
+    await expect(db.tasks.get('deleted-task')).resolves.toBeUndefined();
+    await expect(db.deletedTasks.get('deleted-task')).resolves.toBeDefined();
+  });
+
+  it('restores a deleted task when the remote edit post-dates deletion', async () => {
+    const db = getDb();
+    await db.deletedTasks.add({
+      ...makeTask('edited-after-delete'),
+      deletedAt: '2026-05-19T00:00:00.000Z',
+    });
+    (getPocketBase as ReturnType<typeof vi.fn>).mockReturnValue({
+      collection: () => ({
+        getFullList: vi.fn(async () => [pbRecord('edited-after-delete', '2026-05-20T00:00:00.000Z')]),
+      }),
+    });
+    fetchRemoteTaskIndexMock.mockResolvedValue({
+      index: new Map([
+        ['edited-after-delete', { pbRecordId: 'rec-edited-after-delete', clientUpdatedAt: '2026-05-20T00:00:00.000Z' }],
+      ]),
+      fetchSucceeded: true,
+    });
+
+    const { pulledCount } = await pullRemoteChanges(null);
+
+    expect(pulledCount).toBe(1);
+    await expect(db.tasks.get('edited-after-delete')).resolves.toBeDefined();
+    await expect(db.deletedTasks.get('edited-after-delete')).resolves.toBeUndefined();
   });
 
   it('still pulls non-archived tasks alongside an archived one', async () => {

--- a/tests/data/sync/pb-sync-engine.test.ts
+++ b/tests/data/sync/pb-sync-engine.test.ts
@@ -41,6 +41,7 @@ vi.mock('@/lib/sync/task-mapper', () => ({
 // Mock DB
 const mockTasks = new Map<string, Record<string, unknown>>();
 const mockArchivedTasks = new Map<string, Record<string, unknown>>();
+const mockDeletedTasks = new Map<string, Record<string, unknown>>();
 const mockDb = {
   transaction: vi.fn(async (
     _mode: string,
@@ -66,6 +67,13 @@ const mockDb = {
     get: vi.fn((id: string) => Promise.resolve(mockArchivedTasks.get(id))),
     delete: vi.fn((id: string) => {
       mockArchivedTasks.delete(id);
+      return Promise.resolve();
+    }),
+  },
+  deletedTasks: {
+    get: vi.fn((id: string) => Promise.resolve(mockDeletedTasks.get(id))),
+    delete: vi.fn((id: string) => {
+      mockDeletedTasks.delete(id);
       return Promise.resolve();
     }),
   },
@@ -139,6 +147,7 @@ describe('pb-sync-engine', () => {
     vi.clearAllMocks();
     mockTasks.clear();
     mockArchivedTasks.clear();
+    mockDeletedTasks.clear();
     mockEnsureValidAuth.mockResolvedValue(true);
   });
 
@@ -193,9 +202,31 @@ describe('pb-sync-engine', () => {
       expect(mockArchivedTasks.has('task-1')).toBe(false);
       expect(mockDb.transaction).toHaveBeenCalledWith(
         'rw',
-        [mockDb.tasks, mockDb.archivedTasks],
+        [mockDb.tasks, mockDb.archivedTasks, mockDb.deletedTasks],
         expect.any(Function)
       );
+    });
+
+    it('does not resurrect a deleted task when the remote update predates deletion', async () => {
+      mockDeletedTasks.set('task-1', { id: 'task-1', deletedAt: '2026-04-09T00:00:00.000Z' });
+
+      await applyRemoteChange('update', {
+        task_id: 'task-1', title: 'Stale remote', client_updated_at: '2026-04-08T00:00:00.000Z',
+      } as never);
+
+      expect(mockTasks.has('task-1')).toBe(false);
+      expect(mockDeletedTasks.has('task-1')).toBe(true);
+    });
+
+    it('restores a deleted task when the remote update post-dates deletion', async () => {
+      mockDeletedTasks.set('task-1', { id: 'task-1', deletedAt: '2026-04-07T00:00:00.000Z' });
+
+      await applyRemoteChange('update', {
+        task_id: 'task-1', title: 'Newer remote', client_updated_at: '2026-04-08T00:00:00.000Z',
+      } as never);
+
+      expect(mockTasks.has('task-1')).toBe(true);
+      expect(mockDeletedTasks.has('task-1')).toBe(false);
     });
 
     it('should un-archive on a remote create that post-dates the archive', async () => {

--- a/tests/data/tasks/import-export.test.ts
+++ b/tests/data/tasks/import-export.test.ts
@@ -340,6 +340,22 @@ describe('Task Import/Export Operations', () => {
       await expect(importTasks(invalidPayload, 'replace')).rejects.toThrow();
     });
 
+    it('rejects smart views with criteria that would crash the filter pipeline', async () => {
+      const invalidPayload = {
+        ...validPayload,
+        smartViews: [{
+          id: 'invalid-smart-view',
+          name: 'Invalid smart view',
+          criteria: { searchQuery: {} },
+          isBuiltIn: false,
+          createdAt: '2025-01-17T10:00:00Z',
+          updatedAt: '2025-01-17T10:00:00Z',
+        }],
+      };
+
+      await expect(importTasks(invalidPayload, 'replace')).rejects.toThrow();
+    });
+
     it('should default to replace mode', async () => {
       mockDb.tasks.clear.mockResolvedValue(undefined);
       mockDb.tasks.bulkAdd.mockResolvedValue(undefined);

--- a/tests/pb/encryption-core.test.ts
+++ b/tests/pb/encryption-core.test.ts
@@ -39,7 +39,7 @@ describe("encryption-core", () => {
 
   it("should_encrypt_text_fields_and_roundtrip", () => {
     const r = fakeRecord({ title: "Buy milk", description: "2%" });
-    core.encryptRecord(r, enc);
+    core.encryptRecord(r, enc, dec);
     expect(r._data.title).toMatch(/^enc:v1:/);
     expect(r._data.description).toMatch(/^enc:v1:/);
     core.decryptRecord(r, dec);
@@ -53,7 +53,7 @@ describe("encryption-core", () => {
       tags: ["work", "urgent"],
       subtasks: [{ id: "s1", title: "step", completed: false }],
     });
-    core.encryptRecord(r, enc);
+    core.encryptRecord(r, enc, dec);
     expect(typeof r._data.tags).toBe("string");
     expect(r._data.tags).toMatch(/^enc:v1:/);
     core.decryptRecord(r, dec);
@@ -71,7 +71,7 @@ describe("encryption-core", () => {
       subtasks: [],
       time_entries: timeEntries,
     });
-    core.encryptRecord(r, enc);
+    core.encryptRecord(r, enc, dec);
     // time_entries must be a ciphertext string after encryption
     expect(typeof r._data.time_entries).toBe("string");
     expect(r._data.time_entries).toMatch(/^enc:v1:/);
@@ -87,7 +87,7 @@ describe("encryption-core", () => {
       tags: Buffer.from(JSON.stringify(tags), "utf8"),
     });
 
-    core.encryptRecord(r, enc);
+    core.encryptRecord(r, enc, dec);
     expect(r._data.tags).toMatch(/^enc:v1:/);
     core.decryptRecord(r, dec);
     expect(r._data.tags).toEqual(tags);
@@ -95,9 +95,9 @@ describe("encryption-core", () => {
 
   it("should_be_idempotent_on_double_encrypt", () => {
     const r = fakeRecord({ title: "x", description: "", tags: [] });
-    core.encryptRecord(r, enc);
+    core.encryptRecord(r, enc, dec);
     const once = { ...r._data };
-    core.encryptRecord(r, enc); // second pass must not double-wrap
+    core.encryptRecord(r, enc, dec); // second pass must not double-wrap
     expect(r._data.title).toBe(once.title);
     expect(r._data.tags).toBe(once.tags);
   });
@@ -111,7 +111,30 @@ describe("encryption-core", () => {
 
   it("should_leave_empty_text_fields_unencrypted", () => {
     const r = fakeRecord({ title: "x", description: "" });
-    core.encryptRecord(r, enc);
+    core.encryptRecord(r, enc, dec);
     expect(r._data.description).toBe("");
+  });
+
+  it("re-encrypts_user_content_that_only_spoofs_the_ciphertext_prefix", () => {
+    const authenticatedDec = (value: string) => {
+      const plaintext = Buffer.from(value, "base64").toString("utf8");
+      if (Buffer.from(plaintext, "utf8").toString("base64") !== value) {
+        throw new Error("invalid ciphertext");
+      }
+      return plaintext;
+    };
+    const r = fakeRecord({
+      title: "enc:v1:not-authenticated-ciphertext",
+      tags: "enc:v1:not-json-ciphertext",
+    });
+
+    core.encryptRecord(r, enc, authenticatedDec);
+
+    expect(r._data.title).toBe(
+      "enc:v1:" + enc("enc:v1:not-authenticated-ciphertext"),
+    );
+    expect(r._data.tags).toBe(
+      "enc:v1:" + enc(JSON.stringify("enc:v1:not-json-ciphertext")),
+    );
   });
 });

--- a/tests/pb/encryption-invalid-prefix-migration.test.ts
+++ b/tests/pb/encryption-invalid-prefix-migration.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+
+const migrationPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../docker/pb_migrations/1781200000_reencrypt_invalid_prefixed_task_fields.js",
+);
+
+function fakeRecord(initial: Record<string, unknown>) {
+  const data = { ...initial };
+  return {
+    get: (field: string) => data[field],
+    getString: (field: string) => {
+      const value = data[field];
+      return typeof value === "string" ? value : JSON.stringify(value);
+    },
+  };
+}
+
+describe("invalid ciphertext-prefix migration", () => {
+  it("re-encrypts marker-prefixed content that cannot be authenticated", () => {
+    const record = fakeRecord({
+      id: "record-one",
+      title: "enc:v1:user-controlled-text",
+      tags: "enc:v1:user-controlled-json",
+    });
+    let migrateUp: ((app: object) => void) | undefined;
+    const updates: Array<{ sql: string; params: Record<string, unknown> }> = [];
+    const database = {
+      newQuery: (sql: string) => {
+        let params: Record<string, unknown> = {};
+        const query = {
+          one: (model: { count: number }) => { model.count = 1; },
+          bind: (next: Record<string, unknown>) => {
+            params = next;
+            return query;
+          },
+          execute: () => updates.push({ sql, params }),
+        };
+        return query;
+      },
+    };
+    const app = {
+      db: () => database,
+      findAllRecords: vi.fn(() => [record]),
+    };
+    const sandbox = {
+      migrate: (up: (migrationApp: object) => void) => { migrateUp = up; },
+      $os: { getenv: () => "x".repeat(32) },
+      $security: {
+        encrypt: (value: string) => `cipher(${value})`,
+        decrypt: () => { throw new Error("authentication failed"); },
+      },
+      DynamicModel: function DynamicModel(initial: object) { return initial; },
+    };
+
+    vm.runInNewContext(readFileSync(migrationPath, "utf8"), sandbox, { filename: migrationPath });
+    expect(migrateUp).toBeTypeOf("function");
+    migrateUp!(app);
+
+    expect(updates).toEqual([{
+      sql: "UPDATE tasks SET title = {:title}, tags = {:tags} WHERE id = {:id}",
+      params: {
+        id: "record-one",
+        title: "enc:v1:cipher(enc:v1:user-controlled-text)",
+        tags: 'enc:v1:cipher("enc:v1:user-controlled-json")',
+      },
+    }]);
+  });
+});

--- a/tests/sync/pb-sync-engine.test.ts
+++ b/tests/sync/pb-sync-engine.test.ts
@@ -67,6 +67,12 @@ vi.mock('@/lib/db', () => {
       })),
     })),
   };
+  // Deleted rows are conditional tombstones just like archived rows. Keep this
+  // mock table present so pull-path tests exercise the real transaction shape.
+  const mockDeletedTasks = {
+    get: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
   const mockSyncMetadata = {
     get: vi.fn(),
     put: vi.fn(),
@@ -78,6 +84,7 @@ vi.mock('@/lib/db', () => {
     getDb: vi.fn(() => ({
       tasks: mockTasks,
       archivedTasks: mockArchivedTasks,
+      deletedTasks: mockDeletedTasks,
       syncMetadata: mockSyncMetadata,
       syncQueue: mockSyncQueue,
       transaction: vi.fn(async (_mode, _tables, callback) => callback()),


### PR DESCRIPTION
## Summary

Remediates all four validated findings from the comprehensive security audit:

- restricts Docker image publishing to reviewed push/tag events
- verifies authenticated task ciphertext and repairs spoofed encryption markers
- validates persisted smart-view criteria at import and direct-write boundaries
- preserves deleted task tombstones during pull and realtime LWW reconciliation

The release-version documentation now matches the committed package version.

## Root cause

Manual Docker dispatch could execute an arbitrary selected ref with publishing credentials. Encryption trusted a marker prefix without authenticating it, smart-view criteria accepted untyped values, and sync only guarded archive tombstones.

## Validation

- `bun run test` — 2,753 passed, 1 skipped
- `bun typecheck`
- `bun lint`
- `bun run test:system:pocketbase`
- PocketBase sync reviewer: no actionable findings
