### PR TITLE
feat(review): lead the dashboard with a data-derived verdict

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 12.4.0
+**Current version:** 12.5.0
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -3,14 +3,12 @@
 import type { Route } from "next";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import {
-  CheckCircle2Icon,
-  ListTodoIcon,
-  TrendingUpIcon,
-  AlertTriangleIcon,
-} from "lucide-react";
+import { CheckCircle2Icon, ListTodoIcon, TrendingUpIcon } from "lucide-react";
 import { AppShell } from "@/components/matrix-simplified/app-shell";
+import { ErrorBoundary } from "@/components/error-boundary";
 import { StatsCard } from "@/components/dashboard/stats-card";
+import { ReviewVerdict } from "@/components/dashboard/review-verdict";
+import { DashboardError } from "@/components/dashboard/dashboard-error";
 import { CompletionChart } from "@/components/dashboard/completion-chart";
 import { QuadrantDistribution } from "@/components/dashboard/quadrant-distribution";
 import { StreakIndicator } from "@/components/dashboard/streak-indicator";
@@ -21,7 +19,11 @@ import { useTasks } from "@/lib/use-tasks";
 import { useKeyboardShortcuts } from "@/lib/use-keyboard-shortcuts";
 import { ROUTES } from "@/lib/routes";
 import { SegmentedControl } from "@/components/ui/segmented-control";
-import { DashboardSkeleton } from "@/components/dashboard/dashboard-skeleton";
+import {
+  DashboardSkeleton,
+  StatRailSkeleton,
+  VerdictSkeleton,
+} from "@/components/dashboard/dashboard-skeleton";
 import { ReviewPrompts } from "@/components/dashboard/review-prompts";
 import { Button } from "@/components/ui/button";
 import { OPEN_COMMAND_PALETTE_EVENT } from "@/lib/use-command-palette";
@@ -33,21 +35,21 @@ const TREND_OPTIONS = [
   { value: "90", label: "90 Days" },
 ] as const;
 
