### PR TITLE
feat: editorial imports — mono kicker, terminal block, dark rings, fluid hero

### DIFF
--- a/.ui-craft/tokens.md
+++ b/.ui-craft/tokens.md
@@ -189,9 +189,10 @@ Light shadows are two-layer warm-ink-tinted stacks:
 - `--shadow-lg`: `0 5px 12px rgba(40,33,22,.08), 0 20px 44px rgba(40,33,22,.07)`.
 - `--shadow-card-hover`: `0 4px 10px rgba(40,33,22,.08), 0 16px 34px rgba(40,33,22,.07)`.
 
-Dark shadows use black at 45–55% opacity. `--backdrop` is `rgba(21,18,13,.52)` in light and
-`rgba(0,0,0,.6)` in dark. Component aliases are `--shadow-card`, `--shadow-column`, and
-`--shadow-fab`.
+Dark shadows are a 1px white ring (6–9% alpha, stepping with elevation) plus a faint black
+blur at 35–45% — the ring carries the edge because black blur alone disappears into the dark
+canvas. `--backdrop` is `rgba(21,18,13,.52)` in light and `rgba(0,0,0,.6)` in dark. Component
+aliases are `--shadow-card`, `--shadow-column`, and `--shadow-fab`.
 
 ## Motion and z-index
 

--- a/.ui-craft/tokens.md
+++ b/.ui-craft/tokens.md
@@ -138,7 +138,9 @@ self-hosted in the static build and exposed as `--font-newsreader`.
 - `--serif`: `--font-newsreader` (Newsreader) feeds the serif chain, standing in for Apple's New
   York on non-Apple platforms; it carries display and headlines.
 - `--sans`: the system sans stack — carries body, labels, and working UI.
-- `--mono`: system mono for code and keyboard notation only.
+- `--mono`: system mono for code and keyboard notation, plus the uppercase kicker voice —
+  the `.kicker` component class (11px mono, 0.08em tracking) is the sanctioned eyebrow
+  treatment on marketing/docs surfaces. Mono never carries body text.
 
 | Token | Size / line-height | Weight | Tracking |
 | --- | --- | --- | --- |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -303,7 +303,9 @@ display, headlines, section heads, and card titles.
 legible at the 11–12px chip sizes the matrix leans on.
 
 **Functional mono:** System mono, reserved for code and keyboard notation when equal-width glyphs
-carry meaning.
+carry meaning — plus one editorial exception: the uppercase kicker voice (`.kicker`, 11px mono at
+0.08em tracking), the sanctioned eyebrow treatment on marketing and docs surfaces. Mono never
+carries body text.
 
 This is the same two-voice pairing as the iOS app (New York titles over SF body) and
 gsdtaskmanager.com (Newsreader over system sans).

--- a/app/css/inkwell-tokens.css
+++ b/app/css/inkwell-tokens.css
@@ -228,10 +228,13 @@
     --rail: #1B1812;
     --topbar: #1B1812;
 
-    --shadow-sm:         0 1px 2px  rgba(0, 0, 0, 0.45);
-    --shadow-md:         0 4px 14px rgba(0, 0, 0, 0.50);
-    --shadow-lg:         0 12px 28px rgba(0, 0, 0, 0.55);
-    --shadow-card-hover: 0 10px 30px rgba(0, 0, 0, 0.50);
+    /* Elevation reads as a 1px light ring plus a faint drop — black blur
+       alone disappears into the dark canvas, so the ring carries the edge
+       and the blur only hints at depth. Ring alpha steps with elevation. */
+    --shadow-sm:         0 0 0 1px rgba(255, 255, 255, 0.06), 0 1px 2px  rgba(0, 0, 0, 0.35);
+    --shadow-md:         0 0 0 1px rgba(255, 255, 255, 0.07), 0 4px 14px rgba(0, 0, 0, 0.40);
+    --shadow-lg:         0 0 0 1px rgba(255, 255, 255, 0.09), 0 12px 28px rgba(0, 0, 0, 0.45);
+    --shadow-card-hover: 0 0 0 1px rgba(255, 255, 255, 0.09), 0 10px 30px rgba(0, 0, 0, 0.40);
 
     --backdrop: rgba(0, 0, 0, 0.6);                  /* pure-black scrim for dark surfaces */
 
