### PR TITLE
fix: remediate the design-audit findings (P1, P2, P3)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -303,6 +303,17 @@ weight, spacing, and contrast, not from switching families.
 **The One-Eyebrow Rule.** A small tracked eyebrow can introduce one key section. It is a deliberate
 exception, not a template label stamped above every heading.
 
+**The One-Ramp Rule.** The eight steps above are the whole type scale. Tailwind's default size names
+are permitted only where they land exactly on a step — `text-xs` = Caption, `text-sm` = Small,
+`text-base` = Body, `text-2xl` = H2 — and read as spelling, not as a second scale. Sizes with no step
+behind them are not: `text-xl` (20px) and `text-3xl` (30px) belong to Tailwind's ramp, not this one.
+
+Two consequences follow. Do not add a GSD-only alias for a step Inkwell already ships; `text-title`
+and `text-label` were exactly that, and both had drifted off the documented values before they were
+removed. And do not reach for an arbitrary `text-[Npx]` — the mechanical detector catches whole-pixel
+arbitrary values, but it cannot see a fractional one or a named Tailwind step, so a new size that is
+genuinely needed gets documented here first.
+
 ## 4. Elevation
 
 Violet Frost preserves the compact floating-pane structure. Boundaries are quiet 1px rules;

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.11.10
+**Current version:** 11.11.11
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -117,7 +117,7 @@ function DashboardEmpty({ onOpenMatrix }: { onOpenMatrix: () => void }): React.R
   return (
     <div className="mx-auto max-w-xl border-y border-border/70 py-14 text-center sm:py-16">
       <ListTodoIcon className="mx-auto h-10 w-10 text-foreground-muted" aria-hidden />
-      <h2 className="mt-4 text-xl font-semibold text-foreground">Nothing to review yet</h2>
+      <h2 className="mt-4 text-h3 font-semibold text-foreground">Nothing to review yet</h2>
       <p className="mx-auto mt-2 max-w-md text-sm leading-relaxed text-foreground-muted">
         Your review will take shape as work moves through the matrix. Start with one commitment that deserves your attention.
       </p>

--- a/app/css/inkwell-components.css
+++ b/app/css/inkwell-components.css
@@ -751,3 +751,36 @@ hr.rule       { border: none; border-top: var(--border-rule); margin: 0 0 22px; 
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
+
+/* Coarse-pointer target floor (WCAG 2.5.5 / 2.5.8).
+   DESIGN.md §5 promises controls expand to at least 44px on touch. That used
+   to depend on a developer remembering the `.touch-target` class at each call
+   site, so anything that forgot it shipped at desktop size on a phone. Pinning
+   the floor to the base component classes makes forgetting impossible;
+   `.touch-target` stays available as an override for one-off elements.
+   Covered by tests/e2e/touch-targets.spec.ts. */
+@media (pointer: coarse) {
+  .btn,
+  .input,
+  .select {
+    min-height: 44px;
+  }
+
+  /* The small toggles expand their reach, not their appearance. A pseudo-
+     element is part of its originating element for hit-testing, so the control
+     keeps Violet Frost's compact 18px shape and still answers a 44px tap —
+     growing the boxes themselves would be a different design. Each of these
+     inputs is already `position: relative`, and each uses ::after for its
+     check/dot, so ::before is free. */
+  .checkbox input::before,
+  .radio input::before,
+  .switch input::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: max(44px, 100%);
+    height: max(44px, 100%);
+  }
+}

--- a/app/css/inkwell-components.css
+++ b/app/css/inkwell-components.css
@@ -741,12 +741,11 @@ hr.rule       { border: none; border-top: var(--border-rule); margin: 0 0 22px; 
 /* =====================================================================
    Accessibility
    ===================================================================== */
-@media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after {
-    animation-duration: 0.01ms !important;
-    transition-duration: 0.01ms !important;
-  }
-}
+/* The reduced-motion reset lives in app/globals.css, not here.
+   This file is imported with `layer(components)`, and !important declarations
+   resolve layer order in reverse — so a duplicate reset in this file outranked
+   the unlayered one in globals.css and could not be overridden from there. One
+   reset, one place, and exceptions (progress indicators) stay overridable. */
 
 *:focus-visible {
   outline: 2px solid var(--accent);

--- a/app/globals.css
+++ b/app/globals.css
@@ -530,69 +530,6 @@ main {
     animation: capture-pop 0.32s cubic-bezier(0.22, 1, 0.36, 1) both;
   }
 
-  @keyframes new-task-glow {
-    0%, 100% {
-      box-shadow: 0 0 0 0 var(--accent-focus-ring);
-    }
-    50% {
-      box-shadow: 0 0 0 6px transparent;
-    }
-  }
-
-  .animate-new-task-glow {
-    animation: new-task-glow 1.5s ease-in-out 3;
-  }
-
-  /* Staggered card entrance — each card delays by its index via inline style */
-  .animate-stagger-in {
-    animation: slide-in-card 0.3s ease-out both;
-  }
-
-  /* Enhanced drag lift — used on actively dragged task card */
-  @keyframes drag-lift {
-    from {
-      transform: scale(1);
-      box-shadow: var(--shadow-card);
-    }
-    to {
-      transform: scale(1.03);
-      box-shadow: var(--shadow-card-hover);
-    }
-  }
-
-  .animate-drag-lift {
-    animation: drag-lift 0.15s ease-out forwards;
-  }
-
-  /* Drop zone pulse when drag is over */
-  @keyframes drop-zone-pulse {
-    0%, 100% {
-      box-shadow: 0 0 0 0 var(--accent-focus-ring);
-    }
-    50% {
-      box-shadow: 0 0 0 8px transparent;
-    }
-  }
-
-  .animate-drop-zone-pulse {
-    animation: drop-zone-pulse 1s ease-in-out infinite;
-  }
-
-  @keyframes bulk-bar-in {
-    from {
-      opacity: 0;
-      transform: translateY(16px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-
-  .animate-bulk-bar-in {
-    animation: bulk-bar-in 0.2s ease-out both;
-  }
-
   /* Edit drawer slide-in from right */
   @keyframes drawer-slide-in {
     from {

--- a/app/globals.css
+++ b/app/globals.css
@@ -284,13 +284,12 @@
   --color-status-success-muted:  var(--status-success-muted);
   --color-status-success-ink:    var(--status-success-ink);
 
-  /* Type names Inkwell does not ship — kept verbatim for existing call sites. */
-  --text-title: 18px;
-  --text-title--line-height: 1.35;
-  --text-title--letter-spacing: -0.01em;
-  --text-label: 11px;
-  --text-label--line-height: 1.45;
-  --text-label--letter-spacing: 0.04em;
+  /* No GSD-only type names. `text-title` and `text-label` used to live here as
+     near-duplicates of steps Inkwell already ships, at values that contradicted
+     DESIGN.md §3 — title was 18px/1.35/-0.01em against a documented
+     19px/1.22/-0.008em, and label was 11px/1.45/0.04em against a documented
+     11px/1/0.12em. Two names for one step is how a ramp drifts. Call sites now
+     use `text-h3` and `text-eyebrow`, which are the documented steps. */
 }
 
 /* Violet Frost draws structural rules at 1px — the same width Tailwind ships by

--- a/app/globals.css
+++ b/app/globals.css
@@ -348,13 +348,19 @@ main {
   display: none;  /* Chrome, Safari and Opera */
 }
 
-.button-reset {
-  @apply appearance-none border-0 bg-transparent p-0;
-  font: inherit;
-  color: inherit;
-}
-
 @layer components {
+  /* Must stay inside @layer components. Tailwind v4 resolves cascade layers
+     before specificity, and unlayered CSS outranks every utility — so declared
+     at the top level this rule's `color: inherit` silently beat the
+     `text-*` / `hover:text-*` utilities sitting next to it in the JSX, with no
+     build error and nothing jsdom could observe. Covered by
+     tests/e2e/token-cascade.spec.ts. */
+  .button-reset {
+    @apply appearance-none border-0 bg-transparent p-0;
+    font: inherit;
+    color: inherit;
+  }
+
   .matrix-grid {
     @apply grid grid-cols-1 items-start gap-6 md:grid-cols-2;
   }

--- a/app/globals.css
+++ b/app/globals.css
@@ -634,6 +634,18 @@ main {
     scroll-behavior: auto !important;
   }
 
+  /* Progress feedback is exempt. Reducing motion means removing decoration,
+     not deleting the only signal that the app is still working: clamped by the
+     reset above, `animate-spin` completed one 0.01ms revolution and stopped,
+     leaving a static ring that reads as a hung interface. Screen-reader users
+     still heard "Loading"; sighted users who prefer reduced motion got nothing.
+     A slow, even rotation carries none of the vestibular risk that the
+     preference exists to avoid. */
+  .animate-spin {
+    animation-duration: 1600ms !important;
+    animation-iteration-count: infinite !important;
+  }
+
   ::view-transition-old(root),
   ::view-transition-new(root) {
     animation: none !important;

--- a/components/about/feature-card.tsx
+++ b/components/about/feature-card.tsx
@@ -20,7 +20,7 @@ export function FeatureCard({ icon: Icon, title, description, badge, className }
       <div className="mb-4 grid h-9 w-9 place-items-center rounded-lg bg-accent/10">
         <Icon className="h-4 w-4 text-accent" aria-hidden="true" />
       </div>
-      <h3 className="mb-2 flex flex-wrap items-center gap-2 text-xl font-semibold tracking-tight text-foreground">
+      <h3 className="mb-2 flex flex-wrap items-center gap-2 text-h3 font-semibold tracking-tight text-foreground">
         {title}
         {/* Explicit space: JSX drops newline whitespace between expressions, and
             without it the accessible name runs together as "SubtasksComing soon". */}

--- a/components/dashboard/completion-chart.tsx
+++ b/components/dashboard/completion-chart.tsx
@@ -39,7 +39,7 @@ export function CompletionChart({ data }: CompletionChartProps) {
     <div className="rounded-lg border-hair border-border bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
       <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h3 className="text-title font-semibold text-foreground">
+          <h3 className="text-h3 font-semibold text-foreground">
             Completion Trend
           </h3>
           <p className="mt-1 text-sm text-foreground-muted">

--- a/components/dashboard/quadrant-distribution.tsx
+++ b/components/dashboard/quadrant-distribution.tsx
@@ -46,7 +46,7 @@ export function QuadrantDistribution({ distribution }: QuadrantDistributionProps
     <div className="rounded-lg border-hair border-border bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
       <div className="flex items-baseline justify-between gap-3">
         <div>
-          <h3 className="text-title font-semibold text-foreground">
+          <h3 className="text-h3 font-semibold text-foreground">
             Quadrant Distribution
           </h3>
           <p className="mt-1 text-sm text-foreground-muted">

--- a/components/dashboard/review-prompts.tsx
+++ b/components/dashboard/review-prompts.tsx
@@ -71,7 +71,7 @@ export function ReviewPrompts({ distribution }: ReviewPromptsProps): React.React
               className="py-5 first:pt-0 last:pb-0 md:px-6 md:py-0 md:first:pl-0 md:last:pr-0"
             >
               <p
-                className="text-label font-semibold uppercase tracking-wide"
+                className="text-eyebrow font-semibold uppercase"
                 style={{ color: QUADRANT_INK[prompt.rdKey] }}
               >
                 {prompt.label}

--- a/components/dashboard/stats-card.tsx
+++ b/components/dashboard/stats-card.tsx
@@ -54,7 +54,7 @@ export function StatsCard({
       <div className="relative flex items-start justify-between gap-4">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <p className="text-label font-semibold uppercase text-foreground-muted">
+            <p className="text-eyebrow font-semibold uppercase text-foreground-muted">
               {title}
             </p>
             {insight ? (

--- a/components/dashboard/streak-indicator.tsx
+++ b/components/dashboard/streak-indicator.tsx
@@ -25,7 +25,7 @@ export function StreakIndicator({ streakData }: StreakIndicatorProps) {
       {/* Top: eyebrow + count, with a calm icon matching the other stat cards */}
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
-          <p className="text-label font-semibold uppercase text-foreground-muted">
+          <p className="text-eyebrow font-semibold uppercase text-foreground-muted">
             Streak
           </p>
           <div className="mt-3 flex items-baseline gap-2">

--- a/components/dashboard/tag-analytics.tsx
+++ b/components/dashboard/tag-analytics.tsx
@@ -21,7 +21,7 @@ export function TagAnalytics({ tagStats, maxTags = 10 }: TagAnalyticsProps) {
   if (displayTags.length === 0) {
     return (
       <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
-        <h3 className="mb-4 text-title font-semibold text-foreground">Top Tags</h3>
+        <h3 className="mb-4 text-h3 font-semibold text-foreground">Top Tags</h3>
         <p className="text-sm text-foreground-muted">
           No tags to display. Add tags to your tasks to see analytics here.
         </p>
@@ -31,7 +31,7 @@ export function TagAnalytics({ tagStats, maxTags = 10 }: TagAnalyticsProps) {
 
   return (
     <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
-      <h3 className="mb-4 text-title font-semibold text-foreground">Top Tags</h3>
+      <h3 className="mb-4 text-h3 font-semibold text-foreground">Top Tags</h3>
       <div className="space-y-3">
         {displayTags.map((stat) => {
           const barWidth = Math.max((stat.count / maxCount) * 100, 4);

--- a/components/dashboard/time-analytics.tsx
+++ b/components/dashboard/time-analytics.tsx
@@ -23,7 +23,7 @@ const QUADRANT_LABELS: Record<string, { name: string }> = {
 function EmptyState({ className }: { className?: string }) {
   return (
     <div className={cn("rounded-lg border-hair border-border bg-card p-6 shadow-sm", className)}>
-      <h3 className="flex items-center gap-2 text-title font-semibold text-foreground">
+      <h3 className="flex items-center gap-2 text-h3 font-semibold text-foreground">
         <ClockIcon className="h-5 w-5 text-accent" />
         Time Tracking
       </h3>
@@ -91,7 +91,7 @@ export function TimeAnalytics({ summary, quadrantDistribution, className }: Time
 
   return (
     <div className={cn("rounded-lg border-hair border-border bg-card p-6 shadow-sm", className)}>
-      <h3 className="flex items-center gap-2 text-title font-semibold text-foreground">
+      <h3 className="flex items-center gap-2 text-h3 font-semibold text-foreground">
         <ClockIcon className="h-5 w-5 text-accent" />
         Time Tracking
       </h3>

--- a/components/dashboard/upcoming-deadlines.tsx
+++ b/components/dashboard/upcoming-deadlines.tsx
@@ -51,7 +51,7 @@ export function UpcomingDeadlines({ tasks, onTaskClick }: UpcomingDeadlinesProps
 
   return (
     <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
-      <h3 className="mb-4 text-title font-semibold text-foreground">
+      <h3 className="mb-4 text-h3 font-semibold text-foreground">
         Upcoming Deadlines
       </h3>
 

--- a/components/matrix-simplified/filtered-empty.tsx
+++ b/components/matrix-simplified/filtered-empty.tsx
@@ -28,7 +28,7 @@ export function FilteredEmpty({ query, viewName, onClear }: FilteredEmptyProps) 
     >
       <SearchXIcon className="h-6 w-6 text-foreground-muted" aria-hidden="true" />
       <div className="space-y-1">
-        <p className="rd-serif text-xl text-foreground">No tasks match {label}</p>
+        <p className="text-h3 text-foreground">No tasks match {label}</p>
         <p className="text-sm text-foreground-muted">
           Your tasks are still here — this view is just narrowed.
         </p>

--- a/components/matrix-simplified/matrix-grid.tsx
+++ b/components/matrix-simplified/matrix-grid.tsx
@@ -56,7 +56,12 @@ export function MatrixGrid({
     // them into one bordered container and zeroed the gap, which made the
     // matrix read as a single table; the gutter is what lets each quadrant read
     // as its own surface while the 2x2 arrangement still carries the argument.
-    <div data-testid="matrix-grid" className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:grid-rows-2">
+    //
+    // The two-column switch is md: (768px), not lg:. At lg: the whole tablet
+    // band — iPad portrait, split-screen, small laptops — stacked into one
+    // column, which is the one arrangement that destroys the argument the grid
+    // exists to make. The panes are height-constrained, not width-constrained.
+    <div data-testid="matrix-grid" className="grid grid-cols-1 gap-4 md:grid-cols-2 md:grid-rows-2">
       {quadrants.map((meta) => (
         <QuadrantPane
           key={meta.id}

--- a/components/matrix-simplified/matrix-grid.tsx
+++ b/components/matrix-simplified/matrix-grid.tsx
@@ -31,25 +31,7 @@ export function MatrixGrid({
   onTaskRef,
   onQuadrantRef,
 }: MatrixGridProps) {
-  const grouped = (() => {
-    const out: Record<RedesignQuadrantKey, TaskRecord[]> = { q1: [], q2: [], q3: [], q4: [] };
-    for (const t of tasks) {
-      if (t.urgent && t.important) out.q1.push(t);
-      else if (!t.urgent && t.important) out.q2.push(t);
-      else if (t.urgent && !t.important) out.q3.push(t);
-      else out.q4.push(t);
-    }
-    for (const key of Object.keys(out) as RedesignQuadrantKey[]) {
-      out[key].sort((a, b) => {
-        if (a.completed !== b.completed) return a.completed ? 1 : -1;
-        if (a.dueDate && b.dueDate) return a.dueDate.localeCompare(b.dueDate);
-        if (a.dueDate) return -1;
-        if (b.dueDate) return 1;
-        return 0;
-      });
-    }
-    return out;
-  })();
+  const grouped = groupByQuadrant(tasks);
 
   return (
     // Four floating panes on a constant 16px gutter. The old lg: rules merged
@@ -91,4 +73,31 @@ export function MatrixGrid({
       </div>
     </div>
   );
+}
+
+/**
+ * Bucket tasks into the four quadrants, each sorted with active work first and
+ * then by due date. Lives outside the component so the render function stays
+ * about layout.
+ */
+function groupByQuadrant(tasks: TaskRecord[]): Record<RedesignQuadrantKey, TaskRecord[]> {
+  const out: Record<RedesignQuadrantKey, TaskRecord[]> = { q1: [], q2: [], q3: [], q4: [] };
+  for (const t of tasks) {
+    if (t.urgent && t.important) out.q1.push(t);
+    else if (!t.urgent && t.important) out.q2.push(t);
+    else if (t.urgent && !t.important) out.q3.push(t);
+    else out.q4.push(t);
+  }
+  for (const key of Object.keys(out) as RedesignQuadrantKey[]) {
+    out[key].sort(byActiveThenDueDate);
+  }
+  return out;
+}
+
+function byActiveThenDueDate(a: TaskRecord, b: TaskRecord): number {
+  if (a.completed !== b.completed) return a.completed ? 1 : -1;
+  if (a.dueDate && b.dueDate) return a.dueDate.localeCompare(b.dueDate);
+  if (a.dueDate) return -1;
+  if (b.dueDate) return 1;
+  return 0;
 }

--- a/components/matrix-simplified/matrix-grid.tsx
+++ b/components/matrix-simplified/matrix-grid.tsx
@@ -57,28 +57,38 @@ export function MatrixGrid({
     // matrix read as a single table; the gutter is what lets each quadrant read
     // as its own surface while the 2x2 arrangement still carries the argument.
     //
-    // The two-column switch is md: (768px), not lg:. At lg: the whole tablet
-    // band — iPad portrait, split-screen, small laptops — stacked into one
-    // column, which is the one arrangement that destroys the argument the grid
-    // exists to make. The panes are height-constrained, not width-constrained.
-    <div data-testid="matrix-grid" className="grid grid-cols-1 gap-4 md:grid-cols-2 md:grid-rows-2">
-      {quadrants.map((meta) => (
-        <QuadrantPane
-          key={meta.id}
-          meta={meta}
-          tasks={grouped[meta.rdKey]}
-          allTasks={allTasks}
-          onEdit={onEdit}
-          onInspect={onInspect}
-          onToggleComplete={onToggleComplete}
-          onDelete={onDelete}
-          onShare={onShare}
-          onAddInQuadrant={onAddInQuadrant}
-          highlightedTaskId={highlightedTaskId}
-          onTaskRef={onTaskRef}
-          sectionRef={(element) => onQuadrantRef?.(meta.rdKey, element)}
-        />
-      ))}
+    // Columns are decided by the grid's own available width, not by a viewport
+    // breakpoint. A breakpoint cannot see the icon rail: at 768px the expanded
+    // rail takes ~180px, so a md:grid-cols-2 rule produced 245px panes in which
+    // every task title truncated to about fifteen characters.
+    //
+    // The count is capped at two on purpose. auto-fit would have found three
+    // columns on a wide desktop, and a 3+1 arrangement destroys the argument
+    // exactly as thoroughly as a 1x4 stack: the matrix means Q1/Q2 over Q3/Q4
+    // or it means nothing. 696px is two 340px panes plus the 16px gutter.
+    <div className="@container">
+      <div
+        data-testid="matrix-grid"
+        className="grid gap-4 @min-[696px]:grid-cols-2 @min-[696px]:grid-rows-2"
+      >
+        {quadrants.map((meta) => (
+          <QuadrantPane
+            key={meta.id}
+            meta={meta}
+            tasks={grouped[meta.rdKey]}
+            allTasks={allTasks}
+            onEdit={onEdit}
+            onInspect={onInspect}
+            onToggleComplete={onToggleComplete}
+            onDelete={onDelete}
+            onShare={onShare}
+            onAddInQuadrant={onAddInQuadrant}
+            highlightedTaskId={highlightedTaskId}
+            onTaskRef={onTaskRef}
+            sectionRef={(element) => onQuadrantRef?.(meta.rdKey, element)}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/components/matrix-simplified/quadrant-pane.tsx
+++ b/components/matrix-simplified/quadrant-pane.tsx
@@ -76,13 +76,6 @@ export function QuadrantPane({
   const completedTasks = tasks.filter((task) => task.completed);
   const activeTaskCount = activeTasks.length;
   const [showCompletedHere, setShowCompletedHere] = useState(false);
-  // The cap is a render budget, not a filter: the header count below still
-  // reports every active task, because an overloaded quadrant is exactly the
-  // thing the matrix exists to make visible.
-  const [showAllActive, setShowAllActive] = useState(false);
-  const hasDeferredActive = activeTasks.length > ACTIVE_RENDER_CAP;
-  const visibleActive = showAllActive ? activeTasks : activeTasks.slice(0, ACTIVE_RENDER_CAP);
-  const deferredActiveCount = activeTasks.length - visibleActive.length;
   const cardHandlers: CardHandlers = {
     onEdit, onInspect, onDelete, onShare, onToggleComplete, highlightedTaskId, onTaskRef,
   };
@@ -176,24 +169,7 @@ export function QuadrantPane({
               ) : null}
             </div>
           ) : (
-            <>
-              <TaskCardList tasks={visibleActive} allTasks={allTasks} handlers={cardHandlers} />
-              {hasDeferredActive ? (
-                <button
-                  data-testid="quadrant-more-active"
-                  type="button"
-                  onClick={() => setShowAllActive((open) => !open)}
-                  aria-expanded={showAllActive}
-                  className="mt-1 inline-flex w-fit items-center gap-1.5 rounded-full px-2 py-1 text-caption font-medium text-foreground-muted transition-colors hover:bg-background-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-                >
-                  <ChevronRightIcon
-                    className={cn("h-3.5 w-3.5 transition-transform", showAllActive && "rotate-90")}
-                    aria-hidden="true"
-                  />
-                  {showAllActive ? "Show fewer" : `${deferredActiveCount} more`}
-                </button>
-              ) : null}
-            </>
+            <CappedActiveList tasks={activeTasks} allTasks={allTasks} handlers={cardHandlers} />
           )}
 
           <CompletedDisclosure
@@ -206,6 +182,49 @@ export function QuadrantPane({
         </div>
       </SortableContext>
     </section>
+  );
+}
+
+/**
+ * Active work in this quadrant, rendered up to ACTIVE_RENDER_CAP.
+ *
+ * The cap is a render budget, not a filter — the pane header still reports
+ * every active task, because an overloaded quadrant is exactly the thing the
+ * matrix exists to make visible. Nothing is hidden permanently; one click
+ * renders the rest.
+ */
+function CappedActiveList({
+  tasks,
+  allTasks,
+  handlers,
+}: {
+  tasks: TaskRecord[];
+  allTasks: TaskRecord[];
+  handlers: CardHandlers;
+}) {
+  const [showAll, setShowAll] = useState(false);
+  const visible = showAll ? tasks : tasks.slice(0, ACTIVE_RENDER_CAP);
+  const deferred = tasks.length - visible.length;
+
+  return (
+    <>
+      <TaskCardList tasks={visible} allTasks={allTasks} handlers={handlers} />
+      {tasks.length > ACTIVE_RENDER_CAP ? (
+        <button
+          data-testid="quadrant-more-active"
+          type="button"
+          onClick={() => setShowAll((open) => !open)}
+          aria-expanded={showAll}
+          className="mt-1 inline-flex w-fit items-center gap-1.5 rounded-full px-2 py-1 text-caption font-medium text-foreground-muted transition-colors hover:bg-background-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          <ChevronRightIcon
+            className={cn("h-3.5 w-3.5 transition-transform", showAll && "rotate-90")}
+            aria-hidden="true"
+          />
+          {showAll ? "Show fewer" : `${deferred} more`}
+        </button>
+      ) : null}
+    </>
   );
 }
 

--- a/components/matrix-simplified/quadrant-pane.tsx
+++ b/components/matrix-simplified/quadrant-pane.tsx
@@ -18,6 +18,18 @@ const RD_ICON: Record<RedesignIconKey, LucideIcon> = {
   trash: Trash2Icon,
 };
 
+/**
+ * How many active cards a pane renders before deferring the rest behind a
+ * disclosure.
+ *
+ * The matrix is the one long-list surface here that is not virtualized: every
+ * active card in all four panes is real DOM inside a SortableContext, which is
+ * what lets drag-and-drop stay simple. A render budget buys most of what
+ * windowing would, without asking dnd-kit to drop onto nodes that do not
+ * exist. Every id still goes into SortableContext, so ordering is unaffected.
+ */
+export const ACTIVE_RENDER_CAP = 50;
+
 interface QuadrantPaneProps {
   meta: QuadrantMeta;
   tasks: TaskRecord[];
@@ -64,6 +76,13 @@ export function QuadrantPane({
   const completedTasks = tasks.filter((task) => task.completed);
   const activeTaskCount = activeTasks.length;
   const [showCompletedHere, setShowCompletedHere] = useState(false);
+  // The cap is a render budget, not a filter: the header count below still
+  // reports every active task, because an overloaded quadrant is exactly the
+  // thing the matrix exists to make visible.
+  const [showAllActive, setShowAllActive] = useState(false);
+  const hasDeferredActive = activeTasks.length > ACTIVE_RENDER_CAP;
+  const visibleActive = showAllActive ? activeTasks : activeTasks.slice(0, ACTIVE_RENDER_CAP);
+  const deferredActiveCount = activeTasks.length - visibleActive.length;
   const cardHandlers: CardHandlers = {
     onEdit, onInspect, onDelete, onShare, onToggleComplete, highlightedTaskId, onTaskRef,
   };
@@ -157,7 +176,24 @@ export function QuadrantPane({
               ) : null}
             </div>
           ) : (
-            <TaskCardList tasks={activeTasks} allTasks={allTasks} handlers={cardHandlers} />
+            <>
+              <TaskCardList tasks={visibleActive} allTasks={allTasks} handlers={cardHandlers} />
+              {hasDeferredActive ? (
+                <button
+                  data-testid="quadrant-more-active"
+                  type="button"
+                  onClick={() => setShowAllActive((open) => !open)}
+                  aria-expanded={showAllActive}
+                  className="mt-1 inline-flex w-fit items-center gap-1.5 rounded-full px-2 py-1 text-caption font-medium text-foreground-muted transition-colors hover:bg-background-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                >
+                  <ChevronRightIcon
+                    className={cn("h-3.5 w-3.5 transition-transform", showAllActive && "rotate-90")}
+                    aria-hidden="true"
+                  />
+                  {showAllActive ? "Show fewer" : `${deferredActiveCount} more`}
+                </button>
+              ) : null}
+            </>
           )}
 
           <CompletedDisclosure

--- a/components/settings-page/settings-sidebar.tsx
+++ b/components/settings-page/settings-sidebar.tsx
@@ -26,39 +26,7 @@ export function SettingsSidebar({ activeId, onSelect, visibleSections }: Setting
 
   return (
     <>
-      {/* Mobile: horizontal pill nav.
-          The scrollbar is hidden by design, so a short fade on the trailing
-          edge is the only thing telling the reader the row continues past the
-          fold — eight sections never fit on a phone. */}
-      <nav
-        data-testid="settings-nav-scroller"
-        aria-label="Settings sections"
-        className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-2 lg:hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [mask-image:linear-gradient(to_right,black_calc(100%_-_1.5rem),transparent)]"
-      >
-        {sections.map((section) => {
-          const Icon = section.icon;
-          const isActive = section.id === activeId;
-          return (
-            <button
-              key={section.id}
-              type="button"
-              onClick={() => onSelect(section.id)}
-              className={cn(
-                "inline-flex shrink-0 items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-all",
-                "min-h-11",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
-                isActive
-                  ? "border-accent/40 bg-accent/10 text-accent"
-                  : "border-border bg-card text-foreground-muted hover:text-foreground",
-              )}
-              aria-current={isActive ? "true" : undefined}
-            >
-              <Icon className="h-4 w-4" />
-              {section.label}
-            </button>
-          );
-        })}
-      </nav>
+      <MobilePillNav sections={sections} activeId={activeId} onSelect={onSelect} />
 
       {/* Desktop: vertical nav card */}
       <aside className="hidden lg:block lg:w-[260px] lg:shrink-0">
@@ -90,6 +58,55 @@ export function SettingsSidebar({ activeId, onSelect, visibleSections }: Setting
         </nav>
       </aside>
     </>
+  );
+}
+
+/**
+ * Phone/tablet navigation: one horizontal row of pills.
+ *
+ * The scrollbar is hidden by design, so a short fade on the trailing edge is
+ * the only thing telling the reader the row continues past the fold — eight
+ * sections never fit on a phone.
+ */
+function MobilePillNav({
+  sections,
+  activeId,
+  onSelect,
+}: {
+  sections: SectionMeta[];
+  activeId: SettingsSectionId;
+  onSelect: (id: SettingsSectionId) => void;
+}) {
+  return (
+    <nav
+      data-testid="settings-nav-scroller"
+      aria-label="Settings sections"
+      className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-2 lg:hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [mask-image:linear-gradient(to_right,black_calc(100%_-_1.5rem),transparent)]"
+    >
+      {sections.map((section) => {
+        const Icon = section.icon;
+        const isActive = section.id === activeId;
+        return (
+          <button
+            key={section.id}
+            type="button"
+            onClick={() => onSelect(section.id)}
+            className={cn(
+              "inline-flex shrink-0 items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-all",
+              "min-h-11",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
+              isActive
+                ? "border-accent/40 bg-accent/10 text-accent"
+                : "border-border bg-card text-foreground-muted hover:text-foreground",
+            )}
+            aria-current={isActive ? "true" : undefined}
+          >
+            <Icon className="h-4 w-4" />
+            {section.label}
+          </button>
+        );
+      })}
+    </nav>
   );
 }
 

--- a/components/settings-page/settings-sidebar.tsx
+++ b/components/settings-page/settings-sidebar.tsx
@@ -26,10 +26,14 @@ export function SettingsSidebar({ activeId, onSelect, visibleSections }: Setting
 
   return (
     <>
-      {/* Mobile: horizontal pill nav */}
+      {/* Mobile: horizontal pill nav.
+          The scrollbar is hidden by design, so a short fade on the trailing
+          edge is the only thing telling the reader the row continues past the
+          fold — eight sections never fit on a phone. */}
       <nav
+        data-testid="settings-nav-scroller"
         aria-label="Settings sections"
-        className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-2 lg:hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-2 lg:hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [mask-image:linear-gradient(to_right,black_calc(100%_-_1.5rem),transparent)]"
       >
         {sections.map((section) => {
           const Icon = section.icon;
@@ -47,7 +51,7 @@ export function SettingsSidebar({ activeId, onSelect, visibleSections }: Setting
                   ? "border-accent/40 bg-accent/10 text-accent"
                   : "border-border bg-card text-foreground-muted hover:text-foreground",
               )}
-              aria-current={isActive ? "page" : undefined}
+              aria-current={isActive ? "true" : undefined}
             >
               <Icon className="h-4 w-4" />
               {section.label}
@@ -108,7 +112,7 @@ function SidebarItem({ section, isActive, onSelect }: SidebarItemProps) {
           ? "bg-accent/10 text-foreground"
           : "text-foreground-muted hover:bg-background-muted hover:text-foreground",
       )}
-      aria-current={isActive ? "page" : undefined}
+      aria-current={isActive ? "true" : undefined}
     >
       {/* Active accent bar */}
       <span

--- a/components/settings-page/settings-sidebar.tsx
+++ b/components/settings-page/settings-sidebar.tsx
@@ -58,10 +58,16 @@ export function SettingsSidebar({ activeId, onSelect, visibleSections }: Setting
 
       {/* Desktop: vertical nav card */}
       <aside className="hidden lg:block lg:w-[260px] lg:shrink-0">
-        <div className="sticky top-24 flex flex-col gap-3 rounded-2xl border border-border bg-card p-2 shadow-sm">
+        <nav
+          aria-label="Settings sections"
+          className="sticky top-24 flex flex-col gap-3 rounded-2xl border border-border bg-card p-2 shadow-sm"
+        >
           {groups.map(({ group, items }) => (
             <div key={group}>
-              <p className="px-3 pb-2 pt-4 text-[10px] font-semibold uppercase tracking-[0.12em] text-foreground-muted/80">
+              {/* Full-strength --gray-500, never alpha-reduced: at 10px the /80
+                  composite measured 3.72:1 on paper, under the AA floor, and it
+                  failed in light mode only. */}
+              <p className="px-3 pb-2 pt-4 text-[10px] font-semibold uppercase tracking-[0.12em] text-foreground-muted">
                 {group}
               </p>
               <ul className="space-y-0.5">
@@ -77,7 +83,7 @@ export function SettingsSidebar({ activeId, onSelect, visibleSections }: Setting
               </ul>
             </div>
           ))}
-        </div>
+        </nav>
       </aside>
     </>
   );

--- a/components/sync/sync-auth-dialog.tsx
+++ b/components/sync/sync-auth-dialog.tsx
@@ -118,7 +118,7 @@ function DialogHeader({ syncStatus, sessionExpired, onClose }: DialogHeaderProps
       <div className="flex items-center gap-3">
         <CloudIcon className="h-6 w-6 text-accent" aria-hidden="true" />
         <div>
-          <h2 id="sync-auth-dialog-title" className="text-xl font-semibold text-foreground">
+          <h2 id="sync-auth-dialog-title" className="text-h3 font-semibold text-foreground">
             Sync Settings
           </h2>
           <p className="text-sm text-foreground-muted">{subtitle}</p>

--- a/lib/prefers-reduced-motion.ts
+++ b/lib/prefers-reduced-motion.ts
@@ -1,0 +1,12 @@
+/**
+ * Whether the user has asked the OS to reduce motion.
+ *
+ * CSS animations are handled by the `prefers-reduced-motion: reduce` block in
+ * `app/globals.css`. Anything driven from JavaScript — requestAnimationFrame
+ * loops, the Web Animations API, canvas — is invisible to that stylesheet and
+ * has to ask this question directly.
+ */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}

--- a/lib/use-count-up.ts
+++ b/lib/use-count-up.ts
@@ -1,18 +1,22 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { prefersReducedMotion } from "@/lib/prefers-reduced-motion";
 
 /**
  * Animates a number from 0 to the target value on mount.
- * Skips animation in test environments where rAF callbacks
- * don't fire synchronously.
+ * Skips animation when the user prefers reduced motion, and in test
+ * environments where rAF callbacks don't fire synchronously.
  */
 export function useCountUp(target: number | string, duration = 500): string {
   const numericTarget = typeof target === "string" ? parseFloat(target) : target;
   const isNumeric = !isNaN(numericTarget) && isFinite(numericTarget);
   const suffix = typeof target === "string" ? target.replace(/[\d.-]/g, "") : "";
 
-  const skipAnimation = process.env.NODE_ENV === "test";
+  // Motion preference is evaluated first on purpose. Behind the NODE_ENV check
+  // it would short-circuit away in tests, leaving the guard permanently
+  // unexercised — which is how a reduced-motion regression ships unnoticed.
+  const skipAnimation = prefersReducedMotion() || process.env.NODE_ENV === "test";
   const [current, setCurrent] = useState(skipAnimation ? numericTarget : 0);
   const hasAnimated = useRef(false);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.11.10",
+	"version": "11.11.11",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1201,3 +1201,35 @@ Branch: feat/edit-drawer-dependencies
 - Systemic danger-color token: text-red-400-on-white fails AA in sync-button.tsx:148 and sync-auth-dialog-sections.tsx:212 too — a shared token fix covers all.
 - restoreTask does not re-create inbound dependency edges after delete/undo (pre-existing, noted above).
 - Subtask editing still drawer-less (also lost in #238).
+
+---
+
+## 2026-08-14 — Impeccable audit remediation (P1 + P2)
+
+Branch `fix/audit-p1-p2-remediation`. Audit report:
+https://claude.ai/code/artifact/135957c7-806a-4cbe-9b02-1b9c6ddb440b
+
+- [x] **P1** settings sidebar group labels — dropped `/80`; measured 3.72:1 → 5.69:1 light, 6.84:1 dark
+- [x] **P1** `useCountUp` honors `prefers-reduced-motion` (extracted `lib/prefers-reduced-motion.ts`); predicate is evaluated *before* the NODE_ENV escape or it short-circuits away untested
+- [x] **P2** reduced-motion reset no longer freezes `animate-spin`; duplicate reset removed from `inkwell-components.css`
+- [x] **P2** `.button-reset` moved into `@layer components` — restores dead colour utilities on the dialog close button and task-card title
+- [x] **P2** matrix grid sized by container query (`@min-[696px]`, capped at 2 cols)
+- [x] **P2** desktop settings rail is a named `<nav>` landmark
+- [x] **P2** per-quadrant render cap (`ACTIVE_RENDER_CAP = 50`) with a "N more" disclosure
+- [x] **P2** coarse-pointer 44px floor made structural on `.btn`/`.input`/`.select` + pseudo-element hit expansion on checkbox/radio/switch
+
+Verification: 2767 unit, 107 e2e (chromium), typecheck, lint. Live-verified in
+Chrome light + dark, SW-busted and seeded with 59 tasks.
+
+**Resuming From Here / deferred follow-ups:**
+- All six **P3** findings are untouched by design (scope was P1+P2): dual type
+  vocabulary, `--text-title` 18px vs DESIGN.md 19px, dead `.rd-serif` at
+  `filtered-empty.tsx:31`, three dead animation utilities, mobile settings-nav
+  overflow cue, `aria-current="page"` on section switchers.
+- e2e ran chromium only; firefox/webkit not exercised for the new specs.
+- The audit's tablet claim was **partly overstated**: 768px genuinely cannot fit
+  two readable panes while the icon rail is expanded (506px available, ~696px
+  needed). Collapsing the rail below `lg:` would be the real fix for iPad
+  portrait, and is a separate design decision.
+- `ACTIVE_RENDER_CAP = 50` was not profiled — it is a defensible budget, not a
+  measured one.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1233,3 +1233,30 @@ Chrome light + dark, SW-busted and seeded with 59 tasks.
   portrait, and is a separate design decision.
 - `ACTIVE_RENDER_CAP = 50` was not profiled — it is a defensible budget, not a
   measured one.
+
+### 2026-08-14 (cont.) — P3 remediation
+
+- [x] **P3** off-ramp type sizes — `text-xl` (20px, no ramp step) → `text-h3` at 4 sites; DESIGN.md §3 gains the **One-Ramp Rule**
+- [x] **P3** `--text-title` **and `--text-label`** removed — both were GSD-only aliases for steps Inkwell ships, both drifted off DESIGN.md; 10 call sites → `text-h3` / `text-eyebrow`
+- [x] **P3** inert `.rd-serif` dropped from `filtered-empty.tsx:31`
+- [x] **P3** five (not three) unreferenced animation utilities deleted
+- [x] **P3** mobile settings nav gains a trailing mask fade (`data-testid="settings-nav-scroller"`)
+- [x] **P3** `aria-current="page"` → `"true"` in both sidebar branches
+
+Scope chosen by the user for the type-vocabulary finding: **off-ramp sizes only**,
+not the 236-site migration to Inkwell names.
+
+Verification: 2770 unit, 107 e2e (chromium), typecheck, lint. Live-verified in
+Chrome — `text-h3` renders 19px/23.18px/−0.152px and `text-eyebrow`
+11px/11px/1.32px, matching DESIGN.md exactly.
+
+**Resuming From Here / still open:**
+- **Detector is still at 22 advisories, unchanged.** All 22 are arbitrary
+  `text-[Npx]` values (13px ×10, 10px ×6, 40px ×2, 18/22/26/27px) which the
+  chosen scope did not cover. The One-Ramp Rule now states the policy; moving
+  those onto ramp steps, or documenting them as real steps, is the follow-up.
+- The detector cannot see fractional sizes (`text-[14.5px]`, `text-[12.5px]` on
+  the task card) or named Tailwind steps at all — noted in DESIGN.md §3.
+- `design-lab.spec.ts:119` flaked once under parallel load and passed on re-run
+  and in isolation; it references nothing changed here.
+- e2e still chromium-only.

--- a/tests/data/prefers-reduced-motion.test.ts
+++ b/tests/data/prefers-reduced-motion.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { prefersReducedMotion } from "@/lib/prefers-reduced-motion";
+
+// The predicate guards every JS-driven animation in the app. CSS animations are
+// covered by the `prefers-reduced-motion: reduce` block in app/globals.css, but
+// anything running on requestAnimationFrame is invisible to that stylesheet and
+// has to ask this question itself.
+
+const original = window.matchMedia;
+
+function stubMatchMedia(matches: boolean): void {
+  window.matchMedia = ((query: string) =>
+    ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }) as MediaQueryList) as typeof window.matchMedia;
+}
+
+afterEach(() => {
+  window.matchMedia = original;
+});
+
+describe("prefersReducedMotion", () => {
+  it("returns true when the user has asked for reduced motion", () => {
+    stubMatchMedia(true);
+    expect(prefersReducedMotion()).toBe(true);
+  });
+
+  it("returns false when the user has not asked for reduced motion", () => {
+    stubMatchMedia(false);
+    expect(prefersReducedMotion()).toBe(false);
+  });
+
+  it("queries the reduce preference specifically", () => {
+    let asked = "";
+    window.matchMedia = ((query: string) => {
+      asked = query;
+      return { matches: false } as MediaQueryList;
+    }) as typeof window.matchMedia;
+    prefersReducedMotion();
+    expect(asked).toBe("(prefers-reduced-motion: reduce)");
+  });
+
+  it("returns false rather than throwing when matchMedia is unavailable", () => {
+    // Older Safari and some embedded webviews ship without matchMedia. Motion
+    // is the safe default there: the user never expressed a preference.
+    Reflect.deleteProperty(window, "matchMedia");
+    expect(prefersReducedMotion()).toBe(false);
+  });
+});

--- a/tests/data/use-count-up.test.ts
+++ b/tests/data/use-count-up.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useCountUp } from "@/lib/use-count-up";
+import { prefersReducedMotion } from "@/lib/prefers-reduced-motion";
+
+vi.mock("@/lib/prefers-reduced-motion", () => ({
+  prefersReducedMotion: vi.fn(() => false),
+}));
 
 // Migrated from the former tests/data/functions-branches-boost.test.ts
 // "useCountUp" block (finding F2.1) — this is the module's only test file.
@@ -11,6 +16,10 @@ import { useCountUp } from "@/lib/use-count-up";
 // is therefore capped (~66% functions / ~65% branches) by design, not by a test gap.
 
 describe("useCountUp", () => {
+  beforeEach(() => {
+    vi.mocked(prefersReducedMotion).mockClear();
+  });
+
   it("returns the numeric target immediately in the test env (animation skipped)", () => {
     const { result } = renderHook(() => useCountUp(42));
     expect(result.current).toBe("42");
@@ -39,5 +48,24 @@ describe("useCountUp", () => {
   it("returns 'Infinity' for non-finite input (treated as non-numeric)", () => {
     const { result } = renderHook(() => useCountUp(Infinity));
     expect(result.current).toBe("Infinity");
+  });
+
+  // The stat cards are the densest cluster of simultaneous motion in the app.
+  // Because the count-up runs on requestAnimationFrame, the global
+  // `prefers-reduced-motion` block in app/globals.css cannot reach it — the hook
+  // has to ask. The check must be evaluated before the NODE_ENV escape hatch,
+  // otherwise it short-circuits away and silently stops protecting anyone.
+  it("consults prefers-reduced-motion before deciding to animate", () => {
+    renderHook(() => useCountUp(42));
+    expect(vi.mocked(prefersReducedMotion)).toHaveBeenCalled();
+  });
+
+  it("returns the target immediately when the user prefers reduced motion", () => {
+    vi.mocked(prefersReducedMotion).mockReturnValueOnce(true);
+    const rafSpy = vi.spyOn(window, "requestAnimationFrame");
+    const { result } = renderHook(() => useCountUp(42));
+    expect(result.current).toBe("42");
+    expect(rafSpy).not.toHaveBeenCalled();
+    rafSpy.mockRestore();
   });
 });

--- a/tests/e2e/layout-overlap.spec.ts
+++ b/tests/e2e/layout-overlap.spec.ts
@@ -82,4 +82,37 @@ test.describe("Layout overlap", () => {
     // action below the fold reads as a dialog with no way out.
     expect(actionBox.y + actionBox.height).toBeLessThanOrEqual(720);
   });
+
+  test("the matrix keeps its 2x2 arrangement at tablet width", async ({ page }) => {
+    // iPad portrait. The two-column switch used to sit at lg: (1024px), so this
+    // whole viewport band — tablets, small laptops, split-screen — stacked the
+    // four quadrants into one column. "The matrix is the argument" (PRODUCT.md);
+    // stacked, the urgent/important relationship stops being spatial at all.
+    await page.setViewportSize({ width: 768, height: 1024 });
+    await waitForAppLoad(page);
+
+    const q1 = await box(page.locator("[data-testid='quadrant-q1']"));
+    const q2 = await box(page.locator("[data-testid='quadrant-q2']"));
+    const q3 = await box(page.locator("[data-testid='quadrant-q3']"));
+
+    // Q1 and Q2 share a row: same top, different left edge.
+    expect(Math.abs(q1.y - q2.y)).toBeLessThanOrEqual(2);
+    expect(q2.x).toBeGreaterThan(q1.x + q1.width - 2);
+
+    // Q3 opens the second row beneath Q1, sharing its left edge.
+    expect(q3.y).toBeGreaterThan(q1.y + q1.height - 2);
+    expect(Math.abs(q3.x - q1.x)).toBeLessThanOrEqual(2);
+  });
+
+  test("the matrix still stacks to one column on a phone", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await waitForAppLoad(page);
+
+    const q1 = await box(page.locator("[data-testid='quadrant-q1']"));
+    const q2 = await box(page.locator("[data-testid='quadrant-q2']"));
+
+    // Stacking below the tablet breakpoint is intended, not a regression.
+    expect(Math.abs(q2.x - q1.x)).toBeLessThanOrEqual(2);
+    expect(q2.y).toBeGreaterThan(q1.y + q1.height - 2);
+  });
 });

--- a/tests/e2e/layout-overlap.spec.ts
+++ b/tests/e2e/layout-overlap.spec.ts
@@ -83,12 +83,29 @@ test.describe("Layout overlap", () => {
     expect(actionBox.y + actionBox.height).toBeLessThanOrEqual(720);
   });
 
-  test("the matrix keeps its 2x2 arrangement at tablet width", async ({ page }) => {
-    // iPad portrait. The two-column switch used to sit at lg: (1024px), so this
-    // whole viewport band — tablets, small laptops, split-screen — stacked the
-    // four quadrants into one column. "The matrix is the argument" (PRODUCT.md);
-    // stacked, the urgent/important relationship stops being spatial at all.
-    await page.setViewportSize({ width: 768, height: 1024 });
+  // The matrix goes two-up on available width, not on a viewport breakpoint.
+  //
+  // A viewport breakpoint cannot see the icon rail. At 768px the expanded rail
+  // takes ~180px, so a md: two-column rule produced 245px panes in which every
+  // task title truncated to about fifteen characters ("Escalation 1: in…").
+  // Two columns nobody can read is worse than one column that works, so the
+  // grid asks whether two *readable* panes fit and answers for itself.
+  const MIN_PANE = 340;
+
+  test("never renders a pane too narrow to read a task title", async ({ page }) => {
+    for (const width of [390, 768, 1024, 1440]) {
+      await page.setViewportSize({ width, height: 900 });
+      await waitForAppLoad(page);
+
+      for (const key of ["q1", "q2", "q3", "q4"]) {
+        const pane = await box(page.locator(`[data-testid='quadrant-${key}']`));
+        expect(pane.width, `${key} at ${width}px`).toBeGreaterThanOrEqual(MIN_PANE - 1);
+      }
+    }
+  });
+
+  test("goes two-up as soon as two readable panes fit", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
     await waitForAppLoad(page);
 
     const q1 = await box(page.locator("[data-testid='quadrant-q1']"));
@@ -104,14 +121,13 @@ test.describe("Layout overlap", () => {
     expect(Math.abs(q3.x - q1.x)).toBeLessThanOrEqual(2);
   });
 
-  test("the matrix still stacks to one column on a phone", async ({ page }) => {
+  test("stacks to one column on a phone", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await waitForAppLoad(page);
 
     const q1 = await box(page.locator("[data-testid='quadrant-q1']"));
     const q2 = await box(page.locator("[data-testid='quadrant-q2']"));
 
-    // Stacking below the tablet breakpoint is intended, not a regression.
     expect(Math.abs(q2.x - q1.x)).toBeLessThanOrEqual(2);
     expect(q2.y).toBeGreaterThan(q1.y + q1.height - 2);
   });

--- a/tests/e2e/reduced-motion.spec.ts
+++ b/tests/e2e/reduced-motion.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "./fixtures/test-fixtures";
+import { waitForAppLoad } from "./helpers/test-helpers";
+
+/**
+ * The reduced-motion contract, measured rather than assumed.
+ *
+ * PRODUCT.md promises every animation has a `prefers-reduced-motion: reduce`
+ * fallback. The subtlety the audit found is that "fallback" is not the same as
+ * "off": a blanket kill switch satisfies the letter of the preference while
+ * deleting feedback the user still needs. A frozen spinner does not read as
+ * "motion respectfully removed", it reads as "the app has hung".
+ */
+test.describe("Reduced motion", () => {
+  test.beforeEach(async ({ clearIndexedDB }) => {
+    // Fixture clears IndexedDB
+  });
+
+  test("keeps progress indicators turning while killing decorative motion", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await waitForAppLoad(page);
+
+    // Probe the stylesheet directly. A real spinner only exists during a
+    // transient loading state, which is not something to race a test against.
+    const computed = await page.evaluate(() => {
+      const spinner = document.createElement("div");
+      spinner.className = "animate-spin";
+      const decorative = document.createElement("div");
+      decorative.className = "transition-colors";
+      document.body.append(spinner, decorative);
+
+      const s = getComputedStyle(spinner);
+      const d = getComputedStyle(decorative);
+      const result = {
+        spinIterations: s.animationIterationCount,
+        spinDurationMs: parseFloat(s.animationDuration) * (s.animationDuration.endsWith("ms") ? 1 : 1000),
+        decorativeDurationMs: parseFloat(d.transitionDuration) * (d.transitionDuration.endsWith("ms") ? 1 : 1000),
+      };
+      spinner.remove();
+      decorative.remove();
+      return result;
+    });
+
+    // `animation-iteration-count: 1 !important` in the blanket reset clamped
+    // `animate-spin` to a single 0.01ms revolution — a static ring with a gap
+    // in it. Assistive tech still heard "Loading"; sighted users who prefer
+    // reduced motion saw a stalled app.
+    expect(computed.spinIterations).toBe("infinite");
+    expect(computed.spinDurationMs).toBeGreaterThan(100);
+
+    // The rest of the reset must survive: decorative transitions stay killed.
+    expect(computed.decorativeDurationMs).toBeLessThan(1);
+  });
+
+  test("still animates normally when no preference is expressed", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "no-preference" });
+    await waitForAppLoad(page);
+
+    const durationMs = await page.evaluate(() => {
+      const el = document.createElement("div");
+      el.className = "transition-colors";
+      document.body.append(el);
+      const value = getComputedStyle(el).transitionDuration;
+      el.remove();
+      return parseFloat(value) * (value.endsWith("ms") ? 1 : 1000);
+    });
+
+    // Guards against a fix that quietly disables motion for everyone.
+    expect(durationMs).toBeGreaterThan(1);
+  });
+});

--- a/tests/e2e/token-cascade.spec.ts
+++ b/tests/e2e/token-cascade.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "./fixtures/test-fixtures";
+import { waitForAppLoad, createTaskViaCaptureBar } from "./helpers/test-helpers";
+import type { Locator } from "@playwright/test";
+
+/**
+ * Cascade regressions, measured in a real engine.
+ *
+ * Tailwind v4 orders declarations by cascade LAYER before specificity, and
+ * unlayered CSS outranks everything in `@layer utilities` regardless of how
+ * specific it is. That makes a one-line stylesheet edit able to silently
+ * neutralise a colour utility sitting right there in the JSX — with no build
+ * error, no lint warning, and nothing jsdom can observe, because the unit suite
+ * never loads the built stylesheet.
+ */
+async function colorOf(locator: Locator): Promise<string> {
+  return locator.evaluate((el) => getComputedStyle(el).color);
+}
+
+test.describe("Token cascade", () => {
+  test.beforeEach(async ({ clearIndexedDB }) => {
+    // Fixture clears IndexedDB
+  });
+
+  test("the dialog close button keeps its muted colour and its hover change", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await waitForAppLoad(page);
+    await createTaskViaCaptureBar(page, "Cascade check !!");
+
+    const card = page.locator("[data-testid='task-card']").filter({ hasText: "Cascade check" });
+    await card.hover();
+    await card.getByRole("button", { name: "Share task" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    const close = dialog.getByRole("button", { name: "Close" });
+    await expect(close).toBeVisible();
+
+    // `.button-reset` sets `color: inherit`. Declared unlayered it beat
+    // `text-foreground-muted`, so the control rendered at full foreground
+    // strength — indistinguishable from the dialog's body text.
+    const restColor = await colorOf(close);
+    const bodyColor = await dialog.evaluate((el) => getComputedStyle(el).color);
+    expect(restColor).not.toBe(bodyColor);
+
+    // ...and `hover:text-foreground` was dead too, so the primary dismiss
+    // control on every dialog in the app had no hover feedback at all.
+    await close.hover();
+    await expect
+      .poll(async () => colorOf(close), { timeout: 2000 })
+      .not.toBe(restColor);
+  });
+});

--- a/tests/e2e/touch-targets.spec.ts
+++ b/tests/e2e/touch-targets.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "./fixtures/test-fixtures";
+import { waitForAppLoad } from "./helpers/test-helpers";
+
+/**
+ * The coarse-pointer target floor, measured on a touch context.
+ *
+ * DESIGN.md §5: "Controls are 38px tall on pointer devices and expand to at
+ * least 44px on coarse pointers." That expansion used to be opt-in — it only
+ * reached elements a developer remembered to mark with `.touch-target`, so any
+ * control that forgot the class shipped at desktop size on a phone. These
+ * specs pin the floor to the base component classes instead, where forgetting
+ * is not possible.
+ */
+test.use({ hasTouch: true });
+
+const PROBE_MARKUP = `
+  <div id="tt-probe" style="position:fixed;top:120px;left:120px;z-index:99999;
+       background:var(--paper);padding:40px;display:flex;flex-direction:column;gap:40px;">
+    <button class="btn btn-primary" id="tt-btn">Button</button>
+    <input class="input" id="tt-input" />
+    <label class="checkbox"><input type="checkbox" id="tt-checkbox" /><span>Check</span></label>
+    <label class="radio"><input type="radio" id="tt-radio" /><span>Radio</span></label>
+    <label class="switch"><input type="checkbox" id="tt-switch" /><span>Switch</span></label>
+  </div>
+`;
+
+test.describe("Coarse-pointer target floor", () => {
+  test.beforeEach(async ({ clearIndexedDB }) => {
+    // Fixture clears IndexedDB
+  });
+
+  test("the media query actually matches on a touch context", async ({ page }) => {
+    await waitForAppLoad(page);
+    const coarse = await page.evaluate(() => window.matchMedia("(pointer: coarse)").matches);
+    // If this ever goes false the rest of the file silently tests nothing.
+    expect(coarse).toBe(true);
+  });
+
+  test("sized controls meet the 44px height floor", async ({ page }) => {
+    await waitForAppLoad(page);
+    await page.evaluate((markup) => {
+      document.body.insertAdjacentHTML("beforeend", markup);
+    }, PROBE_MARKUP);
+
+    for (const id of ["tt-btn", "tt-input"]) {
+      const rect = await page.locator(`#${id}`).boundingBox();
+      expect(rect, `#${id} has no box`).not.toBeNull();
+      expect(rect!.height, `#${id} height`).toBeGreaterThanOrEqual(44);
+    }
+  });
+
+  test("small controls reach 44px without growing visually", async ({ page }) => {
+    await waitForAppLoad(page);
+    await page.evaluate((markup) => {
+      document.body.insertAdjacentHTML("beforeend", markup);
+    }, PROBE_MARKUP);
+
+    for (const id of ["tt-checkbox", "tt-radio", "tt-switch"]) {
+      const result = await page.evaluate((elementId) => {
+        const el = document.getElementById(elementId)!;
+        const r = el.getBoundingClientRect();
+        const cx = r.left + r.width / 2;
+        const cy = r.top + r.height / 2;
+        // 21px from centre is inside a 44px target and outside an 18px one.
+        // elementFromPoint resolves a pseudo-element to its originating
+        // element, so this measures the real tap reach rather than the
+        // declared box.
+        const hit = (dx: number, dy: number) =>
+          document.elementFromPoint(cx + dx, cy + dy) === el;
+        return {
+          visualWidth: r.width,
+          visualHeight: r.height,
+          up: hit(0, -21),
+          down: hit(0, 21),
+          left: hit(-21, 0),
+          right: hit(21, 0),
+        };
+      }, id);
+
+      expect(result.up, `#${id} reach up`).toBe(true);
+      expect(result.down, `#${id} reach down`).toBe(true);
+      expect(result.left, `#${id} reach left`).toBe(true);
+      expect(result.right, `#${id} reach right`).toBe(true);
+
+      // The point of expanding the hit area with a pseudo-element rather than
+      // min-width/min-height is that Violet Frost's compact control shapes
+      // survive. A 44px checkbox would be a different design.
+      expect(result.visualHeight, `#${id} visual height`).toBeLessThan(30);
+    }
+  });
+});

--- a/tests/ui/matrix-simplified.test.tsx
+++ b/tests/ui/matrix-simplified.test.tsx
@@ -224,22 +224,22 @@ describe("<MatrixSimplified>", () => {
     });
   });
 
-  // The two-column switch moved from lg: to md: (2026-08-14 design audit).
-  // At lg: the whole 768-1023px band — iPad portrait, Android tablets,
-  // split-screen, small laptops — stacked into one column, which is the one
-  // arrangement that destroys "the matrix is the argument": urgent-vs-important
-  // stops being spatial and becomes four lists in a row. The panes are
-  // constrained by height (min-h-280px), not width.
+  // Columns are decided by the grid's own available width, not by a viewport
+  // breakpoint (2026-08-14 design audit). A breakpoint cannot see the icon
+  // rail: at 768px the rail takes ~180px, so md:grid-cols-2 produced 245px
+  // panes with every title truncated to ~15 characters. Capped at two columns
+  // because auto-fit found three on a wide desktop, and 3+1 destroys the
+  // argument as thoroughly as 1x4.
   //
-  // Real two-column geometry at 768px is asserted in
-  // tests/e2e/layout-overlap.spec.ts; jsdom has no layout, so this only pins
-  // the breakpoint decision itself.
-  it("goes two-up from tablet widths and stacks only below them", () => {
+  // jsdom has no layout, so this only pins the mechanism. Real geometry and
+  // the 340px pane floor are measured in tests/e2e/layout-overlap.spec.ts.
+  it("sizes its columns by container width rather than viewport breakpoints", () => {
     render(<MatrixSimplified />);
     const grid = screen.getByTestId("matrix-grid");
 
-    expect(grid).toHaveClass("grid-cols-1", "md:grid-cols-2", "md:grid-rows-2");
-    expect(grid).not.toHaveClass("lg:grid-cols-2", "lg:grid-rows-2");
+    expect(grid.parentElement).toHaveClass("@container");
+    expect(grid).toHaveClass("@min-[696px]:grid-cols-2", "@min-[696px]:grid-rows-2");
+    expect(grid.className).not.toMatch(/\b(md|lg):grid-cols-2\b/);
   });
 
   // Tidewater un-merges the desktop grid: the four panes float on the page with

--- a/tests/ui/matrix-simplified.test.tsx
+++ b/tests/ui/matrix-simplified.test.tsx
@@ -224,12 +224,22 @@ describe("<MatrixSimplified>", () => {
     });
   });
 
-  it("keeps the matrix single-column at tablet widths and two-up at large widths", () => {
+  // The two-column switch moved from lg: to md: (2026-08-14 design audit).
+  // At lg: the whole 768-1023px band — iPad portrait, Android tablets,
+  // split-screen, small laptops — stacked into one column, which is the one
+  // arrangement that destroys "the matrix is the argument": urgent-vs-important
+  // stops being spatial and becomes four lists in a row. The panes are
+  // constrained by height (min-h-280px), not width.
+  //
+  // Real two-column geometry at 768px is asserted in
+  // tests/e2e/layout-overlap.spec.ts; jsdom has no layout, so this only pins
+  // the breakpoint decision itself.
+  it("goes two-up from tablet widths and stacks only below them", () => {
     render(<MatrixSimplified />);
     const grid = screen.getByTestId("matrix-grid");
 
-    expect(grid).toHaveClass("grid-cols-1", "lg:grid-cols-2", "lg:grid-rows-2");
-    expect(grid).not.toHaveClass("md:grid-cols-2", "md:grid-rows-2");
+    expect(grid).toHaveClass("grid-cols-1", "md:grid-cols-2", "md:grid-rows-2");
+    expect(grid).not.toHaveClass("lg:grid-cols-2", "lg:grid-rows-2");
   });
 
   // Tidewater un-merges the desktop grid: the four panes float on the page with

--- a/tests/ui/quadrant-active-cap.test.tsx
+++ b/tests/ui/quadrant-active-cap.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import {
+  QuadrantPane,
+  ACTIVE_RENDER_CAP,
+} from "@/components/matrix-simplified/quadrant-pane";
+import { quadrantForTask } from "@/lib/quadrants";
+import { createMockTask } from "@/tests/fixtures";
+import type { TaskRecord } from "@/lib/types";
+
+function renderPane(tasks: TaskRecord[]) {
+  return render(
+    <QuadrantPane
+      meta={quadrantForTask(true, true)}
+      tasks={tasks}
+      allTasks={tasks}
+      onEdit={vi.fn()}
+      onToggleComplete={vi.fn()}
+      onDelete={vi.fn()}
+      onShare={vi.fn()}
+      onAddInQuadrant={vi.fn()}
+    />,
+  );
+}
+
+function makeActive(count: number): TaskRecord[] {
+  return Array.from({ length: count }, (_, i) =>
+    createMockTask({
+      id: `t${i}`,
+      title: `Active task ${i}`,
+      urgent: true,
+      important: true,
+    }),
+  );
+}
+
+describe("QuadrantPane active-task cap", () => {
+  it("renders every card when the quadrant is under the cap", () => {
+    renderPane(makeActive(5));
+
+    expect(screen.getByText("Active task 0")).toBeInTheDocument();
+    expect(screen.getByText("Active task 4")).toBeInTheDocument();
+    expect(screen.queryByTestId("quadrant-more-active")).not.toBeInTheDocument();
+  });
+
+  it("renders exactly the cap and defers the rest", () => {
+    renderPane(makeActive(ACTIVE_RENDER_CAP + 12));
+
+    // The matrix is the only long-list surface that is not virtualized: every
+    // active card in all four panes is real DOM inside a SortableContext.
+    // Capping the render keeps a large backlog from turning the board into
+    // thousands of nodes.
+    expect(screen.getByText("Active task 0")).toBeInTheDocument();
+    expect(
+      screen.getByText(`Active task ${ACTIVE_RENDER_CAP - 1}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(`Active task ${ACTIVE_RENDER_CAP}`),
+    ).not.toBeInTheDocument();
+  });
+
+  it("says how many are deferred rather than hiding them silently", () => {
+    renderPane(makeActive(ACTIVE_RENDER_CAP + 12));
+
+    const more = screen.getByTestId("quadrant-more-active");
+    expect(more).toHaveTextContent("12 more");
+    expect(more).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("reveals the rest on request", async () => {
+    const user = userEvent.setup();
+    renderPane(makeActive(ACTIVE_RENDER_CAP + 12));
+
+    await user.click(screen.getByTestId("quadrant-more-active"));
+
+    // Nothing is hidden permanently — the cap is a render budget, not a filter.
+    expect(
+      screen.getByText(`Active task ${ACTIVE_RENDER_CAP + 11}`),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("quadrant-more-active")).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+
+  it("keeps the header count honest about the full total", () => {
+    renderPane(makeActive(ACTIVE_RENDER_CAP + 12));
+
+    // The count is what tells the user the quadrant is overloaded. Reporting
+    // the rendered subset would hide exactly the problem worth acting on.
+    const header = screen.getByTestId("quadrant-header");
+    expect(header).toHaveTextContent(String(ACTIVE_RENDER_CAP + 12));
+  });
+});

--- a/tests/ui/settings-sidebar.test.tsx
+++ b/tests/ui/settings-sidebar.test.tsx
@@ -53,4 +53,38 @@ describe("SettingsSidebar", () => {
       }
     });
   });
+
+  describe("current-section semantics", () => {
+    it("marks the active section without claiming a page navigation occurred", () => {
+      renderSidebar();
+      const current = screen
+        .getAllByRole("button", { name: /Appearance/ })
+        .map((el) => el.getAttribute("aria-current"));
+
+      expect(current).toHaveLength(2);
+      // These buttons switch a section within one route. aria-current="page"
+      // tells assistive tech the user navigated to a different page when they
+      // did not; "true" is the accurate token for a non-navigation selection.
+      expect(current.every((value) => value === "true")).toBe(true);
+    });
+
+    it("leaves inactive sections unmarked", () => {
+      renderSidebar();
+      for (const el of screen.getAllByRole("button", { name: /Notifications/ })) {
+        expect(el).not.toHaveAttribute("aria-current");
+      }
+    });
+  });
+
+  describe("mobile overflow", () => {
+    it("signals that more sections exist past the right edge", () => {
+      const { container } = renderSidebar();
+      // Eight sections in a scroller with the scrollbar deliberately hidden.
+      // Without a cue at the trailing edge, the sections past the fold are
+      // discoverable only by guessing that the row scrolls at all.
+      const scroller = container.querySelector("[data-testid='settings-nav-scroller']");
+      expect(scroller).not.toBeNull();
+      expect(scroller?.className).toMatch(/mask-/);
+    });
+  });
 });

--- a/tests/ui/settings-sidebar.test.tsx
+++ b/tests/ui/settings-sidebar.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SettingsSidebar } from "@/components/settings-page/settings-sidebar";
+import { SETTINGS_SECTION_IDS } from "@/components/settings-page/settings-sidebar-data";
+
+function renderSidebar() {
+  return render(
+    <SettingsSidebar
+      activeId="appearance"
+      onSelect={vi.fn()}
+      visibleSections={SETTINGS_SECTION_IDS}
+    />,
+  );
+}
+
+describe("SettingsSidebar", () => {
+  // The sidebar ships twice — a horizontal pill row for mobile and a vertical
+  // rail for desktop — and only one is visible at a time via CSS. jsdom applies
+  // no stylesheet, so both are in the tree here.
+  describe("landmarks", () => {
+    it("exposes both the mobile and desktop navigation as named landmarks", () => {
+      renderSidebar();
+      const navs = screen.getAllByRole("navigation", { name: "Settings sections" });
+      expect(navs).toHaveLength(2);
+    });
+
+    it("does not leave the desktop rail as an unnamed complementary region", () => {
+      const { container } = renderSidebar();
+      const aside = container.querySelector("aside");
+      expect(aside).not.toBeNull();
+      // Screen-reader and keyboard users navigate settings by landmark. The
+      // desktop rail is where that matters most, so the <nav> has to live
+      // inside the <aside>, not be replaced by it.
+      expect(aside?.querySelector("nav")).not.toBeNull();
+    });
+  });
+
+  describe("group label contrast", () => {
+    it("renders the group headings at full muted strength, never alpha-reduced", () => {
+      const { container } = renderSidebar();
+      const headings = Array.from(container.querySelectorAll("p")).filter((el) =>
+        ["Preferences", "Data", "Info"].includes(el.textContent?.trim() ?? ""),
+      );
+      expect(headings.length).toBeGreaterThan(0);
+
+      for (const heading of headings) {
+        // --gray-500 (#646477) is the documented muted-text floor at 5.69:1 on
+        // paper. An alpha modifier composites it to a lighter colour the token
+        // system never measured: /80 lands at 3.72:1, under the AA 4.5:1 floor,
+        // and it fails in light mode only — so it hides from dark-mode testing.
+        expect(heading.className).toContain("text-foreground-muted");
+        expect(heading.className).not.toMatch(/text-foreground-muted\/\d+/);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes the findings from an `/impeccable audit` of the core product surfaces — matrix + capture bar, task card, dashboard, settings, and the shared `ui/` primitives.

Full report: https://claude.ai/code/artifact/135957c7-806a-4cbe-9b02-1b9c6ddb440b

## What changed

**P1 — WCAG AA / stated-contract violations**

- **Settings sidebar group labels failed AA in light mode.** `text-foreground-muted/80` composited `--gray-500` to ~`#828292`, measuring **3.72:1** at 10px. Dark mode measured 4.89:1 and passed, so the failure was invisible to anyone testing in dark. Alpha modifiers escape the token system's measured contrast guarantees. Now 5.69:1 light / 6.84:1 dark.
- **`useCountUp` ignored `prefers-reduced-motion`.** Because it drives a `requestAnimationFrame` loop, the global CSS reduced-motion block could not reach it — the dashboard's hero numbers animated regardless of the user's setting. PRODUCT.md states every animation has a reduced-motion fallback; this one did not.

**P2**

- **The blanket `0.01ms` reset froze the spinner.** `animation-iteration-count: 1 !important` clamped `animate-spin` to one 0.01ms revolution. Assistive tech still announced "Loading"; sighted reduced-motion users saw an app that looked hung. Progress feedback is now exempt.
- **`.button-reset` defeated adjacent colour utilities.** Declared unlayered, its `color: inherit` beat `text-*`/`hover:text-*` in `@layer utilities` regardless of specificity, killing the hover state on every dialog's close button. Moved into `@layer components`.
- **The matrix grid is now sized by container width.** A viewport breakpoint cannot see the icon rail, so it could not know how much room the grid actually had. Capped at two columns — `auto-fit` found three on a wide desktop, and 3+1 destroys the argument as thoroughly as a 1×4 stack.
- **The desktop settings rail had no navigation landmark** (WCAG 1.3.1, A) — it shipped as `<aside> → <div> → <ul>` while the mobile branch was a proper named `<nav>`.
- **Per-quadrant render cap.** The matrix was the only long-list surface not virtualized. Capped at 50 active cards with a "N more" disclosure; every id still enters `SortableContext`, so drag-and-drop is untouched.
- **The 44px coarse-pointer floor is now structural.** DESIGN.md promised it but delivery depended on hand-placing `.touch-target` at 38 call sites. Small toggles expand their hit area via a pseudo-element, keeping Violet Frost's compact shapes.

**P3**

Off-ramp `text-xl` → `text-h3`; `--text-title` and `--text-label` removed as drifted duplicates of steps Inkwell already ships; inert `.rd-serif` dropped; five unreferenced animation utilities deleted; mobile settings nav gained an overflow cue; `aria-current="page"` → `"true"`.

DESIGN.md §3 gains the **One-Ramp Rule**, recording when Tailwind's default size names are permitted so the two vocabularies coexist by decision rather than drift.

## How to test locally

```
bun run test          # 2770 pass
bun typecheck
bun lint
npx playwright test --project=chromium   # 107 pass
```

Four of these defects are invisible to the unit suite by construction — jsdom never loads the built stylesheet — so they are covered by new Playwright computed-style, geometry and touch-context specs: `token-cascade.spec.ts`, `reduced-motion.spec.ts`, `touch-targets.spec.ts`, and additions to `layout-overlap.spec.ts`.

Live-verified in Chrome, light and dark, service-worker busted and IndexedDB seeded.

## Known deferrals

- **The detector still reports 22 advisories — unchanged.** All 22 are arbitrary `text-[Npx]` values, which the chosen P3 scope did not cover. The One-Ramp Rule states the policy for resolving them.
- The detector cannot see fractional sizes (`text-[14.5px]`) or named Tailwind steps at all.
- **The audit's tablet claim was partly overstated.** At 768px the expanded rail leaves 506px and two readable panes need ~696px, so iPad portrait genuinely cannot show a 2×2. Collapsing the rail below `lg:` is the real fix and is a separate design decision.
- `ACTIVE_RENDER_CAP = 50` is a defensible budget, not a profiled one.
- e2e ran chromium only. `design-lab.spec.ts:119` flaked once under parallel load and passed on re-run and in isolation.

https://claude.ai/code/session_019q2wgxkEad7JgwhZTDEPjL
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->