### PR TITLE
fix(task-card): keep the drag grip inside its lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.11.11
+**Current version:** 11.11.12
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/components/task-card/index.tsx
+++ b/components/task-card/index.tsx
@@ -76,9 +76,13 @@ export function TaskCard({
       className={cn(
         // Explicit property list (not transition-all): only these change on the
         // card, and `all` would also transition the dnd-kit drag transform.
-        // Asymmetric padding: the extra 4px on the left is the gutter the
-        // spine sits in, so the title still starts on the card's optical edge.
-        "group relative flex flex-col gap-2 rounded-md border bg-card py-3 pl-4 pr-3 transition-[transform,border-color,box-shadow,opacity] duration-200 ease-out animate-slide-in-card",
+        "group relative flex flex-col gap-2 rounded-md border bg-card py-3 pr-3 transition-[transform,border-color,box-shadow,opacity] duration-200 ease-out animate-slide-in-card",
+        // The left inset covers the spine's 4px gutter plus the lane the drag
+        // grip floats in. It lives here, on the card, rather than on the title
+        // alone: padding only the title left tags, chips, and the due-date row
+        // starting 8px to its left, so the card read as ragged. Selection mode
+        // swaps the grip for an in-flow checkbox and reclaims the lane.
+        selectionMode ? "pl-4" : "pl-6",
         // Clear the sticky topbar + capture bar (plus ~12pt) when scrolled to.
         "scroll-mt-24",
         "border-card-border",

--- a/components/task-card/task-card-actions.tsx
+++ b/components/task-card/task-card-actions.tsx
@@ -38,7 +38,10 @@ export function TaskCardActions({
   onSnooze,
 }: TaskCardActionsProps) {
   return (
-    <div className="flex items-center justify-between gap-2 text-xs text-foreground-muted">
+    <div
+      data-testid="task-card-actions"
+      className="flex items-center justify-between gap-2 text-xs text-foreground-muted"
+    >
       <div className="flex items-center gap-2">
         {taskIsDueToday && !taskIsOverdue ? (
           // Due today reads as accent-semibold; the warning glyph is reserved

--- a/components/task-card/task-card-header.tsx
+++ b/components/task-card/task-card-header.tsx
@@ -85,9 +85,9 @@ export function TaskCardHeader({
         <div
           className={cn(
             "min-w-0 flex-1",
-            // Clears the grip's column. The grip is absolute from the card's
-            // border and overruns the 16px card padding by 8px, so without this
-            // it lands on the title's first character.
+            // Reserves the grip's lane. The grip is absolute from the card's
+            // border and overruns the 16px card padding, so without this it
+            // lands on the title's first character.
             !selectionMode && "pl-2",
             reserveBadgeSpace && "pr-24"
           )}
@@ -210,12 +210,16 @@ function CardLeadingControl({
           // the pointer, Playwright's `hover()` included.
           <button
             type="button"
-            // The 24px button starts at the card's left border and the card
-            // pads 16px, so it reached 8px into the text column and covered the
-            // title's leading glyph — "QA TEST 3" read as "A TEST 3". An opaque
-            // fill made that look deliberate rather than fixing it; the text
-            // column now reserves the missing 8px instead (see the wrapper).
-            className="task-card-grip touch-target absolute left-0 top-2.5 z-10 flex h-6 w-6 cursor-grab touch-none items-center justify-center rounded-icon bg-card opacity-0 transition-opacity hover:bg-background-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent group-hover:opacity-100 group-focus-within:opacity-100 [@media(pointer:coarse)]:static [@media(pointer:coarse)]:opacity-100"
+            // Sized to the lane, which is narrow: the spine ends 4px in and the
+            // reserved text column starts at 25px, leaving 21px. A 24px button
+            // at left-0 could not fit, so it painted over both neighbours — the
+            // spine vanished under its opaque fill for 24px, and its right edge
+            // landed on the title's first glyph ("Deepsec" read as ")eepsec").
+            // 16px inset 6px leaves 3px of air before the spine and 2px after,
+            // and the fill is gone: a transparent grip cannot erase what it
+            // floats over, so the next rounding error is cosmetic, not a bug.
+            // Coarse pointers drop the float entirely — see globals.css.
+            className="task-card-grip touch-target absolute left-[6px] top-3 z-10 flex h-5 w-4 cursor-grab touch-none items-center justify-center rounded-icon opacity-0 transition-opacity hover:bg-background-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent group-hover:opacity-100 group-focus-within:opacity-100 [@media(pointer:coarse)]:static [@media(pointer:coarse)]:opacity-100"
             aria-label="Drag to move task"
             {...sortableAttributes}
             {...sortableListeners}

--- a/components/task-card/task-card-header.tsx
+++ b/components/task-card/task-card-header.tsx
@@ -85,10 +85,6 @@ export function TaskCardHeader({
         <div
           className={cn(
             "min-w-0 flex-1",
-            // Reserves the grip's lane. The grip is absolute from the card's
-            // border and overruns the 16px card padding, so without this it
-            // lands on the title's first character.
-            !selectionMode && "pl-2",
             reserveBadgeSpace && "pr-24"
           )}
         >
@@ -211,8 +207,8 @@ function CardLeadingControl({
           <button
             type="button"
             // Sized to the lane, which is narrow: the spine ends 4px in and the
-            // reserved text column starts at 25px, leaving 21px. A 24px button
-            // at left-0 could not fit, so it painted over both neighbours — the
+            // card's content edge is at 25px, leaving 21px. A 24px button at
+            // left-0 could not fit, so it painted over both neighbours — the
             // spine vanished under its opaque fill for 24px, and its right edge
             // landed on the title's first glyph ("Deepsec" read as ")eepsec").
             // 16px inset 6px leaves 3px of air before the spine and 2px after,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.11.11",
+	"version": "11.11.12",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '11.11.11';
+const CACHE_VERSION = '11.11.12';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 

--- a/tests/e2e/drag-and-drop.spec.ts
+++ b/tests/e2e/drag-and-drop.spec.ts
@@ -352,9 +352,20 @@ async function keyboardDragOut(page: Page, dragHandle: Locator) {
   await page.keyboard.press("Space");
   await expect(page.locator("[data-testid='drag-overlay']")).toBeVisible();
 
-  for (let press = 0; press < 5; press += 1) {
+  // Each step has to settle before the next one is worth taking. dnd-kit's
+  // KeyboardSensor scrolls between steps with `behavior: 'smooth'` (its
+  // default — lib/use-drag-and-drop.ts does not override it), so the
+  // announcement for a press lands a frame or two after the key. Pressing and
+  // counting in the same breath raced that scroll, which made the number of
+  // steps needed depend on sub-pixel card geometry: a 2px change to the drag
+  // handle's box was enough to flip this test red without touching drag at all.
+  for (let press = 0; press < 8; press += 1) {
     await page.keyboard.press("ArrowUp");
-    if (await overOtherQuadrant.count()) break;
+    const crossed = await overOtherQuadrant
+      .first()
+      .waitFor({ state: "attached", timeout: 500 })
+      .then(() => true, () => false);
+    if (crossed) break;
   }
   await expect(overOtherQuadrant.first()).toBeVisible();
 

--- a/tests/e2e/layout-overlap.spec.ts
+++ b/tests/e2e/layout-overlap.spec.ts
@@ -20,7 +20,13 @@ test.describe("Layout overlap", () => {
     // Fixture clears IndexedDB
   });
 
-  test("the drag grip does not cover the title's first character", async ({ page }) => {
+  // The grip floats in the lane between the quadrant spine and the title. It is
+  // an opaque-on-hover box painted at z-10, so anything it overlaps it erases —
+  // and a lane it merely *touches* re-breaks on the next subpixel rounding.
+  // Both neighbours therefore get a real gap, not a shared edge.
+  const GRIP_CLEARANCE = 2;
+
+  test("the drag grip clears the title's first character", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await waitForAppLoad(page);
     await createTaskViaCaptureBar(page, "QA TEST 3 !!");
@@ -35,8 +41,30 @@ test.describe("Layout overlap", () => {
     const titleBox = await box(card.locator("h3"));
 
     // The grip used to overhang the gutter by 8px, hiding the leading glyph —
-    // "QA TEST 3" rendered as "A TEST 3".
-    expect(gripBox.x + gripBox.width).toBeLessThanOrEqual(titleBox.x + 1);
+    // "QA TEST 3" rendered as "A TEST 3". Reserving exactly enough space fixed
+    // the overhang but left the edges flush, so the glyph's antialiasing was
+    // still being nibbled: "Deepsec" rendered as ")eepsec".
+    expect(gripBox.x + gripBox.width).toBeLessThanOrEqual(titleBox.x - GRIP_CLEARANCE);
+  });
+
+  test("the drag grip clears the quadrant spine", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await waitForAppLoad(page);
+    await createTaskViaCaptureBar(page, "Spine check !!");
+
+    const card = page.locator("[data-testid='task-card']").filter({ hasText: "Spine check" });
+    await card.hover();
+
+    const grip = card.getByRole("button", { name: "Drag to move task" });
+    await expect(grip).toBeVisible();
+
+    const gripBox = await box(grip);
+    const spineBox = await box(card.locator("[data-testid='task-card-spine']"));
+
+    // Both anchor to the card's padding box, so `left-0` stacked them: the
+    // grip's opaque fill painted over the top 24px of the spine and read as the
+    // icon breaking out through the card's left edge.
+    expect(gripBox.x).toBeGreaterThanOrEqual(spineBox.x + spineBox.width + GRIP_CLEARANCE);
   });
 
   test("the mobile capture bar does not cover the last task card", async ({ page }) => {

--- a/tests/e2e/layout-overlap.spec.ts
+++ b/tests/e2e/layout-overlap.spec.ts
@@ -67,6 +67,25 @@ test.describe("Layout overlap", () => {
     expect(gripBox.x).toBeGreaterThanOrEqual(spineBox.x + spineBox.width + GRIP_CLEARANCE);
   });
 
+  test("every row on a card shares one left edge", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await waitForAppLoad(page);
+    await createTaskViaCaptureBar(page, "Aligned rows !! #infra");
+
+    const card = page.locator("[data-testid='task-card']").filter({ hasText: "Aligned rows" });
+    await card.hover();
+
+    const title = await box(card.locator("h3"));
+    const tag = await box(card.locator("[data-testid='task-tag']").first());
+    const actions = await box(card.locator("[data-testid='task-card-actions']"));
+
+    // The grip's lane was reserved by padding the title's wrapper, which its
+    // sibling rows do not share — so tags and the due-date/actions row started
+    // 8px to the title's left and the card read as ragged.
+    expect(Math.abs(tag.x - title.x), "tag row vs title").toBeLessThanOrEqual(1);
+    expect(Math.abs(actions.x - title.x), "actions row vs title").toBeLessThanOrEqual(1);
+  });
+
   test("the mobile capture bar does not cover the last task card", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await waitForAppLoad(page);


### PR DESCRIPTION
## What changed

Two related defects in the task card's left gutter, both reported from the same screenshot.

### 1. The drag grip painted over its neighbours

The grip was a 24px opaque box anchored at `left-0` — the same origin the quadrant spine uses. Both resolve against the card's **padding box**, so they were stacked by construction: the grip's `bg-card` fill painted over the spine's top 24px at `z-10`, and its right edge landed exactly on the title's first glyph. "Deepsec" rendered as ")eepsec", and the grip read as breaking out through the card's left edge.

| | Before | After |
|---|---|---|
| Grip (card-relative) | `x 1 → 25` | `x 7 → 23` |
| Gap to spine | **−3px** (covering it) | **+3px** |
| Gap to title text | **0px** | **+2px** |
| Grip background | opaque `rgb(253,253,255)` | transparent |
| Topmost paint at spine's x | `task-card-grip` | the card (spine visible) |

The lane between the spine (ends at 4px) and the content edge (25px) is **21px** — a 24px box could never fit, so it had to overlap something. An earlier fix added `pl-2` to the title's wrapper, which bought clearance but left the edges flush at exactly 0px, which is why the glyph nibbling survived it.

Two changes, one geometric and one durable: the grip is now 16px inset 6px, and the opaque fill is gone — a transparent handle cannot erase what it floats over, so the next rounding drift degrades to "slightly close" rather than "eats its neighbour."

### 2. The rows didn't share a left edge

That `pl-2` reserve lived on the title's wrapper, which its sibling rows do not share — so tags, dependency chips, and the due-date/actions row all started 8px to the title's left.

| Row | Before | After |
|---|---|---|
| Title / description | 25px | 25px |
| Tags | 17px | **25px** |
| Dependency chips, timer | 17px | **25px** |
| Due date / actions | 17px | **25px** |

The inset moves to the card, where every row sees it. Selection mode keeps the narrower padding — it swaps the grip for an in-flow checkbox, so there is no lane to reserve, and its geometry is unchanged.

### 3. A pre-existing race in the keyboard-drag test

Fixing (1) turned two keyboard-drag e2e tests red, which is worth spelling out because the cause is **not** drag logic.

`lib/use-drag-and-drop.ts` constructs `KeyboardSensor` without a `scrollBehavior` override, so dnd-kit scrolls between arrow steps with `behavior: 'smooth'`. The test helper pressed ArrowUp and counted the announcement in the same breath, racing that scroll — which made the number of steps needed depend on sub-pixel card geometry. A 2px change to the drag handle was enough to flip it.

Instrumenting the traversal showed the chaos runs both ways: under slower probe timing, `main` failed to cross a quadrant in 10 presses while the new geometry crossed at 3. Neither is better — the test was a coin flip that happened to land heads. The helper now waits for each step to settle.

**The helper fix was verified against `main`'s grip geometry as well as the new one — 8/8 both ways.** A test fix that only works with the change under review isn't a fix.

## Testing

`jsdom` has no layout engine — `getBoundingClientRect` returns zeros — so these defects are invisible to the 2,770-test unit suite by construction. Playwright is the only place they can be asserted.

- **Tightened** `the drag grip clears the title's first character` — the existing assertion had a `+1px` tolerance that let the flush case pass (`258 <= 258 + 1`) while the glyph was visibly clipped.
- **Added** `the drag grip clears the quadrant spine`.
- **Added** `every row on a card shares one left edge`, with a `data-testid` on the actions row to anchor it.

Each was confirmed red against the old code before the fix.

- 109/109 chromium e2e pass
- 2,770 unit tests pass
- `bun typecheck` and `bun lint` clean

## Verified in the running app

Driven live at `localhost:3000` with the PWA service worker busted and IndexedDB seeded to reproduce the reported cards. Confirmed in **light and dark mode**, console clean. The `elementFromPoint` probe that used to return `task-card-grip` at the spine's coordinates now returns the card.

## Known trade-off

Card padding is now 24px left / 12px right — measured from the spine's edge, 21px vs 12px. `pr-3` was deliberately left alone: the completion disc's size is pinned *because* it drifts against "the fixed 12px card padding," so widening the right side would contradict that decision. `pr-4` would balance it at 21/16 if the asymmetry proves distracting.

## How to test locally

1. `bun dev`, add a task with a tag and a due date, hover its card.
2. The grip sits inside the card with air on both sides; the spine runs unbroken behind it; the title's first character is fully drawn; title, tags, and the due-date row share one left edge.
3. `bun run test:e2e -- --project=chromium layout-overlap.spec.ts drag-and-drop.spec.ts`

Version bumped 11.11.11 → 11.11.12 (patch), with `README.md` and the service worker `CACHE_VERSION` kept in sync.

https://claude.ai/code/session_01TkRDLjW9NLH38bvkTiFHqJ