@@ -294,10 +297,13 @@
   --rail: #1B1812;
   --topbar: #1B1812;
 
-  --shadow-sm:         0 1px 2px  rgba(0, 0, 0, 0.45);
-  --shadow-md:         0 4px 14px rgba(0, 0, 0, 0.50);
-  --shadow-lg:         0 12px 28px rgba(0, 0, 0, 0.55);
-  --shadow-card-hover: 0 10px 30px rgba(0, 0, 0, 0.50);
+  /* Elevation reads as a 1px light ring plus a faint drop — black blur
+     alone disappears into the dark canvas, so the ring carries the edge
+     and the blur only hints at depth. Ring alpha steps with elevation. */
+  --shadow-sm:         0 0 0 1px rgba(255, 255, 255, 0.06), 0 1px 2px  rgba(0, 0, 0, 0.35);
+  --shadow-md:         0 0 0 1px rgba(255, 255, 255, 0.07), 0 4px 14px rgba(0, 0, 0, 0.40);
+  --shadow-lg:         0 0 0 1px rgba(255, 255, 255, 0.09), 0 12px 28px rgba(0, 0, 0, 0.45);
+  --shadow-card-hover: 0 0 0 1px rgba(255, 255, 255, 0.09), 0 10px 30px rgba(0, 0, 0, 0.40);
 
   --backdrop: rgba(0, 0, 0, 0.6);                  /* pure-black scrim for dark surfaces */
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -330,6 +330,19 @@ body {
   padding-right: env(safe-area-inset-right);
 }
 
+/* The inline-code chip rule (inkwell-components.css) paints a --gray-100
+   ground behind every <code>; inside the terminal panel that renders as
+   light bars over the dark ink. Unlayered on purpose — utilities can't
+   beat the unlayered chip rule, so this override can't either way live
+   in @layer components. Same approach as `.tldr code`. */
+.terminal-block code {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  font-size: var(--t-small);
+  line-height: 1.65;
+}
+
 /* The Two-Voice Rule (DESIGN.md): the serif carries display and headings,
    the sans carries working UI. The ramp's four heading steps are the serif
    voice; body/small/caption stay sans, and the uppercase kicker voice is

--- a/app/globals.css
+++ b/app/globals.css
@@ -185,6 +185,14 @@
   --status-success-muted:  var(--olive-tint);
   --status-success-ink:    var(--olive-d);
 
+  /* Terminal panel — a fixed dark surface in BOTH themes: a terminal that
+     flipped light with the theme would read as a form field, not a console.
+     Light reuses the slate ink hex as ground; dark drops below the canvas
+     so the panel still reads distinct. */
+  --terminal-bg:    #211E1A;
+  --terminal-ink:   #F1ECE2;
+  --terminal-muted: #A79F92;
+
   /* Component-tier shadow aliases. */
   --shadow-card:   var(--shadow-sm);
   --shadow-column: var(--shadow-sm);
@@ -208,6 +216,8 @@
     --ink-hint: #877D6D;
     /* On dark the neutral pigment is already light enough to read as text. */
     --status-blocking-ink: var(--sky);
