### PR TITLE
refactor: retire half-wired multi-select and smart-view plumbing, make the docs true

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -14,7 +14,7 @@ Context of use is varied and often quick: a desktop browser during a planning bl
 
 GSD Task Manager turns the Eisenhower Matrix into a working surface. Tasks are sorted into four quadrants by two booleans (urgent, important): Do First, Schedule, Delegate, and Eliminate. Prioritization becomes a structural decision the app makes visible, not a label the user has to remember.
 
-It is privacy-first by construction: all data lives in the browser via IndexedDB, with JSON export/import for backups and an *optional* self-hosted PocketBase sync for multi-device users. It works fully offline as a PWA. Around the core matrix sit dependencies, recurring tasks, subtasks, tags, batch operations, and a dashboard of completion and quadrant analytics.
+It is privacy-first by construction: all data lives in the browser via IndexedDB, with JSON export/import for backups and an *optional* self-hosted PocketBase sync for multi-device users. It works fully offline as a PWA. Around the core matrix sit dependencies, recurring tasks, subtasks, tags, and a dashboard of completion and quadrant analytics. Bulk multi-select and custom smart-view creation are deliberately absent on the web — they ship on iOS, where touch idioms earn them; the web's power path is the command palette.
 
 Success looks like a user who spends less time in Q1 (reactive firefighting) and more in Q2 (strategic, important-but-not-urgent work), and who trusts the tool enough to keep their real life in it because nothing leaves their device unless they say so.
 
@@ -31,7 +31,7 @@ Success looks like a user who spends less time in Q1 (reactive firefighting) and
 GSD should explicitly NOT look or feel like:
 
 - **A flashy AI startup:** no tide/cyan gradients, glowing blobs, gradient text, glassmorphism-by-default, or supercharge/streamline/seamless copy. Editorial uses tide as restrained interaction ink, never as gradient decoration. Substance over shine.
-- **A gamified todo toy:** no cartoon mascots, no points/badges economy, no juvenile illustration. (One tasteful completion confetti is the deliberate exception, not a license for toy aesthetics.)
+- **A gamified todo toy:** no cartoon mascots, no points/badges economy, no juvenile illustration. (One tasteful completion confetti is the deliberate exception, not a license for toy aesthetics.) The Review page's streak card is consistency *data*, deliberately kept where iOS removed its tiles: factual counts and a 7-day strip, presented like every other stat — never flames, trophies, or guilt copy.
 - **A dense enterprise PM tool:** not Jira/Asana. No overwhelming toolbars, deeply nested settings, or feature soup. GSD is a focused *personal* tool; complexity is a failure, not a feature.
 - **A generic SaaS dashboard:** no cookie-cutter card grids, no hero-metric template (big number + small label + gradient accent), no interchangeable enterprise-app sameness.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ optional PocketBase sync, and the GSD MCP server.
   realtime server-sent events.
 - A separately installed MCP server with 20 task, analytics, and diagnostic
   tools, including validated and dry-run-aware writes.
-- Light and dark Violet Frost themes with WCAG AA as the accessibility floor.
+- Light and dark Inkwell "GSD Editorial" themes with WCAG AA as the
+  accessibility floor.
 
 Retired v7/v8 surfaces such as selection-mode batch operations, the Quick
 Settings panel, and smart-view pinning shortcuts are not part of the v11 shell.

