### PR TITLE
fix(skills): add a GitHub fallback when the local merge check expires

### DIFF
--- a/.claude/skills/cleaning-up-merged-branches/SKILL.md
+++ b/.claude/skills/cleaning-up-merged-branches/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: cleaning-up-merged-branches
+description: Syncs main and deletes the local feature branch after a PR is merged on GitHub. Use when the user says they merged or squash-merged a PR ("I merged PR 411 on GitHub", "merged the PR", "clean up the branch"). Codifies this repo's squash-merge default, where `git branch -d` wrongly reports "not fully merged" and a verified force-delete is required.
+---
+
+# Cleaning up merged branches
+
+Sync `main` and remove the now-stale local feature branch after the user merges a
+PR on GitHub. This repo squash-merges PRs by default, so the plain `git branch -d`
+refuses to delete the branch. Verify the content actually landed in `main`, then
+force-delete.
+
+Verification is two-tier on purpose. The cheap local check (step 4) is conclusive
+only for a branch cut from the current `main`; it decays into false alarms as the
+branch ages. When it comes back dirty, step 5 asks GitHub, which is authoritative
+regardless of how the merge rewrote history. Never force-delete on a `[gone]`
+upstream marker alone: that only means the remote branch was deleted, which says
+nothing about whether the work merged.
+
+## Steps
+
+1. Fetch, prune stale remote-tracking refs, and note the current branch:
+   `git fetch origin --prune && git branch --show-current`
+2. Switch to `main` and pull the merge (local `main` still points at the pre-merge
+   commit until you do this):
+   `git checkout main && git pull origin main`
+3. Try the safe delete of the feature branch:
+   `git branch -d <branch>`
+   - Succeeds → done; go to Verify.
+   - Fails with `error: the branch '<branch>' is not fully merged` → expected for a
+     squash merge. GitHub squashed the branch into one new commit, so its original
+     commits are not ancestors of `main` even though the content landed. Continue.
+4. Confirm the branch's content is fully in `main` before force-deleting. The
+   `':!.blume'` pathspec excludes local `.blume/` tool artifacts that are never
+   committed:
+   `git diff main <branch> -- . ':!.blume'`
+   - Empty output → content is fully in `main`; safe to force-delete.
+   - Non-empty output → **this check has expired, not failed.** It only proves a
+     merge for a branch cut from the current `main`. Fall through to step 5.
+5. Only when step 4 came back non-empty, ask GitHub whether the branch was merged.
+   This is the authoritative answer, because it survives any history rewrite:
+   `gh pr list --state all --head <branch> --json number,state,mergedAt,title`
+   - A `MERGED` PR → the content landed; safe to force-delete.
+   - No PR, or an `OPEN`/`CLOSED` one → genuinely unmerged. Stop, show the user the
+     branch's commits (`git cherry -v main <branch>`), and do NOT force-delete.
+6. Force-delete the redundant local branch:
+   `git branch -D <branch>`
+
+## Verify
+
+- `git branch` shows the feature branch is gone and you are on `main`.
+- `git log --oneline -1` shows `main` at the squash-merge commit.
+
+## Gotchas
+
+- **`git diff main <branch>` is bidirectional, so it expires.** It reports work that
+  landed in `main` *after* the branch was cut as though the branch removed it. That
+  is harmless right after a merge, which is the case this skill was written for, but
+  a branch left sitting for a few weeks reports thousands of diff lines even when its
+  content merged cleanly. A non-empty diff on an older branch is not evidence of
+  unmerged work; it is the check aging out. That is what step 5 is for.
+- **`git cherry main <branch>` is not a fix for that.** It compares patch-ids, and a
+  squash-merge collapses N commits into one that matches none of the N originals.
+  The tell is a perfect correlation between commit count and verdict: every
+  single-commit branch reads "already upstream" and every multi-commit branch reads
+  "not in main". That pattern means squash-merge, not lost work. It is still useful
+  as evidence *for* deletion (nothing flagged → definitely merged), never against.
+- **`git worktree remove --force` discards uncommitted work silently.** Run
+  `git -C <worktree> status --short` first and show the user anything it finds.
+- Deleting **multiple** branches at once: zsh does not word-split an unquoted
+  variable (unlike bash), so `git branch -D $branches` passes the whole list as one
+  bad refspec and deletes nothing. Pipe the list through `xargs` instead:
+  `... | xargs git branch -D`.
+- Deleting **remote** branches (`git push origin --delete <branch>`) is externally
+  visible — confirm with the user first. Local cleanup above does not require it;
+  `git fetch origin --prune` already drops stale remote-tracking refs.

