### PR TITLE
ci(mcp): switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -53,11 +53,14 @@ jobs:
         with:
           bun-version: 1.3.14
 
-      - name: Setup Node (npm registry)
+      # No registry-url here: setup-node's registry-url writes an .npmrc that
+      # references ${NODE_AUTH_TOKEN}, which npm errors on when the var is
+      # unset. Trusted publishing needs no .npmrc — npm >=11.5.1 (Node 24)
+      # exchanges the workflow's OIDC token with npmjs directly.
+      - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: '24'
 
       - name: Verify tag matches package.json version
         if: github.event_name == 'push'
@@ -86,11 +89,12 @@ jobs:
       - name: Build
         run: bun run build
 
+      # Auth is OIDC trusted publishing (id-token: write above + the trusted
+      # publisher configured on npmjs.com for this repo/workflow/environment).
+      # No long-lived token: nothing to expire, nothing to leak.
       - name: Publish to npm
         if: github.event_name == 'push' || inputs.dry_run == false
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Rewrite package name for GitHub Packages
         if: github.event_name == 'push' || inputs.dry_run == false
@@ -110,7 +114,7 @@ jobs:
         if: github.event_name == 'push' || inputs.dry_run == false
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@${{ github.repository_owner }}'
 

--- a/doctor.config.jsonc
+++ b/doctor.config.jsonc
@@ -28,8 +28,9 @@
       { "files": ["components/ui/label.tsx"], "rules": ["react-doctor/label-has-associated-control"] },
       // Links a static .html asset (not an App Router route); next/link would break it.
       { "files": ["components/settings/about-section.tsx"], "rules": ["react-doctor/nextjs-no-a-element"] },
-      // YAML workflow: NPM_TOKEN is scoped to the publish step, so the install
-      // step runs without the secret in its environment.
+      // YAML workflow: npmjs auth is OIDC trusted publishing (no secret at all);
+      // GITHUB_TOKEN is scoped to the GitHub Packages publish step, so the
+      // install step runs without any secret in its environment.
       { "files": [".github/workflows/publish-mcp-server.yml"], "rules": ["react-doctor/build-pipeline-secret-boundary"] },
       // Static HTML report intentionally linked from the About page.
       { "files": ["public/docs/**"], "rules": ["react-doctor/public-debug-artifact"] }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,41 +1,34 @@
-# UI Polish Pass (/ui-craft polish) — 2026-08-16
+# Status — 2026-08-16
 
-Standard tier. Target: v9 single-matrix shell. CRAFT_LEVEL 7 → review.md
-Polish Pass applied; signature ("quadrant stated twice") verified intact and
-left as-built.
+## UI Polish Pass (/ui-craft polish) — DONE
 
-## Resuming From Here
+Shipped as PR #504 (squash-merged to main as 942cab9); local + remote branch
+deleted. Verified live before push (SW busted, DOM assertions, clean console).
 
-Done (committed on `style/matrix-polish-pass`):
-- capture-bar: "Details ↗" glyph → Lucide ArrowUpRightIcon; `n` hint span → kbd
-- filtered-empty: rounded-[20px] → rounded-xl (token scale); clear button
-  gains touch-target + focus-visible accent ring (a11y floor)
-- task-card-actions: bare `transition` → `transition-opacity` on hover reveal
-- quadrant-pane: tabular-nums on the "N more" / "N done" disclosure counts
-- Gates green: 2780 tests, typecheck, lint
+## gsd-mcp-server 1.2.4 publish — DONE
 
-Next:
-- Run /verify-frontend-change (browser check) before any push/PR — changes are
-  class/markup-only and unit-covered, so this was deferred
-- Push + PR only on user go-ahead
-- Optional next rung: /finalize (pre-ship gate)
+npm serves 1.2.4 (latest); GitHub Packages published.
 
-Assumptions:
-- No version bump: package.json/sw.js already carry an uncommitted 12.0.1
-  bump (deliberate leftover from a prior session); entangling it here would
-  sweep unrelated changes into the polish commit
+- Leaked npm token: REVOKED by user 2026-08-16. No replacement token needed —
+  the workflow now uses OIDC Trusted Publishing (see below). The dead
+  `NPM_TOKEN` GitHub secret can be deleted (`gh secret delete NPM_TOKEN`).
 
-Blockers: none.
+## OIDC Trusted Publishing — workflow side DONE, npmjs.com side PENDING (user)
 
----
+publish-mcp-server.yml now authenticates to npmjs via OIDC: Node 24 (npm
+≥11.5.1), no NPM_TOKEN, no registry-url on the npmjs setup-node (its .npmrc
+would reference an unset ${NODE_AUTH_TOKEN} and npm errors). GitHub Packages
+leg unchanged (GITHUB_TOKEN). Guard test added to
+security-hardening-scripts.test.ts.
 