--- a/components/command-palette/index.tsx
+++ b/components/command-palette/index.tsx
@@ -15,8 +15,6 @@ interface CommandPaletteProps {
   handlers: CommandActionHandlers;
   conditions: {
     isSyncEnabled: boolean;
-    selectionMode: boolean;
-    hasSelection: boolean;
   };
   onSelectTask?: (taskId: string) => void;
   /**

--- a/components/task-card/index.tsx
+++ b/components/task-card/index.tsx
@@ -22,9 +22,6 @@ export function TaskCard({
   onSnooze,
   onStartTimer,
   onStopTimer,
-  selectionMode,
-  isSelected,
-  onToggleSelect,
   taskRef,
   isHighlighted,
 }: TaskCardProps) {
@@ -79,9 +76,8 @@ export function TaskCard({
         // The left inset covers the spine's 4px gutter plus the lane the drag
         // grip floats in. It lives here, on the card, rather than on the title
         // alone: padding only the title left tags, chips, and the due-date row
-        // starting 8px to its left, so the card read as ragged. Selection mode
-        // swaps the grip for an in-flow checkbox and reclaims the lane.
-        selectionMode ? "pl-4" : "pl-6",
+        // starting 8px to its left, so the card read as ragged.
+        "pl-6",
         // Clear the sticky topbar + capture bar (plus ~12pt) when scrolled to.
         "scroll-mt-24",
         "border-card-border",
@@ -98,7 +94,6 @@ export function TaskCard({
         // Half-strength so an overdue card is marked, not alarmed — the footer
         // chip carries the actual message.
         taskIsOverdue && "border-status-overdue/50",
-        selectionMode && isSelected && "ring-2 ring-accent ring-offset-2",
         isHighlighted && "animate-pulse-highlight ring-4 ring-accent ring-offset-2"
       )}
     >
@@ -115,9 +110,6 @@ export function TaskCard({
       <TaskCardHeader
         task={task}
         accentVar={accentVar}
-        selectionMode={selectionMode}
-        isSelected={isSelected}
-        onToggleSelect={onToggleSelect}
         onToggleComplete={onToggleComplete}
         onInspect={onInspect}
         sortableAttributes={attributes}

--- a/components/task-card/task-card-header.tsx
+++ b/components/task-card/task-card-header.tsx
@@ -12,9 +12,6 @@ export interface TaskCardHeaderProps {
   task: TaskRecord;
   /** CSS var for the task's quadrant pigment, e.g. "var(--q1)". */
   accentVar: string;
-  selectionMode?: boolean;
-  isSelected?: boolean;
-  onToggleSelect?: (task: TaskRecord) => void;
   onToggleComplete: (task: TaskRecord, completed: boolean) => Promise<void> | void;
   onInspect?: (task: TaskRecord) => void;
   sortableAttributes: SortableAttributes;
@@ -24,9 +21,6 @@ export interface TaskCardHeaderProps {
 export function TaskCardHeader({
   task,
   accentVar,
-  selectionMode,
-  isSelected,
-  onToggleSelect,
   onToggleComplete,
   onInspect,
   sortableAttributes,
@@ -71,10 +65,6 @@ export function TaskCardHeader({
     <div className="flex items-start justify-between gap-2">
       <div className="flex items-start gap-2 min-w-0 flex-1">
         <CardLeadingControl
-          task={task}
-          selectionMode={selectionMode}
-          isSelected={isSelected}
-          onToggleSelect={onToggleSelect}
           sortableAttributes={sortableAttributes}
           sortableListeners={sortableListeners}
         />
@@ -163,32 +153,12 @@ export function TaskCardHeader({
   );
 }
 
-/**
- * The card's left gutter: a selection checkbox in selection mode, otherwise the
- * drag grip.
- */
+/** The card's left gutter: the drag grip. */
 function CardLeadingControl({
-  task,
-  selectionMode,
-  isSelected,
-  onToggleSelect,
   sortableAttributes,
   sortableListeners,
-}: Pick<
-  TaskCardHeaderProps,
-  "task" | "selectionMode" | "isSelected" | "onToggleSelect" | "sortableAttributes" | "sortableListeners"
->) {
-  return selectionMode ? (
-          <label className="touch-target mt-0.5 inline-flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center">
-            <input
-              type="checkbox"
-              checked={isSelected}
-              onChange={() => onToggleSelect?.(task)}
-              className="h-5 w-5 shrink-0 cursor-pointer rounded border-border text-accent focus:ring-2 focus:ring-accent focus:ring-offset-2"
-              aria-label={`Select ${task.title}`}
-            />
-          </label>
-        ) : (
+}: Pick<TaskCardHeaderProps, "sortableAttributes" | "sortableListeners">) {
+  return (
           // Floats over the card's left gutter instead of holding a column, so
           // titles start flush. Visibility (not hit-testing) is what's gated:
           // gating pointer-events too would be a no-op for a real mouse — you

--- a/lib/command-actions.ts
+++ b/lib/command-actions.ts
@@ -46,10 +46,6 @@ export interface CommandActionHandlers {
 
   // Sync
   onTriggerSync?: () => Promise<void>;
-
-  // Selection
-  onToggleSelectionMode?: () => void;
-  onClearSelection?: () => void;
 }
 
 /**
@@ -61,8 +57,6 @@ export function buildCommandActions(
   builtInSmartViews: Array<{ id: string; name: string; icon?: string; criteria: FilterCriteria; description?: string }>,
   conditions: {
     isSyncEnabled: boolean;
-    selectionMode: boolean;
-    hasSelection: boolean;
   }
 ): CommandAction[] {
   // Import icon components dynamically
@@ -183,28 +177,6 @@ export function buildCommandActions(
       keywords: ['sync', 'upload', 'download', 'cloud'],
       onExecute: handlers.onTriggerSync,
       condition: () => conditions.isSyncEnabled
-    });
-  }
-
-  // Add selection mode actions if available
-  if (handlers.onToggleSelectionMode) {
-    actions.push({
-      id: 'toggle-selection-mode',
-      label: conditions.selectionMode ? 'Exit selection mode' : 'Enter selection mode',
-      section: 'actions',
-      keywords: ['select', 'selection', 'multiple', 'batch'],
-      onExecute: handlers.onToggleSelectionMode
-    });
-  }
-
-  if (handlers.onClearSelection && conditions.selectionMode && conditions.hasSelection) {
-    actions.push({
-      id: 'clear-selection',
-      label: 'Clear selection',
-      section: 'actions',
-      keywords: ['clear', 'deselect', 'unselect'],
-      onExecute: handlers.onClearSelection,
-      condition: () => conditions.selectionMode && conditions.hasSelection
     });
   }
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -127,8 +127,6 @@ export const DATE_CONFIG = {
  * Smart Views configuration
  */
 export const SMART_VIEWS_CONFIG = {
-  /** Length of generated nanoid for Smart View IDs */
-  ID_LENGTH: 12,
   /** Maximum number of pinned Smart Views in the header */
   MAX_PINNED: 5,
 } as const;

--- a/lib/smart-views.ts
+++ b/lib/smart-views.ts
@@ -1,9 +1,7 @@
-import { nanoid } from "nanoid";
 import { getDb } from "@/lib/db";
 import { BUILT_IN_SMART_VIEWS, type SmartView } from "@/lib/filters";
 import { smartViewSchema } from "@/lib/schema";
 import type { AppPreferences } from "@/lib/types";
-import { isoNow } from "@/lib/utils";
 import { SMART_VIEWS_CONFIG } from "@/lib/constants";
 
 export const APP_PREFERENCES_EVENT = "gsd:app-preferences";
@@ -18,10 +16,6 @@ const DEFAULT_APP_PREFERENCES: AppPreferences = {
   maxPinnedViews: SMART_VIEWS_CONFIG.MAX_PINNED,
   smartViewsEnabled: false,
 };
-
-function parseSmartView(view: unknown): SmartView {
-  return smartViewSchema.parse(view) as SmartView;
-}
 
 function parseStoredSmartView(view: unknown): SmartView | undefined {
   const parsed = smartViewSchema.safeParse(view);
@@ -66,80 +60,13 @@ export async function getSmartView(id: string): Promise<SmartView | undefined> {
 }
 
 /**
- * Create a new custom Smart View
- */
-export async function createSmartView(
-  view: Omit<SmartView, 'id' | 'createdAt' | 'updatedAt' | 'isBuiltIn'>
-): Promise<SmartView> {
-  const db = getDb();
-  const now = isoNow();
-
-  const newView: SmartView = {
-    ...view,
-    id: nanoid(SMART_VIEWS_CONFIG.ID_LENGTH),
-    isBuiltIn: false,
-    createdAt: now,
-    updatedAt: now
-  };
-
-  const validated = parseSmartView(newView);
-  await db.smartViews.add(validated);
-  return validated;
-}
-
-/**
- * Update an existing custom Smart View
- */
-export async function updateSmartView(
-  id: string,
-  updates: Partial<Omit<SmartView, 'id' | 'createdAt' | 'updatedAt' | 'isBuiltIn'>>
-): Promise<SmartView> {
-  const db = getDb();
-  const existing = await db.smartViews.get(id);
-
-  if (!existing) {
-    throw new Error(`Smart View ${id} not found`);
-  }
-
-  if (existing.isBuiltIn) {
-    throw new Error("Cannot update built-in Smart Views");
-  }
-
-  const updated: SmartView = {
-    ...existing,
-    ...updates,
-    updatedAt: isoNow()
-  };
-
-  const validated = parseSmartView(updated);
-  await db.smartViews.put(validated);
-  return validated;
-}
-
-/**
- * Delete a custom Smart View
- */
-export async function deleteSmartView(id: string): Promise<void> {
-  const db = getDb();
-  const view = await db.smartViews.get(id);
-
-  if (view?.isBuiltIn) {
-    throw new Error("Cannot delete built-in Smart Views");
-  }
-
-  await db.smartViews.delete(id);
-}
-
-/**
- * Clear all custom Smart Views (built-ins are unaffected)
- */
-export async function clearCustomSmartViews(): Promise<void> {
-  const db = getDb();
-  await db.smartViews.clear();
-}
-
-/**
- * Get app preferences (including pinned smart view IDs)
+ * Get app preferences.
+ *
+ * Custom smart-view creation and pinning are deliberately web-absent (retired
+ * with the v9 shell; iOS is the surface that creates views). The read path
+ * above stays so existing custom views keep rendering, and the stored
+ * `pinnedSmartViewIds` / `maxPinnedViews` fields stay in the schema for data
+ * continuity — but nothing on the web writes or reads them anymore.
  */
 export async function getAppPreferences(): Promise<AppPreferences> {
   const db = getDb();
@@ -171,53 +98,4 @@ export async function updateAppPreferences(updates: Partial<Omit<AppPreferences,
 
   await db.appPreferences.put(updated);
   return updated;
-}
-
-/**
- * Get pinned smart views in order
- */
-export async function getPinnedSmartViews(): Promise<SmartView[]> {
-  const [prefs, allViews] = await Promise.all([
-    getAppPreferences(),
-    getSmartViews(),
-  ]);
-
-  // Return views in the order they appear in pinnedSmartViewIds
-  return prefs.pinnedSmartViewIds
-    .map(id => allViews.find(v => v.id === id))
-    .filter((view): view is SmartView => view !== undefined);
-}
-
-/**
- * Pin a smart view to the header
- */
-export async function pinSmartView(viewId: string): Promise<void> {
-  const prefs = await getAppPreferences();
-
-  // Check if already pinned
-  if (prefs.pinnedSmartViewIds.includes(viewId)) {
-    return; // Already pinned, nothing to do
-  }
-
-  // Check if we've reached the maximum
-  if (prefs.pinnedSmartViewIds.length >= prefs.maxPinnedViews) {
-    throw new Error(`Maximum ${prefs.maxPinnedViews} pinned views allowed`);
-  }
-
-  // Add to the end of the pinned list
-  await updateAppPreferences({
-    pinnedSmartViewIds: [...prefs.pinnedSmartViewIds, viewId]
-  });
-}
-
-/**
- * Unpin a smart view from the header
- */
-export async function unpinSmartView(viewId: string): Promise<void> {
-  const prefs = await getAppPreferences();
-
-  // Remove from pinned list
-  await updateAppPreferences({
-    pinnedSmartViewIds: prefs.pinnedSmartViewIds.filter(id => id !== viewId)
-  });
 }

--- a/lib/task-card-memo.ts
+++ b/lib/task-card-memo.ts
@@ -24,9 +24,6 @@ export interface TaskCardProps {
   onSnooze?: (taskId: string, minutes: number) => Promise<void>;
   onStartTimer?: (taskId: string) => Promise<void>;
   onStopTimer?: (taskId: string) => Promise<void>;
-  selectionMode?: boolean;
-  isSelected?: boolean;
-  onToggleSelect?: (task: TaskRecord) => void;
   taskRef?: (el: HTMLElement | null) => void;
   isHighlighted?: boolean;
 }
@@ -113,8 +110,6 @@ function haveArraysChanged(prevProps: TaskCardProps, nextProps: TaskCardProps): 
 /** Check if UI state props changed */
 function hasUIStateChanged(prevProps: TaskCardProps, nextProps: TaskCardProps): boolean {
   return (
-    prevProps.selectionMode !== nextProps.selectionMode ||
-    prevProps.isSelected !== nextProps.isSelected ||
     prevProps.isHighlighted !== nextProps.isHighlighted ||
     Boolean(prevProps.onInspect) !== Boolean(nextProps.onInspect) ||
     prevProps.allTasks.length !== nextProps.allTasks.length

--- a/lib/use-shell-command-handlers.ts
+++ b/lib/use-shell-command-handlers.ts
@@ -45,8 +45,6 @@ interface ShellCommandResult {
   onSelectTask: (taskId: string) => void;
   conditions: {
     isSyncEnabled: boolean;
-    selectionMode: boolean;
-    hasSelection: boolean;
   };
 }
 
@@ -150,8 +148,6 @@ export function useShellCommandHandlers(): ShellCommandResult {
     onSelectTask,
     conditions: {
       isSyncEnabled: false,
-      selectionMode: false,
-      hasSelection: false,
     },
   };
 }

--- a/tests/data/command-actions.test.ts
+++ b/tests/data/command-actions.test.ts
@@ -22,8 +22,6 @@ function createMockHandlers(overrides?: Partial<CommandActionHandlers>): Command
 
 const defaultConditions = {
   isSyncEnabled: false,
-  selectionMode: false,
-  hasSelection: false,
 };
 
 describe('buildCommandActions', () => {
@@ -138,52 +136,9 @@ describe('buildCommandActions', () => {
     expect(actionIds).not.toContain('view-sync-history');
   });
 
-  it('should include selection mode toggle when handler is provided', () => {
-    const handlers = createMockHandlers({
-      onToggleSelectionMode: vi.fn(),
-    });
 
-    const actions = buildCommandActions(handlers, [], defaultConditions);
 
-    const selectionAction = actions.find((a) => a.id === 'toggle-selection-mode');
-    expect(selectionAction).toBeDefined();
-    expect(selectionAction!.label).toBe('Enter selection mode');
-  });
 
-  it('should show exit selection mode label when in selection mode', () => {
-    const handlers = createMockHandlers({
-      onToggleSelectionMode: vi.fn(),
-    });
-    const conditions = { ...defaultConditions, selectionMode: true };
-
-    const actions = buildCommandActions(handlers, [], conditions);
-
-    const selectionAction = actions.find((a) => a.id === 'toggle-selection-mode');
-    expect(selectionAction!.label).toBe('Exit selection mode');
-  });
-
-  it('should include clear selection when in selection mode with active selection', () => {
-    const handlers = createMockHandlers({
-      onClearSelection: vi.fn(),
-    });
-    const conditions = { isSyncEnabled: false, selectionMode: true, hasSelection: true };
-
-    const actions = buildCommandActions(handlers, [], conditions);
-
-    const clearAction = actions.find((a) => a.id === 'clear-selection');
-    expect(clearAction).toBeDefined();
-  });
-
-  it('should not include clear selection when not in selection mode', () => {
-    const handlers = createMockHandlers({
-      onClearSelection: vi.fn(),
-    });
-
-    const actions = buildCommandActions(handlers, [], defaultConditions);
-
-    const clearAction = actions.find((a) => a.id === 'clear-selection');
-    expect(clearAction).toBeUndefined();
-  });
 
   it('should execute smart view handler with correct criteria', () => {
     const handlers = createMockHandlers();
@@ -252,17 +207,6 @@ describe('buildCommandActions', () => {
       });
       const viewSyncHistory = actions.find((a) => a.id === 'view-sync-history');
       expect(viewSyncHistory?.condition?.()).toBe(true);
-    });
-
-    it('gates clear-selection on an active selection in selection mode', () => {
-      const handlers = createMockHandlers({ onClearSelection: vi.fn() });
-      const actions = buildCommandActions(handlers, [], {
-        isSyncEnabled: false,
-        selectionMode: true,
-        hasSelection: true,
-      });
-      const clearSelection = actions.find((a) => a.id === 'clear-selection');
-      expect(clearSelection?.condition?.()).toBe(true);
     });
   });
 });

--- a/tests/data/smart-views.test.ts
+++ b/tests/data/smart-views.test.ts
@@ -1,44 +1,42 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   getSmartViews,
   getSmartView,
-  createSmartView,
-  updateSmartView,
-  deleteSmartView,
-  clearCustomSmartViews,
   getAppPreferences,
   updateAppPreferences,
-  getPinnedSmartViews,
-  pinSmartView,
-  unpinSmartView,
 } from '@/lib/smart-views';
 import { getDb } from '@/lib/db';
+import type { SmartView } from '@/lib/filters';
 
-// Mock nanoid to get predictable IDs
-vi.mock('nanoid', () => ({
-  nanoid: vi.fn(() => 'test-id-123'),
-}));
-
-// Mock isoNow for predictable timestamps
-vi.mock('@/lib/utils', async () => {
-  const actual = await vi.importActual('@/lib/utils');
+/**
+ * Custom smart-view creation and pinning are deliberately web-absent (retired
+ * with the v9 shell; iOS is the surface that creates views), so tests seed the
+ * `smartViews` table directly — the read path must keep serving views that
+ * already exist in a user's database.
+ */
+function seedCustomView(overrides: Partial<SmartView> = {}): SmartView {
   return {
-    ...actual,
-    isoNow: vi.fn(() => '2025-01-15T12:00:00.000Z'),
-  };
-});
+    id: 'custom-view-1',
+    name: 'My Custom View',
+    criteria: { tags: ['custom'] },
+    isBuiltIn: false,
+    createdAt: '2025-01-15T12:00:00.000Z',
+    updatedAt: '2025-01-15T12:00:00.000Z',
+    ...overrides,
+  } as SmartView;
+}
 
 describe('Smart Views', () => {
   beforeEach(async () => {
     // Start each test from a clean slate: clear both custom views and the
-    // pin/preference state so app-preferences tests are isolated.
+    // preference state so app-preferences tests are isolated.
     const db = getDb();
-    await clearCustomSmartViews();
+    await db.smartViews.clear();
     await db.appPreferences.clear();
   });
 
   afterEach(async () => {
-    await clearCustomSmartViews();
+    await getDb().smartViews.clear();
   });
 
   describe('getSmartViews', () => {
@@ -55,10 +53,8 @@ describe('Smart Views', () => {
     });
 
     it('should include custom smart views after built-ins', async () => {
-      const customView = await createSmartView({
-        name: 'My Custom View',
-        criteria: { tags: ['custom'] },
-      });
+      const customView = seedCustomView();
+      await getDb().smartViews.add(customView);
 
       const views = await getSmartViews();
 
@@ -118,14 +114,12 @@ describe('Smart Views', () => {
     });
 
     it('should get custom smart view by ID', async () => {
-      const created = await createSmartView({
-        name: 'Test View',
-        criteria: { tags: ['test'] },
-      });
+      const seeded = seedCustomView({ id: 'custom-view-2', name: 'Test View', criteria: { tags: ['test'] } });
+      await getDb().smartViews.add(seeded);
 
-      const retrieved = await getSmartView(created.id);
+      const retrieved = await getSmartView(seeded.id);
 
-      expect(retrieved).toEqual(created);
+      expect(retrieved).toEqual(seeded);
     });
 
     it('should return undefined for non-existent ID', async () => {
@@ -141,233 +135,6 @@ describe('Smart Views', () => {
     });
   });
 
-  describe('createSmartView', () => {
-    it('rejects malformed criteria from direct runtime callers', async () => {
-      await expect(createSmartView({
-        name: 'Malformed',
-        criteria: { searchQuery: {} },
-      } as never)).rejects.toThrow();
-    });
-
-    it('should create new custom smart view', async () => {
-      const newView = await createSmartView({
-        name: 'High Priority',
-        criteria: { quadrants: ['urgent-important'] },
-      });
-
-      expect(newView).toMatchObject({
-        id: 'test-id-123',
-        name: 'High Priority',
-        criteria: { quadrants: ['urgent-important'] },
-        isBuiltIn: false,
-        createdAt: '2025-01-15T12:00:00.000Z',
-        updatedAt: '2025-01-15T12:00:00.000Z',
-      });
-    });
-
-    it('should persist smart view to database', async () => {
-      const created = await createSmartView({
-        name: 'Persistent View',
-        criteria: { tags: ['work'] },
-      });
-
-      const db = getDb();
-      const retrieved = await db.smartViews.get(created.id);
-
-      expect(retrieved).toEqual(created);
-    });
-
-    it('should generate unique ID for each view', async () => {
-      const mocked = await import('nanoid');
-      let idCounter = 0;
-      vi.mocked(mocked.nanoid).mockImplementation(() => `id-${idCounter++}`);
-
-      const view1 = await createSmartView({ name: 'View 1', criteria: {} });
-      const view2 = await createSmartView({ name: 'View 2', criteria: {} });
-
-      expect(view1.id).not.toBe(view2.id);
-    });
-
-    it('should handle complex filter criteria', async () => {
-      const newView = await createSmartView({
-        name: 'Complex View',
-        criteria: {
-          quadrants: ['urgent-important', 'not-urgent-important'],
-          status: 'active',
-          tags: ['work', 'urgent'],
-          dueDate: {
-            mode: 'relative',
-            days: 7,
-          },
-        },
-      });
-
-      expect(newView.criteria).toEqual({
-        quadrants: ['urgent-important', 'not-urgent-important'],
-        status: 'active',
-        tags: ['work', 'urgent'],
-        dueDate: {
-          mode: 'relative',
-          days: 7,
-        },
-      });
-    });
-  });
-
-  describe('updateSmartView', () => {
-    it('should update existing custom smart view', async () => {
-      const created = await createSmartView({
-        name: 'Original Name',
-        criteria: { tags: ['old'] },
-      });
-
-      const utils = await import('@/lib/utils');
-      vi.mocked(utils.isoNow).mockReturnValue('2025-01-15T13:00:00.000Z');
-
-      const updated = await updateSmartView(created.id, {
-        name: 'Updated Name',
-        criteria: { tags: ['new'] },
-      });
-
-      expect(updated).toMatchObject({
-        id: created.id,
-        name: 'Updated Name',
-        criteria: { tags: ['new'] },
-        createdAt: created.createdAt,
-        updatedAt: '2025-01-15T13:00:00.000Z',
-      });
-    });
-
-    it('should persist updates to database', async () => {
-      const created = await createSmartView({
-        name: 'Test',
-        criteria: {},
-      });
-
-      await updateSmartView(created.id, { name: 'Updated' });
-
-      const db = getDb();
-      const retrieved = await db.smartViews.get(created.id);
-
-      expect(retrieved?.name).toBe('Updated');
-    });
-
-    it('should throw error for non-existent view', async () => {
-      await expect(
-        updateSmartView('non-existent', { name: 'Updated' })
-      ).rejects.toThrow('Smart View non-existent not found');
-    });
-
-    it('should throw error when updating built-in view', async () => {
-      const db = getDb();
-
-      // Add a fake built-in view to database (simulating data corruption)
-      await db.smartViews.add({
-        id: 'fake-built-in',
-        name: 'Fake Built-in',
-        criteria: {},
-        isBuiltIn: true,
-        createdAt: '2025-01-01T00:00:00.000Z',
-        updatedAt: '2025-01-01T00:00:00.000Z',
-      });
-
-      await expect(
-        updateSmartView('fake-built-in', { name: 'Hacked' })
-      ).rejects.toThrow('Cannot update built-in Smart Views');
-    });
-
-    it('should allow partial updates', async () => {
-      const created = await createSmartView({
-        name: 'Original',
-        criteria: { tags: ['tag1', 'tag2'] },
-      });
-
-      const updated = await updateSmartView(created.id, {
-        name: 'New Name',
-      });
-
-      expect(updated.name).toBe('New Name');
-      expect(updated.criteria).toEqual({ tags: ['tag1', 'tag2'] });
-    });
-  });
-
-  describe('deleteSmartView', () => {
-    it('should delete custom smart view', async () => {
-      const created = await createSmartView({
-        name: 'To Delete',
-        criteria: {},
-      });
-
-      await deleteSmartView(created.id);
-
-      const db = getDb();
-      const retrieved = await db.smartViews.get(created.id);
-
-      expect(retrieved).toBeUndefined();
-    });
-
-    it('should throw error when deleting built-in view', async () => {
-      const db = getDb();
-
-      // Add a fake built-in view
-      await db.smartViews.add({
-        id: 'fake-built-in',
-        name: 'Fake Built-in',
-        criteria: {},
-        isBuiltIn: true,
-        createdAt: '2025-01-01T00:00:00.000Z',
-        updatedAt: '2025-01-01T00:00:00.000Z',
-      });
-
-      await expect(
-        deleteSmartView('fake-built-in')
-      ).rejects.toThrow('Cannot delete built-in Smart Views');
-    });
-
-    it('should not throw error for non-existent view', async () => {
-      await expect(deleteSmartView('non-existent')).resolves.not.toThrow();
-    });
-  });
-
-  describe('clearCustomSmartViews', () => {
-    it('should clear all custom smart views', async () => {
-      await createSmartView({ name: 'View 1', criteria: {} });
-      await createSmartView({ name: 'View 2', criteria: {} });
-      await createSmartView({ name: 'View 3', criteria: {} });
-
-      await clearCustomSmartViews();
-
-      const db = getDb();
-      const remaining = await db.smartViews.toArray();
-
-      expect(remaining).toHaveLength(0);
-    });
-
-    it('should not affect built-in views (they are not in db)', async () => {
-      await createSmartView({ name: 'Custom', criteria: {} });
-
-      const viewsBeforeClear = await getSmartViews();
-      const builtInCount = viewsBeforeClear.filter(v => v.isBuiltIn).length;
-
-      await clearCustomSmartViews();
-
-      const viewsAfterClear = await getSmartViews();
-      const builtInCountAfter = viewsAfterClear.filter(v => v.isBuiltIn).length;
-
-      expect(builtInCount).toBe(builtInCountAfter);
-      expect(viewsAfterClear.every(v => v.isBuiltIn)).toBe(true);
-    });
-
-    it('should work when no custom views exist', async () => {
-      await expect(clearCustomSmartViews()).resolves.not.toThrow();
-    });
-  });
-
-  // Migrated from the former tests/data/coverage-boost.test.ts "smart-views"
-  // block (finding F2.1). The CRUD cases there duplicated the suites above and
-  // were dropped; these app-preferences / pinning cases were the block's unique
-  // coverage of lib/smart-views.ts and are preserved here, rewritten against the
-  // real `criteria` API with deterministic (no conditional) assertions.
   describe('app preferences', () => {
     it('should return default preferences when none are stored', async () => {
       const prefs = await getAppPreferences();
@@ -380,69 +147,11 @@ describe('Smart Views', () => {
 
     it('should persist updated preferences', async () => {
       await updateAppPreferences({
-        pinnedSmartViewIds: ['view-1', 'view-2'],
         smartViewsEnabled: true,
       });
 
       const prefs = await getAppPreferences();
-      expect(prefs.pinnedSmartViewIds).toEqual(['view-1', 'view-2']);
       expect(prefs.smartViewsEnabled).toBe(true);
-    });
-  });
-
-  describe('pinning', () => {
-    it('should pin a smart view', async () => {
-      await pinSmartView('view-1');
-
-      const prefs = await getAppPreferences();
-      expect(prefs.pinnedSmartViewIds).toContain('view-1');
-    });
-
-    it('should be a no-op when pinning an already-pinned view', async () => {
-      await updateAppPreferences({ pinnedSmartViewIds: ['view-1'] });
-      await pinSmartView('view-1');
-
-      const prefs = await getAppPreferences();
-      expect(prefs.pinnedSmartViewIds).toEqual(['view-1']);
-    });
-
-    it('should throw when the maximum number of pinned views is reached', async () => {
-      await updateAppPreferences({
-        pinnedSmartViewIds: ['v1', 'v2', 'v3', 'v4', 'v5'],
-        maxPinnedViews: 5,
-      });
-
-      await expect(pinSmartView('v6')).rejects.toThrow(/Maximum/);
-    });
-
-    it('should unpin a smart view', async () => {
-      await updateAppPreferences({ pinnedSmartViewIds: ['v1', 'v2'] });
-      await unpinSmartView('v1');
-
-      const prefs = await getAppPreferences();
-      expect(prefs.pinnedSmartViewIds).toEqual(['v2']);
-    });
-
-    it('should resolve pinned views in the stored order', async () => {
-      const allViews = await getSmartViews();
-      const [first, second] = allViews;
-
-      await updateAppPreferences({ pinnedSmartViewIds: [second.id, first.id] });
-
-      const pinned = await getPinnedSmartViews();
-      expect(pinned.map(v => v.id)).toEqual([second.id, first.id]);
-    });
-
-    it('should skip pinned IDs that no longer resolve to a view', async () => {
-      const allViews = await getSmartViews();
-      const real = allViews[0];
-
-      await updateAppPreferences({
-        pinnedSmartViewIds: ['deleted-or-unknown', real.id],
-      });
-
-      const pinned = await getPinnedSmartViews();
-      expect(pinned.map(v => v.id)).toEqual([real.id]);
     });
   });
 });

--- a/tests/data/task-card-memo.test.ts
+++ b/tests/data/task-card-memo.test.ts
@@ -87,17 +87,7 @@ describe('areTaskCardPropsEqual', () => {
     expect(areTaskCardPropsEqual(prev, next)).toBe(false);
   });
 
-  it('returns false when selection mode changes', () => {
-    const prev = createProps({ selectionMode: false });
-    const next = createProps({ selectionMode: true });
-    expect(areTaskCardPropsEqual(prev, next)).toBe(false);
-  });
 
-  it('returns false when isSelected changes', () => {
-    const prev = createProps({ isSelected: false });
-    const next = createProps({ isSelected: true });
-    expect(areTaskCardPropsEqual(prev, next)).toBe(false);
-  });
 
   it('returns false when highlight state changes', () => {
     const prev = createProps({ isHighlighted: false });

--- a/tests/data/use-shell-command-handlers.test.ts
+++ b/tests/data/use-shell-command-handlers.test.ts
@@ -197,8 +197,6 @@ describe("useShellCommandHandlers", () => {
     const { result } = renderHook(() => useShellCommandHandlers());
     expect(result.current.conditions).toEqual({
       isSyncEnabled: false,
-      selectionMode: false,
-      hasSelection: false,
     });
   });
 

--- a/tests/ui/command-palette.test.tsx
+++ b/tests/ui/command-palette.test.tsx
@@ -205,8 +205,6 @@ function makeHandlers(): CommandActionHandlers {
 
 const defaultConditions = {
   isSyncEnabled: false,
-  selectionMode: false,
-  hasSelection: false,
 };
 
 describe('CommandPalette (full component)', () => {

--- a/tests/ui/task-card-states.test.tsx
+++ b/tests/ui/task-card-states.test.tsx
@@ -106,26 +106,8 @@ describe("TaskCard states", () => {
     vi.clearAllMocks();
   });
 
-  it("renders selection checkbox when selectionMode is true", () => {
-    renderTaskCard({}, { selectionMode: true, isSelected: false, onToggleSelect: vi.fn() });
-    expect(screen.getByRole("checkbox")).toBeInTheDocument();
-    expect(screen.getByRole("checkbox").closest("label")).toHaveClass("touch-target");
-  });
 
-  it("renders selected checkbox state", () => {
-    renderTaskCard({}, { selectionMode: true, isSelected: true, onToggleSelect: vi.fn() });
-    const checkbox = screen.getByRole("checkbox") as HTMLInputElement;
-    expect(checkbox.checked).toBe(true);
-  });
 
-  it("calls onToggleSelect when checkbox is toggled", async () => {
-    const onToggleSelect = vi.fn();
-    const user = userEvent.setup();
-    renderTaskCard({}, { selectionMode: true, isSelected: false, onToggleSelect });
-
-    await user.click(screen.getByRole("checkbox"));
-    expect(onToggleSelect).toHaveBeenCalled();
-  });
 
   it("renders dependency blocked indicator", () => {
     const blockingTask = createMockTask({

--- a/tests/ui/task-card-subcomponents.test.tsx
+++ b/tests/ui/task-card-subcomponents.test.tsx
@@ -50,8 +50,6 @@ describe("TaskCardHeader", () => {
           notificationEnabled: true,
           notificationSent: false,
         }}
-        selectionMode={false}
-        isSelected={false}
         onToggleComplete={vi.fn()}
         sortableAttributes={{} as SortableAttributes}
         sortableListeners={undefined}
@@ -86,8 +84,6 @@ describe("TaskCardHeader", () => {
           notificationEnabled: true,
           notificationSent: false,
         }}
-        selectionMode={false}
-        isSelected={false}
         onToggleComplete={vi.fn()}
         sortableAttributes={{} as SortableAttributes}
         sortableListeners={undefined}
@@ -120,8 +116,6 @@ describe("TaskCardHeader", () => {
       notificationSent: false,
     };
     const props = {
-      selectionMode: false,
-      isSelected: false,
       onToggleComplete: vi.fn(),
       sortableAttributes: {} as SortableAttributes,
       sortableListeners: undefined,
@@ -157,8 +151,6 @@ describe("TaskCardHeader", () => {
     };
     const onToggleComplete = vi.fn().mockResolvedValue(undefined);
     const props = {
-      selectionMode: false,
-      isSelected: false,
       onToggleComplete,
       sortableAttributes: {} as SortableAttributes,
       sortableListeners: undefined,


### PR DESCRIPTION
## What changed

**+43 / −630.** Three features were threaded through the shell with no consumer, so PRODUCT.md claimed capabilities no user could reach. Per the feature decisions (2026-08-28): the web diverges deliberately — iOS keeps these as touch idioms.

- **Multi-select** — `selectionMode`/`isSelected`/`onToggleSelect` never left their hardcoded defaults. Removed from task-card, the memo comparator, command actions, and the shell conditions.
- **Custom smart views** — the CRUD trio had no callers. The **read path stays**: custom views already in a user's database keep rendering and applying.
- **Pinning** — pin/unpin/getPinned had no callers. The stored prefs fields stay in the schema for data continuity.

## Docs made true

- PRODUCT.md no longer claims batch operations; it names the deliberate web absences and declares the Review page's streak card as consistency data (kept where iOS removed its tiles — factual counts, never flames or trophies), so the next parity audit stops flagging it.
- README's theme line said "Violet Frost"; it now says Inkwell "GSD Editorial".

## How to test

```
bun run test    # 2834 passing (removed tests covered only the dead paths)
bun typecheck · bun lint · bun run build
```

Verified in the running app via the Stagehand runner: cards render in all four quadrants (spine, completion disc, no checkboxes), completing a task works end-to-end, the ⌘K palette carries no selection actions, console clean. Evidence under `tools/stagehand/evidence/verify-2026-08-29T00-34-56.488Z` and `...00-35-29.551Z`.

https://claude.ai/code/session_01KF8Y9yjYjYAaQgnxaWoKNn

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes unused web plumbing for task multi-select, custom smart-view mutation, and smart-view pinning while preserving existing custom-view reads and stored preference fields for data continuity.
- Simplifies task cards to always expose their drag control.
- Removes unreachable selection commands and shell conditions.
- Retires unused smart-view mutation and pinning APIs.
- Updates tests and documentation to reflect the supported web surface.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the retired interfaces have no remaining repository consumers or reachable web workflows.

The component, command, and smart-view contracts were updated consistently across their production callers and tests, while the custom-view read path and persisted preference schema remain intact.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| components/task-card/index.tsx | Removes dormant selection props and selected-card styling while preserving the normal task-card interaction path. |
| components/task-card/task-card-header.tsx | Removes the unreachable selection checkbox branch and consistently renders the drag grip. |
| lib/command-actions.ts | Removes selection handlers and command actions that had no live shell wiring. |
| lib/smart-views.ts | Retires unused mutation and pinning APIs while retaining custom-view reads and preference storage for existing data. |
| lib/use-shell-command-handlers.ts | Removes hardcoded false selection conditions from the shell command contract. |
| PRODUCT.md | Aligns the documented web feature set and review-page presentation with the implemented product. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(shell): retire the half-wired m..."](https://github.com/vscarpenter/gsd-task-manager/commit/71e30ad5f9d76b3fe331b1e35b9bdf3bb24ae513) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58126530)</sub>

<!-- /greptile_comment -->