### PR TITLE
docs(mcp): remove changelog links to tags that never existed

### DIFF
--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -576,8 +576,3 @@ audits every tool for schema fidelity, input validation, and side-effect safety.
 - `Improved` - Enhancements to existing features
 
 [1.2.5]: https://github.com/vscarpenter/gsd-task-manager/compare/mcp-v1.2.4...mcp-v1.2.5
-[1.1.4]: https://github.com/vscarpenter/gsd-task-manager/compare/v1.1.3...v1.1.4
-[0.3.0]: https://github.com/vscarpenter/gsd-task-manager/compare/v0.2.1...v0.3.0
-[0.2.1]: https://github.com/vscarpenter/gsd-task-manager/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/vscarpenter/gsd-task-manager/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/vscarpenter/gsd-task-manager/releases/tag/v0.1.0


### PR DESCRIPTION
Five link definitions in `packages/mcp-server/CHANGELOG.md` pointed at tags that do not exist.

## Verified against the remote

```
$ git ls-remote --tags origin
mcp-server-v0.5.1  mcp-v1.1.3  mcp-v1.2.4  mcp-v1.2.5
v1.0 v2.0 v3.0.0 ... v12.0.0 v12.2.0
```

Cited by the dead links: `v0.1.0`, `v0.2.0`, `v0.2.1`, `v0.3.0`, `v1.1.3`, `v1.1.4` — **all missing**. The MCP line uses an `mcp-v` prefix; the bare `v*` tags are the app's releases, a different version line entirely.

PR #509 corrected the slug in these URLs, which left them pointing at a real repository and a missing ref. Still 404.

## Why delete rather than repair

Most of those releases were never tagged, so there is no correct target. `mcp-v1.1.3` exists but `mcp-v1.1.4` does not, so even the one partially-recoverable compare cannot be reconstructed.

## Rendering impact: none meaningful

The `## [1.1.4]` headings now render as plain bracketed text — which already describes the ~24 other version headings in the file that never had a definition. This makes the file more consistent, not less.

`[1.2.5]` survives and returns **200**. A deleted one returns **404**.

## Not adding a guard test

A test validating link definitions against `git tag` would be the natural regression guard, but `ci.yml` checks out with `fetch-depth: 1` — a shallow clone with no tags. The test would find zero tags and fail spuriously. Viable only if the checkout config changes, which is out of scope here.

## Verification

```
bun run test (root)         2808 passed, 1 skipped
bun run test (mcp-server)   294 passed, 3 skipped
```

No version bump: this touches no shipped code, so it rides with the next MCP release.

https://claude.ai/code/session_01KeJ8svJc1VPodbjXdGsdgY
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes five dead reference links from the MCP server changelog while preserving the valid `1.2.5` comparison link.

- Removes links targeting nonexistent bare `v*` tags.
- Leaves the affected release headings as readable, unlinked text.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The documentation-only change removes links to nonexistent tags, leaves the release headings readable, and preserves the valid MCP comparison link.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/mcp-server/CHANGELOG.md | Removes five invalid release-link definitions without changing changelog content or introducing a documentation regression. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(mcp): remove changelog links to tag..."](https://github.com/vscarpenter/gsd-task-manager/commit/bfde47e315b04a592e4e45fd835d3cfecbbaf4d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56028040)</sub>

<!-- /greptile_comment -->