+    /* Below the canvas (#17150F) so the fixed-dark panel stays distinct. */
+    --terminal-bg: #11100B;
   }
 }
 :root[data-theme="dark"] {
@@ -219,6 +229,7 @@
 
   --ink-hint: #877D6D;
   --status-blocking-ink: var(--sky);
+  --terminal-bg: #11100B;
 }
 
 /* =====================================================================

--- a/app/globals.css
+++ b/app/globals.css
@@ -321,7 +321,8 @@ body {
 
 /* The Two-Voice Rule (DESIGN.md): the serif carries display and headings,
    the sans carries working UI. The ramp's four heading steps are the serif
-   voice; body/small/caption/eyebrow stay sans. Unlayered like `body` above,
+   voice; body/small/caption stay sans, and the uppercase kicker voice is
+   mono via `.kicker`. Unlayered like `body` above,
    not inside @layer components — not to beat the `.text-h1` etc. utilities
    (the @theme text sizes emit no font-family, so there's no property
    collision there), but so this rule also wins against any future
@@ -378,6 +379,18 @@ main {
     @apply appearance-none border-0 bg-transparent p-0;
     font: inherit;
     color: inherit;
+  }
+
+  /* The kicker: the uppercase mono eyebrow voice. Mono glyphs are already
+     wide, so tracking sits at 0.08em rather than the sans eyebrow's 0.12em —
+     reusing 0.12em here reads gappy. Color is the call site's decision. */
+  .kicker {
+    font-family: var(--mono);
+    font-size: var(--t-eyebrow);
+    font-weight: 600;
+    line-height: 1;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
 
   .matrix-grid {

--- a/components/about/features-section.tsx
+++ b/components/about/features-section.tsx
@@ -97,7 +97,7 @@ export function FeaturesSection() {
     <section className="py-20 sm:py-28">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         <ScrollReveal>
-          <p className="text-xs uppercase tracking-widest text-accent mb-3 text-center">
+          <p className="kicker text-accent mb-3 text-center">
             Features
           </p>
           <h2 className="font-semibold text-display tracking-tight text-foreground mb-12 text-center">

--- a/components/about/footer-cta.tsx
+++ b/components/about/footer-cta.tsx
@@ -10,7 +10,7 @@ export function FooterCta({ version }: FooterCtaProps) {
     <section className="bg-gradient-to-b from-background-muted/20 to-background py-20 sm:py-28">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
         <ScrollReveal>
-          <p className="mb-4 text-[11px] font-semibold uppercase tracking-[0.18em] text-foreground-muted">
+          <p className="kicker mb-4 text-foreground-muted">
             Ready When You Are
           </p>
           <h2 className="mb-4 text-h2 font-semibold tracking-tight text-foreground sm:text-h1">

--- a/components/about/hero-section.tsx
+++ b/components/about/hero-section.tsx
@@ -16,7 +16,7 @@ export function HeroSection() {
             Productivity Framework
           </p>
 
-          <h1 className="mb-6 text-4xl font-serif font-semibold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
+          <h1 className="mb-6 text-[clamp(2.75rem,1.2rem+5.2vw,5rem)] font-serif font-semibold leading-[1.05] tracking-tight text-foreground">
             Stop juggling.
             <br />
             Start finishing.

--- a/components/about/hero-section.tsx
+++ b/components/about/hero-section.tsx
@@ -12,7 +12,7 @@ export function HeroSection() {
     <section className="bg-gradient-to-b from-background to-background-muted/30 py-24 sm:py-32">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
         <ScrollReveal>
-          <p className="mb-4 text-xs uppercase tracking-[0.24em] text-foreground-muted">
+          <p className="kicker mb-4 text-foreground-muted">
             Productivity Framework
           </p>
 

--- a/components/about/matrix-section.tsx
+++ b/components/about/matrix-section.tsx
@@ -35,7 +35,7 @@ export function MatrixSection() {
           {/* Explanation column */}
           <div className="order-2 lg:order-1 mt-12 lg:mt-0">
             <ScrollReveal>
-              <p className="text-xs uppercase tracking-widest text-accent mb-3">
+              <p className="kicker text-accent mb-3">
                 The Eisenhower Matrix
               </p>
               <h2 className="font-semibold text-display tracking-tight text-foreground mb-6">
@@ -67,7 +67,7 @@ export function MatrixSection() {
                     key={q.label}
                     className={`rounded-xl border p-4 sm:p-5 ${q.className}`}
                   >
-                    <span className="text-[10px] uppercase tracking-widest text-foreground-muted font-medium">
+                    <span className="kicker text-foreground-muted">
                       {q.label}
                     </span>
                     <h3 className="text-base font-semibold text-foreground mt-1">

--- a/components/about/mcp-section.tsx
+++ b/components/about/mcp-section.tsx
@@ -25,7 +25,7 @@ export function McpSection() {
         <div className="lg:grid lg:grid-cols-2 lg:gap-16 lg:items-center">
           {/* Text column */}
           <ScrollReveal>
-            <p className="text-xs uppercase tracking-widest text-accent mb-3">
+            <p className="kicker text-accent mb-3">
               For power users
             </p>
             <h2 className="text-h2 font-semibold tracking-tight text-foreground sm:text-h1 mb-4">

--- a/components/about/mcp-section.tsx
+++ b/components/about/mcp-section.tsx
@@ -1,4 +1,5 @@
 import { ScrollReveal } from "@/components/about/scroll-reveal";
+import { TerminalBlock } from "@/components/about/terminal-block";
 
 const exampleQueries = [
   '"What are my urgent tasks this week?"',
@@ -53,16 +54,10 @@ export function McpSection() {
 
           {/* Code column */}
           <ScrollReveal className="mt-10 lg:mt-0" delay={200}>
-            <p className="text-[10px] uppercase tracking-widest text-foreground-muted mb-2 font-medium">
-              Claude Desktop Config
-            </p>
-            <div className="rounded-xl border border-border bg-background-muted p-4 sm:p-6 overflow-x-auto">
-              <pre>
-                <code className="text-sm font-mono leading-relaxed text-foreground-muted">
-                  {claudeDesktopConfig}
-                </code>
-              </pre>
-            </div>
+            <TerminalBlock
+              label="Claude Desktop config"
+              code={claudeDesktopConfig}
+            />
           </ScrollReveal>
         </div>
       </div>

--- a/components/about/terminal-block.tsx
+++ b/components/about/terminal-block.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type CopyState = "idle" | "copied" | "failed";
+
+const COPY_FEEDBACK_MS = 2000;
+
+const BUTTON_LABEL: Record<CopyState, string> = {
+  idle: "Copy",
+  copied: "Copied",
+  failed: "Copy failed",
+};
+
+interface TerminalBlockProps {
+  label: string;
+  code: string;
+}
+
+/**
+ * Dark code panel with a title bar and one-click copy, for install/config
+ * snippets on marketing surfaces. The panel keeps a fixed dark surface in
+ * both themes (--terminal-* tokens), so the white-alpha borders in here are
+ * safe — they never sit on a light ground.
+ */
+export function TerminalBlock({ label, code }: TerminalBlockProps) {
+  const [copyState, setCopyState] = useState<CopyState>("idle");
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => () => clearTimeout(resetTimer.current), []);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopyState("copied");
+    } catch {
+      setCopyState("failed");
+    }
+    clearTimeout(resetTimer.current);
+    resetTimer.current = setTimeout(() => setCopyState("idle"), COPY_FEEDBACK_MS);
+  };
+
+  return (
+    <div className="overflow-hidden rounded-xl bg-[var(--terminal-bg)] text-[var(--terminal-ink)] shadow-md">
+      <div className="flex items-center justify-between gap-3 border-b border-white/10 py-2 pl-4 pr-2.5">
+        <span className="flex min-w-0 items-center gap-3">
+          <span className="flex gap-1.5" aria-hidden="true">
+            <span className="h-2 w-2 rounded-full border border-current opacity-50" />
+            <span className="h-2 w-2 rounded-full border border-current opacity-50" />
+            <span className="h-2 w-2 rounded-full border border-current opacity-50" />
+          </span>
+          <span className="kicker truncate text-[var(--terminal-muted)]">
+            {label}
+          </span>
+        </span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-live="polite"
+          className="kicker min-h-8 shrink-0 cursor-pointer rounded-md border border-white/25 px-3 transition-colors pointer-coarse:min-h-11 hover:border-white/50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--terminal-ink)]"
+        >
+          {BUTTON_LABEL[copyState]}
+        </button>
+      </div>
+      <pre className="overflow-x-auto p-4 sm:p-5">
+        <code className="font-mono text-sm leading-relaxed">{code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/components/about/terminal-block.tsx
+++ b/components/about/terminal-block.tsx
@@ -41,7 +41,7 @@ export function TerminalBlock({ label, code }: TerminalBlockProps) {
   };
 
   return (
-    <div className="overflow-hidden rounded-xl bg-[var(--terminal-bg)] text-[var(--terminal-ink)] shadow-md">
+    <div className="terminal-block overflow-hidden rounded-xl bg-[var(--terminal-bg)] text-[var(--terminal-ink)] shadow-[var(--shadow-md)]">
       <div className="flex items-center justify-between gap-3 border-b border-white/10 py-2 pl-4 pr-2.5">
         <span className="flex min-w-0 items-center gap-3">
           <span className="flex gap-1.5" aria-hidden="true">
@@ -63,7 +63,7 @@ export function TerminalBlock({ label, code }: TerminalBlockProps) {
         </button>
       </div>
       <pre className="overflow-x-auto p-4 sm:p-5">
-        <code className="font-mono text-sm leading-relaxed">{code}</code>
+        <code>{code}</code>
       </pre>
     </div>
   );

--- a/tests/ui/terminal-block.test.tsx
+++ b/tests/ui/terminal-block.test.tsx
@@ -1,0 +1,65 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TerminalBlock } from "@/components/about/terminal-block";
+
+const code = '{\n  "mcpServers": {}\n}';
+
+// jsdom ships no navigator.clipboard; installing one is the only way to
+// exercise the copy path. fireEvent + advanceTimersByTime (not userEvent)
+// is this repo's pattern for fake-timer tests — userEvent's click deadlocks
+// under vitest fake timers (see install-pwa-prompt.test.tsx).
+function installClipboard(writeText: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+}
+
+describe("TerminalBlock", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the bar label and the code content", () => {
+    render(<TerminalBlock label="Claude Desktop config" code={code} />);
+
+    expect(screen.getByText("Claude Desktop config")).toBeInTheDocument();
+    expect(screen.getByText(/"mcpServers"/)).toBeInTheDocument();
+  });
+
+  it("copies the code, confirms, and reverts after the feedback window", async () => {
+    vi.useFakeTimers();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    installClipboard(writeText);
+    render(<TerminalBlock label="Claude Desktop config" code={code} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    await act(async () => {});
+
+    expect(writeText).toHaveBeenCalledWith(code);
+    expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+  });
+
+  it("shows a failure state when the clipboard write is rejected", async () => {
+    vi.useFakeTimers();
+    installClipboard(vi.fn().mockRejectedValue(new Error("denied")));
+    render(<TerminalBlock label="Claude Desktop config" code={code} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    await act(async () => {});
+
+    expect(screen.getByRole("button", { name: "Copy failed" })).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What changed

Four design elements pulled into GSD from the first-run-guide comparison (side-by-side analysis done in-session on 2026-08-17), in five commits:

1. **Mono kicker eyebrow voice** (`521c0a1`) — new `.kicker` component class (11px mono, uppercase, 0.08em tracking) replaces four slightly different ad-hoc eyebrow treatments across the about page. Contract amended in `.ui-craft/tokens.md` and `DESIGN.md`: mono now covers code, keyboard notation, and the kicker voice — never body text.
2. **TerminalBlock** (`3b07155`) — the MCP section's bare pre/code becomes a terminal panel with title bar and one-click Copy (copied/failed feedback, 2s revert). New `--terminal-*` tokens keep the panel fixed-dark in both themes.
3. **Dark-mode ring elevation** (`e978888`) — dark shadow tokens lead with a 1px white ring (6–9% alpha stepping with elevation) over a quieter blur; black blur alone disappeared into the dark canvas. Both dark branches identical.
4. **Fluid hero display** (`5f78e12`) — about hero h1 goes `clamp(2.75rem, 1.2rem + 5.2vw, 5rem)`; app surfaces keep the fixed Inkwell scale.
5. **Cascade fix from live verification** (`6702a15`) — the unlayered inline-code chip rule painted `--gray-100` bars behind the terminal's code in light mode; scoped `.terminal-block code` override (same pattern as `.tldr code`) plus the panel now consumes the Inkwell shadow token instead of Tailwind's default.

No version bump — the pre-staged release leftovers (bun.lock / package.json / sw.js) ride with the next release per tasks/todo.md.

## Why

The guide's palette turned out to be near-identical to GSD Editorial; the genuinely importable elements were the mono kicker voice, the terminal treatment, the dark ring trick, and marketing-scale display type. The kicker also fixes a real drift (four different eyebrow size/tracking combos), and the terminal block adds a missing copy affordance.

## How to test locally

- `bun run test -- tests/ui/terminal-block.test.tsx tests/ui/about-components.test.tsx`
- `bun dev`, then `/about`: kickers render mono uppercase; hero scales fluidly with viewport width; MCP section shows the terminal panel — Copy flips to Copied, pastes the config, reverts after 2s.
- Dark mode: terminal ground drops to `#11100B`; matrix quadrant panes show a subtle 1px light ring instead of pure black blur.

## Verification done

TDD for TerminalBlock (red first, all three tests watched failing). Full suite 2784 green, typecheck + lint clean. Live-verified headlessly (Playwright against `bun dev`, SW busted): 80px hero at 1280w, mono kicker computed styles, the full copy→Copied→revert cycle with the real config read back from Chromium's clipboard, `rgba(255,255,255,0.06) 0 0 0 1px` ring measured on dark matrix panes, console clean in both themes.

## Deferred / follow-ups

- The about page still has an eyebrow on nearly every section; rationing them (ui-craft eyebrow budget) was out of scope for this unification pass.
- Settings/docs surfaces could adopt `.kicker` and `TerminalBlock` later; this PR only touches the about page.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces a reusable fixed-dark terminal panel, standardizes editorial kickers, adds fluid hero typography, and improves dark-theme elevation.
- Replaces the MCP configuration snippet with a client-side copy-enabled terminal component.
- Consolidates about-page eyebrows under the documented `.kicker` treatment.
- Updates dark shadow tokens with light elevation rings and scopes terminal code styling around the existing inline-code cascade.
- Adds focused rendering, clipboard-success, and clipboard-failure tests.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking clipboard-feedback race during rapid repeated clicks.

The primary feature paths are coherent, but overlapping clipboard operations may settle out of order and allow an older attempt to replace the latest feedback state and reset timing.

**Files Needing Attention:** components/about/terminal-block.tsx, tests/ui/terminal-block.test.tsx
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/about/terminal-block.tsx | Adds the terminal presentation and clipboard feedback behavior; overlapping writes can leave stale feedback because asynchronous completions share state and one timer. |
| tests/ui/terminal-block.test.tsx | Covers rendering and individual clipboard success/failure paths but omits overlapping copy attempts. |
| app/globals.css | Adds terminal theme tokens, a correctly scoped code reset, and the reusable kicker class. |
| app/css/inkwell-tokens.css | Reworks both dark-theme branches to use consistent light rings and quieter drop shadows. |
| components/about/hero-section.tsx | Applies the shared kicker treatment and replaces breakpoint typography with a bounded fluid heading size. |
| components/about/mcp-section.tsx | Replaces the bare configuration preformatted block with the new TerminalBlock component. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20vscarpenter%2Fgsd-task-manager%20PR%20%23506%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=vscarpenter%2Fgsd-task-manager&pr=506&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acomponents%2Fabout%2Fterminal-block.tsx%3A34-40%0A**Stale%20clipboard%20feedback%20state**%0A%0AWhen%20a%20user%20clicks%20Copy%20again%20while%20the%20first%20clipboard%20write%20is%20pending%2C%20the%20operations%20update%20%60copyState%60%20and%20%60resetTimer%60%20in%20completion%20order%20rather%20than%20click%20order.%20An%20older%20attempt%20can%20therefore%20replace%20the%20latest%20result%20and%20shift%20its%20two-second%20reset%20window%2C%20leaving%20the%20button%20with%20stale%20or%20incorrectly%20timed%20feedback.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=vscarpenter%2Fgsd-task-manager&pr=506&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
components/about/terminal-block.tsx:34-40
**Stale clipboard feedback state**

When a user clicks Copy again while the first clipboard write is pending, the operations update `copyState` and `resetTimer` in completion order rather than click order. An older attempt can therefore replace the latest result and shift its two-second reset window, leaving the button with stale or incorrectly timed feedback.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(about): keep the inline-code chip ti..."](https://github.com/vscarpenter/gsd-task-manager/commit/6702a158b0136f102b92a1280361d06c244a382b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54152847)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->