### PR TITLE
feat(matrix): compact briefing, axis labels, inked counts, overdue chip

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 12.0.0
+**Current version:** 12.0.1
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/components/matrix-simplified/matrix-grid.tsx
+++ b/components/matrix-simplified/matrix-grid.tsx
@@ -49,10 +49,11 @@ export function MatrixGrid({
     // exactly as thoroughly as a 1x4 stack: the matrix means Q1/Q2 over Q3/Q4
     // or it means nothing. 696px is two 340px panes plus the 16px gutter.
     <div className="@container">
-      <div
-        data-testid="matrix-grid"
-        className="grid gap-4 @min-[696px]:grid-cols-2 @min-[696px]:grid-rows-2"
-      >
+      <AxisFrame>
+        <div
+          data-testid="matrix-grid"
+          className="grid gap-4 @min-[696px]:grid-cols-2 @min-[696px]:grid-rows-2"
+        >
         {quadrants.map((meta) => (
           <QuadrantPane
             key={meta.id}
@@ -70,10 +71,65 @@ export function MatrixGrid({
             sectionRef={(element) => onQuadrantRef?.(meta.rdKey, element)}
           />
         ))}
-      </div>
+        </div>
+      </AxisFrame>
     </div>
   );
 }
+
+/**
+ * Labels both ends of both axes and hands the 2x2 grid the rest of the row.
+ *
+ * The axes are the argument, and until now a reader had to reconstruct them
+ * from four quadrant hints. The frame spends a 22px gutter and an 8px band on
+ * saying them outright, and collapses to nothing below the width that produces
+ * two columns — a single-column stack has no axes, and labelling it would be a
+ * lie. The query is on the container rather than the viewport for the same
+ * reason the grid's is: only the container knows whether the rail is expanded.
+ * The labels are aria-hidden; each pane already carries "… quadrant".
+ */
+function AxisFrame({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      data-testid="matrix-axis-frame"
+      className="@min-[696px]:grid @min-[696px]:grid-cols-[22px_minmax(0,1fr)] @min-[696px]:gap-x-1.5"
+    >
+      <div data-testid="matrix-axis-corner" aria-hidden="true" className="hidden @min-[696px]:block" />
+
+      <div
+        data-testid="matrix-axis-columns"
+        aria-hidden="true"
+        className="mb-2 hidden grid-cols-2 gap-4 @min-[696px]:grid"
+      >
+        <p className={AXIS_LABEL}>Urgent</p>
+        <p className={AXIS_LABEL}>Not urgent</p>
+      </div>
+
+      <div
+        data-testid="matrix-axis-rows"
+        aria-hidden="true"
+        className="hidden grid-rows-2 gap-4 @min-[696px]:grid"
+      >
+        <p className={VERTICAL_AXIS_LABEL}>Important</p>
+        <p className={VERTICAL_AXIS_LABEL}>Not important</p>
+      </div>
+
+      {children}
+    </div>
+  );
+}
+
+/**
+ * The kicker voice, one step quieter than a kicker normally speaks: 10px and
+ * wider tracking, so the labels frame the matrix without competing with the
+ * quadrant titles they sit beside.
+ */
+const AXIS_LABEL =
+  "kicker m-0 text-center text-[10px] tracking-[0.14em] text-foreground-muted";
+
+/** Reads bottom-to-top, so the pair sits beside the rows it names. */
+const VERTICAL_AXIS_LABEL =
+  `${AXIS_LABEL} self-center justify-self-center rotate-180 [writing-mode:vertical-rl]`;
 
 /**
  * Bucket tasks into the four quadrants, each sorted with active work first and

--- a/components/matrix-simplified/matrix-intro.tsx
+++ b/components/matrix-simplified/matrix-intro.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowDownRightIcon, CalendarRangeIcon } from "lucide-react";
+import { CalendarRangeIcon } from "lucide-react";
 
 interface MatrixIntroProps {
   /** Formatted local date for the h1; null until hydrated so the static export stays date-free. */
@@ -11,10 +11,11 @@ interface MatrixIntroProps {
   onFocusSchedule: () => void;
 }
 
-function scheduleMessage(count: number): string {
-  if (count === 0) return "Q2 is clear. Reserve the next strategic block here.";
-  if (count === 1) return "1 strategic commitment needs protected time.";
-  return `${count} strategic commitments need protected time.`;
+/** The button's own label carries the count, so it has to fit on one line. */
+function scheduleLabel(count: number | null): string {
+  if (count === null) return "Protect Q2";
+  if (count === 0) return "Protect Q2 · clear";
+  return `Protect Q2 · ${count} to schedule`;
 }
 
 // Firefox can restore a button's dynamic disabled state across reloads. React's
@@ -24,46 +25,44 @@ const preventPersistedDisabledState = { autoComplete: "off" } as const;
 
 export function MatrixIntro({ dateLabel, message, scheduleCount, onFocusSchedule }: MatrixIntroProps) {
   return (
-    <section className="mb-6 grid items-end gap-5 border-b border-border/70 pb-6 lg:grid-cols-[minmax(0,1fr)_minmax(300px,0.58fr)] lg:gap-10">
-      <div>
+    // One row, not two columns. The display-size date and the three-line
+    // Protect Q2 card together cost ~190px before the first task, which on a
+    // 13" laptop pushed the bottom two quadrant headers below the fold — the
+    // matrix cannot make its argument if half of it is a scroll away.
+    //
+    // The row starts at sm. A phone cannot fit a 205px date, a sentence, and a
+    // 193px button on one line: unconditional, the row overflowed 390px by
+    // 64px and scrolled the page sideways.
+    <section className="mb-5 flex flex-col items-start gap-3 border-b border-border/70 pb-4 sm:flex-row sm:items-center sm:gap-5">
+      <div className="shrink-0">
         <p className="text-eyebrow uppercase text-foreground-muted">Today&rsquo;s matrix</p>
-        <h1 className="mt-3 text-display font-semibold text-foreground">
+        {/* h2 rather than display: at 24px the date still reads as the page's
+            subject in the serif voice without spending a fifth of the fold. */}
+        <h1 className="mt-1 text-h2 text-foreground">
           <span className="sr-only">Today&rsquo;s matrix — </span>
-          {dateLabel ?? " "}
+          {dateLabel ?? " "}
         </h1>
-        <p className="mt-3 max-w-[58ch] text-body text-foreground-muted">
-          {message ?? " "}
-        </p>
       </div>
 
-      <aside className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-3 gap-y-3 rounded-lg border border-border bg-card p-4 shadow-[var(--shadow-card)] sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-center">
-        <span
-          aria-hidden
-          className="flex h-10 w-10 items-center justify-center rounded-lg bg-background-muted text-q2-ink"
-        >
-          <CalendarRangeIcon className="h-5 w-5" />
-        </span>
-        <div className="min-w-0">
-          <p className="text-small font-semibold text-foreground">Protect Q2</p>
-          <p className="mt-0.5 text-caption text-foreground-muted" aria-live="polite">
-            {scheduleCount === null
-              ? "Reserve one strategic block before reacting."
-              : scheduleMessage(scheduleCount)}
-          </p>
-        </div>
-        <button type="button"
-          {...preventPersistedDisabledState}
-          onClick={onFocusSchedule}
-          disabled={scheduleCount === null}
-          className="touch-target col-span-2 inline-flex items-center justify-center gap-2 rounded-lg bg-accent px-3 py-2 text-small font-semibold text-on-accent transition-colors hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-50 sm:col-span-1"
-        >
-          Show Schedule
-          <kbd className="rounded border border-on-accent/40 px-1.5 py-0.5 font-mono text-caption" aria-label="Option 2">
-            ⌥2
-          </kbd>
-          <ArrowDownRightIcon className="h-4 w-4" aria-hidden />
-        </button>
-      </aside>
+      <p className="min-w-0 flex-1 text-small text-foreground-muted">
+        {message ?? " "}
+      </p>
+
+      {/* The card's icon tile, heading, and supporting line all restated what
+          the button already says once the count moves into its label. Radius
+          steps down to --r-sm with the smaller type, per the Inkwell ladder. */}
+      <button type="button"
+        {...preventPersistedDisabledState}
+        onClick={onFocusSchedule}
+        disabled={scheduleCount === null}
+        className="touch-target inline-flex shrink-0 items-center gap-2 rounded-sm bg-accent px-3 py-2 text-[13px] font-semibold text-on-accent transition-colors hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-50"
+      >
+        <CalendarRangeIcon className="h-[15px] w-[15px] shrink-0" aria-hidden />
+        {scheduleLabel(scheduleCount)}
+        <kbd className="rounded-xs border border-on-accent/40 px-1.5 py-px font-mono text-[11px]" aria-label="Option 2">
+          ⌥2
+        </kbd>
+      </button>
     </section>
   );
 }

--- a/components/matrix-simplified/quadrant-pane.tsx
+++ b/components/matrix-simplified/quadrant-pane.tsx
@@ -30,6 +30,15 @@ const RD_ICON: Record<RedesignIconKey, LucideIcon> = {
  */
 export const ACTIVE_RENDER_CAP = 50;
 
+/**
+ * The active-count pill. It takes its quadrant's ink so the count joins the
+ * four-color language instead of sitting outside it in neutral gray, but the
+ * ground stays paper rather than the quadrant's own tint: the --q*-ink tokens
+ * are AA-checked against paper, and ochre ink on ochre measures under 4.5:1.
+ */
+const COUNT_PILL =
+  "ml-auto shrink-0 rounded-full bg-card px-2 py-0.5 text-[11px] font-semibold tabular-nums";
+
 interface QuadrantPaneProps {
   meta: QuadrantMeta;
   tasks: TaskRecord[];
@@ -119,7 +128,7 @@ export function QuadrantPane({
         <span data-testid="quadrant-hint" className="min-w-0 truncate text-caption" style={{ color: ink }}>
           {meta.rdHint}
         </span>
-        <span className="ml-auto shrink-0 rounded-full bg-background-muted px-2 py-0.5 text-[11px] font-medium tabular-nums text-foreground-muted">
+        <span data-testid="quadrant-count" className={COUNT_PILL} style={{ color: ink }}>
           {activeTaskCount}
         </span>
         <button

--- a/components/task-card/index.tsx
+++ b/components/task-card/index.tsx
@@ -2,7 +2,6 @@
 
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { AlertTriangleIcon } from "lucide-react";
 import { cn, isOverdue, isDueToday, daysOverdue } from "@/lib/utils";
 import { getUncompletedBlockingTasks, getUncompletedBlockedTasks } from "@/lib/dependencies";
 import { quadrantForTask, QUADRANT_ACCENT } from "@/lib/quadrants";
@@ -96,8 +95,8 @@ export function TaskCard({
         !task.completed && "hover:-translate-y-0.5 hover:border-accent/40 focus-within:border-accent/40",
         task.completed && "animate-complete-flash",
         isDragging && "cursor-grabbing",
-        // Half-strength so an overdue card is marked, not alarmed — the badge
-        // above carries the actual message.
+        // Half-strength so an overdue card is marked, not alarmed — the footer
+        // chip carries the actual message.
         taskIsOverdue && "border-status-overdue/50",
         selectionMode && isSelected && "ring-2 ring-accent ring-offset-2",
         isHighlighted && "animate-pulse-highlight ring-4 ring-accent ring-offset-2"
@@ -113,17 +112,9 @@ export function TaskCard({
         style={{ backgroundColor: accentVar }}
       />
 
-      {taskIsOverdue ? (
-        <span className="pointer-events-none absolute right-3 top-2.5 inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-[0.04em] text-status-overdue-ink">
-          <AlertTriangleIcon className="h-[11px] w-[11px]" aria-hidden />
-          {overdueDays}d overdue
-        </span>
-      ) : null}
-
       <TaskCardHeader
         task={task}
         accentVar={accentVar}
-        reserveBadgeSpace={taskIsOverdue}
         selectionMode={selectionMode}
         isSelected={isSelected}
         onToggleSelect={onToggleSelect}
@@ -150,6 +141,7 @@ export function TaskCard({
         task={task}
         taskIsOverdue={taskIsOverdue}
         taskIsDueToday={taskIsDueToday}
+        overdueDays={overdueDays}
         onEdit={onEdit}
         onDelete={onDelete}
         onShare={onShare}

--- a/components/task-card/task-card-actions.tsx
+++ b/components/task-card/task-card-actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PencilIcon, Trash2Icon, RepeatIcon, Share2Icon, CopyIcon, MoreHorizontalIcon, ClockIcon } from "lucide-react";
+import { PencilIcon, Trash2Icon, RepeatIcon, Share2Icon, CopyIcon, MoreHorizontalIcon, ClockIcon, AlertTriangleIcon } from "lucide-react";
 import { cn, formatRelative } from "@/lib/utils";
 import { TIME_MS } from "@/lib/constants";
 import { SnoozeDropdown } from "@/components/snooze-dropdown";
@@ -16,10 +16,24 @@ function isWithinDay(iso: string): boolean {
   return diff > 0 && diff < TIME_MS.DAY;
 }
 
+const SHORT_DATE = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" });
+
+/**
+ * "2d overdue · Aug 20". The date half is the point of moving this into the
+ * footer: the old corner badge stated the age and hid the date it was measured
+ * from, which is the one number a reader needs to reschedule.
+ */
+function overdueLabel(days: number, dueDate?: string): string {
+  const age = `${days}d overdue`;
+  return dueDate ? `${age} · ${SHORT_DATE.format(new Date(dueDate))}` : age;
+}
+
 export interface TaskCardActionsProps {
   task: TaskRecord;
   taskIsOverdue: boolean;
   taskIsDueToday: boolean;
+  /** Whole days past due; only read when taskIsOverdue. */
+  overdueDays: number;
   onEdit: (task: TaskRecord) => void;
   onDelete: (task: TaskRecord) => Promise<void> | void;
   onShare?: (task: TaskRecord) => void;
@@ -31,6 +45,7 @@ export function TaskCardActions({
   task,
   taskIsOverdue,
   taskIsDueToday,
+  overdueDays,
   onEdit,
   onDelete,
   onShare,
@@ -43,7 +58,18 @@ export function TaskCardActions({
       className="flex items-center justify-between gap-2 text-xs text-foreground-muted"
     >
       <div className="flex items-center gap-2">
-        {taskIsDueToday && !taskIsOverdue ? (
+        {taskIsOverdue ? (
+          // Same anatomy as the "Due today" chip below, one row down the
+          // temperature scale, so the footer stays a single scan column
+          // instead of asking the eye to also check the card's corner.
+          <span
+            data-testid="task-card-overdue-chip"
+            className="flex items-center gap-1 rounded-full bg-status-overdue-muted px-[9px] py-0.5 font-semibold text-status-overdue-ink"
+          >
+            <AlertTriangleIcon className="h-3 w-3 shrink-0" aria-hidden />
+            {overdueLabel(overdueDays, task.dueDate)}
+          </span>
+        ) : taskIsDueToday ? (
           // Due today reads as accent-semibold; the warning glyph is reserved
           // for the overdue state. Text is --accent-d, not --accent: the base
           // accent measures 4.53:1 on its own tint, too close to the floor.
@@ -51,7 +77,7 @@ export function TaskCardActions({
             <ClockIcon className="h-3 w-3" />
             Due today
           </span>
-        ) : task.dueDate && !taskIsOverdue ? (
+        ) : task.dueDate ? (
           <span
             className={cn(
               "inline-flex items-center gap-1 truncate",

--- a/components/task-card/task-card-header.tsx
+++ b/components/task-card/task-card-header.tsx
@@ -12,9 +12,6 @@ export interface TaskCardHeaderProps {
   task: TaskRecord;
   /** CSS var for the task's quadrant pigment, e.g. "var(--q1)". */
   accentVar: string;
-  /** Reserves room for the absolutely-positioned overdue badge so a long title
-   *  truncates instead of rendering underneath it. */
-  reserveBadgeSpace?: boolean;
   selectionMode?: boolean;
   isSelected?: boolean;
   onToggleSelect?: (task: TaskRecord) => void;
@@ -27,7 +24,6 @@ export interface TaskCardHeaderProps {
 export function TaskCardHeader({
   task,
   accentVar,
-  reserveBadgeSpace,
   selectionMode,
   isSelected,
   onToggleSelect,
@@ -82,12 +78,7 @@ export function TaskCardHeader({
           sortableAttributes={sortableAttributes}
           sortableListeners={sortableListeners}
         />
-        <div
-          className={cn(
-            "min-w-0 flex-1",
-            reserveBadgeSpace && "pr-24"
-          )}
-        >
+        <div className="min-w-0 flex-1">
           <h3 className={cn(
             "text-[14.5px] font-semibold leading-[1.4] tracking-[-0.005em]",
             !onInspect && "truncate",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "12.0.0",
+	"version": "12.0.1",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '12.0.0';
+const CACHE_VERSION = '12.0.1';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,60 @@
+# Status — 2026-08-22
+
+## Matrix usability tweaks (design handoff) — DONE (uncommitted → see below)
+
+Branch `feat/matrix-usability-tweaks`. Source: `design_handoff_matrix_usability_tweaks/README.md`
+(+ `Matrix Review.dc.html` frames 1a baseline / 1b target). Tier: Standard.
+
+- [x] ① `matrix-intro.tsx` — one flex row; h1 `text-display` → `text-h2`; Protect Q2
+      card → one accent button `Protect Q2 · {n} to schedule` (`· clear` at 0).
+      Props unchanged. Row starts at `sm:` — see the mobile trap below.
+- [x] ② `matrix-grid.tsx` — `AxisFrame` wraps the grid with URGENT / NOT URGENT
+      column labels and vertical IMPORTANT / NOT IMPORTANT row labels, all
+      `aria-hidden`, all hidden below `@min-[696px]`.
+- [x] ③ `quadrant-pane.tsx` — count pill takes `bg-card` + inline `--q*-ink`,
+      weight 600. Measured AA: q3 ochre 6.59:1 light, 8.07:1 dark.
+- [x] ④ task-card — corner badge and `reserveBadgeSpace`/`pr-24` removed; rust
+      chip leads the footer row, `{n}d overdue · {short date}`. `overdueDays`
+      is now a required `TaskCardActions` prop.
+
+Verified live (dev, SW busted, IndexedDB seeded, 1440x900 + 390 + dark):
+all four quadrant headers at y=347/658, well above the 900 fold; console clean
+apart from the pre-existing `[PWA] Periodic sync registration failed` warning.
+
+### Traps found
+
+- **The handoff frame is a 1500px desktop board.** Taking its single row
+  literally overflowed a 390px phone by 64px — the old layout was a grid that
+  stacked below `lg`, and an unconditional flex row dropped that. Fixed with
+  `flex-col … sm:flex-row`; pinned by `tests/e2e/matrix-briefing-fold.spec.ts`,
+  which fails against the unconditional row.
+- **The handoff says `rounded-lg` "(10px radius)".** In this repo `rounded-lg`
+  is 14px; 10px is `--r-sm` → `rounded-sm`. Frame 1a confirms the step-down is
+  intentional. Trust the pixel value and token name, not the class name.
+- **`quality:shape` is already red on a clean `main`** (pb-pull, pb-sync-engine,
+  sentry, terminal-block, capture-bar). This change adds nothing to it — the
+  axis frame and the count-pill class list were extracted to keep both touched
+  files at their baseline.
+
+### Resuming From Here
+
+Done: all four changes implemented, verified live, and green on
+`bun run test` (2799), `bun typecheck`, `bun lint`, `bun run test:e2e --project=chromium` (112).
+
+Next: **not yet committed at the time of writing** — commit the source/test
+files only. Deliberately NOT staged: `package.json` + `bun.lock` (unrelated
+`@browserbasehq/stagehand` bump already in the tree), `design_handoff_*/`,
+`first-run-guide.html`.
+
+Blockers: none. Open decision for the user: the compact briefing drops the
+`aria-live="polite"` region that used to announce the Q2 count, because the
+handoff collapses that whole card into the button label. The count is still in
+the button's accessible name. Re-adding a live region to a button label would
+announce on every Q2 change, which is noisier than what it replaces.
+
+Version bump deferred: `package.json` is 12.0.0 and the release trio
+(package.json + README:7 + sw.js CACHE_VERSION) should move together at ship time.
+
 # Status — 2026-08-16
 
 ## UI Polish Pass (/ui-craft polish) — DONE
@@ -13,22 +70,57 @@ npm serves 1.2.4 (latest); GitHub Packages published.
   the workflow now uses OIDC Trusted Publishing (see below). The dead
   `NPM_TOKEN` GitHub secret can be deleted (`gh secret delete NPM_TOKEN`).
 
-## OIDC Trusted Publishing — workflow side DONE, npmjs.com side PENDING (user)
+## OIDC Trusted Publishing — DONE (validated as far as possible pre-release)
 
-publish-mcp-server.yml now authenticates to npmjs via OIDC: Node 24 (npm
-≥11.5.1), no NPM_TOKEN, no registry-url on the npmjs setup-node (its .npmrc
-would reference an unset ${NODE_AUTH_TOKEN} and npm errors). GitHub Packages
-leg unchanged (GITHUB_TOKEN). Guard test added to
-security-hardening-scripts.test.ts.
+PR #505 merged (58ed107). npmjs.com trusted publisher configured by user
+2026-08-16 and reviewed field-by-field: vscarpenter/gsd-task-manager /
+publish-mcp-server.yml / environment mcp-release / npm publish permission.
+Dry-run dispatch (run 31969840150) green end-to-end on the new workflow:
+Node 24, npm 11.17.0, build + pack clean, publish steps correctly skipped.
 
-Before the next `mcp-v*` release the user must configure the trusted
-publisher on npmjs.com (package gsd-mcp-server → Settings → Publishing
-access): GitHub Actions / vscarpenter / gsd-task-manager /
-`publish-mcp-server.yml` / environment `mcp-release`. Until then a publish
-fails auth — that failure is the expected signal that config is missing.
+Cleanup completed 2026-08-16 (all user-approved):
+- `NPM_TOKEN` secret deleted from GitHub (verified absent)
+- Remote OIDC branch was already auto-removed at merge; refs pruned
+- npmjs Publishing access set to strict ("require 2FA, disallow bypass-2fa
+  tokens") — saved with security-key confirmation, "package scope updated!"
+
+Remaining: the OIDC exchange itself is only provable on the next real
+`mcp-v*` release — if it fails auth, suspect a publisher-config field
+mismatch before the workflow.
 
 ## Working-tree leftovers (deliberate, uncommitted on main)
 
 bun.lock + package.json (stagehand ^4.0.1 bump) and public/sw.js
 (CACHE_VERSION 12.0.1) — pre-staged version-bump material from a prior
 session; commit them with the next release, not with feature work.
+
+## In flight: editorial imports from first-run-guide (feat/editorial-imports)
+
+Pulling four approved design elements from first-run-guide.html into GSD
+(analysis + side-by-side artifact in session 824c95b2, 2026-08-17):
+
+1. `.kicker` mono eyebrow class in globals.css; unify the seven drifting
+   about-page eyebrow call sites; amend the mono-scope line in
+   .ui-craft/tokens.md + DESIGN.md.
+2. TerminalBlock component (TDD) with copy button; replaces the bare
+   pre/code in components/about/mcp-section.tsx.
+3. Dark-mode shadows become 1px white ring + faint blur in
+   inkwell-tokens.css (both dark branches identical).
+4. About hero h1 goes clamp()-fluid; app surfaces keep the fixed scale.
+
+No version bump here — per the note above, version material rides with
+the next release. Left untouched: bun.lock/package.json/sw.js leftovers.
+
+### Resuming From Here (2026-08-17, feat/editorial-imports)
+
+Done: all four editorial imports implemented, verified, and committed
+locally (5 commits, 521c0a1..6702a15). Full suite 2784 green, typecheck +
+lint clean. Live-verified headlessly (Playwright vs bun dev): 80px fluid
+hero, mono kickers, copy → Copied → revert with real clipboard content,
+#11100B dark terminal, ring shadow live on dark matrix panes. Verification
+caught + fixed: code-chip tint bleeding into the terminal (6702a15).
+
+Next: push + open PR (awaiting go-ahead). Not committed on purpose:
+bun.lock / package.json / sw.js release leftovers, this file,
+first-run-guide.html, next-env.d.ts (dev-server regen),
+.tmp-preview-guide-vs-editorial.html (rm was denied — delete manually).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -52,8 +52,10 @@ handoff collapses that whole card into the button label. The count is still in
 the button's accessible name. Re-adding a live region to a button label would
 announce on every Q2 change, which is noisier than what it replaces.
 
-Version bump deferred: `package.json` is 12.0.0 and the release trio
-(package.json + README:7 + sw.js CACHE_VERSION) should move together at ship time.
+Version bumped to **12.0.1** (patch) across the release trio: `package.json`,
+`README.md:7`, and `public/sw.js` CACHE_VERSION. Hand-edited rather than run
+through `scripts/update-sw-version.cjs` — `.build-info.json` is stale at 12.0.0
+and the script prefers it, so it would have written the old version back.
 
 # Status — 2026-08-16
 

--- a/tests/e2e/helpers/test-helpers.ts
+++ b/tests/e2e/helpers/test-helpers.ts
@@ -14,7 +14,7 @@ export async function waitForAppLoad(page: Page): Promise<void> {
     await expect(onboarding).toBeHidden();
   }
 
-  await expect(page.getByRole("button", { name: /Show Schedule/ })).toBeEnabled();
+  await expect(page.getByRole("button", { name: /Protect Q2/ })).toBeEnabled();
 }
 
 export async function getTaskCount(page: Page): Promise<number> {

--- a/tests/e2e/matrix-briefing-fold.spec.ts
+++ b/tests/e2e/matrix-briefing-fold.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "./fixtures/test-fixtures";
+import { waitForAppLoad } from "./helpers/test-helpers";
+
+/**
+ * The matrix briefing, measured rather than asserted by class name.
+ *
+ * The briefing was compacted to one row so the matrix clears the fold on a
+ * laptop. Both risks in that change are geometric, and jsdom cannot see
+ * either: the row has to actually buy the fold back at 1440x900, and taking
+ * the 1500px design frame literally overflowed a 390px phone by 64px, because
+ * a 205px date, a sentence, and a 193px button do not share one line there.
+ */
+test.describe("Matrix briefing", () => {
+  test("keeps all four quadrant headers above the fold at 1440x900", async ({ page, clearIndexedDB }) => {
+    void clearIndexedDB;
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await waitForAppLoad(page);
+
+    const headers = page.getByTestId("quadrant-header");
+    await expect(headers).toHaveCount(4);
+
+    for (let i = 0; i < 4; i += 1) {
+      const box = await headers.nth(i).boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.y + box!.height).toBeLessThan(900);
+    }
+  });
+
+  test("does not scroll the page sideways on a phone", async ({ page, clearIndexedDB }) => {
+    void clearIndexedDB;
+    await page.setViewportSize({ width: 390, height: 844 });
+    await waitForAppLoad(page);
+
+    const overflow = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+    expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth);
+  });
+
+  test("labels the axes only where the panes form a 2x2", async ({ page, clearIndexedDB }) => {
+    void clearIndexedDB;
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await waitForAppLoad(page);
+    await expect(page.getByTestId("matrix-axis-columns")).toBeVisible();
+    await expect(page.getByTestId("matrix-axis-rows")).toBeVisible();
+
+    // Below the container width that yields two columns the stack has no axes.
+    await page.setViewportSize({ width: 700, height: 900 });
+    await expect(page.getByTestId("matrix-axis-columns")).toBeHidden();
+    await expect(page.getByTestId("matrix-axis-rows")).toBeHidden();
+  });
+});

--- a/tests/e2e/pages/matrix-page.ts
+++ b/tests/e2e/pages/matrix-page.ts
@@ -36,7 +36,7 @@ export class MatrixPage {
     }
     
     await this.matrixGrid.waitFor({ state: "visible", timeout: 20000 });
-    await expect(this.page.getByRole("button", { name: /Show Schedule/ })).toBeEnabled();
+    await expect(this.page.getByRole("button", { name: /Protect Q2/ })).toBeEnabled();
   }
 
   async createTask(title: string): Promise<void> {

--- a/tests/e2e/production-hybrid.spec.ts
+++ b/tests/e2e/production-hybrid.spec.ts
@@ -10,7 +10,7 @@ test.describe("Refined Evolution production hybrid", () => {
   });
 
   test("supports the physical Option shortcut model", async ({ page }) => {
-    await expect(page.getByRole("button", { name: /show schedule/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /protect q2/i })).toBeVisible();
 
     await page.keyboard.press("Alt+n");
     await expect(page.getByTestId("capture-input")).toBeFocused();

--- a/tests/ui/matrix-grid-axes.test.tsx
+++ b/tests/ui/matrix-grid-axes.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MatrixGrid } from "@/components/matrix-simplified/matrix-grid";
+
+vi.mock("@dnd-kit/core", () => ({
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  verticalListSortingStrategy: vi.fn(),
+}));
+
+function renderGrid() {
+  return render(
+    <MatrixGrid
+      tasks={[]}
+      allTasks={[]}
+      onEdit={vi.fn()}
+      onToggleComplete={vi.fn()}
+      onDelete={vi.fn()}
+      onShare={vi.fn()}
+      onAddInQuadrant={vi.fn()}
+    />
+  );
+}
+
+/**
+ * The two axes are the whole argument of an Eisenhower matrix, and until now a
+ * reader had to infer them from four quadrant hints. jsdom has no layout and
+ * evaluates no container queries, so these assert the class contract that
+ * hides the frame in the single-column stack rather than the rendered geometry.
+ */
+describe("MatrixGrid — axis labels", () => {
+  it("names both ends of the urgency and importance axes", () => {
+    renderGrid();
+
+    expect(screen.getByText("Urgent")).toBeInTheDocument();
+    expect(screen.getByText("Not urgent")).toBeInTheDocument();
+    expect(screen.getByText("Important")).toBeInTheDocument();
+    expect(screen.getByText("Not important")).toBeInTheDocument();
+  });
+
+  it("speaks in the kicker voice and stays out of the accessibility tree", () => {
+    renderGrid();
+    const columns = screen.getByTestId("matrix-axis-columns");
+    const rows = screen.getByTestId("matrix-axis-rows");
+
+    expect(columns).toHaveAttribute("aria-hidden", "true");
+    expect(rows).toHaveAttribute("aria-hidden", "true");
+    // The panes already carry `aria-label="… quadrant"`; repeating the axes
+    // would make a screen reader announce urgency twice per pane.
+    expect(screen.getByText("Urgent").className).toContain("kicker");
+  });
+
+  it("hides the label frame below the container width that produces two columns", () => {
+    renderGrid();
+
+    for (const testId of ["matrix-axis-columns", "matrix-axis-rows", "matrix-axis-corner"]) {
+      const node = screen.getByTestId(testId);
+      expect(node.className).toContain("hidden");
+      expect(node.className).toContain("@min-[696px]:");
+    }
+  });
+
+  it("keeps the labels inside the grid's own container scope, not the viewport", () => {
+    const { container } = renderGrid();
+    const scope = container.querySelector(".\\@container");
+    const frame = screen.getByTestId("matrix-axis-frame");
+
+    expect(scope).toContainElement(frame);
+    expect(frame).toContainElement(screen.getByTestId("matrix-grid"));
+    expect(frame.className).toContain("@min-[696px]:grid-cols-[22px_minmax(0,1fr)]");
+  });
+});

--- a/tests/ui/matrix-intro.test.tsx
+++ b/tests/ui/matrix-intro.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MatrixIntro } from "@/components/matrix-simplified/matrix-intro";
+
+/**
+ * The briefing is one row, not a two-column section: on a 13" laptop the old
+ * display-size date plus the Protect Q2 card cost ~190px before the first
+ * task, which pushed the bottom two quadrant headers below the fold. These
+ * assert the compact contract — the props themselves are unchanged.
+ */
+function renderIntro(overrides?: Partial<Parameters<typeof MatrixIntro>[0]>) {
+  const onFocusSchedule = vi.fn();
+  const result = render(
+    <MatrixIntro
+      dateLabel="Saturday, August 22"
+      message="The overdue task sits in Do First."
+      scheduleCount={4}
+      onFocusSchedule={onFocusSchedule}
+      {...overrides}
+    />
+  );
+  return { onFocusSchedule, ...result };
+}
+
+describe("MatrixIntro — compact one-row briefing", () => {
+  it("drops the date heading from display scale to h2", () => {
+    renderIntro();
+    const heading = screen.getByRole("heading", { level: 1 });
+
+    expect(heading.className).toContain("text-h2");
+    expect(heading.className).not.toContain("text-display");
+    expect(heading).toHaveTextContent("Saturday, August 22");
+  });
+
+  it("keeps the screen-reader prefix so the bare date still reads as a heading", () => {
+    renderIntro();
+    expect(screen.getByRole("heading", { level: 1, name: /today.s matrix/i })).toBeInTheDocument();
+  });
+
+  it("collapses the Protect Q2 card into one accent button carrying the count", () => {
+    renderIntro({ scheduleCount: 4 });
+    const button = screen.getByRole("button", { name: /protect q2/i });
+
+    expect(button).toHaveTextContent("Protect Q2 · 4 to schedule");
+    expect(button.className).toContain("bg-accent");
+    expect(button.className).toContain("text-on-accent");
+    expect(screen.getByText("⌥2")).toBeInTheDocument();
+  });
+
+  it("reads 'clear' rather than '0 to schedule' when Q2 is empty", () => {
+    renderIntro({ scheduleCount: 0 });
+    expect(screen.getByRole("button", { name: /protect q2/i })).toHaveTextContent(
+      "Protect Q2 · clear"
+    );
+  });
+
+  it("waits for the count before enabling, and guards Firefox state restore", () => {
+    renderIntro({ scheduleCount: null });
+    const button = screen.getByRole("button", { name: /protect q2/i });
+
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("autocomplete", "off");
+  });
+
+  it("still hands the ⌥2 focus request to its caller", async () => {
+    const user = userEvent.setup();
+    const { onFocusSchedule } = renderIntro();
+
+    await user.click(screen.getByRole("button", { name: /protect q2/i }));
+    expect(onFocusSchedule).toHaveBeenCalledTimes(1);
+  });
+
+  // The design frame is a 1500px desktop board, and taking its single row
+  // literally overflowed a 390px phone by 64px — the date, the reading, and a
+  // 193px button cannot share one line there. The row starts at sm; below it
+  // the three parts stack, which is what the two-column section used to do.
+  it("stacks the three parts on a phone instead of overflowing the viewport", () => {
+    const { container } = renderIntro();
+    const section = container.querySelector("section");
+
+    expect(section?.className).toContain("flex-col");
+    expect(section?.className).toContain("sm:flex-row");
+    expect(section?.className).toContain("sm:items-center");
+  });
+
+  it("renders no date text before hydration so the static export stays date-free", () => {
+    renderIntro({ dateLabel: null, message: null });
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(/^Today.s matrix —\s*$/);
+  });
+});

--- a/tests/ui/matrix-simplified.test.tsx
+++ b/tests/ui/matrix-simplified.test.tsx
@@ -237,7 +237,8 @@ describe("<MatrixSimplified>", () => {
     render(<MatrixSimplified />);
     const grid = screen.getByTestId("matrix-grid");
 
-    expect(grid.parentElement).toHaveClass("@container");
+    // The axis-label frame now sits between the grid and its container scope.
+    expect(grid.closest(".\\@container")).not.toBeNull();
     expect(grid).toHaveClass("@min-[696px]:grid-cols-2", "@min-[696px]:grid-rows-2");
     expect(grid.className).not.toMatch(/\b(md|lg):grid-cols-2\b/);
   });
@@ -414,7 +415,7 @@ describe("<MatrixSimplified>", () => {
     const snapshot = document.createElement("div");
     snapshot.innerHTML = html;
     const showSchedule = Array.from(snapshot.querySelectorAll("button")).find((button) =>
-      button.textContent?.includes("Show Schedule")
+      button.textContent?.includes("Protect Q2")
     );
 
     expect(html).toContain("GSD Matrix");
@@ -453,15 +454,19 @@ describe("<MatrixSimplified>", () => {
 
     render(<MatrixSimplified />);
 
-    expect(screen.getByText("2 strategic commitments need protected time.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /protect q2/i })).toHaveTextContent(
+      "Protect Q2 · 2 to schedule"
+    );
   });
 
   it("does not publish a false Q2 count while tasks are loading", () => {
     tasksFixture.loading = true;
     render(<MatrixSimplified />);
 
-    expect(screen.queryByText(/strategic commitment.*protected time/i)).not.toBeInTheDocument();
-    expect(screen.getByText("Reserve one strategic block before reacting.")).toBeInTheDocument();
+    const scheduleButton = screen.getByRole("button", { name: /protect q2/i });
+    expect(scheduleButton).toHaveTextContent("Protect Q2");
+    expect(scheduleButton).not.toHaveTextContent(/to schedule|clear/);
+    expect(scheduleButton).toBeDisabled();
   });
 
   it("keeps the Q2 planning count stable when search filters the matrix", async () => {
@@ -473,7 +478,9 @@ describe("<MatrixSimplified>", () => {
 
     await userEvent.type(screen.getByLabelText("Shell search"), "production");
 
-    expect(screen.getByText("1 strategic commitment needs protected time.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /protect q2/i })).toHaveTextContent(
+      "Protect Q2 · 1 to schedule"
+    );
     expect(screen.queryByText("Write the strategy")).not.toBeInTheDocument();
   });
 
@@ -482,7 +489,7 @@ describe("<MatrixSimplified>", () => {
     Element.prototype.scrollIntoView = scrollIntoView;
     render(<MatrixSimplified />);
 
-    await userEvent.click(screen.getByRole("button", { name: /show schedule/i }));
+    await userEvent.click(screen.getByRole("button", { name: /protect q2/i }));
 
     expect(screen.getByTestId("quadrant-q2")).toHaveFocus();
     expect(screen.getByTestId("quadrant-q2")).toHaveClass(

--- a/tests/ui/task-card-anatomy.test.tsx
+++ b/tests/ui/task-card-anatomy.test.tsx
@@ -142,23 +142,40 @@ describe("TaskCard anatomy — four-pigment language", () => {
     expect(chip.className).toContain("bg-background-muted");
   });
 
-  // The overdue badge is absolutely positioned over the card's top-right. Without
-  // reserved space the title rendered *underneath* it (measured 39px of overlap
-  // at 1440px), so a long overdue title was partly unreadable. jsdom has no
-  // layout, so assert the reservation rather than the geometry.
-  it("reserves room for the overdue badge so the title truncates instead of colliding", () => {
+  // Overdue used to be a 10px caption absolutely positioned over the card's
+  // top-right, which forced every overdue title to reserve 96px it did not
+  // otherwise need. It now sits in the footer row, the column where a reader
+  // already scans for dates.
+  it("states overdue as a footer chip carrying the day count and the due date", () => {
+    const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000).toISOString();
+    renderCard({ dueDate: twoDaysAgo, completed: false });
+    const chip = screen.getByTestId("task-card-overdue-chip");
+
+    expect(screen.getByTestId("task-card-actions")).toContainElement(chip);
+    expect(chip).toHaveTextContent(/^2d overdue · \w{3} \d{1,2}$/);
+    expect(chip.className).toContain("bg-status-overdue-muted");
+    expect(chip.className).toContain("text-status-overdue-ink");
+  });
+
+  it("no longer reserves right padding for a corner overdue badge", () => {
     const yesterday = new Date(Date.now() - 86_400_000).toISOString();
     renderCard({ dueDate: yesterday, completed: false });
     const title = screen.getByRole("heading", { level: 3 });
-    expect(title.parentElement?.className).toContain("pr-24");
+    expect(title.parentElement?.className).not.toContain("pr-24");
     expect(title.className).toContain("truncate");
   });
 
-  it("does not reserve badge space when the task is not overdue", () => {
+  it("keeps the half-strength rust border as the only other overdue mark", () => {
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString();
+    renderCard({ dueDate: yesterday, completed: false });
+    expect(screen.getByTestId("task-card")).toHaveClass("border-status-overdue/50");
+    expect(screen.queryAllByText(/overdue/i)).toHaveLength(1);
+  });
+
+  it("shows no overdue chip on a card that is not overdue", () => {
     const tomorrow = new Date(Date.now() + 86_400_000).toISOString();
     renderCard({ dueDate: tomorrow, completed: false });
-    const title = screen.getByRole("heading", { level: 3 });
-    expect(title.parentElement?.className).not.toContain("pr-24");
+    expect(screen.queryByTestId("task-card-overdue-chip")).not.toBeInTheDocument();
   });
 
   it("keeps a blocked card opaque so its text remains contrast-safe", () => {
@@ -235,6 +252,20 @@ describe("QuadrantPane header — quadrant identity", () => {
     expect(screen.getByTestId("quadrant-q3").style.backgroundColor).toBe("var(--q3-wash)");
     expect(screen.getByTestId("quadrant-header").style.backgroundColor).toBe("var(--q3-header)");
     expect(screen.getByTestId("quadrant-icon").style.color).toBe("var(--q3-ink)");
+  });
+
+  // Paper, not the quadrant tint: ochre ink on the ochre header band measures
+  // under 4.5:1. The `--q*-ink` tokens are AA-checked against `--paper`, so a
+  // paper pill is the one ground on which every quadrant's ink is legible.
+  it("prints the count pill in the quadrant ink on a paper ground", () => {
+    renderPane("q3");
+    const pill = screen.getByTestId("quadrant-count");
+
+    expect(pill.style.color).toBe("var(--q3-ink)");
+    expect(pill.className).toContain("bg-card");
+    expect(pill.className).toContain("font-semibold");
+    expect(pill.className).not.toContain("bg-background-muted");
+    expect(pill.className).toContain("tabular-nums");
   });
 
   it("shows an empty-state mark tile when the quadrant is empty", () => {

--- a/tests/ui/task-card-subcomponents.test.tsx
+++ b/tests/ui/task-card-subcomponents.test.tsx
@@ -306,6 +306,7 @@ describe("TaskCardActions", () => {
         }}
         taskIsOverdue={false}
         taskIsDueToday={false}
+        overdueDays={0}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />
@@ -342,6 +343,7 @@ describe("TaskCardActions", () => {
         }}
         taskIsOverdue={false}
         taskIsDueToday={false}
+        overdueDays={0}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
         onShare={vi.fn()}
@@ -353,7 +355,7 @@ describe("TaskCardActions", () => {
     expect(screen.getByRole("button", { name: /duplicate task/i })).toBeInTheDocument();
   });
 
-  it("does not render overdue badge in actions row (now hoisted to card root)", async () => {
+  it("leads the footer row with the overdue chip", async () => {
     const { TaskCardActions } = await import(
       "@/components/task-card/task-card-actions"
     );
@@ -379,14 +381,16 @@ describe("TaskCardActions", () => {
         }}
         taskIsOverdue={true}
         taskIsDueToday={false}
+        overdueDays={3}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />
     );
 
-    // Polish v0.9.2: the overdue caption now lives on the TaskCard root,
-    // not in the actions footer. Confirm it is gone from this scope.
-    expect(screen.queryByText("Overdue")).not.toBeInTheDocument();
+    // The overdue caption came back down from the card root into the footer,
+    // where it shares a scan column with "Due today" and the relative date.
+    // Without a dueDate the chip states the age alone rather than an em-dash.
+    expect(screen.getByTestId("task-card-overdue-chip")).toHaveTextContent("3d overdue");
   });
 
   it("shows recurrence icon", async () => {
@@ -415,6 +419,7 @@ describe("TaskCardActions", () => {
         }}
         taskIsOverdue={false}
         taskIsDueToday={false}
+        overdueDays={0}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />


### PR DESCRIPTION
Implements the four tweaks in `design_handoff_matrix_usability_tweaks/README.md`, diffed against frames 1a (baseline) and 1b (target) in the bundled design reference. Ships as 12.0.1.

## What changed

**① One-row briefing** (`components/matrix-simplified/matrix-intro.tsx`). The two-column section becomes a single row. The date drops from `text-display` (48px) to `text-h2` (24px), and the Protect Q2 card collapses into one accent button carrying the count: `Protect Q2 · 4 to schedule`, or `Protect Q2 · clear` at zero. That buys back roughly 140px. `MatrixIntroProps` is unchanged.

**② Axis labels** (`matrix-grid.tsx`). A new `AxisFrame` names both axes: URGENT and NOT URGENT above the columns, IMPORTANT and NOT IMPORTANT rotated beside the rows. The labels are `aria-hidden` because each pane already carries its own quadrant label, and they hide below `@min-[696px]`, where the panes stack into one column and have no axes to name. The query is on the container, not the viewport, so the labels respond to the icon rail collapsing.

**③ Inked count pills** (`quadrant-pane.tsx`). The pill takes its quadrant's ink on a paper ground, which joins it to the four-color language.

**④ Overdue chip** (`components/task-card/*`). Overdue moves from a corner badge into a chip at the head of the footer row, where a reader already scans for dates. The chip also restores the due date the badge hid, and removing the badge lets long overdue titles reclaim the 96px of right padding they reserved for it.

## Why the pill ground is paper, not the quadrant tint

Measured contrast against `--paper`, which is what the `--q*-ink` tokens are checked against:

| Quadrant | Light | Dark |
|---|---|---|
| q1 rust | 5.94:1 | 5.25:1 |
| q2 tide | 6.33:1 | 6.55:1 |
| q3 ochre | 6.59:1 | 8.07:1 |
| q4 slate | 6.70:1 | 6.44:1 |

Ochre ink on the ochre header band falls under the 4.5:1 floor, so the pill ground has to stay paper. The overdue chip measures 6.49:1 on its rust tint.

## One deviation from the handoff

Its frame is a 1500px desktop board. Reproducing that single row literally overflowed a 390px phone by 64px and scrolled the page sideways, because the layout it replaced was a grid that stacked below `lg`. The row now starts at `sm`. `tests/e2e/matrix-briefing-fold.spec.ts` pins both the fold and the phone, and it fails against the unconditional row.

The handoff also names `rounded-lg` while annotating it "(10px radius)". In this repo `rounded-lg` is 14px and 10px is `--r-sm`. Frame 1a has the button at 14px and 1b at 10px, so the step-down is real; the class name was not.

## How to test locally

```
bun run test
bun typecheck
bun lint
bun run test:e2e -- --project=chromium
```

Then `bun dev`, clear the service worker and the `gsd-*` caches, seed some tasks including one overdue, and check the board at 1440x900, 700px, and 390px in both themes.

## Verification

Verified in the running app with the service worker busted and IndexedDB seeded. All four quadrant headers clear the fold at 1440x900, measuring y=347 and y=658. Axis labels compute `display: none` at 700px. The overdue chip renders `2d overdue · Aug 20` with no corner badge. Console clean apart from the pre-existing `[PWA] Periodic sync registration failed` warning.

Gates: `bun run test` 2799 passed, `bun typecheck` clean, `bun lint` clean, `bun run test:e2e --project=chromium` 112 passed.

`bun run quality:shape` fails, but it fails identically on a clean `main` (pb-pull, pb-sync-engine, sentry, terminal-block, capture-bar). This branch adds nothing to that debt: `AxisFrame` and the count pill's class list were extracted so both touched files sit at their baseline.

## One decision to review

The old Protect Q2 card had an `aria-live="polite"` region announcing the Q2 count. The handoff collapses that card into the button, and this PR does not re-add the live region. The count still lives in the button's accessible name. Re-adding a live region on a button label would announce on every Q2 change, which is noisier than what it replaces. Happy to add it back if you would rather keep the announcement.

## Not included

The working tree still carries an unrelated `@browserbasehq/stagehand` `^4.0.0 → ^4.0.1` bump in `package.json` and `bun.lock`, plus the untracked handoff bundle and `first-run-guide.html`. Those are deliberately left out of both commits.

https://claude.ai/code/session_01SacBqq6dpRZ2YGBWYao3JB

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR compacts the matrix briefing, adds responsive axis labels, applies quadrant ink to count pills, and moves overdue information into task-card footers. It also updates associated UI and end-to-end coverage and advances the application and service-worker versions to 12.0.1.
- Reworks the matrix introduction into a responsive compact briefing.
- Adds container-responsive urgency and importance labels around the 2×2 matrix.
- Restyles quadrant counts and introduces overdue chips containing age and due date.
- Updates release metadata, cache versioning, and regression tests.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no concrete blocking or independently actionable non-blocking defect was established.

The responsive matrix changes, overdue presentation, release metadata, and accompanying tests remain internally consistent, and the investigated edge cases lacked evidence of a reachable observable failure.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| components/matrix-simplified/matrix-grid.tsx | Adds an axis frame whose labels appear only when the container supports the 2×2 matrix layout. |
| components/matrix-simplified/matrix-intro.tsx | Replaces the large two-column briefing with a responsive compact row and count-bearing Q2 button. |
| components/matrix-simplified/quadrant-pane.tsx | Restyles active-count pills using each quadrant’s ink color on the paper ground. |
| components/task-card/task-card-actions.tsx | Moves overdue status into the footer and adds localized short-date text without an established actionable defect. |
| components/task-card/index.tsx | Removes the corner overdue badge and passes the calculated overdue age into footer actions. |
| public/sw.js | Advances the service-worker cache namespace to match version 12.0.1. |
| tests/e2e/matrix-briefing-fold.spec.ts | Adds browser-level checks for desktop fold placement, phone overflow, and responsive axis visibility. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): 12.0.1"](https://github.com/vscarpenter/gsd-task-manager/commit/999f68f3ac9ed7c9243411e3ffa28e90571182c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55938530)</sub>

<!-- /greptile_comment -->