-# Previous task: Publish gsd-mcp-server 1.2.4 (DONE)
+Before the next `mcp-v*` release the user must configure the trusted
+publisher on npmjs.com (package gsd-mcp-server → Settings → Publishing
+access): GitHub Actions / vscarpenter / gsd-task-manager /
+`publish-mcp-server.yml` / environment `mcp-release`. Until then a publish
+fails auth — that failure is the expected signal that config is missing.
 
-Outstanding (user):
-- REVOKE the npm token used 2026-08-16 on npmjs.com — it leaked into shell
-  history/transcript during `gh secret set` (was passed as the secret name).
-  Mint a replacement and `gh secret set NPM_TOKEN` before the next release.
+## Working-tree leftovers (deliberate, uncommitted on main)
 
-Optional follow-up: switch to npm Trusted Publishing (OIDC) so the token
-never expires again; requires npmjs.com config + bumping the workflow's
-setup-node to Node 24 (npm ≥11.5 needed for OIDC).
+bun.lock + package.json (stagehand ^4.0.1 bump) and public/sw.js
+(CACHE_VERSION 12.0.1) — pre-staged version-bump material from a prior
+session; commit them with the next release, not with feature work.

--- a/tests/data/security-hardening-scripts.test.ts
+++ b/tests/data/security-hardening-scripts.test.ts
@@ -56,6 +56,16 @@ describe('security hardening scripts and workflows', () => {
     expect(workflow).toContain('fetch-depth: 0');
   });
 
+  it('publishes to npm via OIDC trusted publishing instead of a long-lived token', () => {
+    const workflow = readRepoFile('.github/workflows/publish-mcp-server.yml');
+
+    expect(workflow).toContain('id-token: write');
+    expect(workflow).not.toContain('NPM_TOKEN');
+    // npm CLI >=11.5.1 (bundled with Node 24) is required for the OIDC exchange.
+    expect(workflow).toContain("node-version: '24'");
+    expect(workflow).not.toContain("node-version: '20'");
+  });
+
   it('deletes stale HTML and service-worker objects during production deploy sync', () => {
     const deployScript = readRepoFile('scripts/deploy-app.sh');
     const htmlSyncStart = deployScript.indexOf('Syncing HTML files and service worker');


### PR DESCRIPTION
## What changed

`publish-mcp-server.yml` now authenticates to npmjs with **OIDC Trusted Publishing** instead of the `NPM_TOKEN` granular token (which expired every ~90 days, failed as a masked `E404`, and was leaked + revoked on 2026-08-16):

- **Node 20 → 24** on both setup-node steps — npm ≥11.5.1 is the first CLI that performs the OIDC exchange
- **No `NODE_AUTH_TOKEN`/`NPM_TOKEN`** on the npmjs publish step — the workflow's OIDC token (`id-token: write`, already present for provenance) is exchanged with npmjs directly
- **No `registry-url`** on the npmjs setup-node — it writes an `.npmrc` referencing `${NODE_AUTH_TOKEN}`, which npm errors on when the var is unset; trusted publishing needs no `.npmrc`
- **GitHub Packages leg unchanged** — still `GITHUB_TOKEN` + `registry-url` (OIDC doesn't cover it)
- **Guard test added** (`security-hardening-scripts.test.ts`): `id-token: write` present, `NPM_TOKEN` absent, Node 24 pinned — written red-first, green after the workflow change
- `doctor.config.jsonc` secret-boundary comment updated to match

All existing guards preserved: `mcp-release` environment, main-ancestry check before publish, `fetch-depth: 0`, `bun-version: 1.3.14`, SHA-pinned actions.

## Required follow-up (one-time, npmjs.com — package owner only)

On npmjs.com → `gsd-mcp-server` → Settings → **Trusted Publisher**: GitHub Actions, org `vscarpenter`, repo `gsd-task-manager`, workflow `publish-mcp-server.yml`, environment `mcp-release`. Until configured, a publish fails auth — that failure is the expected signal, not a regression. The dead `NPM_TOKEN` secret can then be deleted.

## How to test

- `bun run test -- tests/data/security-hardening-scripts.test.ts` (18 green, incl. the new contract test)
- Full gates: 2781 tests, typecheck, lint — all green
- Real proof is the next `mcp-v*` tag push after the npmjs.com config; `workflow_dispatch` dry-run still works without auth

https://claude.ai/code/session_01CDBca9cxVXirzW23DfUevU
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->