### PR TITLE
fix: remediate the Sentry review findings (telemetry signal + hydration)

### DIFF
--- a/.claude/skills/sentry-verification/SKILL.md
+++ b/.claude/skills/sentry-verification/SKILL.md
@@ -5,9 +5,23 @@ description: Verify Sentry error capture is working after a DSN change or deploy
 
 ## Sentry verification (recurring debugging task)
 
-When testing Sentry capture after a DSN change or deploy:
+**Development never sends events.** `initSentry()` in `lib/sentry.ts` returns
+early when `ENV_CONFIG.isDevelopment` (localhost/127.0.0.1/*.local), so a dev
+server will not report to Sentry no matter what you trigger. Verify capture one
+of two ways:
 
-1. Confirm DSN is loaded: `console.log` in `lib/sentry/init.ts` (or wherever Sentry.init runs) and grep dev console for "Sentry initialized".
-2. Trigger a test error: `Sentry.captureException(new Error("manual-test-from-claude"))` in a dev-only handler, OR throw from a component error boundary.
-3. Verify in Sentry dashboard within ~30s.
-4. Remove the test trigger before commit (it's not a regression — leave it out of source).
+- **Staging (preferred):** deploy to `gsd-dev.vinny.dev` and trigger the test
+  error there.
+- **Local, gate lifted:** temporarily remove `|| ENV_CONFIG.isDevelopment` from
+  the `initSentry` guard, verify, then restore it before commit.
+
+Then:
+
+1. Confirm DSN is loaded: `console.log` in `lib/sentry.ts` where `Sentry.init`
+   runs and grep the console for it.
+2. Trigger a test error: `captureException(new Error("manual-test-from-claude"))`
+   in a dev-only handler, OR throw from a component error boundary.
+3. Verify in the Sentry dashboard within ~30s. Expect the message to read
+   "Error details redacted" — that's the privacy sanitizer working, not a
+   failure. Check the event's type, stack frames, and `gsd` context instead.
+4. Remove the test trigger (and restore the dev gate if lifted) before commit.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 11.11.12
+**Current version:** 11.11.13
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -22,6 +22,7 @@
  */
 
 import { captureException, captureMessage } from '@/lib/sentry';
+import { SENTRY_SAFE_METADATA_KEYS } from '@/lib/sentry-safe-keys';
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
@@ -230,17 +231,6 @@ function maskError(error: Error): Error {
   masked.stack = error.stack ? maskSensitiveString(error.stack) : undefined;
   return masked;
 }
-
-/**
- * Diagnostic metadata keys that are safe to send to Sentry (an external SaaS).
- * Allowlist, not denylist: anything not listed — task `input`, PocketBase
- * `record`, etc. — is dropped so free-text user content never leaves the device.
- */
-const SENTRY_SAFE_METADATA_KEYS: ReadonlySet<string> = new Set([
-  'correlationId', 'userId', 'taskId', 'deviceId', 'phase', 'operation',
-  'action', 'trigger', 'triggeredBy', 'validationErrors', 'componentStack',
-  'count', 'attempt', 'status', 'statusCode', 'type', 'url', 'timestamp',
-]);
 
 /**
  * Keep only allowlisted, secret-masked diagnostic metadata. This is the single

--- a/lib/sentry-safe-keys.ts
+++ b/lib/sentry-safe-keys.ts
@@ -1,0 +1,16 @@
+/**
+ * Diagnostic metadata keys that are safe to send to Sentry (an external SaaS).
+ * Allowlist, not denylist: anything not listed — task `input`, PocketBase
+ * `record`, etc. — is dropped so free-text user content never leaves the device.
+ *
+ * Lives in its own module because both gates need it — `lib/logger.ts` filters
+ * metadata before capture, and `lib/sentry.ts` filters the `gsd` context again
+ * in `beforeSend` — and logger tests mock `@/lib/sentry` wholesale, which would
+ * erase the set if it lived there.
+ */
+export const SENTRY_SAFE_METADATA_KEYS: ReadonlySet<string> = new Set([
+  'correlationId', 'userId', 'taskId', 'deviceId', 'phase', 'operation',
+  'action', 'trigger', 'triggeredBy', 'validationErrors', 'componentStack',
+  'count', 'attempt', 'status', 'statusCode', 'type', 'url', 'timestamp',
+  'errorCode',
+]);

--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/browser";
 import type { Breadcrumb, ErrorEvent } from "@sentry/browser";
 import { ENV_CONFIG } from "@/lib/env-config";
+import { SENTRY_SAFE_METADATA_KEYS } from "@/lib/sentry-safe-keys";
 
 const REDACTED = "***";
 const REDACTED_ERROR_MESSAGE = "Error details redacted";
@@ -11,18 +12,35 @@ const MAX_CONTEXT_ARRAY_ITEMS = 20;
 const MAX_EVENT_BREADCRUMBS = 50;
 const MAX_EVENT_EXCEPTIONS = 10;
 const MAX_STACK_FRAMES = 100;
+// Fixed vocabulary only — names carry no user content. The DOMException names
+// cover IndexedDB, AbortController, and permission failures so stackless
+// errors from those APIs still group by cause instead of collapsing to "Error".
 const SAFE_ERROR_TYPES = new Set([
+  "AbortError",
   "AggregateError",
   "ApiError",
+  "ClientResponseError",
+  "ConstraintError",
+  "DataError",
   "DOMException",
   "Error",
   "EvalError",
+  "InvalidStateError",
+  "NetworkError",
+  "NotAllowedError",
+  "NotFoundError",
   "PocketBaseError",
+  "QuotaExceededError",
   "RangeError",
   "ReferenceError",
+  "SecurityError",
   "SyntaxError",
+  "TimeoutError",
+  "TransactionInactiveError",
   "TypeError",
+  "UnknownError",
   "URIError",
+  "VersionError",
   "ZodError",
 ]);
 const SAFE_APP_ROUTE_PATHS = new Set([
@@ -40,6 +58,13 @@ const SAFE_APP_ROUTE_PATHS = new Set([
   "/sync-history",
   "/sync-history/",
 ]);
+// `context` is the logger's fixed context name; `logMessage` is the vouched
+// copy of an already-masked log message that only our captureMessage writes.
+const SAFE_GSD_CONTEXT_KEYS: ReadonlySet<string> = new Set([
+  "context",
+  "logMessage",
+  ...SENTRY_SAFE_METADATA_KEYS,
+]);
 const SENSITIVE_KEY_PATTERN =
   /(?:password|passcode|secret|token|api[_-]?key|apikey|authorization|auth|session|cookie|refresh|access[_-]?token)/i;
 const SENSITIVE_ASSIGNMENT_PATTERN =
@@ -53,7 +78,11 @@ const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
 export function initSentry(): void {
   const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
-  if (!dsn) {
+  // Development stays local: dev sessions produced most of the Sentry noise
+  // (78% of the highest-volume issue) while never representing real users.
+  // To test capture end-to-end, use staging or temporarily lift this gate —
+  // see .claude/skills/sentry-verification/SKILL.md.
+  if (!dsn || ENV_CONFIG.isDevelopment) {
     return;
   }
 
@@ -82,6 +111,11 @@ export function captureException(
 /**
  * Capture a string message as an error-level Sentry event.
  * Used for logged errors that carry no Error object (e.g. validation failures).
+ *
+ * The masked message rides along as `contexts.gsd.logMessage` because the
+ * `beforeSend` allowlist drops the untrusted top-level `message` field; only
+ * this vouched copy — written exclusively here, after masking — is promoted
+ * back to `message` on the outgoing event.
  */
 export function captureMessage(
   message: string,
@@ -89,9 +123,15 @@ export function captureMessage(
 ): void {
   if (!Sentry.getClient()) return;
 
-  Sentry.captureMessage(maskSensitiveString(message), {
+  const masked = maskSensitiveString(message);
+  Sentry.captureMessage(masked, {
     level: "error",
-    ...(context ? { contexts: { gsd: sanitizeContext(context) } } : {}),
+    contexts: {
+      gsd: {
+        ...(context ? sanitizeContext(context) : {}),
+        logMessage: masked,
+      },
+    },
   });
 }
 
@@ -110,6 +150,11 @@ function sanitizeException(error: unknown): Error {
       .slice(1, MAX_STACK_FRAMES + 1)
       .map((line) => maskSensitiveString(line));
     sanitized.stack = [`${sanitized.name}: ${REDACTED_ERROR_MESSAGE}`, ...frames].join("\n");
+  } else {
+    // A stackless original must stay stackless. Leaving the copy's own stack
+    // in place would point every such event at this wrapper and collapse all
+    // stackless errors into one misleading Sentry issue.
+    sanitized.stack = undefined;
   }
 
   // Deliberately do not copy custom properties, `cause`, or AggregateError
@@ -276,6 +321,17 @@ function sanitizeEvent(event: ErrorEvent): ErrorEvent {
         .map((breadcrumb) => sanitizeBreadcrumb(breadcrumb));
     }
 
+    const gsd = sanitizeEventGsdContext(event.contexts);
+    if (gsd) {
+      const { logMessage, ...rest } = gsd;
+      if (typeof logMessage === "string") {
+        sanitized.message = logMessage;
+      }
+      if (Object.keys(rest).length > 0) {
+        sanitized.contexts = { gsd: rest };
+      }
+    }
+
     return sanitized;
   } catch {
     return minimalSafeEvent(event);
@@ -387,6 +443,30 @@ function sanitizeEventException(
       };
     }),
   };
+}
+
+/**
+ * Keep only allowlisted keys of the app's own `gsd` context, re-masked. All
+ * other contexts (and non-allowlisted gsd keys) stay dropped — they may carry
+ * task content from any capture path.
+ */
+function sanitizeEventGsdContext(
+  contexts: ErrorEvent["contexts"]
+): Record<string, unknown> | undefined {
+  const gsd = contexts?.gsd;
+  if (!gsd || typeof gsd !== "object" || Array.isArray(gsd)) {
+    return undefined;
+  }
+
+  const allowed = Object.fromEntries(
+    Object.entries(gsd as Record<string, unknown>).filter(([key]) =>
+      SAFE_GSD_CONTEXT_KEYS.has(key)
+    )
+  );
+  if (Object.keys(allowed).length === 0) {
+    return undefined;
+  }
+  return sanitizeRecord(allowed, new WeakSet(), 0);
 }
 
 function sanitizeTelemetryUrl(

--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -5,6 +5,16 @@ import { SENTRY_SAFE_METADATA_KEYS } from "@/lib/sentry-safe-keys";
 
 const REDACTED = "***";
 const REDACTED_ERROR_MESSAGE = "Error details redacted";
+// Fixed labels for React's minified production errors. Only the error number
+// is read from the original message — never its args, which can carry DOM
+// text. Keeping the number makes hydration failures identifiable in Sentry
+// instead of collapsing into the generic redaction.
+const REACT_ERROR_PATTERN = /react\.dev\/errors\/(\d{3})/;
+const REACT_ERROR_LABELS: Record<string, string> = {
+  "418": "hydration mismatch",
+  "423": "root switched to client render",
+  "425": "hydration text mismatch",
+};
 const CAPTURE_QUERY_KEYS = ["action", "title", "url", "tags"] as const;
 const MAX_CONTEXT_DEPTH = 4;
 const MAX_CONTEXT_KEYS = 30;
@@ -428,7 +438,7 @@ function sanitizeEventException(
 
       return {
         type,
-        value: REDACTED_ERROR_MESSAGE,
+        value: describeExceptionValue(value.value),
         ...(value.mechanism
           ? {
               mechanism: {
@@ -443,6 +453,21 @@ function sanitizeEventException(
       };
     }),
   };
+}
+
+/**
+ * Redact an exception message, preserving only a React minified-error number
+ * (a fixed framework vocabulary, no user content) when one is present.
+ */
+function describeExceptionValue(raw: unknown): string {
+  if (typeof raw === "string") {
+    const match = raw.match(REACT_ERROR_PATTERN);
+    if (match) {
+      const label = REACT_ERROR_LABELS[match[1]];
+      return `React minified error #${match[1]}${label ? ` (${label})` : ""}`;
+    }
+  }
+  return REDACTED_ERROR_MESSAGE;
 }
 
 /**

--- a/lib/use-count-up.ts
+++ b/lib/use-count-up.ts
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useSyncExternalStore } from "react";
 import { prefersReducedMotion } from "@/lib/prefers-reduced-motion";
+
+const noopSubscribe = () => () => {};
 
 /**
  * Animates a number from 0 to the target value on mount.
@@ -17,7 +19,17 @@ export function useCountUp(target: number | string, duration = 500): string {
   // it would short-circuit away in tests, leaving the guard permanently
   // unexercised — which is how a reduced-motion regression ships unnoticed.
   const skipAnimation = prefersReducedMotion() || process.env.NODE_ENV === "test";
-  const [current, setCurrent] = useState(skipAnimation ? numericTarget : 0);
+  // Hydration parity: the static export prerenders every count-up as 0, so the
+  // hydration render must also produce 0 even when the client prefers reduced
+  // motion — a motion-dependent first paint is a text mismatch (React #418).
+  // useSyncExternalStore's server snapshot keeps the hydration render at 0;
+  // the first post-hydration render then shows the target directly.
+  const hydrated = useSyncExternalStore(
+    noopSubscribe,
+    () => true,
+    () => false
+  );
+  const [current, setCurrent] = useState(0);
   const hasAnimated = useRef(false);
 
   useEffect(() => {
@@ -46,5 +58,6 @@ export function useCountUp(target: number | string, duration = 500): string {
   }, [numericTarget, duration, isNumeric, skipAnimation]);
 
   if (!isNumeric) return String(target);
-  return `${current}${suffix}`;
+  const value = skipAnimation && hydrated ? numericTarget : current;
+  return `${value}${suffix}`;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "11.11.12",
+	"version": "11.11.13",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '11.11.12';
+const CACHE_VERSION = '11.11.13';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 

--- a/tests/data/sentry.test.ts
+++ b/tests/data/sentry.test.ts
@@ -384,6 +384,33 @@ describe("Sentry wrapper", () => {
     expect(event?.user).toBeUndefined();
   });
 
+  it("should label React minified errors by number instead of generic redaction", async () => {
+    process.env.NEXT_PUBLIC_SENTRY_DSN = "https://key@sentry.io/123";
+
+    const { initSentry } = await import("@/lib/sentry");
+    initSentry();
+
+    const options = mockInit.mock.calls[0]?.[0] as TestSentryOptions;
+    const event = options.beforeSend?.({
+      level: "error",
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value:
+              "Minified React error #418; visit https://react.dev/errors/418?args[]=HTML&args[]=TASK_ARG_SENTINEL for the full message",
+            mechanism: { type: "onerror", handled: false },
+          },
+        ],
+      },
+    });
+
+    expect(event?.exception?.values?.[0]?.value).toBe(
+      "React minified error #418 (hydration mismatch)"
+    );
+    expect(JSON.stringify(event)).not.toContain("TASK_ARG_SENTINEL");
+  });
+
   it("should restore the vouched log message and keep allowlisted gsd context keys", async () => {
     process.env.NEXT_PUBLIC_SENTRY_DSN = "https://key@sentry.io/123";
 

--- a/tests/data/sentry.test.ts
+++ b/tests/data/sentry.test.ts
@@ -62,6 +62,18 @@ interface TestSentryOptions {
   beforeSend?: (event: TestEvent) => TestEvent | null;
 }
 
+const mockEnvConfig = vi.hoisted(() => ({
+  environment: "production",
+  isDevelopment: false,
+  isProduction: true,
+  isStaging: false,
+  pocketBaseUrl: "https://api.vinny.io",
+}));
+
+vi.mock("@/lib/env-config", () => ({
+  ENV_CONFIG: mockEnvConfig,
+}));
+
 vi.mock("@sentry/browser", () => ({
   init: (...args: unknown[]) => {
     mockInit(...args);
@@ -79,6 +91,9 @@ describe("Sentry wrapper", () => {
     vi.resetModules();
     vi.clearAllMocks();
     mockGetClient.mockReturnValue(undefined);
+    mockEnvConfig.environment = "production";
+    mockEnvConfig.isDevelopment = false;
+    mockEnvConfig.isProduction = true;
     delete process.env.NEXT_PUBLIC_SENTRY_DSN;
   });
 
@@ -102,6 +117,19 @@ describe("Sentry wrapper", () => {
         enabled: true,
       })
     );
+  });
+
+  it("should not initialize Sentry in development", async () => {
+    process.env.NEXT_PUBLIC_SENTRY_DSN = "https://key@sentry.io/123";
+    mockEnvConfig.environment = "development";
+    mockEnvConfig.isDevelopment = true;
+    mockEnvConfig.isProduction = false;
+
+    const { initSentry, isInitialized } = await import("@/lib/sentry");
+    initSentry();
+
+    expect(mockInit).not.toHaveBeenCalled();
+    expect(isInitialized()).toBe(false);
   });
 
   it("should not initialize Sentry when DSN is empty", async () => {
@@ -196,6 +224,35 @@ describe("Sentry wrapper", () => {
     expect(serializedOptions).not.toContain("context-secret");
     expect(serializedOptions).not.toContain("password-secret");
     expect(serializedOptions).toContain("***");
+  });
+
+  it("should not substitute its own stack for a stackless error", async () => {
+    process.env.NEXT_PUBLIC_SENTRY_DSN = "https://key@sentry.io/123";
+
+    const { initSentry, captureException } = await import("@/lib/sentry");
+    initSentry();
+
+    const error = new TypeError("native failure with no frames");
+    error.stack = undefined;
+    captureException(error);
+
+    const [capturedError] = mockCaptureException.mock.calls[0] as [Error];
+    expect(capturedError.name).toBe("TypeError");
+    expect(capturedError.stack).toBeUndefined();
+  });
+
+  it("should preserve well-known DOMException names for grouping", async () => {
+    process.env.NEXT_PUBLIC_SENTRY_DSN = "https://key@sentry.io/123";
+
+    const { initSentry, captureException } = await import("@/lib/sentry");
+    initSentry();
+
+    const error = new Error("quota hit");
+    error.name = "QuotaExceededError";
+    captureException(error);
+
+    const [capturedError] = mockCaptureException.mock.calls[0] as [Error];
+    expect(capturedError.name).toBe("QuotaExceededError");
   });
 
   it("should drop custom error properties, causes, and AggregateError members", async () => {
@@ -327,6 +384,38 @@ describe("Sentry wrapper", () => {
     expect(event?.user).toBeUndefined();
   });
 
+  it("should restore the vouched log message and keep allowlisted gsd context keys", async () => {
+    process.env.NEXT_PUBLIC_SENTRY_DSN = "https://key@sentry.io/123";
+
+    const { initSentry } = await import("@/lib/sentry");
+    initSentry();
+
+    const options = mockInit.mock.calls[0]?.[0] as TestSentryOptions;
+    const event = options.beforeSend?.({
+      level: "error",
+      message: "RAW_MESSAGE_SENTINEL",
+      contexts: {
+        gsd: {
+          context: "sync-engine",
+          logMessage: "Sync failed",
+          action: "manual",
+          errorCode: "network_error",
+          taskTitle: "TASK_TITLE_SENTINEL",
+          input: "INPUT_SENTINEL",
+        },
+      },
+    });
+
+    expect(event?.message).toBe("Sync failed");
+    expect(event?.contexts).toEqual({
+      gsd: { context: "sync-engine", action: "manual", errorCode: "network_error" },
+    });
+    const serialized = JSON.stringify(event);
+    expect(serialized).not.toContain("RAW_MESSAGE_SENTINEL");
+    expect(serialized).not.toContain("TASK_TITLE_SENTINEL");
+    expect(serialized).not.toContain("INPUT_SENTINEL");
+  });
+
   it("should keep only structural HTTP breadcrumb data", async () => {
     process.env.NEXT_PUBLIC_SENTRY_DSN = "https://key@sentry.io/123";
 
@@ -420,8 +509,24 @@ describe("Sentry wrapper", () => {
 
     expect(mockCaptureMessage).toHaveBeenCalledWith("something went wrong", {
       level: "error",
-      contexts: { gsd: { action: "test" } },
+      contexts: { gsd: { action: "test", logMessage: "something went wrong" } },
     });
+  });
+
+  it("should embed a vouched masked copy of the message for beforeSend", async () => {
+    process.env.NEXT_PUBLIC_SENTRY_DSN = "https://key@sentry.io/123";
+
+    const { initSentry, captureMessage } = await import("@/lib/sentry");
+    initSentry();
+
+    captureMessage("sync failed with token=abc123", { action: "push" });
+
+    const [, capturedOptions] = mockCaptureMessage.mock.calls[0] as [
+      string,
+      { contexts?: { gsd?: Record<string, unknown> } },
+    ];
+    expect(capturedOptions.contexts?.gsd?.logMessage).toBe("sync failed with token=***");
+    expect(capturedOptions.contexts?.gsd?.action).toBe("push");
   });
 
   it("should mask token-bearing messages and message context before capture", async () => {

--- a/tests/data/use-count-up.test.ts
+++ b/tests/data/use-count-up.test.ts
@@ -1,3 +1,5 @@
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useCountUp } from "@/lib/use-count-up";
@@ -67,5 +69,23 @@ describe("useCountUp", () => {
     expect(result.current).toBe("42");
     expect(rafSpy).not.toHaveBeenCalled();
     rafSpy.mockRestore();
+  });
+
+  // The static export prerenders every count-up as "0". If a reduced-motion
+  // client's hydration render produced the target instead, React would see
+  // mismatched text and throw #418 — so the server-rendered value must be "0"
+  // regardless of the motion preference, with the jump to the target deferred
+  // until after hydration (useSyncExternalStore's server snapshot guarantees
+  // the hydration render matches this prerender).
+  it("prerenders 0 even when the environment reports reduced motion", () => {
+    vi.mocked(prefersReducedMotion).mockImplementation(() => true);
+    try {
+      function Probe() {
+        return createElement("span", null, useCountUp(42));
+      }
+      expect(renderToString(createElement(Probe))).toContain(">0<");
+    } finally {
+      vi.mocked(prefersReducedMotion).mockImplementation(() => false);
+    }
   });
 });


### PR DESCRIPTION
## Summary

A review of the last 14 days of Sentry issues found that the privacy redaction pipeline had crossed from content-masking into self-inflicted blindness, and that production has a low-volume React #418 hydration-mismatch issue (GSD-TASK-MANAGER-12). This PR restores the diagnostic signal without widening what user content can leave the device, and hardens the one latent hydration hazard the investigation surfaced.

## Telemetry (lib/sentry.ts, lib/logger.ts, lib/sentry-safe-keys.ts)

- **`captureMessage` events arrived empty** (`<unlabeled event>`, issue GSD-TASK-MANAGER-14): `beforeSend`'s allowlist never carried `message`. The masked message now rides as a vouched copy in `contexts.gsd.logMessage` and only that copy is promoted back to `event.message`; a raw top-level `message` is still dropped.
- **`contexts.gsd` was dropped wholesale**, defeating the logger's key-allowlist. It now passes through, filtered by the shared `SENTRY_SAFE_METADATA_KEYS` (moved to `lib/sentry-safe-keys.ts`, plus `errorCode`) and re-masked.
- **Stackless errors shipped the sanitizer's own construction stack** (issue GSD-TASK-MANAGER-T groups every such error under one misleading stack). Stackless originals now stay stackless, and `SAFE_ERROR_TYPES` gains the fixed DOMException vocabulary plus `ClientResponseError` so they group by cause.
- **Development no longer reports to Sentry** — dev sessions produced 78% of the noisiest issue (GSD-TASK-MANAGER-V, 139 events). The sentry-verification skill doc covers how to test capture with the gate in place.
- **React minified errors keep their number**: `React minified error #418 (hydration mismatch)` instead of `Error details redacted`. Only the number survives; args never do.

## Hydration (lib/use-count-up.ts)

Investigation of GSD-TASK-MANAGER-12 (details below) surfaced one latent hazard: `useCountUp` evaluated `prefers-reduced-motion` in its `useState` initializer, so a reduced-motion client's hydration render could disagree with the prerendered `0`. The hydration render now stays at `0` via a `useSyncExternalStore` server snapshot; the target renders immediately after hydration.

## Hydration investigation findings

The live #418 events were **not reproducible from app code**: A/B of the CSP inline-asset externalizer (processed vs pristine exports), theming, first-run redirect, returning-user state, and reduced-motion across `/`, `/dashboard/`, `/settings/` all came back clean under Playwright with `reducedMotion: 'reduce'`. Events scatter across those three pages in single-user bursts (e.g. 7 events in 14s), which fits pre-hydration DOM mutation by browser extensions (auto-translate is the canonical source) or stale-service-worker artifact skew — not an app defect. The React-error labeling above means future occurrences will be identifiable per page instead of anonymous.

## Test plan

- `bun run test` — 2777 passing (35 in the touched suites, 7 new)
- `bun typecheck`, `bun lint` — clean
- Static export rebuilt and probed with Playwright (`reducedMotion: reduce` and `no-preference` × `/`, `/dashboard/`, `/settings/`) — no console errors
- Coverage: sentry.ts 84% stmts / 97% funcs; logger.ts 98%; use-count-up.ts stays capped by its documented untestable rAF loop

Bumps version to 11.11.13 (SW cache version aligned).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->