--- a/.claude/skills/cleaning-up-merged-branches/SKILL.md
+++ b/.claude/skills/cleaning-up-merged-branches/SKILL.md
@@ -38,11 +38,21 @@ nothing about whether the work merged.
    - Non-empty output → **this check has expired, not failed.** It only proves a
      merge for a branch cut from the current `main`. Fall through to step 5.
 5. Only when step 4 came back non-empty, ask GitHub whether the branch was merged.
-   This is the authoritative answer, because it survives any history rewrite:
-   `gh pr list --state all --head <branch> --json number,state,mergedAt,title`
-   - A `MERGED` PR → the content landed; safe to force-delete.
-   - No PR, or an `OPEN`/`CLOSED` one → genuinely unmerged. Stop, show the user the
-     branch's commits (`git cherry -v main <branch>`), and do NOT force-delete.
+   This survives any history rewrite, and still answers after the remote branch is
+   deleted. `--head` matches on branch *name*, so you must also confirm the PR was
+   built from the commit the local branch actually points at:
+   ```bash
+   gh pr list --state all --head <branch> --json number,state,mergedAt,headRefOid
+   git rev-parse <branch>
+   ```
+   - A `MERGED` PR **whose `headRefOid` equals the local tip** → the content landed;
+     safe to force-delete.
+   - A `MERGED` PR whose `headRefOid` **differs** → the local branch has moved since
+     that PR merged, or the name was reused. Those extra commits are not in `main`.
+     Stop, show the user `git log --oneline <headRefOid>..<branch>`, and do NOT
+     force-delete.
+   - No PR, or only `OPEN`/`CLOSED` ones → genuinely unmerged. Stop, show the user
+     `git cherry -v main <branch>`, and do NOT force-delete.
 6. Force-delete the redundant local branch:
    `git branch -D <branch>`
 
@@ -65,6 +75,13 @@ nothing about whether the work merged.
   single-commit branch reads "already upstream" and every multi-commit branch reads
   "not in main". That pattern means squash-merge, not lost work. It is still useful
   as evidence *for* deletion (nothing flagged → definitely merged), never against.
+- **A merged PR proves the *name* merged, not the branch you are holding.**
+  `gh pr list --head` filters by branch name, so a branch that gained local commits
+  after its PR merged, or a name reused for new work, still returns the old `MERGED`
+  record. Acting on that deletes commits that never landed. This is why step 5
+  compares `headRefOid` against `git rev-parse <branch>` rather than trusting the
+  `MERGED` state alone. `headRefOid` remains readable long after the remote branch
+  is gone, which is what makes the comparison possible at cleanup time.
 - **`git worktree remove --force` discards uncommitted work silently.** Run
   `git -C <worktree> status --short` first and show the user anything it finds.
 - Deleting **multiple** branches at once: zsh does not word-split an unquoted

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ sync.md
 !.claude/skills/verify-frontend-change/
 !.claude/skills/claude-code-primitives/
 !.claude/skills/sentry-verification/
+!.claude/skills/cleaning-up-merged-branches/
 
 *.tsbuildinfo
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 12.3.0
+**Current version:** 12.3.1
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "12.3.0",
+	"version": "12.3.1",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '12.3.0';
+const CACHE_VERSION = '12.3.1';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 


