### PR TITLE
feat(settings): surface the sound and quiet-hours notification controls

### DIFF
--- a/components/settings-page/settings-body.tsx
+++ b/components/settings-page/settings-body.tsx
@@ -33,6 +33,31 @@ const ImportDialog = lazy(() =>
 const logger = createLogger("UI");
 const MAX_IMPORT_BYTES = 10 * 1024 * 1024; // 10 MB
 
+/** Open a JSON file picker; hand syntactically-valid contents to `onReady`. */
+function pickImportFile(onReady: (contents: string) => void): void {
+  const input = document.createElement("input");
+  input.type = "file";
+  input.accept = "application/json";
+  input.onchange = async (event) => {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (!file) return;
+    if (file.size > MAX_IMPORT_BYTES) {
+      toast.error(
+        `Import file is too large (max 10 MB). Selected file: ${(file.size / 1024 / 1024).toFixed(1)} MB`,
+      );
+      return;
+    }
+    try {
+      const contents = await file.text();
+      JSON.parse(contents);
+      onReady(contents);
+    } catch {
+      toast.error("Invalid JSON format in import file");
+    }
+  };
+  input.click();
+}
+
 interface SettingsBodyProps {
   activeSection: SettingsSectionId;
   tasks: TaskRecord[];
@@ -89,30 +114,11 @@ export function SettingsBody({
     }
   };
 
-  const handleImportClick = () => {
-    const input = document.createElement("input");
-    input.type = "file";
-    input.accept = "application/json";
-    input.onchange = async (event) => {
-      const file = (event.target as HTMLInputElement).files?.[0];
-      if (!file) return;
-      if (file.size > MAX_IMPORT_BYTES) {
-        toast.error(
-          `Import file is too large (max 10 MB). Selected file: ${(file.size / 1024 / 1024).toFixed(1)} MB`,
-        );
-        return;
-      }
-      try {
-        const contents = await file.text();
-        JSON.parse(contents);
-        setPendingImportContents(contents);
-        setImportDialogOpen(true);
-      } catch {
-        toast.error("Invalid JSON format in import file");
-      }
-    };
-    input.click();
-  };
+  const handleImportClick = () =>
+    pickImportFile((contents) => {
+      setPendingImportContents(contents);
+      setImportDialogOpen(true);
+    });
 
   return (
     <div className="min-w-0 flex-1">

--- a/components/settings-page/settings-body.tsx
+++ b/components/settings-page/settings-body.tsx
@@ -139,6 +139,9 @@ export function SettingsBody({
             settings={settings.notificationSettings}
             onNotificationToggle={settings.notificationToggle}
             onDefaultReminderChange={settings.defaultReminderChange}
+            onSoundToggle={settings.soundToggle}
+            onQuietHoursToggle={settings.quietHoursToggle}
+            onQuietHoursChange={settings.quietHoursChange}
           />
         )}
         {activeSection === "sync" && settings.syncEnabled && (

--- a/components/settings-page/use-settings-data.ts
+++ b/components/settings-page/use-settings-data.ts
@@ -5,6 +5,9 @@ import { useEffect, useState } from "react";
 import {
   getNotificationSettings,
   updateNotificationSettings,
+  toggleNotificationSound,
+  toggleQuietHours,
+  setQuietHoursEdge,
 } from "@/lib/notifications";
 import type { AppPreferences, NotificationSettings } from "@/lib/types";
 import { getSyncStatus } from "@/lib/sync/config";
@@ -109,53 +112,9 @@ export function useSettingsData(): SettingsData {
     );
   };
 
-  const reloadNotificationSettings = async () => {
-    setNotificationSettings(await getNotificationSettings());
-  };
-
-  const notificationToggle = async () => {
-    if (!notificationSettings) return;
-    const newEnabled = !notificationSettings.enabled;
-    if (newEnabled && "Notification" in window) {
-      const permission = await Notification.requestPermission();
-      if (permission !== "granted") return;
-    }
-    await updateNotificationSettings({ enabled: newEnabled });
-    await reloadNotificationSettings();
-  };
-
-  const defaultReminderChange = async (value: string) => {
-    await updateNotificationSettings({ defaultReminder: Number.parseInt(value, 10) });
-    await reloadNotificationSettings();
-  };
-
-  const soundToggle = async () => {
-    if (!notificationSettings) return;
-    await updateNotificationSettings({ soundEnabled: !notificationSettings.soundEnabled });
-    await reloadNotificationSettings();
-  };
-
-  // Quiet hours are "on" exactly when both edges exist — the same condition
-  // isInQuietHours() checks — so the toggle seeds a sensible overnight window
-  // and clearing both edges is what turns the feature off.
-  const quietHoursToggle = async () => {
-    if (!notificationSettings) return;
-    const isOn = Boolean(notificationSettings.quietHoursStart && notificationSettings.quietHoursEnd);
-    await updateNotificationSettings(
-      isOn
-        ? { quietHoursStart: undefined, quietHoursEnd: undefined }
-        : { quietHoursStart: "22:00", quietHoursEnd: "08:00" },
-    );
-    await reloadNotificationSettings();
-  };
-
-  const quietHoursChange = async (which: "start" | "end", value: string) => {
-    if (!value) return; // an emptied time input is not a window edge
-    await updateNotificationSettings(
-      which === "start" ? { quietHoursStart: value } : { quietHoursEnd: value },
-    );
-    await reloadNotificationSettings();
-  };
+  const notificationHandlers = buildNotificationHandlers(notificationSettings, () =>
+    getNotificationSettings().then(setNotificationSettings),
+  );
 
   const markAccountDeleted = () => {
     setSyncEnabled(false);
@@ -171,11 +130,46 @@ export function useSettingsData(): SettingsData {
     pendingSync,
     toggleCompleted,
     toggleSmartViews,
-    notificationToggle,
-    defaultReminderChange,
-    soundToggle,
-    quietHoursToggle,
-    quietHoursChange,
+    ...notificationHandlers,
     markAccountDeleted,
+  };
+}
+
+/**
+ * The five notification mutations, each followed by a state reload. The
+ * mutation semantics themselves (seed/clear the quiet-hours window, ignore
+ * empty edges) live in lib/notifications/settings.ts, unit-tested directly.
+ */
+function buildNotificationHandlers(
+  current: NotificationSettings | null,
+  reload: () => Promise<void>,
+) {
+  return {
+    notificationToggle: async () => {
+      if (!current) return;
+      const newEnabled = !current.enabled;
+      if (newEnabled && "Notification" in window) {
+        const permission = await Notification.requestPermission();
+        if (permission !== "granted") return;
+      }
+      await updateNotificationSettings({ enabled: newEnabled });
+      await reload();
+    },
+    defaultReminderChange: async (value: string) => {
+      await updateNotificationSettings({ defaultReminder: Number.parseInt(value, 10) });
+      await reload();
+    },
+    soundToggle: async () => {
+      await toggleNotificationSound();
+      await reload();
+    },
+    quietHoursToggle: async () => {
+      await toggleQuietHours();
+      await reload();
+    },
+    quietHoursChange: async (which: "start" | "end", value: string) => {
+      await setQuietHoursEdge(which, value);
+      await reload();
+    },
   };
 }

--- a/components/settings-page/use-settings-data.ts
+++ b/components/settings-page/use-settings-data.ts
@@ -34,6 +34,9 @@ export interface SettingsData {
   toggleSmartViews: () => Promise<void>;
   notificationToggle: () => Promise<void>;
   defaultReminderChange: (value: string) => Promise<void>;
+  soundToggle: () => Promise<void>;
+  quietHoursToggle: () => Promise<void>;
+  quietHoursChange: (which: "start" | "end", value: string) => Promise<void>;
   markAccountDeleted: () => void;
 }
 
@@ -126,6 +129,34 @@ export function useSettingsData(): SettingsData {
     await reloadNotificationSettings();
   };
 
+  const soundToggle = async () => {
+    if (!notificationSettings) return;
+    await updateNotificationSettings({ soundEnabled: !notificationSettings.soundEnabled });
+    await reloadNotificationSettings();
+  };
+
+  // Quiet hours are "on" exactly when both edges exist — the same condition
+  // isInQuietHours() checks — so the toggle seeds a sensible overnight window
+  // and clearing both edges is what turns the feature off.
+  const quietHoursToggle = async () => {
+    if (!notificationSettings) return;
+    const isOn = Boolean(notificationSettings.quietHoursStart && notificationSettings.quietHoursEnd);
+    await updateNotificationSettings(
+      isOn
+        ? { quietHoursStart: undefined, quietHoursEnd: undefined }
+        : { quietHoursStart: "22:00", quietHoursEnd: "08:00" },
+    );
+    await reloadNotificationSettings();
+  };
+
+  const quietHoursChange = async (which: "start" | "end", value: string) => {
+    if (!value) return; // an emptied time input is not a window edge
+    await updateNotificationSettings(
+      which === "start" ? { quietHoursStart: value } : { quietHoursEnd: value },
+    );
+    await reloadNotificationSettings();
+  };
+
   const markAccountDeleted = () => {
     setSyncEnabled(false);
     setPendingSync(0);
@@ -142,6 +173,9 @@ export function useSettingsData(): SettingsData {
     toggleSmartViews,
     notificationToggle,
     defaultReminderChange,
+    soundToggle,
+    quietHoursToggle,
+    quietHoursChange,
     markAccountDeleted,
   };
 }

--- a/components/settings/notification-settings.tsx
+++ b/components/settings/notification-settings.tsx
@@ -8,6 +8,9 @@ interface NotificationSettingsProps {
 	settings: NotificationSettings | null;
 	onNotificationToggle: () => Promise<void>;
 	onDefaultReminderChange: (value: string) => Promise<void>;
+	onSoundToggle: () => Promise<void>;
+	onQuietHoursToggle: () => Promise<void>;
+	onQuietHoursChange: (which: "start" | "end", value: string) => Promise<void>;
 }
 
 const REMINDER_OPTIONS = [
@@ -25,6 +28,9 @@ export function NotificationSettingsSection({
 	settings,
 	onNotificationToggle,
 	onDefaultReminderChange,
+	onSoundToggle,
+	onQuietHoursToggle,
+	onQuietHoursChange,
 }: NotificationSettingsProps) {
 	if (!settings) {
 		return (
@@ -38,6 +44,10 @@ export function NotificationSettingsSection({
 		(opt) => opt.value === settings.defaultReminder.toString()
 	);
 
+	// The checker treats quiet hours as active only when both edges exist, so
+	// the switch mirrors that exact condition rather than a separate flag.
+	const quietHoursOn = Boolean(settings.quietHoursStart && settings.quietHoursEnd);
+
 	return (
 		<>
 			{/* Enable Notifications Row */}
@@ -47,6 +57,7 @@ export function NotificationSettingsSection({
 				state={settings.enabled}
 			>
 				<Switch
+					aria-label="Push notifications"
 					checked={settings.enabled}
 					onCheckedChange={onNotificationToggle}
 				/>
@@ -62,6 +73,50 @@ export function NotificationSettingsSection({
 				/>
 			)}
 
+			{/* Sound + quiet hours - only meaningful while notifications fire */}
+			{settings.enabled && (
+				<>
+					<SettingsRow
+						label="Sound"
+						description="Play a sound with each notification"
+						state={settings.soundEnabled}
+					>
+						<Switch
+							aria-label="Sound"
+							checked={settings.soundEnabled}
+							onCheckedChange={onSoundToggle}
+						/>
+					</SettingsRow>
+
+					<SettingsRow
+						label="Quiet hours"
+						description="Hold notifications during a daily window"
+						state={quietHoursOn}
+					>
+						<Switch
+							aria-label="Quiet hours"
+							checked={quietHoursOn}
+							onCheckedChange={onQuietHoursToggle}
+						/>
+					</SettingsRow>
+
+					{quietHoursOn && (
+						<>
+							<QuietHoursTimeRow
+								label="From"
+								value={settings.quietHoursStart ?? ""}
+								onChange={(value) => onQuietHoursChange("start", value)}
+							/>
+							<QuietHoursTimeRow
+								label="To"
+								value={settings.quietHoursEnd ?? ""}
+								onChange={(value) => onQuietHoursChange("end", value)}
+							/>
+						</>
+					)}
+				</>
+			)}
+
 			{/* Permission Status Row */}
 			{"Notification" in window && (
 				<SettingsRow label="Browser permission">
@@ -69,6 +124,33 @@ export function NotificationSettingsSection({
 				</SettingsRow>
 			)}
 		</>
+	);
+}
+
+/**
+ * One edge of the quiet-hours window as an iOS-style row with a native time
+ * input — the same disclosure position SettingsSelectRow puts its control in.
+ */
+function QuietHoursTimeRow({
+	label,
+	value,
+	onChange,
+}: {
+	label: string;
+	value: string;
+	onChange: (value: string) => void;
+}) {
+	return (
+		<label className="flex items-center justify-between gap-4 px-4 py-3.5 min-h-[52px] cursor-pointer">
+			<span className="text-sm font-medium text-foreground">{label}</span>
+			<input
+				type="time"
+				aria-label={label}
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				className="bg-transparent text-sm text-foreground-muted text-right cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-xs"
+			/>
+		</label>
 	);
 }
 

--- a/components/settings/notification-settings.tsx
+++ b/components/settings/notification-settings.tsx
@@ -40,80 +40,25 @@ export function NotificationSettingsSection({
 		);
 	}
 
-	const currentReminder = REMINDER_OPTIONS.find(
-		(opt) => opt.value === settings.defaultReminder.toString()
-	);
-
-	// The checker treats quiet hours as active only when both edges exist, so
-	// the switch mirrors that exact condition rather than a separate flag.
-	const quietHoursOn = Boolean(settings.quietHoursStart && settings.quietHoursEnd);
-
 	return (
 		<>
-			{/* Enable Notifications Row */}
-			<SettingsRow
-				label="Push notifications"
-				description="Get reminded about tasks"
-				state={settings.enabled}
-			>
-				<Switch
-					aria-label="Push notifications"
-					checked={settings.enabled}
-					onCheckedChange={onNotificationToggle}
-				/>
-			</SettingsRow>
+			<PushNotificationsRow enabled={settings.enabled} onToggle={onNotificationToggle} />
 
-			{/* Reminder Time Row - Only show when enabled */}
-			{settings.enabled && (
-				<SettingsSelectRow
-					label="Default reminder"
-					value={currentReminder?.label || "30 minutes"}
-					options={REMINDER_OPTIONS}
-					onChange={onDefaultReminderChange}
-				/>
-			)}
-
-			{/* Sound + quiet hours - only meaningful while notifications fire */}
+			{/* Reminder, sound, quiet hours - only meaningful while notifications fire */}
 			{settings.enabled && (
 				<>
-					<SettingsRow
-						label="Sound"
-						description="Play a sound with each notification"
-						state={settings.soundEnabled}
-					>
-						<Switch
-							aria-label="Sound"
-							checked={settings.soundEnabled}
-							onCheckedChange={onSoundToggle}
-						/>
-					</SettingsRow>
-
-					<SettingsRow
-						label="Quiet hours"
-						description="Hold notifications during a daily window"
-						state={quietHoursOn}
-					>
-						<Switch
-							aria-label="Quiet hours"
-							checked={quietHoursOn}
-							onCheckedChange={onQuietHoursToggle}
-						/>
-					</SettingsRow>
-
-					{quietHoursOn && (
-						<>
-							<QuietHoursTimeRow
-								label="From"
-								value={settings.quietHoursStart ?? ""}
-								onChange={(value) => onQuietHoursChange("start", value)}
-							/>
-							<QuietHoursTimeRow
-								label="To"
-								value={settings.quietHoursEnd ?? ""}
-								onChange={(value) => onQuietHoursChange("end", value)}
-							/>
-						</>
-					)}
+					<SettingsSelectRow
+						label="Default reminder"
+						value={reminderLabel(settings.defaultReminder)}
+						options={REMINDER_OPTIONS}
+						onChange={onDefaultReminderChange}
+					/>
+					<SoundAndQuietHoursRows
+						settings={settings}
+						onSoundToggle={onSoundToggle}
+						onQuietHoursToggle={onQuietHoursToggle}
+						onQuietHoursChange={onQuietHoursChange}
+					/>
 				</>
 			)}
 
@@ -122,6 +67,112 @@ export function NotificationSettingsSection({
 				<SettingsRow label="Browser permission">
 					<PermissionBadge permission={Notification.permission} />
 				</SettingsRow>
+			)}
+		</>
+	);
+}
+
+/** Label for the stored default-reminder offset. */
+function reminderLabel(defaultReminder: number): string {
+	return (
+		REMINDER_OPTIONS.find((opt) => opt.value === defaultReminder.toString())?.label ||
+		"30 minutes"
+	);
+}
+
+/** The master switch for notifications. */
+function PushNotificationsRow({
+	enabled,
+	onToggle,
+}: {
+	enabled: boolean;
+	onToggle: () => Promise<void>;
+}) {
+	return (
+		<SettingsRow
+			label="Push notifications"
+			description="Get reminded about tasks"
+			state={enabled}
+		>
+			<Switch
+				aria-label="Push notifications"
+				checked={enabled}
+				onCheckedChange={onToggle}
+			/>
+		</SettingsRow>
+	);
+}
+
+/** The sound switch, then the quiet-hours switch with its window rows. */
+function SoundAndQuietHoursRows({
+	settings,
+	onSoundToggle,
+	onQuietHoursToggle,
+	onQuietHoursChange,
+}: Pick<
+	NotificationSettingsProps,
+	"onSoundToggle" | "onQuietHoursToggle" | "onQuietHoursChange"
+> & { settings: NotificationSettings }) {
+	return (
+		<>
+			<SettingsRow
+				label="Sound"
+				description="Play a sound with each notification"
+				state={settings.soundEnabled}
+			>
+				<Switch
+					aria-label="Sound"
+					checked={settings.soundEnabled}
+					onCheckedChange={onSoundToggle}
+				/>
+			</SettingsRow>
+			<QuietHoursRows
+				settings={settings}
+				onQuietHoursToggle={onQuietHoursToggle}
+				onQuietHoursChange={onQuietHoursChange}
+			/>
+		</>
+	);
+}
+
+/** The quiet-hours switch, revealing the window's From/To rows when on. */
+function QuietHoursRows({
+	settings,
+	onQuietHoursToggle,
+	onQuietHoursChange,
+}: Pick<NotificationSettingsProps, "onQuietHoursToggle" | "onQuietHoursChange"> & {
+	settings: NotificationSettings;
+}) {
+	// The checker treats quiet hours as active only when both edges exist, so
+	// the switch mirrors that exact condition rather than a separate flag.
+	const quietHoursOn = Boolean(settings.quietHoursStart && settings.quietHoursEnd);
+
+	return (
+		<>
+			<SettingsRow
+				label="Quiet hours"
+				description="Hold notifications during a daily window"
+				state={quietHoursOn}
+			>
+				<Switch
+					aria-label="Quiet hours"
+					checked={quietHoursOn}
+					onCheckedChange={onQuietHoursToggle}
+				/>
+			</SettingsRow>
+			{quietHoursOn && (
+				<>
+					<QuietHoursTimeRow
+						label="From"
+						value={settings.quietHoursStart ?? ""}
+						onChange={(value) => onQuietHoursChange("start", value)}
+					/>
+					<QuietHoursTimeRow
+						label="To"
+						value={settings.quietHoursEnd ?? ""}
+						onChange={(value) => onQuietHoursChange("end", value)}
+					/>
+				</>
 			)}
 		</>
 	);

--- a/lib/notifications/index.ts
+++ b/lib/notifications/index.ts
@@ -20,7 +20,10 @@ export {
 // Settings functions
 export {
   getNotificationSettings,
-  updateNotificationSettings
+  updateNotificationSettings,
+  toggleNotificationSound,
+  toggleQuietHours,
+  setQuietHoursEdge
 } from "./settings";
 
 // Badge functions

--- a/lib/notifications/settings.ts
+++ b/lib/notifications/settings.ts
@@ -76,3 +76,38 @@ export async function updateNotificationSettings(
   }
   await db.notificationSettings.put(result.data);
 }
+
+/** The window toggleQuietHours seeds — the same overnight span the iOS client defaults to. */
+const DEFAULT_QUIET_HOURS = { start: "22:00", end: "08:00" } as const;
+
+/** Flip whether notifications play a sound. */
+export async function toggleNotificationSound(): Promise<void> {
+  const current = await getNotificationSettings();
+  await updateNotificationSettings({ soundEnabled: !current.soundEnabled });
+}
+
+/**
+ * Toggle the quiet-hours window.
+ *
+ * "On" is exactly the condition isInQuietHours() checks — both edges set — so
+ * there is no separate flag to drift: turning on seeds the overnight window,
+ * turning off clears both edges. A half-set state can never fire, so it reads
+ * as off and toggling completes the window.
+ */
+export async function toggleQuietHours(): Promise<void> {
+  const current = await getNotificationSettings();
+  const isOn = Boolean(current.quietHoursStart && current.quietHoursEnd);
+  await updateNotificationSettings(
+    isOn
+      ? { quietHoursStart: undefined, quietHoursEnd: undefined }
+      : { quietHoursStart: DEFAULT_QUIET_HOURS.start, quietHoursEnd: DEFAULT_QUIET_HOURS.end },
+  );
+}
+
+/** Move one edge of the quiet-hours window. An empty value is ignored — an emptied time input is not an edge. */
+export async function setQuietHoursEdge(which: "start" | "end", value: string): Promise<void> {
+  if (!value) return;
+  await updateNotificationSettings(
+    which === "start" ? { quietHoursStart: value } : { quietHoursEnd: value },
+  );
+}

--- a/tests/data/notification-controls.test.ts
+++ b/tests/data/notification-controls.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getNotificationSettings,
+  updateNotificationSettings,
+  toggleNotificationSound,
+  toggleQuietHours,
+  setQuietHoursEdge,
+} from "@/lib/notifications/settings";
+import { getDb } from "@/lib/db";
+
+describe("notification control mutations", () => {
+  beforeEach(async () => {
+    await getDb().notificationSettings.clear();
+  });
+
+  describe("toggleNotificationSound", () => {
+    it("flips soundEnabled from its default on", async () => {
+      await toggleNotificationSound();
+      expect((await getNotificationSettings()).soundEnabled).toBe(false);
+
+      await toggleNotificationSound();
+      expect((await getNotificationSettings()).soundEnabled).toBe(true);
+    });
+  });
+
+  describe("toggleQuietHours", () => {
+    it("seeds the overnight window when no hours are set", async () => {
+      await toggleQuietHours();
+
+      const settings = await getNotificationSettings();
+      expect(settings.quietHoursStart).toBe("22:00");
+      expect(settings.quietHoursEnd).toBe("08:00");
+    });
+
+    it("clears both edges when the window is set", async () => {
+      await updateNotificationSettings({ quietHoursStart: "21:00", quietHoursEnd: "07:00" });
+
+      await toggleQuietHours();
+
+      const settings = await getNotificationSettings();
+      expect(settings.quietHoursStart).toBeUndefined();
+      expect(settings.quietHoursEnd).toBeUndefined();
+    });
+
+    it("treats a single set edge as off and seeds the full window", async () => {
+      // Half-set state can't fire (isInQuietHours needs both edges), so the
+      // toggle reads it as off and completes the window.
+      await updateNotificationSettings({ quietHoursStart: "23:00" });
+
+      await toggleQuietHours();
+
+      const settings = await getNotificationSettings();
+      expect(settings.quietHoursStart).toBe("22:00");
+      expect(settings.quietHoursEnd).toBe("08:00");
+    });
+  });
+
+  describe("setQuietHoursEdge", () => {
+    it("updates only the named edge", async () => {
+      await updateNotificationSettings({ quietHoursStart: "22:00", quietHoursEnd: "08:00" });
+
+      await setQuietHoursEdge("start", "21:30");
+      expect((await getNotificationSettings()).quietHoursStart).toBe("21:30");
+      expect((await getNotificationSettings()).quietHoursEnd).toBe("08:00");
+
+      await setQuietHoursEdge("end", "07:15");
+      expect((await getNotificationSettings()).quietHoursEnd).toBe("07:15");
+    });
+
+    it("ignores an empty value — an emptied time input is not a window edge", async () => {
+      await updateNotificationSettings({ quietHoursStart: "22:00", quietHoursEnd: "08:00" });
+
+      await setQuietHoursEdge("start", "");
+
+      expect((await getNotificationSettings()).quietHoursStart).toBe("22:00");
+    });
+  });
+});

--- a/tests/ui/settings-components.test.tsx
+++ b/tests/ui/settings-components.test.tsx
@@ -68,14 +68,17 @@ vi.mock('@/components/ui/switch', () => ({
     checked,
     onCheckedChange,
     disabled,
+    'aria-label': ariaLabel,
   }: {
     checked: boolean;
     onCheckedChange: (v: boolean) => void;
     disabled?: boolean;
+    'aria-label'?: string;
   }) => (
     <button
       role="switch"
       aria-checked={checked}
+      aria-label={ariaLabel}
       onClick={() => !disabled && onCheckedChange(!checked)}
       disabled={disabled}
     >
@@ -308,7 +311,7 @@ describe('Settings Components', () => {
           onDefaultReminderChange={vi.fn()}
         />
       );
-      fireEvent.click(screen.getByRole('switch'));
+      fireEvent.click(screen.getByRole('switch', { name: /push notifications/i }));
       expect(onToggle).toHaveBeenCalled();
     });
 
@@ -326,6 +329,86 @@ describe('Settings Components', () => {
         />
       );
       expect(screen.getByText('Granted')).toBeInTheDocument();
+    });
+
+    describe('sound and quiet hours', () => {
+      const quietSettings = {
+        ...enabledSettings,
+        quietHoursStart: '22:00',
+        quietHoursEnd: '08:00',
+      };
+
+      const renderSection = (
+        settings: typeof enabledSettings | typeof quietSettings | null,
+        handlers: Partial<{
+          onSoundToggle: () => Promise<void>;
+          onQuietHoursToggle: () => Promise<void>;
+          onQuietHoursChange: (which: 'start' | 'end', value: string) => Promise<void>;
+        }> = {}
+      ) =>
+        render(
+          <NotificationSettingsSection
+            settings={settings}
+            onNotificationToggle={vi.fn()}
+            onDefaultReminderChange={vi.fn()}
+            onSoundToggle={handlers.onSoundToggle ?? vi.fn()}
+            onQuietHoursToggle={handlers.onQuietHoursToggle ?? vi.fn()}
+            onQuietHoursChange={handlers.onQuietHoursChange ?? vi.fn()}
+          />
+        );
+
+      it('renders a Sound row reflecting soundEnabled and calls onSoundToggle on click', () => {
+        const onSoundToggle = vi.fn();
+        renderSection(enabledSettings, { onSoundToggle });
+
+        const soundSwitch = screen.getByRole('switch', { name: /sound/i });
+        expect(soundSwitch).toBeChecked();
+        fireEvent.click(soundSwitch);
+        expect(onSoundToggle).toHaveBeenCalledTimes(1);
+      });
+
+      it('renders the Quiet hours switch off when no hours are set and calls onQuietHoursToggle', () => {
+        const onQuietHoursToggle = vi.fn();
+        renderSection(enabledSettings, { onQuietHoursToggle });
+
+        const quietSwitch = screen.getByRole('switch', { name: /quiet hours/i });
+        expect(quietSwitch).not.toBeChecked();
+        fireEvent.click(quietSwitch);
+        expect(onQuietHoursToggle).toHaveBeenCalledTimes(1);
+      });
+
+      it('reveals From/To time inputs with the stored values when quiet hours are set', () => {
+        renderSection(quietSettings);
+
+        expect(screen.getByRole('switch', { name: /quiet hours/i })).toBeChecked();
+        expect(screen.getByLabelText('From')).toHaveValue('22:00');
+        expect(screen.getByLabelText('To')).toHaveValue('08:00');
+      });
+
+      it('hides the From/To time inputs when quiet hours are off', () => {
+        renderSection(enabledSettings);
+
+        expect(screen.queryByLabelText('From')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('To')).not.toBeInTheDocument();
+      });
+
+      it('changing a time input calls onQuietHoursChange with which edge and the value', () => {
+        const onQuietHoursChange = vi.fn();
+        renderSection(quietSettings, { onQuietHoursChange });
+
+        fireEvent.change(screen.getByLabelText('From'), { target: { value: '21:30' } });
+        expect(onQuietHoursChange).toHaveBeenCalledWith('start', '21:30');
+
+        fireEvent.change(screen.getByLabelText('To'), { target: { value: '07:00' } });
+        expect(onQuietHoursChange).toHaveBeenCalledWith('end', '07:00');
+      });
+
+      it('hides sound and quiet hours rows when notifications are disabled', () => {
+        renderSection({ ...enabledSettings, enabled: false });
+
+        expect(screen.queryByRole('switch', { name: /sound/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('switch', { name: /quiet hours/i })).not.toBeInTheDocument();
+      });
     });
   });
 


### PR DESCRIPTION
## What changed

The logic already shipped — `isInQuietHours()` holds notifications during the window and `display.ts` passes `silent: !soundEnabled` — but the settings page rendered neither control. This adds the missing UI, matching the iOS app's shape:

- **Sound** — a toggle bound to `soundEnabled`.
- **Quiet hours** — a toggle that reveals **From**/**To** time pickers. The switch mirrors the checker's exact condition (both edges set): on seeds a 22:00–08:00 overnight window, off clears both edges. No separate flag to drift.
- The push-notifications switch gains an `aria-label` — with three switches in the section, the unnamed role was ambiguous for screen readers.

## How to test

```
bun run test    # 2872 passing, 6 new tests
bun typecheck · bun lint
```

Or live: Settings → Notifications → flip Quiet hours; the From/To pickers appear holding 22:00/08:00 and the state survives reload. Stagehand evidence under `tools/stagehand/evidence/verify-2026-08-29T00-40-41.466Z` and `...00-41-04.809Z`.

https://claude.ai/code/session_01KF8Y9yjYjYAaQgnxaWoKNn



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR exposes the existing sound and quiet-hours notification preferences in Settings.
- Adds accessible switches for push notifications, sound, and quiet hours.
- Adds time inputs for editing the quiet-hours window.
- Introduces notification preference mutation helpers and focused data/UI tests.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR does not appear safe to merge until concurrent notification-setting changes can no longer overwrite persisted preferences or restore stale UI state.

The previously reported concurrency defect remains: independent handlers can overlap whole-record read-modify-write operations and independently ordered reloads, losing a preference update or displaying stale settings.

**Files Needing Attention:** components/settings-page/use-settings-data.ts and lib/notifications/settings.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| components/settings-page/use-settings-data.ts | Wires five independent asynchronous notification mutations and reloads, leaving the previously reported concurrent-update ordering issue outstanding. |
| lib/notifications/settings.ts | Adds sound and quiet-hours helpers on top of a whole-record read-modify-write path that can lose overlapping updates. |
| components/settings/notification-settings.tsx | Adds accessible sound and quiet-hours controls with conditional time inputs. |
| tests/data/notification-controls.test.ts | Covers sequential sound and quiet-hours mutations but does not exercise overlapping preference updates. |
| tests/ui/settings-components.test.tsx | Verifies control rendering, accessibility names, values, visibility, and handler wiring. |

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(shape): move notification mutat..."](https://github.com/vscarpenter/gsd-task-manager/commit/d6ac0404654337ec614e117e0bbbd1a4b2b5e628) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58127385)</sub>

<!-- /greptile_comment -->