+type TrendPeriod = 7 | 30 | 90;
+type OpenMatrix = (params?: URLSearchParams) => void;
+
 /**
- * Dashboard page showing productivity metrics and analytics.
- * Uses a bento-grid layout with visual hierarchy:
- *   Row 1: Stats cards + streak indicator
- *   Row 2: Completion trend (wide) + quadrant donut (narrow)
- *   Row 3: Upcoming deadlines + tag analytics
- *   Row 4: Time tracking (full width, conditional)
+ * The weekly review.
+ *
+ * Composition is Overview-shaped: one verdict answering "did my week go where I
+ * meant it to", a three-measure rail backing it, then the evidence. Deadlines
+ * and tags sit below the fold on purpose — the matrix at `/` is where doing
+ * happens, and this page is where looking back happens.
  */
 export default function DashboardPage(): React.ReactElement {
   const router = useRouter();
-  const { all: tasks, isLoading } = useTasks();
-  const [trendPeriod, setTrendPeriod] = useState<7 | 30 | 90>(30);
-  const data = useDashboardData(tasks, trendPeriod);
 
-  const openMatrixAction = (params?: URLSearchParams) => {
+  const openMatrixAction: OpenMatrix = (params) => {
     const query = params?.toString();
     router.push(query ? (`/?${query}` as Route) : ROUTES.HOME);
   };
@@ -58,58 +60,158 @@ export default function DashboardPage(): React.ReactElement {
     openMatrixAction(params);
   };
 
-  useKeyboardShortcuts(
-    {
-      onNewTask: () => {
-        const params = new URLSearchParams();
-        params.set("action", "new-task");
-        openMatrixAction(params);
-      },
-      onSearch: () => {
-        window.dispatchEvent(new CustomEvent(OPEN_COMMAND_PALETTE_EVENT));
-      },
-      onHelp: () => {
-        window.dispatchEvent(new CustomEvent("gsd:open-help"));
-      },
-    }
-  );
+  useKeyboardShortcuts({
+    onNewTask: () => {
+      const params = new URLSearchParams();
+      params.set("action", "new-task");
+      openMatrixAction(params);
+    },
+    onSearch: () => {
+      window.dispatchEvent(new CustomEvent(OPEN_COMMAND_PALETTE_EVENT));
+    },
+    onHelp: () => {
+      window.dispatchEvent(new CustomEvent("gsd:open-help"));
+    },
+  });
 
   return (
     <AppShell title="Review">
-      <div className="space-y-8 pb-10">
-        <header className="border-b border-border/60 px-4 py-8 sm:px-6 sm:py-10">
-          <div className="mx-auto max-w-7xl">
-            <p className="eyebrow">Weekly review</p>
-            <h2 className="mt-2 text-h2 text-foreground">
-              What did this week make room for?
-            </h2>
-            <p className="mt-3 max-w-2xl text-sm leading-relaxed text-foreground-muted sm:text-base">
-              Look back before you look ahead. See what closed, what still needs an answer, and where intention can replace reaction.
-            </p>
-          </div>
-        </header>
-
-        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 sm:py-8">
-          {isLoading ? (
-            <div role="status" aria-busy="true" aria-label="Loading review data">
-              <div aria-hidden="true">
-                <DashboardSkeleton />
-              </div>
-            </div>
-          ) : tasks.length === 0 ? (
-            <DashboardEmpty onOpenMatrix={() => openMatrixAction()} />
-          ) : (
-            <DashboardContent
-              data={data}
-              tasks={tasks}
-              trendPeriod={trendPeriod}
-              onTrendPeriodChange={setTrendPeriod}
-              onDeadlineTaskClick={handleDeadlineTaskClick}
-            />
-          )}
-        </div>
-      </div>
+      {/* Scoped to the data region: a failed local read must not cost the
+          reader their navigation back to the matrix. */}
+      <ErrorBoundary fallback={<DashboardError />}>
+        <ReviewBody
+          onOpenMatrix={openMatrixAction}
+          onDeadlineTaskClick={handleDeadlineTaskClick}
+        />
+      </ErrorBoundary>
     </AppShell>
+  );
+}
+
+interface ReviewBodyProps {
+  onOpenMatrix: OpenMatrix;
+  onDeadlineTaskClick: (task: { id: string }) => void;
+}
+
+function ReviewBody({ onOpenMatrix, onDeadlineTaskClick }: ReviewBodyProps): React.ReactElement {
+  const { all: tasks, isLoading } = useTasks();
+  const [trendPeriod, setTrendPeriod] = useState<TrendPeriod>(30);
+  const data = useDashboardData(tasks, trendPeriod);
+  const isEmpty = !isLoading && tasks.length === 0;
+
+  return (
+    <div className="pb-10">
+      <header className="border-b border-border/60 px-4 py-8 sm:px-6 sm:py-10">
+        <div className="mx-auto max-w-7xl">
+          <p className="eyebrow">Weekly review</p>
+          <div className="mt-2">
+            <HeroSlot isLoading={isLoading} isEmpty={isEmpty} data={data} />
+          </div>
+          {isLoading ? <StatRailSkeleton /> : isEmpty ? null : <StatRail data={data} />}
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 sm:py-8">
+        {isLoading ? (
+          <div role="status" aria-busy="true" aria-label="Loading review data">
+            <div aria-hidden="true">
+              <DashboardSkeleton />
+            </div>
+          </div>
+        ) : isEmpty ? (
+          <DashboardEmpty onOpenMatrix={() => onOpenMatrix()} />
+        ) : (
+          <DashboardContent
+            data={data}
+            tasks={tasks}
+            trendPeriod={trendPeriod}
+            onTrendPeriodChange={setTrendPeriod}
+            onDeadlineTaskClick={onDeadlineTaskClick}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The hero. The static question only survives where it is still true — with no
+ * tasks there is nothing to answer it with, so it stands in for the verdict.
+ */
+function HeroSlot({
+  isLoading,
+  isEmpty,
+  data,
+}: {
+  isLoading: boolean;
+  isEmpty: boolean;
+  data: ReturnType<typeof useDashboardData>;
+}): React.ReactElement {
+  if (isLoading) return <VerdictSkeleton />;
+  if (isEmpty) {
+    return (
+      <h2 className="max-w-[34rem] text-pretty text-h2 text-foreground sm:text-h1">
+        What did this week make room for?
+      </h2>
+    );
+  }
+  return <ReviewVerdict metrics={data.metrics} />;
+}
+
+/**
+ * Three measures behind hairline dividers rather than three bordered cards:
+ * side-by-side cards would rebuild the equal-weight grid and tie the squint
+ * test against the verdict above them.
+ */
+function StatRail({ data }: { data: ReturnType<typeof useDashboardData> }): React.ReactElement {
+  const {
+    metrics,
+    completedSeries,
+    createdSeries,
+    completionRateSeries,
+    completedTrend,
+    previousSixAverage,
+    completedInsight,
+    activeInsight,
+    completionInsight,
+    plannedActiveShare,
+  } = data;
+
+  const paceNote =
+    previousSixAverage > 0
+      ? `${Math.abs(completedTrend)}% ${completedTrend >= 0 ? "above" : "below"} your recent pace`
+      : completedInsight;
+
+  return (
+    <div className="mt-8 grid gap-6 border-t border-border/70 pt-6 sm:grid-cols-3 sm:gap-0 sm:divide-x sm:divide-border/70">
+      <StatsCard
+        className="sm:pr-6"
+        title="Closed today"
+        value={metrics.completedToday}
+        icon={CheckCircle2Icon}
+        note={paceNote}
+        meta={`${metrics.completedThisWeek} closed in 7 days`}
+        series={completedSeries}
+      />
+      <StatsCard
+        className="sm:px-6"
+        title="Active commitments"
+        value={metrics.activeTasks}
+        icon={ListTodoIcon}
+        note={activeInsight}
+        meta={`${plannedActiveShare}% scheduled`}
+        series={createdSeries}
+      />
+      <StatsCard
+        className="sm:pl-6"
+        title="Follow-through"
+        value={`${metrics.completionRate}%`}
+        icon={TrendingUpIcon}
+        note={completionInsight}
+        meta={`${metrics.completedTasks} closed overall`}
+        series={completionRateSeries}
+      />
+    </div>
   );
 }
 
@@ -131,91 +233,47 @@ function DashboardEmpty({ onOpenMatrix }: { onOpenMatrix: () => void }): React.R
 interface DashboardContentProps {
   data: ReturnType<typeof useDashboardData>;
   tasks: ReturnType<typeof useTasks>["all"];
-  trendPeriod: 7 | 30 | 90;
-  onTrendPeriodChange: (v: 7 | 30 | 90) => void;
+  trendPeriod: TrendPeriod;
+  onTrendPeriodChange: (v: TrendPeriod) => void;
   onDeadlineTaskClick: (task: { id: string }) => void;
 }
 
-function DashboardContent({ data, tasks, trendPeriod, onTrendPeriodChange, onDeadlineTaskClick }: DashboardContentProps): React.ReactElement {
-  const { metrics, trendData, streakData, timeTrackingSummary, timeByQuadrant,
-    completedSeries, createdSeries, completionRateSeries,
-    completedTrend, previousSixAverage,
-    completedInsight, activeInsight, completionInsight, plannedActiveShare } = data;
+function DashboardContent({
+  data,
+  tasks,
+  trendPeriod,
+  onTrendPeriodChange,
+  onDeadlineTaskClick,
+}: DashboardContentProps): React.ReactElement {
+  const { metrics, trendData, streakData, timeTrackingSummary, timeByQuadrant } = data;
 
   return (
-    <div className="space-y-6">
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-        <StatsCard
-          title="Closed today"
-          value={metrics.completedToday}
-          icon={CheckCircle2Icon}
-          trend={previousSixAverage > 0 ? { value: completedTrend, isPositive: completedTrend >= 0 } : undefined}
-          insight={completedInsight}
-          footerMeta={`${metrics.completedThisWeek} / 7d`}
-          series={completedSeries}
-        />
-        <StatsCard
-          title="Active commitments"
-          value={metrics.activeTasks}
-          icon={ListTodoIcon}
-          insight={activeInsight}
-          footerMeta={`${plannedActiveShare}% scheduled`}
-          series={createdSeries}
-        />
-        <StatsCard
-          title="Follow-through"
-          value={`${metrics.completionRate}%`}
-          icon={TrendingUpIcon}
-          insight={completionInsight}
-          footerMeta={`${metrics.completedTasks} done overall`}
-          series={completionRateSeries}
-        />
-        <StreakIndicator streakData={streakData} />
-      </div>
-
-      {metrics.overdueCount > 0 && (
-        <div className="alert is-danger items-center rounded-xl px-5 py-3.5">
-          <AlertTriangleIcon className="h-5 w-5 shrink-0 text-rust" />
-          <div className="flex-1">
-            <p className="alert-title text-sm">
-              {metrics.overdueCount} overdue {metrics.overdueCount === 1 ? "task" : "tasks"}
-              {metrics.dueTodayCount > 0 && (
-                <span className="alert-body"> &middot; {metrics.dueTodayCount} due today</span>
-              )}
-            </p>
-          </div>
+    <div className="space-y-8">
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <CompletionChart
+            data={trendData}
+            control={
+              <SegmentedControl
+                label="Completion trend period"
+                options={TREND_OPTIONS}
+                value={String(trendPeriod) as "7" | "30" | "90"}
+                onChange={(v) => onTrendPeriodChange(Number(v) as TrendPeriod)}
+              />
+            }
+          />
         </div>
-      )}
+        <div className="flex flex-col gap-6">
+          <QuadrantDistribution distribution={metrics.quadrantDistribution} />
+          <StreakIndicator streakData={streakData} />
+        </div>
+      </div>
 
       <ReviewPrompts distribution={metrics.quadrantDistribution} />
 
-      <div className="grid gap-6 lg:grid-cols-3">
-        <div className="space-y-4 lg:col-span-2">
-          <div className="flex items-center">
-            <SegmentedControl
-              label="Completion trend period"
-              options={TREND_OPTIONS}
-              value={String(trendPeriod) as "7" | "30" | "90"}
-              onChange={(v) => onTrendPeriodChange(Number(v) as 7 | 30 | 90)}
-            />
-          </div>
-          <CompletionChart data={trendData} />
-        </div>
-        <QuadrantDistribution distribution={metrics.quadrantDistribution} />
-      </div>
-
       <div className="grid gap-6 lg:grid-cols-2">
         <UpcomingDeadlines tasks={tasks} onTaskClick={onDeadlineTaskClick} />
-        {metrics.tagStats.length > 0 ? (
-          <TagAnalytics tagStats={metrics.tagStats} maxTags={8} />
-        ) : (
-          <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
-            <h3 className="mb-4 text-h3 font-semibold text-foreground">Top Tags</h3>
-            <div className="flex h-[240px] items-center justify-center">
-              <p className="text-sm text-foreground-muted">Add tags to your tasks to see analytics here.</p>
-            </div>
-          </div>
-        )}
+        <TagAnalytics tagStats={metrics.tagStats} maxTags={8} />
       </div>
 
       <TimeAnalytics summary={timeTrackingSummary} quadrantDistribution={timeByQuadrant} />

--- a/components/dashboard/completion-chart.tsx
+++ b/components/dashboard/completion-chart.tsx
@@ -20,6 +20,12 @@ const DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
 
 interface CompletionChartProps {
   data: TrendDataPoint[];
+  /**
+   * Period selector. It lives in this header rather than the page header on
+   * purpose: it governs this chart alone, and a control's placement is how a
+   * reader learns its scope. The verdict above is always a seven-day read.
+   */
+  control?: React.ReactNode;
 }
 
 /**
@@ -28,7 +34,7 @@ interface CompletionChartProps {
  *   Created   → dotted graphite (ink-3), strokeWidth 1.6 — de-blued from the old accent
  * The single soft area anchors "completed" without crowding the comparison.
  */
-export function CompletionChart({ data }: CompletionChartProps) {
+export function CompletionChart({ data, control }: CompletionChartProps) {
   const chartData = data.map((point) => ({
     date: formatDate(point.date),
     Completed: point.completed,
@@ -37,30 +43,7 @@ export function CompletionChart({ data }: CompletionChartProps) {
 
   return (
     <div className="rounded-lg border-hair border-border bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
-      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h3 className="text-h3 font-semibold text-foreground">
-            Completion Trend
-          </h3>
-          <p className="mt-1 text-sm text-foreground-muted">
-            Recent throughput across completed and newly created tasks.
-          </p>
-        </div>
-        <div className="flex items-center gap-2 rounded-full border border-border/70 bg-background-muted/70 px-3 py-1.5">
-          <span className="h-[2px] w-3 rounded-full bg-status-success" />
-          <span className="text-xs font-medium text-foreground-muted">Completed</span>
-          <span
-            className="ml-2 h-[2px] w-3 rounded-full"
-            style={{
-              backgroundImage: "linear-gradient(to right, currentColor 50%, transparent 50%)",
-              backgroundSize: "4px 2px",
-              backgroundColor: "transparent",
-              color: "var(--ink-3)",
-            }}
-          />
-          <span className="text-xs font-medium text-foreground-muted">Created</span>
-        </div>
-      </div>
+      <ChartHeader control={control} />
       <ResponsiveContainer width="100%" height={280}>
         <ComposedChart data={chartData}>
           <CartesianGrid
@@ -117,6 +100,37 @@ export function CompletionChart({ data }: CompletionChartProps) {
           />
         </ComposedChart>
       </ResponsiveContainer>
+    </div>
+  );
+}
+
+/** Title, the two-series key, and the period control that scopes this chart. */
+function ChartHeader({ control }: { control?: React.ReactNode }) {
+  return (
+    <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <h3 className="text-h3 font-semibold text-foreground">Completion trend</h3>
+        <p className="mt-1 text-sm text-foreground-muted">
+          Recent throughput across completed and newly created tasks.
+        </p>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-2 rounded-full border border-border/70 bg-background-muted/70 px-3 py-1.5">
+          <span className="h-[2px] w-3 rounded-full bg-status-success" />
+          <span className="text-xs font-medium text-foreground-muted">Completed</span>
+          <span
+            className="ml-2 h-[2px] w-3 rounded-full"
+            style={{
+              backgroundImage: "linear-gradient(to right, currentColor 50%, transparent 50%)",
+              backgroundSize: "4px 2px",
+              backgroundColor: "transparent",
+              color: "var(--ink-3)",
+            }}
+          />
+          <span className="text-xs font-medium text-foreground-muted">Created</span>
+        </div>
+        {control}
+      </div>
     </div>
   );
 }

--- a/components/dashboard/completion-chart.tsx
+++ b/components/dashboard/completion-chart.tsx
@@ -42,7 +42,7 @@ export function CompletionChart({ data, control }: CompletionChartProps) {
   }));
 
   return (
-    <div className="rounded-lg border-hair border-border bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
+    <div className="rounded-lg border border-border bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
       <ChartHeader control={control} />
       <ResponsiveContainer width="100%" height={280}>
         <ComposedChart data={chartData}>

--- a/components/dashboard/dashboard-error.tsx
+++ b/components/dashboard/dashboard-error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { UnplugIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Scoped fallback for the review's data region.
+ *
+ * Geometry mirrors the empty state rather than the app-wide boundary's
+ * full-screen takeover, so the rail, topbar and matrix link stay reachable when
+ * only the local read failed. Copy states where the data actually is — the
+ * failure is a read, not a loss (brief principle 2).
+ */
+export function DashboardError(): React.ReactElement {
+  return (
+    <div
+      role="alert"
+      className="mx-auto max-w-xl border-y border-border/70 py-14 text-center sm:py-16"
+    >
+      <UnplugIcon className="mx-auto h-10 w-10 text-foreground-muted" aria-hidden />
+      <h2 className="mt-4 text-h3 font-semibold text-foreground">
+        Couldn&rsquo;t read your review
+      </h2>
+      <p className="mx-auto mt-2 max-w-md text-sm leading-relaxed text-foreground-muted">
+        Your tasks are still on this device. This is a problem reading them back, not a
+        problem with the data itself.
+      </p>
+      <Button className="touch-target mt-6" onClick={() => window.location.reload()}>
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/components/dashboard/dashboard-skeleton.tsx
+++ b/components/dashboard/dashboard-skeleton.tsx
@@ -1,59 +1,118 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
-function StatsCardSkeleton() {
+/**
+ * Skeletons mirror the geometry they replace, so the page does not reflow when
+ * the local read resolves. Each block below is measured against its real
+ * counterpart rather than being a generic grey box.
+ */
+
+/** Two serif lines: the verdict lead (32px) and its observation (19px). */
+export function VerdictSkeleton() {
+  return (
+    <div className="max-w-[34rem] space-y-3" aria-hidden="true">
+      <Skeleton className="h-8 w-full" />
+      <Skeleton className="h-5 w-3/4" />
+    </div>
+  );
+}
+
+/** Three borderless rail measures behind hairline dividers. */
+export function StatRailSkeleton() {
   return (
     <div
-      className="rounded-lg border-hair border-border bg-card p-6"
-      style={{ boxShadow: "var(--shadow-column)" }}
+      className="mt-8 grid gap-6 border-t border-border/70 pt-6 sm:grid-cols-3 sm:gap-0 sm:divide-x sm:divide-border/70"
+      aria-hidden="true"
     >
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex-1 space-y-3">
-          <div className="flex items-center gap-2">
-            <Skeleton className="h-3 w-20" />
-            <Skeleton className="h-5 w-24 rounded-full" />
-          </div>
-          <Skeleton className="h-9 w-14" />
-          <Skeleton className="h-3 w-28" />
+      {["closed", "active", "follow-through"].map((key, i) => (
+        <div key={key} className={i === 0 ? "sm:pr-6" : i === 1 ? "sm:px-6" : "sm:pl-6"}>
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="mt-3 h-10 w-16" />
+          <Skeleton className="mt-2 h-3 w-40" />
+          <Skeleton className="mt-3 h-7 w-full" />
         </div>
-        <Skeleton className="h-12 w-12 rounded-2xl" />
-      </div>
-      <div className="mt-5 space-y-2">
-        <div className="flex items-center justify-between">
-          <Skeleton className="h-3 w-20" />
-          <Skeleton className="h-3 w-8" />
-        </div>
-        <Skeleton className="h-2 w-full rounded-full" />
-      </div>
+      ))}
     </div>
   );
 }
 
 function ChartSkeleton() {
   return (
-    <div className="rounded-lg border-hair border-border bg-card p-6 space-y-4" style={{ boxShadow: "var(--shadow-column)" }}>
+    <div
+      className="space-y-4 rounded-lg border-hair border-border bg-card p-6"
+      style={{ boxShadow: "var(--shadow-column)" }}
+    >
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-2">
           <Skeleton className="h-5 w-40" />
           <Skeleton className="h-4 w-56" />
         </div>
-        <Skeleton className="h-9 w-40 rounded-full" />
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-8 w-40 rounded-full" />
+          <Skeleton className="h-8 w-44 rounded-full" />
+        </div>
       </div>
       <Skeleton className="h-[280px] w-full rounded-lg" />
     </div>
   );
 }
 
-function DonutSkeleton() {
+/** Segmented bar plus its four-row legend — not a donut. */
+function DistributionSkeleton() {
   return (
-    <div className="rounded-lg border-hair border-border bg-card p-6 space-y-4" style={{ boxShadow: "var(--shadow-column)" }}>
-      <Skeleton className="h-5 w-44" />
-      <Skeleton className="h-4 w-44" />
-      <div className="flex items-center justify-center py-4">
-        <Skeleton className="h-[190px] w-[190px] rounded-full" />
+    <div
+      className="space-y-5 rounded-lg border-hair border-border bg-card p-6"
+      style={{ boxShadow: "var(--shadow-column)" }}
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <div className="space-y-2">
+          <Skeleton className="h-5 w-44" />
+          <Skeleton className="h-4 w-48" />
+        </div>
+        <Skeleton className="h-4 w-16" />
       </div>
-      <div className="grid grid-cols-2 gap-2">
+      <Skeleton className="h-3 w-full rounded-full" />
+      <div className="space-y-2.5">
         {Array.from({ length: 4 }, (_, i) => (
-          <Skeleton key={i} className="h-10 w-full rounded-2xl" />
+          <Skeleton key={i} className="h-5 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StreakSkeleton() {
+  return (
+    <div
+      className="rounded-lg border-hair border-border bg-card p-6"
+      style={{ boxShadow: "var(--shadow-column)" }}
+    >
+      <Skeleton className="h-3 w-16" />
+      <Skeleton className="mt-3 h-10 w-20" />
+      <div className="mt-4 flex items-center gap-1.5">
+        {Array.from({ length: 7 }, (_, i) => (
+          <Skeleton key={i} className="h-6 w-6 rounded-full" />
+        ))}
+      </div>
+      <Skeleton className="mt-4 h-3 w-24" />
+    </div>
+  );
+}
+
+/** The three-column reflection band, which is ruled rather than carded. */
+function PromptsSkeleton() {
+  return (
+    <div className="space-y-5 border-y border-border/70 py-6">
+      <div className="space-y-2">
+        <Skeleton className="h-3 w-32" />
+        <Skeleton className="h-6 w-72" />
+      </div>
+      <div className="grid gap-5 md:grid-cols-3">
+        {Array.from({ length: 3 }, (_, i) => (
+          <div key={i} className="space-y-2">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-5 w-48" />
+            <Skeleton className="h-4 w-40" />
+          </div>
         ))}
       </div>
     </div>
@@ -62,7 +121,7 @@ function DonutSkeleton() {
 
 function ListSkeleton() {
   return (
-    <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm space-y-4">
+    <div className="space-y-4 rounded-lg border-hair border-border bg-card p-6 shadow-sm">
       <Skeleton className="h-5 w-40" />
       {Array.from({ length: 4 }, (_, i) => (
         <Skeleton key={i} className="h-14 w-full rounded-lg" />
@@ -73,22 +132,18 @@ function ListSkeleton() {
 
 export function DashboardSkeleton() {
   return (
-    <div className="space-y-6">
-      {/* Row 1: Stats + Streak */}
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-        <StatsCardSkeleton />
-        <StatsCardSkeleton />
-        <StatsCardSkeleton />
-        <StatsCardSkeleton />
-      </div>
-      {/* Row 2: Chart + Donut */}
+    <div className="space-y-8">
+      {/* Evidence row: trend chart beside the distribution and streak stack */}
       <div className="grid gap-6 lg:grid-cols-3">
         <div className="lg:col-span-2">
           <ChartSkeleton />
         </div>
-        <DonutSkeleton />
+        <div className="space-y-6">
+          <DistributionSkeleton />
+          <StreakSkeleton />
+        </div>
       </div>
-      {/* Row 3: Deadlines + Tags */}
+      <PromptsSkeleton />
       <div className="grid gap-6 lg:grid-cols-2">
         <ListSkeleton />
         <ListSkeleton />

--- a/components/dashboard/dashboard-skeleton.tsx
+++ b/components/dashboard/dashboard-skeleton.tsx
@@ -38,7 +38,7 @@ export function StatRailSkeleton() {
 function ChartSkeleton() {
   return (
     <div
-      className="space-y-4 rounded-lg border-hair border-border bg-card p-6"
+      className="space-y-4 rounded-lg border border-border bg-card p-6"
       style={{ boxShadow: "var(--shadow-column)" }}
     >
       <div className="flex items-start justify-between gap-4">
@@ -60,7 +60,7 @@ function ChartSkeleton() {
 function DistributionSkeleton() {
   return (
     <div
-      className="space-y-5 rounded-lg border-hair border-border bg-card p-6"
+      className="space-y-5 rounded-lg border border-border bg-card p-6"
       style={{ boxShadow: "var(--shadow-column)" }}
     >
       <div className="flex items-baseline justify-between gap-3">
@@ -83,7 +83,7 @@ function DistributionSkeleton() {
 function StreakSkeleton() {
   return (
     <div
-      className="rounded-lg border-hair border-border bg-card p-6"
+      className="rounded-lg border border-border bg-card p-6"
       style={{ boxShadow: "var(--shadow-column)" }}
     >
       <Skeleton className="h-3 w-16" />
@@ -121,7 +121,7 @@ function PromptsSkeleton() {
 
 function ListSkeleton() {
   return (
-    <div className="space-y-4 rounded-lg border-hair border-border bg-card p-6 shadow-sm">
+    <div className="space-y-4 rounded-lg border border-border bg-card p-6 shadow-sm">
       <Skeleton className="h-5 w-40" />
       {Array.from({ length: 4 }, (_, i) => (
         <Skeleton key={i} className="h-14 w-full rounded-lg" />

--- a/components/dashboard/empty-region.tsx
+++ b/components/dashboard/empty-region.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { ROUTES } from "@/lib/routes";
+import { cn } from "@/lib/utils";
+
+/**
+ * Empty state for a data region inside the review.
+ *
+ * One line naming why the region is blank, then one route back to where the
+ * work actually happens. Three regions need exactly this, which is where the
+ * helper earns its keep rather than being a premature abstraction.
+ *
+ * The label is "Open matrix" everywhere on purpose: it is one intent, and two
+ * labels for one intent is the template tell.
+ */
+export function EmptyRegion({ line, className }: { line: string; className?: string }): React.ReactElement {
+  return (
+    <div className={cn("flex flex-col items-center justify-center gap-3 text-center", className)}>
+      <p className="text-sm leading-relaxed text-foreground-muted">{line}</p>
+      <Link
+        href={ROUTES.HOME}
+        className="rounded-sm text-sm font-medium text-accent underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      >
+        Open matrix
+      </Link>
+    </div>
+  );
+}

--- a/components/dashboard/empty-region.tsx
+++ b/components/dashboard/empty-region.tsx
@@ -11,6 +11,11 @@ import { cn } from "@/lib/utils";
  *
  * The label is "Open matrix" everywhere on purpose: it is one intent, and two
  * labels for one intent is the template tell.
+ *
+ * touch-target is not decoration: this is a standalone block link, so WCAG's
+ * inline-text exception does not apply and it must clear the 44px floor the
+ * brief sets for coarse pointers. It needs inline-flex for the min-height to
+ * take effect on an anchor.
  */
 export function EmptyRegion({ line, className }: { line: string; className?: string }): React.ReactElement {
   return (
@@ -18,7 +23,7 @@ export function EmptyRegion({ line, className }: { line: string; className?: str
       <p className="text-sm leading-relaxed text-foreground-muted">{line}</p>
       <Link
         href={ROUTES.HOME}
-        className="rounded-sm text-sm font-medium text-accent underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        className="touch-target inline-flex items-center justify-center rounded-sm px-2 text-sm font-medium text-accent underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background"
       >
         Open matrix
       </Link>

--- a/components/dashboard/quadrant-distribution.tsx
+++ b/components/dashboard/quadrant-distribution.tsx
@@ -2,6 +2,7 @@
 
 import type { QuadrantId } from "@/lib/types";
 import { quadrants, QUADRANT_ACCENT_BY_ID } from "@/lib/quadrants";
+import { EmptyRegion } from "./empty-region";
 
 interface QuadrantDistributionProps {
   distribution: Record<QuadrantId, number>;
@@ -43,7 +44,7 @@ export function QuadrantDistribution({ distribution }: QuadrantDistributionProps
   }
 
   return (
-    <div className="rounded-lg border-hair border-border bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
+    <div className="rounded-lg border border-border bg-card p-6" style={{ boxShadow: "var(--shadow-column)" }}>
       <div className="flex items-baseline justify-between gap-3">
         <div>
           <h3 className="text-h3 font-semibold text-foreground">
@@ -59,8 +60,8 @@ export function QuadrantDistribution({ distribution }: QuadrantDistributionProps
       </div>
 
       {segments.length === 0 ? (
-        <div className="mt-6 flex h-[120px] items-center justify-center rounded-lg border border-dashed border-border bg-background-muted/30">
-          <p className="text-sm text-foreground-muted">No active tasks to display</p>
+        <div className="mt-6 flex h-[120px] items-center justify-center rounded-md border border-dashed border-border bg-background-muted/30">
+          <EmptyRegion line="No active work to split yet." />
         </div>
       ) : (
         <div className="mt-6 space-y-5">

--- a/components/dashboard/quadrant-distribution.tsx
+++ b/components/dashboard/quadrant-distribution.tsx
@@ -47,7 +47,7 @@ export function QuadrantDistribution({ distribution }: QuadrantDistributionProps
       <div className="flex items-baseline justify-between gap-3">
         <div>
           <h3 className="text-h3 font-semibold text-foreground">
-            Quadrant Distribution
+            Quadrant distribution
           </h3>
           <p className="mt-1 text-sm text-foreground-muted">
             Active work split across the matrix.

--- a/components/dashboard/review-verdict.tsx
+++ b/components/dashboard/review-verdict.tsx
@@ -1,0 +1,70 @@
+import type { ProductivityMetrics } from "@/lib/analytics";
+
+export interface ReviewVerdictText {
+  /** Factual lead — what closed in the last seven days. */
+  lead: string;
+  /** The single most notable true fact about what is still open. */
+  observation: string;
+}
+
+/** "1 commitment" / "23 commitments". Numerals throughout, so the count carries the weight. */
+function commitments(count: number): string {
+  return `${count} commitment${count === 1 ? "" : "s"}`;
+}
+
+/**
+ * First true fact wins: overdue outranks undated, which outranks full coverage.
+ * The shape of active work by quadrant belongs to ReviewPrompts — stating it
+ * here too would make both statements timid (brief, learned constraint 2).
+ */
+function observe(active: number, overdue: number, undated: number): string {
+  if (active === 0) return "Nothing is still open.";
+  if (overdue > 0) {
+    return `${commitments(overdue)} slipped past ${overdue === 1 ? "its" : "their"} due date.`;
+  }
+  if (undated > 0) {
+    const agreement = undated === 1 ? "has" : "have";
+    return `${undated} of ${commitments(active)} still open ${agreement} no date yet.`;
+  }
+  return `${commitments(active)} still open, each with a date.`;
+}
+
+/**
+ * Reduce the week to two plain sentences.
+ *
+ * Every branch is provable from ProductivityMetrics alone. `quadrantDistribution`
+ * counts *active* tasks only, so the verdict never characterises the quadrant of
+ * completed work — the same honesty constraint ReviewPrompts documents.
+ */
+export function buildReviewVerdict(metrics: ProductivityMetrics): ReviewVerdictText {
+  const { completedThisWeek, activeTasks, overdueCount, noDueDateCount } = metrics;
+
+  const lead =
+    completedThisWeek === 0
+      ? "Nothing closed this week."
+      : `You closed ${commitments(completedThisWeek)} this week.`;
+
+  return { lead, observation: observe(activeTasks, overdueCount, noDueDateCount) };
+}
+
+/**
+ * The review's answer, in the house serif. This is the page's hero: a sentence
+ * rather than a tinted metric tile, because a tile would restate a number the
+ * stat rail already carries and read as the generic SaaS dashboard the brief
+ * lists as an anti-reference.
+ */
+export function ReviewVerdict({ metrics }: { metrics: ProductivityMetrics }): React.ReactElement {
+  const { lead, observation } = buildReviewVerdict(metrics);
+
+  return (
+    <div className="max-w-[34rem]">
+      {/* text-pretty, not text-balance: balancing equalises the two lines, which
+          parks the count alone at the end of line one — the worst break for a
+          sentence whose whole job is to deliver that number. */}
+      <h2 className="text-pretty text-h2 text-foreground sm:text-h1">{lead}</h2>
+      <p className="mt-3 text-pretty text-h3 font-normal leading-snug text-foreground-muted">
+        {observation}
+      </p>
+    </div>
+  );
+}

--- a/components/dashboard/stats-card.tsx
+++ b/components/dashboard/stats-card.tsx
@@ -5,119 +5,73 @@ import { cn } from "@/lib/utils";
 interface StatsCardProps {
   title: string;
   value: string | number;
-  /** Footer meta string, e.g. "20 / 7d". Sits next to the trend delta. */
-  footerMeta?: string;
+  /** Plain-text comparison, e.g. "12% above your recent pace". Never a pill, never coloured. */
+  note?: string;
+  /** Volume context, e.g. "20 closed in 7 days". Rendered after the note. */
+  meta?: string;
   icon?: LucideIcon;
-  trend?: {
-    /** Percentage delta vs previous period. */
-    value: number;
-    isPositive: boolean;
-    /** Comparison label, e.g. "vs last week". Defaults to "vs last week". */
-    label?: string;
-  };
-  /** Neutral status pill copy ("Holding steady", "3 overdue"). */
-  insight?: string;
   /** 7–12 numeric points rendered as the inline sparkline. */
   series?: number[];
   className?: string;
 }
 
 /**
- * Unified stat card. One rhythm: eyebrow → neutral pill → serif hero number →
- * footer (delta + meta) → sparkline. Color is reserved for state deltas only.
+ * A single measurement in the review's hero rail.
+ *
+ * Deliberately borderless: the hero band groups these behind hairline dividers,
+ * because three bordered cards side by side rebuild the equal-weight card grid
+ * that reads as a generic SaaS dashboard. Hierarchy on this page comes from the
+ * verdict above, not from tinting one of these three.
  */
 export function StatsCard({
   title,
   value,
-  footerMeta,
+  note,
+  meta,
   icon: Icon,
-  trend,
-  insight,
   series,
   className,
 }: StatsCardProps) {
   const animatedValue = useCountUp(value);
-  const trendColor = trend
-    ? trend.isPositive
-      ? "text-status-success-ink"
-      : "text-status-overdue-ink"
-    : "text-foreground-muted";
 
   return (
-    <div
-      className={cn(
-        "relative overflow-hidden rounded-lg border-hair border-border bg-card p-6",
-        className
-      )}
-      style={{ boxShadow: "var(--shadow-card)" }}
-    >
-      <div className="relative flex items-start justify-between gap-4">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <p className="text-eyebrow font-semibold uppercase text-foreground-muted">
-              {title}
-            </p>
-            {insight ? (
-              <span className="inline-flex rounded-full bg-background-muted px-2 py-0.5 text-[10px] font-medium text-foreground-muted">
-                {insight}
-              </span>
-            ) : null}
-          </div>
-          {/* 40px, not 48: at this weight the metric already dominates the card,
-              so the larger size read as shouting. */}
-          <p
-            className="mt-3 text-[40px] font-semibold leading-none tabular-nums text-foreground"
-            style={{ letterSpacing: "-0.02em" }}
-          >
-            {animatedValue}
-          </p>
-        </div>
-        {Icon && (
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-background-muted">
-            <Icon className="h-4 w-4 text-foreground-muted" aria-hidden />
-          </div>
-        )}
+    <div className={cn("min-w-0", className)}>
+      <div className="flex items-center gap-2">
+        {Icon && <Icon className="h-3.5 w-3.5 shrink-0 text-foreground-muted" aria-hidden />}
+        <p className="text-eyebrow font-semibold uppercase text-foreground-muted">{title}</p>
       </div>
 
-      <div className="mt-4 flex items-center gap-2 text-xs">
-        {trend ? (
-          <span className={cn("font-medium tabular-nums", trendColor)}>
-            {trend.isPositive ? "↑" : "↓"} {Math.abs(trend.value)}%
-          </span>
-        ) : null}
-        {trend ? (
-          <span className="text-foreground-muted">{trend.label ?? "vs last week"}</span>
-        ) : null}
-        {footerMeta ? (
-          <>
-            {trend ? <span className="text-foreground-muted/60">·</span> : null}
-            <span className="text-foreground-muted">{footerMeta}</span>
-          </>
-        ) : null}
-      </div>
+      {/* 40px, not 48: at this weight the metric already dominates its column,
+          and the serif verdict above owns the page's largest voice. */}
+      <p
+        className="mt-3 text-[40px] font-semibold leading-none tabular-nums text-foreground"
+        style={{ letterSpacing: "-0.02em" }}
+      >
+        {animatedValue}
+      </p>
 
-      {series && series.length > 1 ? (
-        <Sparkline
-          values={series}
-          isPositive={trend ? trend.isPositive : undefined}
-        />
+      {note || meta ? (
+        <p className="mt-2 text-xs leading-relaxed text-foreground-muted">
+          {note}
+          {note && meta ? " · " : ""}
+          {meta}
+        </p>
       ) : null}
+
+      {series && series.length > 1 ? <Sparkline values={series} /> : null}
     </div>
   );
 }
 
 /**
- * Inline SVG sparkline. Stroke color follows the trend delta:
- * accent (up), overdue (down), tertiary ink (flat / no trend). A flat series
- * carries no judgement, so it drops out of the color system entirely.
+ * Inline SVG sparkline in a single neutral ink.
+ *
+ * Direction is deliberately uncoloured: a seven-point series is context, not a
+ * verdict, and colour on this page is reserved for quadrant identity and status.
+ * --ink-hint, not --ink-3: the handoff's #9AA5AE measures 2.48:1 on the card,
+ * under the 3:1 floor for a graphic that carries meaning (WCAG 1.4.11).
  */
-function Sparkline({
-  values,
-  isPositive,
-}: {
-  values: number[];
-  isPositive?: boolean;
-}) {
+function Sparkline({ values }: { values: number[] }) {
   const width = 120;
   const height = 28;
   const max = Math.max(...values, 1);
@@ -132,15 +86,6 @@ function Sparkline({
     })
     .join(" ");
 
-  // --ink-hint, not --ink-3: the handoff's #9AA5AE measures 2.48:1 on the card,
-  // under the 3:1 floor for a graphic that carries meaning (WCAG 1.4.11).
-  const stroke =
-    isPositive === undefined
-      ? "stroke-ink-hint"
-      : isPositive
-        ? "stroke-accent"
-        : "stroke-status-overdue";
-
   return (
     <svg
       viewBox={`0 0 ${width} ${height}`}
@@ -154,7 +99,7 @@ function Sparkline({
         strokeWidth={1.6}
         strokeLinecap="round"
         strokeLinejoin="round"
-        className={stroke}
+        className="stroke-ink-hint"
       />
     </svg>
   );

--- a/components/dashboard/streak-indicator.tsx
+++ b/components/dashboard/streak-indicator.tsx
@@ -22,7 +22,7 @@ export function StreakIndicator({ streakData }: StreakIndicatorProps) {
     // under the distribution card it resolved 100% against a grid row sized by
     // the chart beside it, overflowing 199px into the prompts band below.
     <div
-      className="flex flex-col gap-4 rounded-lg border-hair border-border bg-card p-6"
+      className="flex flex-col gap-4 rounded-lg border border-border bg-card p-6"
       style={{ boxShadow: "var(--shadow-column)" }}
     >
       {/* Top: eyebrow + count, with a calm icon matching the other stat cards */}
@@ -43,7 +43,7 @@ export function StreakIndicator({ streakData }: StreakIndicatorProps) {
             </span>
           </div>
         </div>
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-background-muted">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-icon bg-background-muted">
           <CalendarCheckIcon className="h-4 w-4 text-foreground-muted" aria-hidden />
         </div>
       </div>

--- a/components/dashboard/streak-indicator.tsx
+++ b/components/dashboard/streak-indicator.tsx
@@ -18,8 +18,11 @@ export function StreakIndicator({ streakData }: StreakIndicatorProps) {
   const { current, longest, last7Days } = streakData;
 
   return (
+    // No h-full: this card used to sit in a four-up equal-height row. Stacked
+    // under the distribution card it resolved 100% against a grid row sized by
+    // the chart beside it, overflowing 199px into the prompts band below.
     <div
-      className="flex h-full flex-col justify-between rounded-lg border-hair border-border bg-card p-6"
+      className="flex flex-col gap-4 rounded-lg border-hair border-border bg-card p-6"
       style={{ boxShadow: "var(--shadow-column)" }}
     >
       {/* Top: eyebrow + count, with a calm icon matching the other stat cards */}
@@ -46,7 +49,7 @@ export function StreakIndicator({ streakData }: StreakIndicatorProps) {
       </div>
 
       {/* Middle: 7-day activity strip — olive marks a completed day */}
-      <div className="mt-4 flex items-center gap-1.5">
+      <div className="flex items-center gap-1.5">
         {last7Days.map((active, index) => (
           <div key={DAY_LABELS[index]} className="flex flex-col items-center gap-1">
             <div
@@ -63,7 +66,7 @@ export function StreakIndicator({ streakData }: StreakIndicatorProps) {
       </div>
 
       {/* Bottom: factual personal best */}
-      <p className="mt-4 text-xs text-foreground-muted">
+      <p className="text-xs text-foreground-muted">
         {longest > 0
           ? `Best ${longest} ${longest === 1 ? "day" : "days"}`
           : "No streak yet"}

--- a/components/dashboard/tag-analytics.tsx
+++ b/components/dashboard/tag-analytics.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { TagStatistic } from "@/lib/analytics";
+import { EmptyRegion } from "./empty-region";
 
 interface TagAnalyticsProps {
   tagStats: TagStatistic[];
@@ -20,17 +21,15 @@ export function TagAnalytics({ tagStats, maxTags = 10 }: TagAnalyticsProps) {
 
   if (displayTags.length === 0) {
     return (
-      <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
+      <div className="rounded-lg border border-border bg-card p-6 shadow-sm">
         <h3 className="mb-4 text-h3 font-semibold text-foreground">Top tags</h3>
-        <p className="text-sm text-foreground-muted">
-          No tags to display. Add tags to your tasks to see analytics here.
-        </p>
+        <EmptyRegion className="py-6" line="Tag a task to see how each tag is tracking." />
       </div>
     );
   }
 
   return (
-    <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
+    <div className="rounded-lg border border-border bg-card p-6 shadow-sm">
       <h3 className="mb-4 text-h3 font-semibold text-foreground">Top tags</h3>
       <div className="space-y-3">
         {displayTags.map((stat) => {
@@ -54,13 +53,16 @@ export function TagAnalytics({ tagStats, maxTags = 10 }: TagAnalyticsProps) {
               <div className="relative h-2 w-full overflow-hidden rounded-full bg-background-muted">
                 {/* Total tasks for this tag — graphite, because a tag is not a
                     quadrant and borrows no pigment (reference §07 polish). */}
+                {/* No transition on either layer: these are static proportions
+                    on a read-only surface, and animating width forces reflow
+                    every frame. */}
                 <div
-                  className="absolute inset-y-0 left-0 rounded-full bg-foreground-muted/30 transition-[width] duration-300 ease-out motion-reduce:transition-none"
+                  className="absolute inset-y-0 left-0 rounded-full bg-foreground-muted/30"
                   style={{ width: `${barWidth}%` }}
                 />
                 {/* Completed portion — success green, matching the dashboard's completed language */}
                 <div
-                  className="absolute inset-y-0 left-0 rounded-full bg-status-success transition-[width] duration-300 ease-out motion-reduce:transition-none"
+                  className="absolute inset-y-0 left-0 rounded-full bg-status-success"
                   style={{
                     width: `${barWidth * (stat.completionRate / 100)}%`,
                   }}

--- a/components/dashboard/tag-analytics.tsx
+++ b/components/dashboard/tag-analytics.tsx
@@ -21,7 +21,7 @@ export function TagAnalytics({ tagStats, maxTags = 10 }: TagAnalyticsProps) {
   if (displayTags.length === 0) {
     return (
       <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
-        <h3 className="mb-4 text-h3 font-semibold text-foreground">Top Tags</h3>
+        <h3 className="mb-4 text-h3 font-semibold text-foreground">Top tags</h3>
         <p className="text-sm text-foreground-muted">
           No tags to display. Add tags to your tasks to see analytics here.
         </p>
@@ -31,7 +31,7 @@ export function TagAnalytics({ tagStats, maxTags = 10 }: TagAnalyticsProps) {
 
   return (
     <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
-      <h3 className="mb-4 text-h3 font-semibold text-foreground">Top Tags</h3>
+      <h3 className="mb-4 text-h3 font-semibold text-foreground">Top tags</h3>
       <div className="space-y-3">
         {displayTags.map((stat) => {
           const barWidth = Math.max((stat.count / maxCount) * 100, 4);
@@ -55,12 +55,12 @@ export function TagAnalytics({ tagStats, maxTags = 10 }: TagAnalyticsProps) {
                 {/* Total tasks for this tag — graphite, because a tag is not a
                     quadrant and borrows no pigment (reference §07 polish). */}
                 <div
-                  className="absolute inset-y-0 left-0 rounded-full bg-foreground-muted/30 transition-all"
+                  className="absolute inset-y-0 left-0 rounded-full bg-foreground-muted/30 transition-[width] duration-300 ease-out motion-reduce:transition-none"
                   style={{ width: `${barWidth}%` }}
                 />
                 {/* Completed portion — success green, matching the dashboard's completed language */}
                 <div
-                  className="absolute inset-y-0 left-0 rounded-full bg-status-success transition-all"
+                  className="absolute inset-y-0 left-0 rounded-full bg-status-success transition-[width] duration-300 ease-out motion-reduce:transition-none"
                   style={{
                     width: `${barWidth * (stat.completionRate / 100)}%`,
                   }}

--- a/components/dashboard/time-analytics.tsx
+++ b/components/dashboard/time-analytics.tsx
@@ -5,6 +5,7 @@ import type { TimeTrackingSummary, QuadrantTimeDistribution } from "@/lib/analyt
 import { formatDuration } from "@/lib/analytics";
 import { QUADRANT_ACCENT_BY_ID } from "@/lib/quadrants";
 import { cn } from "@/lib/utils";
+import { EmptyRegion } from "./empty-region";
 
 interface TimeAnalyticsProps {
   summary: TimeTrackingSummary;
@@ -22,14 +23,15 @@ const QUADRANT_LABELS: Record<string, { name: string }> = {
 /** Empty state when no time tracking data exists */
 function EmptyState({ className }: { className?: string }) {
   return (
-    <div className={cn("rounded-lg border-hair border-border bg-card p-6 shadow-sm", className)}>
+    <div className={cn("rounded-lg border border-border bg-card p-6 shadow-sm", className)}>
       <h3 className="flex items-center gap-2 text-h3 font-semibold text-foreground">
         <ClockIcon className="h-5 w-5 text-foreground-muted" aria-hidden />
         Time tracking
       </h3>
-      <p className="mt-4 text-sm text-foreground-muted">
-        No time tracking data yet. Start tracking time on tasks to see analytics here.
-      </p>
+      <EmptyRegion
+        className="mt-6 py-4"
+        line="Track time on a task to see where your hours go."
+      />
     </div>
   );
 }
@@ -44,13 +46,16 @@ function QuadrantBar({ dist, totalMinutes }: { dist: QuadrantTimeDistribution; t
     <div className="space-y-1">
       <div className="flex items-center justify-between text-sm">
         <span className="text-foreground">{config.name}</span>
-        <span className="text-foreground-muted">
+        <span className="tabular-nums text-foreground-muted">
           {formatDuration(dist.totalMinutes)} ({percentage}%)
         </span>
       </div>
-      <div className="h-2 w-full rounded-full bg-background-muted overflow-hidden">
+      <div className="h-2 w-full overflow-hidden rounded-full bg-background-muted">
+        {/* No transition: this is a static proportion on a read-only surface.
+            Animating width forces reflow per frame, and scaleX would distort
+            the pill's end caps — the honest fix is not to animate at all. */}
         <div
-          className="h-full rounded-full transition-[width] duration-300 ease-out motion-reduce:transition-none"
+          className="h-full rounded-full"
           style={{ width: `${percentage}%`, backgroundColor: accent }}
         />
       </div>
@@ -63,15 +68,15 @@ function EstimationInsights({ overCount, underCount }: { overCount: number; unde
   if (overCount === 0 && underCount === 0) return null;
 
   return (
-    <div className="mt-6 rounded-lg bg-background-muted p-4">
+    <div className="mt-6 rounded-md bg-background-muted p-4">
       <h4 className="text-sm font-medium text-foreground">Estimation insights</h4>
       <div className="mt-2 flex gap-6 text-sm">
         <div>
-          <span className="text-status-overdue-ink font-medium">{overCount}</span>
+          <span className="font-medium tabular-nums text-status-overdue-ink">{overCount}</span>
           <span className="text-foreground-muted"> tasks over estimate</span>
         </div>
         <div>
-          <span className="text-status-success-ink font-medium">{underCount}</span>
+          <span className="font-medium tabular-nums text-status-success-ink">{underCount}</span>
           <span className="text-foreground-muted"> tasks under estimate</span>
         </div>
       </div>
@@ -90,7 +95,7 @@ export function TimeAnalytics({ summary, quadrantDistribution, className }: Time
   }
 
   return (
-    <div className={cn("rounded-lg border-hair border-border bg-card p-6 shadow-sm", className)}>
+    <div className={cn("rounded-lg border border-border bg-card p-6 shadow-sm", className)}>
       <h3 className="flex items-center gap-2 text-h3 font-semibold text-foreground">
         <ClockIcon className="h-5 w-5 text-foreground-muted" aria-hidden />
         Time tracking
@@ -113,7 +118,7 @@ export function TimeAnalytics({ summary, quadrantDistribution, className }: Time
         <StatBlock
           icon={TrendingUpIcon}
           label="Estimation accuracy"
-          value={summary.estimationAccuracy > 0 ? `${summary.estimationAccuracy}%` : "N/A"}
+          value={summary.estimationAccuracy > 0 ? `${summary.estimationAccuracy}%` : "\u2014"}
           subtitle={getAccuracyLabel(summary.estimationAccuracy)}
           valueColor={getAccuracyColor(summary.estimationAccuracy)}
         />
@@ -153,12 +158,12 @@ interface StatBlockProps {
 
 function StatBlock({ icon: Icon, label, value, subtitle, valueColor }: StatBlockProps) {
   return (
-    <div className="rounded-lg bg-background-muted p-4">
+    <div className="rounded-md bg-background-muted p-4">
       <div className="flex items-center gap-2">
         <Icon className="h-4 w-4 text-foreground-muted" />
         <span className="text-xs font-medium text-foreground-muted">{label}</span>
       </div>
-      <p className={cn("mt-2 text-2xl font-bold", valueColor || "text-foreground")}>
+      <p className={cn("mt-2 text-2xl font-bold tabular-nums", valueColor || "text-foreground")}>
         {value}
       </p>
       <p className="text-xs text-foreground-muted">{subtitle}</p>

--- a/components/dashboard/time-analytics.tsx
+++ b/components/dashboard/time-analytics.tsx
@@ -24,8 +24,8 @@ function EmptyState({ className }: { className?: string }) {
   return (
     <div className={cn("rounded-lg border-hair border-border bg-card p-6 shadow-sm", className)}>
       <h3 className="flex items-center gap-2 text-h3 font-semibold text-foreground">
-        <ClockIcon className="h-5 w-5 text-accent" />
-        Time Tracking
+        <ClockIcon className="h-5 w-5 text-foreground-muted" aria-hidden />
+        Time tracking
       </h3>
       <p className="mt-4 text-sm text-foreground-muted">
         No time tracking data yet. Start tracking time on tasks to see analytics here.
@@ -50,7 +50,7 @@ function QuadrantBar({ dist, totalMinutes }: { dist: QuadrantTimeDistribution; t
       </div>
       <div className="h-2 w-full rounded-full bg-background-muted overflow-hidden">
         <div
-          className="h-full rounded-full transition-all"
+          className="h-full rounded-full transition-[width] duration-300 ease-out motion-reduce:transition-none"
           style={{ width: `${percentage}%`, backgroundColor: accent }}
         />
       </div>
@@ -64,7 +64,7 @@ function EstimationInsights({ overCount, underCount }: { overCount: number; unde
 
   return (
     <div className="mt-6 rounded-lg bg-background-muted p-4">
-      <h4 className="text-sm font-medium text-foreground">Estimation Insights</h4>
+      <h4 className="text-sm font-medium text-foreground">Estimation insights</h4>
       <div className="mt-2 flex gap-6 text-sm">
         <div>
           <span className="text-status-overdue-ink font-medium">{overCount}</span>
@@ -92,34 +92,34 @@ export function TimeAnalytics({ summary, quadrantDistribution, className }: Time
   return (
     <div className={cn("rounded-lg border-hair border-border bg-card p-6 shadow-sm", className)}>
       <h3 className="flex items-center gap-2 text-h3 font-semibold text-foreground">
-        <ClockIcon className="h-5 w-5 text-accent" />
-        Time Tracking
+        <ClockIcon className="h-5 w-5 text-foreground-muted" aria-hidden />
+        Time tracking
       </h3>
 
       {/* Summary Stats */}
       <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <StatBlock
           icon={TimerIcon}
-          label="Total Tracked"
+          label="Total tracked"
           value={formatDuration(summary.totalMinutesTracked)}
           subtitle={`${summary.tasksWithTimeTracking} tasks`}
         />
         <StatBlock
           icon={TargetIcon}
-          label="Total Estimated"
+          label="Total estimated"
           value={formatDuration(summary.totalMinutesEstimated)}
           subtitle={`${summary.tasksWithEstimates} tasks`}
         />
         <StatBlock
           icon={TrendingUpIcon}
-          label="Estimation Accuracy"
+          label="Estimation accuracy"
           value={summary.estimationAccuracy > 0 ? `${summary.estimationAccuracy}%` : "N/A"}
           subtitle={getAccuracyLabel(summary.estimationAccuracy)}
           valueColor={getAccuracyColor(summary.estimationAccuracy)}
         />
         <StatBlock
           icon={ClockIcon}
-          label="Running Timers"
+          label="Running timers"
           value={summary.tasksWithRunningTimers}
           subtitle={summary.tasksWithRunningTimers > 0 ? "active now" : "none active"}
           valueColor={summary.tasksWithRunningTimers > 0 ? "text-status-success-ink" : undefined}
@@ -129,7 +129,7 @@ export function TimeAnalytics({ summary, quadrantDistribution, className }: Time
       {/* Quadrant Time Distribution */}
       {summary.totalMinutesTracked > 0 && (
         <div className="mt-6">
-          <h4 className="text-sm font-medium text-foreground-muted">Time by Quadrant</h4>
+          <h4 className="text-sm font-medium text-foreground-muted">Time by quadrant</h4>
           <div className="mt-3 space-y-3">
             {quadrantDistribution.map((dist) => (
               <QuadrantBar key={dist.quadrantId} dist={dist} totalMinutes={summary.totalMinutesTracked} />

--- a/components/dashboard/upcoming-deadlines.tsx
+++ b/components/dashboard/upcoming-deadlines.tsx
@@ -50,7 +50,7 @@ export function UpcomingDeadlines({ tasks, onTaskClick }: UpcomingDeadlinesProps
   })();
 
   return (
-    <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
+    <div className="rounded-lg border border-border bg-card p-6 shadow-sm">
       <h3 className="mb-4 text-h3 font-semibold text-foreground">
         Upcoming deadlines
       </h3>
@@ -58,7 +58,7 @@ export function UpcomingDeadlines({ tasks, onTaskClick }: UpcomingDeadlinesProps
       {!hasDeadlines ? (
         <div className="flex h-[240px] items-center justify-center">
           <p className="text-sm text-foreground-muted">
-            No upcoming deadlines. You&apos;re all caught up!
+            No deadlines in the next seven days.
           </p>
         </div>
       ) : (
@@ -141,7 +141,7 @@ function DeadlineSection({
               <button
                 type="button"
                 onClick={() => onTaskClick?.(task)}
-                className={`w-full cursor-pointer rounded-lg border ${borderColor} ${bgColor} p-3 text-left transition-[box-shadow,transform] duration-150 ease-out hover:shadow-sm active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transition-none motion-reduce:active:scale-100`}
+                className={`w-full cursor-pointer rounded-sm border ${borderColor} ${bgColor} p-3 text-left transition-[box-shadow,transform] duration-150 ease-out hover:shadow-sm active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transition-none motion-reduce:active:scale-100`}
               >
                 <div className="flex items-start justify-between gap-2">
                   <div className="min-w-0 flex-1">

--- a/components/dashboard/upcoming-deadlines.tsx
+++ b/components/dashboard/upcoming-deadlines.tsx
@@ -52,7 +52,7 @@ export function UpcomingDeadlines({ tasks, onTaskClick }: UpcomingDeadlinesProps
   return (
     <div className="rounded-lg border-hair border-border bg-card p-6 shadow-sm">
       <h3 className="mb-4 text-h3 font-semibold text-foreground">
-        Upcoming Deadlines
+        Upcoming deadlines
       </h3>
 
       {!hasDeadlines ? (
@@ -75,7 +75,7 @@ export function UpcomingDeadlines({ tasks, onTaskClick }: UpcomingDeadlinesProps
 
           {dueTodayTasks.length > 0 && (
             <DeadlineSection
-              title="Due Today"
+              title="Due today"
               icon={<CalendarIcon className="h-4 w-4 text-warning" />}
               tasks={dueTodayTasks}
               onTaskClick={onTaskClick}
@@ -85,7 +85,7 @@ export function UpcomingDeadlines({ tasks, onTaskClick }: UpcomingDeadlinesProps
 
           {dueThisWeekTasks.length > 0 && (
             <DeadlineSection
-              title="Due This Week"
+              title="Due this week"
               icon={<ClockIcon className="h-4 w-4 text-sky" />}
               tasks={dueThisWeekTasks}
               onTaskClick={onTaskClick}
@@ -141,7 +141,7 @@ function DeadlineSection({
               <button
                 type="button"
                 onClick={() => onTaskClick?.(task)}
-                className={`w-full cursor-pointer rounded-lg border ${borderColor} ${bgColor} p-3 text-left transition-all hover:shadow-sm`}
+                className={`w-full cursor-pointer rounded-lg border ${borderColor} ${bgColor} p-3 text-left transition-[box-shadow,transform] duration-150 ease-out hover:shadow-sm active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transition-none motion-reduce:active:scale-100`}
               >
                 <div className="flex items-start justify-between gap-2">
                   <div className="min-w-0 flex-1">

--- a/components/error-boundary.tsx
+++ b/components/error-boundary.tsx
@@ -8,6 +8,12 @@ const logger = createLogger("ERROR_BOUNDARY");
 
 interface ErrorBoundaryProps {
   children: ReactNode;
+  /**
+   * Scoped replacement for the full-screen fallback. Pass one when only a
+   * region failed and the surrounding shell should survive — a page that loses
+   * its data region still owes the reader working navigation.
+   */
+  fallback?: ReactNode;
 }
 
 interface ErrorBoundaryState {
@@ -38,7 +44,11 @@ class ErrorBoundaryClass extends Component<ErrorBoundaryProps, ErrorBoundaryStat
 
   render() {
     if (this.state.hasError) {
-      return <ErrorFallback error={this.state.error} fallbackRef={this.fallbackRef} />;
+      return (
+        this.props.fallback ?? (
+          <ErrorFallback error={this.state.error} fallbackRef={this.fallbackRef} />
+        )
+      );
     }
 
     return this.props.children;
@@ -98,6 +108,6 @@ function navigateHome() {
   window.location.href = "/";
 }
 
-export function ErrorBoundary({ children }: ErrorBoundaryProps) {
-  return <ErrorBoundaryClass>{children}</ErrorBoundaryClass>;
+export function ErrorBoundary({ children, fallback }: ErrorBoundaryProps) {
+  return <ErrorBoundaryClass fallback={fallback}>{children}</ErrorBoundaryClass>;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "12.4.0",
+	"version": "12.5.0",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '12.4.0';
+const CACHE_VERSION = '12.5.0';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 

--- a/tests/ui/dashboard-components.test.tsx
+++ b/tests/ui/dashboard-components.test.tsx
@@ -239,7 +239,8 @@ describe('Dashboard Components', () => {
       render(<QuadrantDistribution distribution={distribution} />);
 
       expect(screen.getByText(/quadrant distribution/i)).toBeInTheDocument();
-      expect(screen.getByText(/no active tasks/i)).toBeInTheDocument();
+      expect(screen.getByText(/no active work to split yet/i)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Open matrix' })).toHaveAttribute('href', '/');
     });
 
     it('should render with task distribution and show total in center', () => {
@@ -309,7 +310,7 @@ describe('Dashboard Components', () => {
     it('should render empty state when no tags', () => {
       render(<TagAnalytics tagStats={[]} />);
 
-      expect(screen.getByText(/no tags to display/i)).toBeInTheDocument();
+      expect(screen.getByText(/tag a task to see how each tag is tracking/i)).toBeInTheDocument();
     });
 
     it('should render tag statistics with completion info', () => {
@@ -393,7 +394,7 @@ describe('Dashboard Components', () => {
       render(<TimeAnalytics summary={emptySummary} quadrantDistribution={emptyDistribution} />);
 
       expect(screen.getByRole('heading', { name: /time tracking/i })).toBeInTheDocument();
-      expect(screen.getByText(/no time tracking data yet/i)).toBeInTheDocument();
+      expect(screen.getByText(/track time on a task to see where your hours go/i)).toBeInTheDocument();
     });
 
     it('should render summary stats when time data exists', () => {
@@ -468,7 +469,7 @@ describe('Dashboard Components', () => {
       expect(screen.getByText('not enough data')).toBeInTheDocument();
     });
 
-    it('should show N/A for accuracy value when accuracy is 0', () => {
+    it('should show an em-dash for accuracy value when accuracy is 0', () => {
       const summary: TimeTrackingSummary = {
         ...emptySummary,
         tasksWithTimeTracking: 1,
@@ -478,7 +479,9 @@ describe('Dashboard Components', () => {
 
       render(<TimeAnalytics summary={summary} quadrantDistribution={emptyDistribution} />);
 
-      expect(screen.getByText('N/A')).toBeInTheDocument();
+      // Partial state: unknown is an em-dash, never "N/A" or a misleading 0.
+      expect(screen.getByText('\u2014')).toBeInTheDocument();
+      expect(screen.queryByText('N/A')).not.toBeInTheDocument();
     });
 
     it('should show running timers count with active label', () => {
@@ -682,7 +685,7 @@ describe('Dashboard Components', () => {
     it('should render empty state when no upcoming deadlines', () => {
       render(<UpcomingDeadlines tasks={[]} />);
 
-      expect(screen.getByText(/no upcoming deadlines/i)).toBeInTheDocument();
+      expect(screen.getByText(/no deadlines in the next seven days/i)).toBeInTheDocument();
     });
 
     it('should show overdue tasks', () => {
@@ -770,6 +773,113 @@ describe('Dashboard Components', () => {
       // Clicking should not throw even without handler
       const lateTaskButton = screen.getByRole('button', { name: /Late Task/i });
       await user.click(lateTaskButton);
+    });
+  });
+  describe('Finish-bar fixes', () => {
+    const trackedSummary: TimeTrackingSummary = {
+      totalMinutesTracked: 150,
+      totalMinutesEstimated: 180,
+      tasksWithTimeTracking: 5,
+      tasksWithEstimates: 4,
+      tasksWithRunningTimers: 1,
+      estimationAccuracy: 83,
+      overEstimateTasks: 1,
+      underEstimateTasks: 2,
+    };
+    const trackedDistribution: QuadrantTimeDistribution[] = [
+      { quadrantId: 'urgent-important', totalMinutes: 90, taskCount: 3 },
+      { quadrantId: 'not-urgent-important', totalMinutes: 60, taskCount: 2 },
+    ];
+    const emptySummary: TimeTrackingSummary = {
+      totalMinutesTracked: 0,
+      totalMinutesEstimated: 0,
+      tasksWithTimeTracking: 0,
+      tasksWithEstimates: 0,
+      tasksWithRunningTimers: 0,
+      estimationAccuracy: 0,
+      overEstimateTasks: 0,
+      underEstimateTasks: 0,
+    };
+
+    it('should not animate layout properties on tag bars', () => {
+      const { container } = render(
+        <TagAnalytics tagStats={[{ tag: 'work', count: 4, completedCount: 2, completionRate: 50 }]} />
+      );
+
+      // width/left/top animations force reflow every frame (ui-craft-detect).
+      expect(container.innerHTML).not.toMatch(/transition-\[width\]|transition-all/);
+    });
+
+    it('should not animate layout properties on quadrant time bars', () => {
+      const { container } = render(
+        <TimeAnalytics summary={trackedSummary} quadrantDistribution={trackedDistribution} />
+      );
+
+      expect(container.innerHTML).not.toMatch(/transition-\[width\]|transition-all/);
+    });
+
+    it('should set tabular-nums on every time-tracking figure', () => {
+      const { container } = render(
+        <TimeAnalytics summary={trackedSummary} quadrantDistribution={trackedDistribution} />
+      );
+
+      // Four KPI values, two quadrant rows, two estimation counts — all compared
+      // against each other, so proportional figures make the columns unreadable.
+      expect(container.querySelectorAll('.tabular-nums').length).toBeGreaterThanOrEqual(8);
+    });
+
+    it('should keep a border on the card built through cn()', () => {
+      const { container } = render(
+        <TimeAnalytics summary={trackedSummary} quadrantDistribution={trackedDistribution} />
+      );
+      const card = container.firstElementChild as HTMLElement;
+
+      // twMerge groups border-hair with border-border and drops the former,
+      // leaving border-width:0. `border` is a width utility it keeps.
+      expect(card.className).toContain('border-border');
+      expect(card.className).not.toContain('border-hair');
+      expect(card.className).toMatch(/(^|\s)border(\s|$)/);
+    });
+
+    it('should offer a next step from the tags empty region', () => {
+      render(<TagAnalytics tagStats={[]} />);
+
+      expect(screen.getByText(/tag a task to see how each tag is tracking/i)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Open matrix' })).toHaveAttribute('href', '/');
+    });
+
+    it('should offer a next step from the time-tracking empty region', () => {
+      render(<TimeAnalytics summary={emptySummary} quadrantDistribution={[]} />);
+
+      expect(screen.getByText(/track time on a task to see where your hours go/i)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Open matrix' })).toHaveAttribute('href', '/');
+    });
+
+    it('should state an empty deadline list without cheerleading', () => {
+      render(<UpcomingDeadlines tasks={[]} />);
+
+      const copy = screen.getByText(/no deadlines in the next seven days/i);
+      expect(copy).toBeInTheDocument();
+      // brief.md anti-reference: no exclamation-point cheerleading.
+      expect(copy.textContent).not.toContain('!');
+    });
+
+    it('should step the radius ladder rather than flattening it to one value', () => {
+      const { container } = render(
+        <TimeAnalytics summary={trackedSummary} quadrantDistribution={trackedDistribution} />
+      );
+
+      // Panel 14px (lg), the blocks nested inside it 12px (md).
+      expect((container.firstElementChild as HTMLElement).className).toContain('rounded-lg');
+      expect(container.querySelectorAll('.rounded-md').length).toBeGreaterThan(0);
+    });
+
+    it('should render deadline rows as controls on the control radius', () => {
+      const tasks = [createMockTask({ id: 'due-1', title: 'Due soon', completed: false, dueDate: new Date(Date.now() + 86400000).toISOString() })];
+      render(<UpcomingDeadlines tasks={tasks} />);
+
+      const row = screen.getByRole('button', { name: /Due soon/i });
+      expect(row.className).toContain('rounded-sm');
     });
   });
 });

--- a/tests/ui/dashboard-components.test.tsx
+++ b/tests/ui/dashboard-components.test.tsx
@@ -841,6 +841,16 @@ describe('Dashboard Components', () => {
       expect(card.className).toMatch(/(^|\s)border(\s|$)/);
     });
 
+    it('should meet the coarse-pointer target floor on the empty-region link', () => {
+      render(<TagAnalytics tagStats={[]} />);
+      const link = screen.getByRole('link', { name: 'Open matrix' });
+
+      // A standalone block link, so WCAG's inline-text exception does not apply.
+      // brief.md Constraints: >=44px touch targets on coarse pointers.
+      expect(link.className).toContain('touch-target');
+      expect(link.className).toContain('inline-flex');
+    });
+
     it('should offer a next step from the tags empty region', () => {
       render(<TagAnalytics tagStats={[]} />);
 

--- a/tests/ui/dashboard-components.test.tsx
+++ b/tests/ui/dashboard-components.test.tsx
@@ -8,7 +8,11 @@ import { StreakIndicator } from '@/components/dashboard/streak-indicator';
 import { TagAnalytics } from '@/components/dashboard/tag-analytics';
 import { UpcomingDeadlines } from '@/components/dashboard/upcoming-deadlines';
 import { TimeAnalytics } from '@/components/dashboard/time-analytics';
-import { DashboardSkeleton } from '@/components/dashboard/dashboard-skeleton';
+import {
+  DashboardSkeleton,
+  StatRailSkeleton,
+  VerdictSkeleton,
+} from '@/components/dashboard/dashboard-skeleton';
 import { getDb } from '@/lib/db';
 import type { TaskRecord } from '@/lib/types';
 import type { TimeTrackingSummary, QuadrantTimeDistribution } from '@/lib/analytics';
@@ -28,29 +32,32 @@ describe('Dashboard Components', () => {
 
   describe('StatsCard', () => {
     it('should render stat value and label', () => {
-      render(<StatsCard value={42} title="Total Tasks" />);
+      render(<StatsCard value={42} title="Total tasks" />);
 
       expect(screen.getByText('42')).toBeInTheDocument();
-      expect(screen.getByText('Total Tasks')).toBeInTheDocument();
+      expect(screen.getByText('Total tasks')).toBeInTheDocument();
     });
 
-    it('should render with trend indicator up', () => {
-      render(<StatsCard value={42} title="Completed" trend={{ value: 15, isPositive: true }} />);
+    it('should render a comparison as plain text, with no arrow glyph', () => {
+      render(<StatsCard value={42} title="Closed today" note="15% above your recent pace" />);
 
-      expect(screen.getByText('42')).toBeInTheDocument();
-      expect(screen.getByText(/↑/)).toBeInTheDocument();
-      expect(screen.getByText(/15%/)).toBeInTheDocument();
+      expect(screen.getByText(/15% above your recent pace/)).toBeInTheDocument();
+      expect(screen.queryByText(/[\u2191\u2193]/)).not.toBeInTheDocument();
     });
 
-    it('should render with trend indicator down', () => {
-      render(<StatsCard value={10} title="Pending" trend={{ value: 8, isPositive: false }} />);
+    it('should render a downward comparison with the same neutral treatment', () => {
+      const { container } = render(
+        <StatsCard value={10} title="Closed today" note="8% below your recent pace" />
+      );
 
-      expect(screen.getByText('10')).toBeInTheDocument();
-      expect(screen.getByText(/↓/)).toBeInTheDocument();
-      expect(screen.getByText(/8%/)).toBeInTheDocument();
+      const note = screen.getByText(/8% below your recent pace/);
+      expect(note).toBeInTheDocument();
+      // Direction is carried by the words, never by colour (recipe acceptance bar).
+      expect(note.className).toContain('text-foreground-muted');
+      expect(container.querySelector('.text-status-overdue-ink')).not.toBeInTheDocument();
     });
 
-    it('should render without trend indicator', () => {
+    it('should render without a comparison', () => {
       render(<StatsCard value={5} title="Categories" />);
 
       expect(screen.getByText('5')).toBeInTheDocument();
@@ -64,28 +71,32 @@ describe('Dashboard Components', () => {
     });
 
     it('should render large numbers', () => {
-      render(<StatsCard value={1234} title="All Time Completed" />);
+      render(<StatsCard value={1234} title="All time closed" />);
 
       expect(screen.getByText('1234')).toBeInTheDocument();
     });
 
     it('should render without icon', () => {
-      render(<StatsCard value={5} title="No Icon" />);
+      render(<StatsCard value={5} title="No icon" />);
 
       expect(screen.getByText('5')).toBeInTheDocument();
-      expect(screen.getByText('No Icon')).toBeInTheDocument();
+      expect(screen.getByText('No icon')).toBeInTheDocument();
     });
 
-    it('should render footer meta string when provided', () => {
-      render(<StatsCard value={5} title="Active" footerMeta="20 / 7d" />);
+    it('should render meta context when provided', () => {
+      render(<StatsCard value={5} title="Active" meta="20 closed in 7 days" />);
 
-      expect(screen.getByText('20 / 7d')).toBeInTheDocument();
+      expect(screen.getByText(/20 closed in 7 days/)).toBeInTheDocument();
     });
 
-    it('should render insight pill when provided', () => {
-      render(<StatsCard value={5} title="Completed" insight="Holding steady" />);
+    it('should render as a rail item, not a bordered card', () => {
+      const { container } = render(<StatsCard value={5} title="Active" />);
+      const root = container.firstElementChild as HTMLElement;
 
-      expect(screen.getByText('Holding steady')).toBeInTheDocument();
+      // The hero band groups these with hairline dividers; a card border here
+      // would rebuild the equal-weight card grid the recipe bans.
+      expect(root.className).not.toContain('bg-card');
+      expect(root.className).not.toContain('border-hair');
     });
 
     it('should render an inline sparkline when series has 2+ points', () => {
@@ -96,6 +107,17 @@ describe('Dashboard Components', () => {
       // Sparkline is an SVG polyline; presence is enough to verify the wiring.
       expect(container.querySelector('svg polyline')).toBeInTheDocument();
     });
+
+    it('should draw every sparkline in the same neutral ink', () => {
+      const { container } = render(
+        <StatsCard value={5} title="Trend" series={[5, 4, 3, 2, 1]} />
+      );
+
+      // A seven-point series is not a judgement, so it never borrows the accent
+      // or the overdue pigment (brief: tide means interaction, not decoration).
+      const line = container.querySelector('svg polyline');
+      expect(line?.getAttribute('class')).toContain('stroke-ink-hint');
+    });
   });
 
   describe('StreakIndicator', () => {
@@ -104,6 +126,17 @@ describe('Dashboard Components', () => {
 
       expect(screen.getByText('7')).toBeInTheDocument();
       expect(screen.getByText(/streak/i)).toBeInTheDocument();
+    });
+
+    it('should size to its content rather than stretching to fill', () => {
+      const { container } = render(
+        <StreakIndicator streakData={{ current: 3, longest: 15, lastCompletionDate: null, last7Days: [false, false, false, false, true, true, true] }} />
+      );
+      const root = container.firstElementChild as HTMLElement;
+
+      // Regression: h-full resolved 100% against a grid row sized by the chart
+      // beside it, overflowing 199px into the reflection prompts band below.
+      expect(root.className).not.toContain('h-full');
     });
 
     it('should render longest streak as "Best" label', () => {
@@ -377,10 +410,10 @@ describe('Dashboard Components', () => {
 
       render(<TimeAnalytics summary={summary} quadrantDistribution={emptyDistribution} />);
 
-      expect(screen.getByText('Total Tracked')).toBeInTheDocument();
-      expect(screen.getByText('Total Estimated')).toBeInTheDocument();
-      expect(screen.getByText('Estimation Accuracy')).toBeInTheDocument();
-      expect(screen.getByText('Running Timers')).toBeInTheDocument();
+      expect(screen.getByText('Total tracked')).toBeInTheDocument();
+      expect(screen.getByText('Total estimated')).toBeInTheDocument();
+      expect(screen.getByText('Estimation accuracy')).toBeInTheDocument();
+      expect(screen.getByText('Running timers')).toBeInTheDocument();
     });
 
     it('should show "good accuracy" label for accuracy 80-120', () => {
@@ -534,7 +567,7 @@ describe('Dashboard Components', () => {
 
       render(<TimeAnalytics summary={summary} quadrantDistribution={emptyDistribution} />);
 
-      expect(screen.getByText('Total Estimated')).toBeInTheDocument();
+      expect(screen.getByText('Total estimated')).toBeInTheDocument();
     });
 
     it('should apply red color for very low accuracy', () => {
@@ -580,13 +613,30 @@ describe('Dashboard Components', () => {
       expect(grids.length).toBeGreaterThanOrEqual(3); // stats row + chart row + bottom row
     });
 
-    it('should render 4 stats card skeletons in top row', () => {
+    it('should leave the measure rail to the header skeleton', () => {
       const { container } = render(<DashboardSkeleton />);
 
-      // Stats row has lg:grid-cols-4
-      const statsRow = container.querySelector('.lg\\:grid-cols-4');
-      expect(statsRow).toBeInTheDocument();
-      expect(statsRow?.children.length).toBe(4);
+      // The three measures live in the hero band now, so the body skeleton must
+      // not reserve a four-up card row the page will never render.
+      expect(container.querySelector('.lg\\:grid-cols-4')).not.toBeInTheDocument();
+    });
+
+    it('should render three rail measures behind hairline dividers', () => {
+      const { container } = render(<StatRailSkeleton />);
+
+      const rail = container.querySelector('.sm\\:grid-cols-3');
+      expect(rail).toBeInTheDocument();
+      expect(rail?.children.length).toBe(3);
+      expect(rail?.className).toContain('divide-x');
+    });
+
+    it('should hold the verdict geometry while the local read resolves', () => {
+      const { container } = render(<VerdictSkeleton />);
+
+      // Two lines, matching the serif lead and its observation.
+      const root = container.firstElementChild as HTMLElement;
+      expect(root.children.length).toBe(2);
+      expect(root.getAttribute('aria-hidden')).toBe('true');
     });
 
     it('should render chart and donut skeletons in second row', () => {

--- a/tests/ui/dashboard-page.test.tsx
+++ b/tests/ui/dashboard-page.test.tsx
@@ -78,6 +78,8 @@ vi.mock("@/components/dashboard/time-analytics", () => ({
 
 vi.mock("@/components/dashboard/dashboard-skeleton", () => ({
   DashboardSkeleton: () => <div data-testid="dashboard-skeleton" />,
+  VerdictSkeleton: () => <div data-testid="verdict-skeleton" />,
+  StatRailSkeleton: () => <div data-testid="stat-rail-skeleton" />,
 }));
 
 vi.mock("@/components/ui/segmented-control", () => ({
@@ -157,8 +159,9 @@ describe("DashboardPage review framing", () => {
     expect(screen.getByTestId("app-shell")).toHaveAttribute("data-has-search", "false");
     expect(screen.getByText("Weekly review")).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { level: 2, name: "What did this week make room for?" })
+      screen.getByRole("heading", { level: 2, name: "You closed 7 commitments this week." })
     ).toBeInTheDocument();
+    expect(screen.getByText("1 commitment slipped past its due date.")).toBeInTheDocument();
     expect(screen.getByTestId("completion-chart")).toBeInTheDocument();
     expect(screen.getByTestId("quadrant-distribution")).toBeInTheDocument();
     expect(screen.getByTestId("time-analytics")).toBeInTheDocument();
@@ -180,9 +183,29 @@ describe("DashboardPage review framing", () => {
     mocks.useTasks.mockReturnValue({ all: [], isLoading: false });
     render(<DashboardPage />);
 
+    expect(
+      screen.getByRole("heading", { level: 2, name: "What did this week make room for?" })
+    ).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Nothing to review yet" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Open matrix" }));
     expect(mocks.push).toHaveBeenCalledWith("/");
+  });
+
+  it("keeps the review shell and offers recovery when the local read fails", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.useTasks.mockImplementation(() => {
+      throw new Error("IndexedDB unavailable");
+    });
+
+    render(<DashboardPage />);
+
+    // A scoped fallback, not the app-wide boundary: the nav must survive so the
+    // matrix is still one click away when only the review data is unreadable.
+    expect(screen.getByTestId("app-shell")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(/couldn.t read your review/i);
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+
+    consoleError.mockRestore();
   });
 
   it("announces loading review data while keeping skeleton geometry decorative", () => {
@@ -196,5 +219,7 @@ describe("DashboardPage review framing", () => {
       "true"
     );
     expect(screen.queryByRole("heading", { name: "Nothing to review yet" })).not.toBeInTheDocument();
+    expect(screen.getByTestId("verdict-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("stat-rail-skeleton")).toBeInTheDocument();
   });
 });

--- a/tests/ui/review-verdict.test.tsx
+++ b/tests/ui/review-verdict.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ReviewVerdict, buildReviewVerdict } from "@/components/dashboard/review-verdict";
+import type { ProductivityMetrics } from "@/lib/analytics";
+
+/**
+ * The verdict is the dashboard's hero: one factual sentence about what closed,
+ * followed by the single most notable true fact about what remains. Every branch
+ * must be provable from ProductivityMetrics alone — the analytics model does not
+ * record the quadrant of completed work, so the verdict never claims it.
+ */
+function metrics(overrides: Partial<ProductivityMetrics> = {}): ProductivityMetrics {
+  return {
+    completedToday: 0,
+    completedThisWeek: 0,
+    completedThisMonth: 0,
+    activeStreak: 0,
+    longestStreak: 0,
+    completionRate: 0,
+    quadrantDistribution: {
+      "urgent-important": 0,
+      "not-urgent-important": 0,
+      "urgent-not-important": 0,
+      "not-urgent-not-important": 0,
+    },
+    tagStats: [],
+    overdueCount: 0,
+    dueTodayCount: 0,
+    dueThisWeekCount: 0,
+    noDueDateCount: 0,
+    activeTasks: 0,
+    completedTasks: 0,
+    totalTasks: 0,
+    ...overrides,
+  };
+}
+
+describe("buildReviewVerdict", () => {
+  describe("lead — what closed this week", () => {
+    it("names an empty week without judgement", () => {
+      expect(buildReviewVerdict(metrics()).lead).toBe("Nothing closed this week.");
+    });
+
+    it("uses the singular noun for a single completion", () => {
+      expect(buildReviewVerdict(metrics({ completedThisWeek: 1 })).lead).toBe(
+        "You closed 1 commitment this week."
+      );
+    });
+
+    it("uses the plural noun beyond one", () => {
+      expect(buildReviewVerdict(metrics({ completedThisWeek: 23 })).lead).toBe(
+        "You closed 23 commitments this week."
+      );
+    });
+  });
+
+  describe("observation — the one fact worth noticing about what remains", () => {
+    it("reports a clear matrix when nothing is open", () => {
+      const verdict = buildReviewVerdict(metrics({ completedThisWeek: 5, completedTasks: 5 }));
+      expect(verdict.observation).toBe("Nothing is still open.");
+    });
+
+    it("ranks overdue work above every other observation", () => {
+      const verdict = buildReviewVerdict(
+        metrics({ activeTasks: 10, overdueCount: 3, noDueDateCount: 6 })
+      );
+      expect(verdict.observation).toBe("3 commitments slipped past their due date.");
+    });
+
+    it("uses singular agreement for a single overdue commitment", () => {
+      const verdict = buildReviewVerdict(metrics({ activeTasks: 4, overdueCount: 1 }));
+      expect(verdict.observation).toBe("1 commitment slipped past its due date.");
+    });
+
+    it("falls through to undated work when nothing is overdue", () => {
+      const verdict = buildReviewVerdict(metrics({ activeTasks: 41, noDueDateCount: 14 }));
+      expect(verdict.observation).toBe("14 of 41 commitments still open have no date yet.");
+    });
+
+    it("uses singular agreement for a single undated commitment", () => {
+      const verdict = buildReviewVerdict(metrics({ activeTasks: 5, noDueDateCount: 1 }));
+      expect(verdict.observation).toBe("1 of 5 commitments still open has no date yet.");
+    });
+
+    it("confirms full coverage when every open commitment carries a date", () => {
+      const verdict = buildReviewVerdict(metrics({ activeTasks: 7 }));
+      expect(verdict.observation).toBe("7 commitments still open, each with a date.");
+    });
+  });
+
+  it("never claims the quadrant of completed work", () => {
+    const verdict = buildReviewVerdict(
+      metrics({
+        completedThisWeek: 9,
+        activeTasks: 12,
+        quadrantDistribution: {
+          "urgent-important": 8,
+          "not-urgent-important": 4,
+          "urgent-not-important": 0,
+          "not-urgent-not-important": 0,
+        },
+      })
+    );
+    const sentence = `${verdict.lead} ${verdict.observation}`;
+    expect(sentence).not.toMatch(/scheduled|urgent|important|quadrant/i);
+  });
+});
+
+describe("ReviewVerdict", () => {
+  it("renders the verdict as the page's leading heading", () => {
+    render(<ReviewVerdict metrics={metrics({ completedThisWeek: 23, activeTasks: 41, noDueDateCount: 14 })} />);
+
+    expect(
+      screen.getByRole("heading", { name: "You closed 23 commitments this week." })
+    ).toBeInTheDocument();
+    expect(screen.getByText("14 of 41 commitments still open have no date yet.")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What changed

The Review page (`/dashboard`) opened on four identical stat cards, so nothing won the squint test and the surface read as the generic SaaS dashboard `.ui-craft/brief.md` lists as an anti-reference.

It now leads with a **verdict**: one serif sentence stating what the week actually closed, backed by three measures behind hairline dividers instead of bordered cards. The body is reordered so evidence follows the claim, and the reflection prompts follow the evidence.

The recipe this was built from prescribes an accent-tinted hero *metric card*. The brief bans a "hero-metric template" and forbids tide as decorative wash, so hierarchy comes from size and voice instead of tint — the hero is a sentence, and the three measures below it stay deliberately equal.

Every branch of that sentence is provable from `ProductivityMetrics` alone. `quadrantDistribution` counts **active** tasks only, so the verdict never characterises the quadrant of completed work — the same honesty constraint `ReviewPrompts` already documents.

## Also in this PR

- **Plain comparisons.** Dropped the coloured `↑`/`↓` deltas and the insight pill. Sparklines lose their trend colouring too, which frees three accent placements on a page where tide should mean interaction.
- **Scoped error state.** A failed IndexedDB read now costs the reader their data region but not their navigation back to the matrix. `ErrorBoundary` gains an optional `fallback`.
- **Sentence case** across twelve headings and labels.
- **Empty regions** get a next step via a shared `EmptyRegion` — one line plus one "Open matrix" link, the same label everywhere because it is one intent.
- **Removed the overdue banner**, which restated the verdict verbatim and spent a danger-coloured band doing it.

## Bugs found and fixed along the way

| Bug | Evidence |
|---|---|
| Streak card overflowed the prompts band | measured **364 × 199px** overlap; `h-full` resolved against a grid row sized by the chart beside it |
| Two cards rendered with **no border at all** | `twMerge` groups `border-hair` with `border-border` and drops the former — the only border-*width* utility. Measured **0px → 1px** |
| Verdict orphaned its own number | `max-w-[42ch]` resolved against the wrapper's 16px sans, not the 32px serif, halving the measure |
| Empty-region link failed the target floor | **81 × 20px → 97 × 44px** on a coarse pointer |
| Three bars animated `width` | forces reflow per frame; removed rather than converted to `scaleX`, which would distort the pills' end caps |
| Radius ladder flattened to one 14px value | now steps **8 / 10 / 12 / 14px** per the documented Inkwell rungs |

## How to test locally

```bash
bun install && bun dev   # then open /dashboard
```

The surface is data-dependent and the PWA service worker caches JS chunks, so a naive reload can show stale code against an empty page. Seed and bust with:

```bash
bun tools/stagehand/verify.ts --path /dashboard/ --seed dashboard --goal "..."
```

To exercise the regional empty states, seed `gsdSeed.matrix()` instead — tasks with no tags and no tracked time.

## Verification

- `bun run test` — **2866 passing**, 1 skipped (+21 from this branch)
- `bun typecheck`, `bun lint`, `bun run quality:shape` — clean
- `ui-craft-detect` — **0 errors, 0 warnings** across the surface (was 3 errors)
- Browser-verified at 1440px, 390px, and dark mode, with the service worker busted and IndexedDB seeded. Console clean in every scenario, populated and empty.

## Deferred follow-ups

Minor findings from `/finalize`, none blocking:

- Fourth font weight — a single `font-bold` in `time-analytics.tsx`
- `text-[40px]` / `text-[10px]` sit off the documented type ramp
- Icon-to-type ratio drifts across the surface
- Vocabulary drift: the hero rail speaks the product's voice, Time tracking speaks generic analytics
- `border-hair` survives in `components/matrix-simplified/help-drawer.tsx` — outside this surface, and a literal string there, so it is not hitting the `twMerge` bug

Two findings are **deferred against the brief** rather than fixed: the equal-weight measure rail (principle: no hero-metric template) and the absence of expressive easing curves (principle 5, "restraint on pages").

https://claude.ai/code/session_01H89VtXK4hzPeLe9n7yNo8c
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/gsd-task-manager/pull/519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restructures the Review dashboard around a metrics-derived weekly verdict and adds scoped loading, empty, and error treatments.

- Adds a two-sentence verdict and three-measure evidence rail.
- Reorders charts, prompts, deadline, tag, streak, and time-tracking regions.
- Adds reusable regional empty states and a dashboard-specific error fallback.
- Updates component styling, tests, package version, README version, and service-worker cache version.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after addressing the non-blocking repository-convention violations in the new dashboard components and imports.

The dashboard metrics and release-version paths remain internally consistent; the only accepted concern is that newly added components omit required client directives and several changed files use disallowed relative internal imports.

**Files Needing Attention:** components/dashboard/empty-region.tsx, components/dashboard/review-verdict.tsx, components/dashboard/quadrant-distribution.tsx, components/dashboard/tag-analytics.tsx, components/dashboard/time-analytics.tsx
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/(dashboard)/dashboard/page.tsx | Reorganizes dashboard composition around the verdict, measure rail, scoped boundary, and reordered evidence regions. |
| components/dashboard/review-verdict.tsx | Adds deterministic verdict text whose metric populations are consistent, but omits the repository-required client directive. |
| components/dashboard/empty-region.tsx | Adds a shared actionable empty state but does not declare the required client boundary. |
| components/error-boundary.tsx | Adds optional regional fallback rendering while retaining the existing full-page fallback by default. |
| components/dashboard/stats-card.tsx | Converts stat cards into borderless rail measures and replaces colored deltas with neutral comparison copy. |
| public/sw.js | Synchronizes the service-worker cache version with the 12.5.0 release bump. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20vscarpenter%2Fgsd-task-manager%20PR%20%23519%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=vscarpenter%2Fgsd-task-manager&pr=519&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acomponents%2Fdashboard%2Fempty-region.tsx%3A1-3%0A**Component%20conventions%20are%20inconsistent**%0A%0AThe%20new%20%60EmptyRegion%60%20and%20%60ReviewVerdict%60%20components%20omit%20the%20repository-required%20%60%22use%20client%22%60%20directive%2C%20while%20three%20changed%20consumers%20import%20%60EmptyRegion%60%20through%20a%20relative%20path%20instead%20of%20the%20required%20%60%40%2F%60%20alias.%20Align%20these%20files%20with%20the%20documented%20component%20and%20import%20conventions%20to%20avoid%20inconsistent%20boundaries%20and%20maintenance%20patterns.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=vscarpenter%2Fgsd-task-manager&pr=519&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
components/dashboard/empty-region.tsx:1-3
**Component conventions are inconsistent**

The new `EmptyRegion` and `ReviewVerdict` components omit the repository-required `"use client"` directive, while three changed consumers import `EmptyRegion` through a relative path instead of the required `@/` alias. Align these files with the documented component and import conventions to avoid inconsistent boundaries and maintenance patterns.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump to 12.5.0"](https://github.com/vscarpenter/gsd-task-manager/commit/300ad76e4cd0ba205a336c4c21ffb9f5e4e6f810) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57769632)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/vscarpenter/gsd-task-manager/blob/main/CLAUDE.md))

<!-- /greptile_comment -->