### PR DESCRIPTION
## The gap

`cleaning-up-merged-branches` verified that a branch had merged with `git diff main <branch>`. That comparison is bidirectional: it reports work which landed in `main` *after* the branch was cut as though the branch had removed it. The check is therefore sound only for a branch just merged off the current `main`, which is the case the skill was written for.

On an older branch it decays into a false alarm. Cleaning up nine stale `[gone]` branches, it flagged all nine, reporting up to 50,000 diff lines. Every one of them had in fact been merged. Followed literally, the skill blocks a deletion that is perfectly safe.

## The fix

Step 5 now falls back to GitHub when the local check comes back dirty:

```
gh pr list --state all --head <branch> --json number,state,mergedAt,title
```

That answer is authoritative. It survives any history rewrite and still works after the remote branch has been deleted, which is exactly the situation in which you are cleaning up. A non-empty local diff is reframed as **expired, not failed**, so the skill falls through instead of stopping.

Verified both directions:

- `--head chore/remove-pwa-install-prompt` (remote already deleted) returns `MERGED` for #514
- `--head fix/branch-cleanup-skill-squash-fallback` (no PR at the time) returns `[]`

## Why not `git cherry`

Worth recording, because it is the obvious second guess and it also fails. `git cherry` compares patch-ids, and a squash-merge collapses N commits into one that matches none of the N originals. The tell is a perfect correlation between commit count and verdict: every single-commit branch reads "already upstream" and every multi-commit branch reads "not in main". That pattern means squash-merge, not lost work.

It remains useful as evidence *for* deletion (nothing flagged means definitely merged), never against. The skill now says so.

Also documented: `git worktree remove --force` discards uncommitted work silently, so check `git -C <worktree> status --short` first.

## Tracking the skill

The skill lived under the blanket `.claude/skills/*` ignore, so the fix would have stayed local-only. Adds it to the existing allowlist alongside the other repo-workflow skills. This one encodes this repo's squash-merge behavior, so it belongs with them rather than in a personal directory.

## Version

Bumps 12.3.0 to 12.3.1 across the three synchronized pins: `package.json`, `README.md` line 7, and `CACHE_VERSION` in `public/sw.js`. Bumping `package.json` alone fails `documentation-currentness.test.ts`, which asserts the README matches.

`.build-info.json` stays stale at 12.2.6 deliberately. It is untracked, and it differing from `package.json` is what makes `generate-build-info.cjs` reset to the package version rather than increment past it.

## How to test locally

```
bun run test          # 2769 passed, 1 skipped
bun typecheck
bun lint
bun run quality:shape
```

No application code changes, so there is nothing to verify in the browser.

https://claude.ai/code/session_01FZbw3EmDWhRdDBaF8NSUV6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes stale-branch cleanup fall back to GitHub when local content comparison is inconclusive, while tying merge authorization to the exact local branch tip.
- Adds and tracks the branch-cleanup skill.
- Requires a merged PR’s `headRefOid` to match the current local tip before force deletion.
- Synchronizes the 12.3.1 version across the package, README, and service-worker cache.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .claude/skills/cleaning-up-merged-branches/SKILL.md | Adds the GitHub fallback and closes the previously reported historic-merge hazard by validating the exact branch-tip commit. |
| .gitignore | Adds the new repository workflow skill to the existing tracked-skill allowlist. |
| README.md | Updates the documented current version to 12.3.1. |
| package.json | Bumps the package version to 12.3.1. |
| public/sw.js | Synchronizes the service-worker cache version with the package release. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(skills): tie the merged-PR check to ..."](https://github.com/vscarpenter/gsd-task-manager/commit/8d56ac79965cd676c4a466e201a99c4c7ca1d1e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57082471)</sub>

<!-- /greptile_comment -->