### PR TITLE
feat(capture): shared cross-platform parser corpus; align with spec §6.2

### DIFF
--- a/lib/capture-parser.ts
+++ b/lib/capture-parser.ts
@@ -1,3 +1,5 @@
+import { SCHEMA_LIMITS } from "./constants/schema";
+
 export interface ParsedCapture {
   title: string;
   urgent: boolean;
@@ -15,19 +17,21 @@ const FALLBACK_TITLE_FOR_URL_ONLY = "Review link below";
 // Matches http/https URLs; reuses the same pattern as lib/task-links.ts
 const TITLE_URL_PATTERN = /\bhttps?:\/\/[^\s<>"'`{}|\\^]+/giu;
 const TRAILING_PUNCTUATION = /[),.!?;:]+$/u;
-const MAX_URL_LENGTH = 2048;
+const MAX_URL_LENGTH = 2048; // spec §6.2: URLs of 2048 chars or more are rejected
 const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
 
 function sanitizeTitleUrl(candidate: string): string | null {
   const value = candidate.trim();
-  if (value.length === 0 || value.length > MAX_URL_LENGTH || /[\u0000-\u001F\u007F\s]/u.test(value)) {
+  if (value.length === 0 || value.length >= MAX_URL_LENGTH || /[\u0000-\u001F\u007F\s]/u.test(value)) {
     return null;
   }
   try {
     const url = new URL(value);
     if (!ALLOWED_PROTOCOLS.has(url.protocol.toLowerCase())) return null;
     if (!url.hostname || url.username || url.password) return null;
-    return url.href;
+    // Return the raw (trimmed) candidate, not url.href: both clients store the
+    // URL exactly as typed, so captures stay byte-identical across platforms.
+    return value;
   } catch {
     return null;
   }
@@ -53,7 +57,7 @@ export function extractUrlsFromTitle(title: string): ExtractedUrls {
     const trimmed = raw.replace(TRAILING_PUNCTUATION, "");
     const safe = sanitizeTitleUrl(trimmed);
     if (!safe) return raw; // leave invalid/unsafe candidates untouched
-    urls.push(safe);
+    if (!urls.includes(safe)) urls.push(safe); // dedupe repeats; still remove from title
     // Trailing punctuation (e.g. a period at the end of a sentence) is dropped
     // along with the URL — it was sentence-level punctuation around the link.
     return "";
@@ -76,19 +80,33 @@ export function buildDescription(existing: string, urls: string[]): string {
   return existing.trim() ? `${existing.trim()}\n${urlBlock}` : urlBlock;
 }
 
-const TAG_PATTERN = /(^|\s)#([a-z0-9_-]+)/gi;
-const DOUBLE_BANG = /(^|\s)!!(\s|$)/g;
-const SINGLE_BANG = /(^|\s)!(\s|$)/g;
-const STAR = /(^|\s)\*(\s|$)/g;
+// A tag starts with a Unicode word character (letter, mark, number, underscore) and
+// may continue with those plus hyphens — the iOS parser's `\w[\w-]*`, pinned by the
+// cross-platform corpus (tests/fixtures/cross-platform/capture-parser-corpus.json).
+const TAG_PATTERN = /(^|\s)#([\p{L}\p{M}\p{N}_][\p{L}\p{M}\p{N}_-]*)/gu;
+// Flag tokens strip with their leading whitespace; the lookahead keeps the trailing
+// separator so repeated tokens ("!! !!") all match in one pass.
+const DOUBLE_BANG = /(?:^|\s)!!(?=\s|$)/g;
+const SINGLE_BANG = /(?:^|\s)!(?=\s|$)/g;
+const STAR = /(?:^|\s)\*(?=\s|$)/g;
 
 export function parseCapture(input: string): ParsedCapture {
   let working = input;
   const tags: string[] = [];
 
-  // Extract tags
-  working = working.replace(TAG_PATTERN, (_match, lead: string, tag: string) => {
-    tags.push(tag.toLowerCase());
-    return lead;
+  // Extract tags: lowercased, length-checked, deduplicated, capped at MAX_TAGS
+  // (spec §6.2). Out-of-range or over-cap tags are dropped from the tag list but
+  // still stripped from the title.
+  working = working.replace(TAG_PATTERN, (_match, _lead: string, tag: string) => {
+    const t = tag.toLowerCase();
+    if (
+      t.length <= SCHEMA_LIMITS.TAG_MAX_LENGTH &&
+      !tags.includes(t) &&
+      tags.length < SCHEMA_LIMITS.MAX_TAGS
+    ) {
+      tags.push(t);
+    }
+    return "";
   });
 
   let urgent = false;
@@ -100,7 +118,7 @@ export function parseCapture(input: string): ParsedCapture {
     urgent = true;
     important = true;
     DOUBLE_BANG.lastIndex = 0;
-    working = working.replace(DOUBLE_BANG, "$1$2");
+    working = working.replace(DOUBLE_BANG, "");
   }
 
   // Check for single ! (reset lastIndex)
@@ -108,7 +126,7 @@ export function parseCapture(input: string): ParsedCapture {
   if (SINGLE_BANG.test(working)) {
     urgent = true;
     SINGLE_BANG.lastIndex = 0;
-    working = working.replace(SINGLE_BANG, "$1$2");
+    working = working.replace(SINGLE_BANG, "");
   }
 
   // Check for * (reset lastIndex)
@@ -116,7 +134,7 @@ export function parseCapture(input: string): ParsedCapture {
   if (STAR.test(working)) {
     important = true;
     STAR.lastIndex = 0;
-    working = working.replace(STAR, "$1$2");
+    working = working.replace(STAR, "");
   }
 
   // Collapse whitespace and trim

--- a/packages/mcp-server/src/__tests__/text/capture-parser-parity.test.ts
+++ b/packages/mcp-server/src/__tests__/text/capture-parser-parity.test.ts
@@ -22,22 +22,22 @@ const FIXTURES: Fixture[] = [
   {
     name: 'single url in title',
     input: 'Read https://example.com later',
-    expected: { cleanTitle: 'Read later', urls: ['https://example.com/'] },
+    expected: { cleanTitle: 'Read later', urls: ['https://example.com'] },
   },
   {
     name: 'multiple urls',
     input: 'See https://a.test and https://b.test',
-    expected: { cleanTitle: 'See and', urls: ['https://a.test/', 'https://b.test/'] },
+    expected: { cleanTitle: 'See and', urls: ['https://a.test', 'https://b.test'] },
   },
   {
     name: 'url-only title falls back',
     input: 'https://example.com',
-    expected: { cleanTitle: 'Review link below', urls: ['https://example.com/'] },
+    expected: { cleanTitle: 'Review link below', urls: ['https://example.com'] },
   },
   {
     name: 'trailing punctuation stripped',
     input: 'Check https://example.com.',
-    expected: { cleanTitle: 'Check', urls: ['https://example.com/'] },
+    expected: { cleanTitle: 'Check', urls: ['https://example.com'] },
   },
   {
     name: 'javascript protocol url left in place',
@@ -87,13 +87,13 @@ describe('capture-parser parity: behavior', () => {
   });
 
   it('mcp buildDescription empty existing returns urls joined', () => {
-    expect(mcpBuild('', ['https://a.test/', 'https://b.test/'])).toBe(
-      'https://a.test/\nhttps://b.test/'
+    expect(mcpBuild('', ['https://a.test', 'https://b.test'])).toBe(
+      'https://a.test\nhttps://b.test'
     );
   });
 
   it('mcp buildDescription appends urls below trimmed existing', () => {
-    expect(mcpBuild('  Plan trip  ', ['https://a.test/'])).toBe('Plan trip\nhttps://a.test/');
+    expect(mcpBuild('  Plan trip  ', ['https://a.test'])).toBe('Plan trip\nhttps://a.test');
   });
 });
 

--- a/packages/mcp-server/src/__tests__/write-ops/task-operations-create.test.ts
+++ b/packages/mcp-server/src/__tests__/write-ops/task-operations-create.test.ts
@@ -45,7 +45,7 @@ describe('createTask URL extraction', () => {
     });
 
     expect(result.task.title).toBe('Read later');
-    expect(result.task.description).toBe('https://example.com/');
+    expect(result.task.description).toBe('https://example.com');
   });
 
   it('uses the fallback title when the title is url-only', async () => {
@@ -57,7 +57,7 @@ describe('createTask URL extraction', () => {
     });
 
     expect(result.task.title).toBe('Review link below');
-    expect(result.task.description).toBe('https://example.com/');
+    expect(result.task.description).toBe('https://example.com');
   });
 
   it('appends the url below an existing description', async () => {
@@ -70,7 +70,7 @@ describe('createTask URL extraction', () => {
     });
 
     expect(result.task.title).toBe('Read later');
-    expect(result.task.description).toBe('Notes here\nhttps://example.com/');
+    expect(result.task.description).toBe('Notes here\nhttps://example.com');
   });
 
   it('does not extract javascript protocol urls', async () => {

--- a/packages/mcp-server/src/text/capture-parser.ts
+++ b/packages/mcp-server/src/text/capture-parser.ts
@@ -18,19 +18,21 @@ const FALLBACK_TITLE_FOR_URL_ONLY = "Review link below";
 // Matches http/https URLs; reuses the same pattern as lib/task-links.ts
 const TITLE_URL_PATTERN = /\bhttps?:\/\/[^\s<>"'`{}|\\^]+/giu;
 const TRAILING_PUNCTUATION = /[),.!?;:]+$/u;
-const MAX_URL_LENGTH = 2048;
+const MAX_URL_LENGTH = 2048; // spec §6.2: URLs of 2048 chars or more are rejected
 const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
 
 function sanitizeTitleUrl(candidate: string): string | null {
   const value = candidate.trim();
-  if (value.length === 0 || value.length > MAX_URL_LENGTH || /[\u0000-\u001F\u007F\s]/u.test(value)) {
+  if (value.length === 0 || value.length >= MAX_URL_LENGTH || /[\u0000-\u001F\u007F\s]/u.test(value)) {
     return null;
   }
   try {
     const url = new URL(value);
     if (!ALLOWED_PROTOCOLS.has(url.protocol.toLowerCase())) return null;
     if (!url.hostname || url.username || url.password) return null;
-    return url.href;
+    // Return the raw (trimmed) candidate, not url.href: both clients store the
+    // URL exactly as typed, so captures stay byte-identical across platforms.
+    return value;
   } catch {
     return null;
   }
@@ -56,7 +58,7 @@ export function extractUrlsFromTitle(title: string): ExtractedUrls {
     const trimmed = raw.replace(TRAILING_PUNCTUATION, "");
     const safe = sanitizeTitleUrl(trimmed);
     if (!safe) return raw; // leave invalid/unsafe candidates untouched
-    urls.push(safe);
+    if (!urls.includes(safe)) urls.push(safe); // dedupe repeats; still remove from title
     // Trailing punctuation (e.g. a period at the end of a sentence) is dropped
     // along with the URL — it was sentence-level punctuation around the link.
     return "";

--- a/tests/data/capture-parser-corpus.test.ts
+++ b/tests/data/capture-parser-corpus.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { extractUrlsFromTitle, parseCapture } from "@/lib/capture-parser";
+
+/**
+ * Runs the shared cross-platform capture-parser corpus — a byte-identical copy lives at
+ * gsd-iosapp/GSDKit/Tests/GSDModelTests/Fixtures/capture-parser-corpus.json and both
+ * suites execute every case, so the two parsers cannot drift apart unnoticed (the same
+ * discipline as the backup fixture pair). The composition mirrors the real capture path:
+ * parseCapture (capture-bar) then extractUrlsFromTitle (createTask). If a case here
+ * fails, decide the correct behavior first, then change the corpus in BOTH repos and
+ * both implementations together.
+ */
+
+interface CorpusCase {
+  name: string;
+  input: string;
+  expect: {
+    title: string;
+    urgent: boolean;
+    important: boolean;
+    tags: string[];
+    urls: string[];
+  };
+}
+
+const corpus: { cases: CorpusCase[] } = JSON.parse(
+  readFileSync(
+    join(process.cwd(), "tests/fixtures/cross-platform/capture-parser-corpus.json"),
+    "utf8"
+  )
+);
+
+describe("cross-platform capture-parser corpus", () => {
+  it("has the full corpus", () => {
+    expect(corpus.cases.length).toBeGreaterThanOrEqual(40);
+  });
+
+  for (const c of corpus.cases) {
+    it(c.name, () => {
+      const parsed = parseCapture(c.input);
+      const { cleanTitle, urls } = extractUrlsFromTitle(parsed.title);
+      expect({
+        title: cleanTitle,
+        urgent: parsed.urgent,
+        important: parsed.important,
+        tags: parsed.tags,
+        urls,
+      }).toEqual(c.expect);
+    });
+  }
+});

--- a/tests/data/capture-parser.test.ts
+++ b/tests/data/capture-parser.test.ts
@@ -95,34 +95,34 @@ describe("extractUrlsFromTitle", () => {
   it("extracts a single URL from the end of a title", () => {
     expect(extractUrlsFromTitle("Review this https://example.com")).toEqual({
       cleanTitle: "Review this",
-      urls: ["https://example.com/"],
+      urls: ["https://example.com"],
     });
   });
 
   it("extracts a single URL from the middle of a title", () => {
     expect(extractUrlsFromTitle("Check https://example.com for details")).toEqual({
       cleanTitle: "Check for details",
-      urls: ["https://example.com/"],
+      urls: ["https://example.com"],
     });
   });
 
   it("extracts all URLs when multiple are present", () => {
     const result = extractUrlsFromTitle("Compare https://foo.com and https://bar.com");
     expect(result.cleanTitle).toBe("Compare and");
-    expect(result.urls).toEqual(["https://foo.com/", "https://bar.com/"]);
+    expect(result.urls).toEqual(["https://foo.com", "https://bar.com"]);
   });
 
   it("returns 'Review link below' as cleanTitle when title is only a URL", () => {
     expect(extractUrlsFromTitle("https://example.com")).toEqual({
       cleanTitle: "Review link below",
-      urls: ["https://example.com/"],
+      urls: ["https://example.com"],
     });
   });
 
   it("returns 'Review link below' when title is only whitespace + URL", () => {
     expect(extractUrlsFromTitle("  https://example.com  ")).toEqual({
       cleanTitle: "Review link below",
-      urls: ["https://example.com/"],
+      urls: ["https://example.com"],
     });
   });
 
@@ -149,13 +149,13 @@ describe("extractUrlsFromTitle", () => {
   it("collapses extra whitespace in cleanTitle after URL removal", () => {
     const result = extractUrlsFromTitle("foo   https://example.com   bar");
     expect(result.cleanTitle).toBe("foo bar");
-    expect(result.urls).toEqual(["https://example.com/"]);
+    expect(result.urls).toEqual(["https://example.com"]);
   });
 
   it("preserves capture markers (! * #tag) alongside URL extraction", () => {
     const result = extractUrlsFromTitle("Review https://example.com ! #work");
     expect(result.cleanTitle).toBe("Review ! #work");
-    expect(result.urls).toEqual(["https://example.com/"]);
+    expect(result.urls).toEqual(["https://example.com"]);
   });
 });
 

--- a/tests/data/tasks/crud.test.ts
+++ b/tests/data/tasks/crud.test.ts
@@ -218,7 +218,7 @@ describe('Task CRUD Operations', () => {
         title: 'https://example.com',
         description: '',
         expectedTitle: 'Review link below',
-        expectedDescription: 'https://example.com/',
+        expectedDescription: 'https://example.com',
       },
       {
         scenario: 'leaves title unchanged when no URLs are present',
@@ -379,7 +379,7 @@ describe('Task CRUD Operations', () => {
         initialDescription: '',
         newTitle: 'https://example.com',
         expectedTitle: 'Review link below',
-        expectedDescription: 'https://example.com/',
+        expectedDescription: 'https://example.com',
       },
       {
         scenario: 'leaves the title unchanged when the updated title has no URL',

--- a/tests/fixtures/cross-platform/capture-parser-corpus.json
+++ b/tests/fixtures/cross-platform/capture-parser-corpus.json
@@ -1,0 +1,515 @@
+{
+  "note": "Canonical capture-parser behavior shared by the web client (lib/capture-parser.ts, composed as the app does: parseCapture then extractUrlsFromTitle) and the iOS client (GSDKit CaptureParser.parse). Byte-identical copies live at gsd-taskmanager/tests/fixtures/cross-platform/capture-parser-corpus.json and gsd-iosapp/GSDKit/Tests/GSDModelTests/Fixtures/capture-parser-corpus.json; both suites run every case. If you change parser behavior, change it in both clients and regenerate this file in both places.",
+  "cases": [
+    {
+      "name": "plain text, no shorthand",
+      "input": "Just a note",
+      "expect": {
+        "title": "Just a note",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "double bang sets urgent and important",
+      "input": "Ship the build !!",
+      "expect": {
+        "title": "Ship the build",
+        "urgent": true,
+        "important": true,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "single bang sets urgent only",
+      "input": "Call dentist !",
+      "expect": {
+        "title": "Call dentist",
+        "urgent": true,
+        "important": false,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "star sets important only",
+      "input": "Plan roadmap *",
+      "expect": {
+        "title": "Plan roadmap",
+        "urgent": false,
+        "important": true,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "bang plus star sets both",
+      "input": "Do it ! *",
+      "expect": {
+        "title": "Do it",
+        "urgent": true,
+        "important": true,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "double bang mid-sentence",
+      "input": "Urgent thing !! now",
+      "expect": {
+        "title": "Urgent thing now",
+        "urgent": true,
+        "important": true,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "flag glued to a word is literal text",
+      "input": "wow!much excitement",
+      "expect": {
+        "title": "wow!much excitement",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "repeated flag tokens are all stripped",
+      "input": "!! !! x",
+      "expect": {
+        "title": "x",
+        "urgent": true,
+        "important": true,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "flag-only input leaves an empty title",
+      "input": "!",
+      "expect": {
+        "title": "",
+        "urgent": true,
+        "important": false,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "whitespace collapses after token removal",
+      "input": "a   !!   b",
+      "expect": {
+        "title": "a b",
+        "urgent": true,
+        "important": true,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "basic tag",
+      "input": "Buy milk #errand",
+      "expect": {
+        "title": "Buy milk",
+        "urgent": false,
+        "important": false,
+        "tags": [
+          "errand"
+        ],
+        "urls": []
+      }
+    },
+    {
+      "name": "tags lowercase and dedupe case-insensitively",
+      "input": "Buy milk #Errand #errand #Home",
+      "expect": {
+        "title": "Buy milk",
+        "urgent": false,
+        "important": false,
+        "tags": [
+          "errand",
+          "home"
+        ],
+        "urls": []
+      }
+    },
+    {
+      "name": "unicode tags are whole tags",
+      "input": "Trip plan #café #日本語 #Grüße",
+      "expect": {
+        "title": "Trip plan",
+        "urgent": false,
+        "important": false,
+        "tags": [
+          "café",
+          "日本語",
+          "grüße"
+        ],
+        "urls": []
+      }
+    },
+    {
+      "name": "hyphen underscore and digits allowed in tags",
+      "input": "Task #to-do #a_b #123",
+      "expect": {
+        "title": "Task",
+        "urgent": false,
+        "important": false,
+        "tags": [
+          "to-do",
+          "a_b",
+          "123"
+        ],
+        "urls": []
+      }
+    },
+    {
+      "name": "tag over 30 chars is dropped but stripped",
+      "input": "Task #aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "expect": {
+        "title": "Task",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "tag of exactly 30 chars is kept",
+      "input": "Task #aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "expect": {
+        "title": "Task",
+        "urgent": false,
+        "important": false,
+        "tags": [
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ],
+        "urls": []
+      }
+    },
+    {
+      "name": "tags cap at 20 keeping the first 20",
+      "input": "Task #t1 #t2 #t3 #t4 #t5 #t6 #t7 #t8 #t9 #t10 #t11 #t12 #t13 #t14 #t15 #t16 #t17 #t18 #t19 #t20 #t21 #t22 #t23 #t24 #t25",
+      "expect": {
+        "title": "Task",
+        "urgent": false,
+        "important": false,
+        "tags": [
+          "t1",
+          "t2",
+          "t3",
+          "t4",
+          "t5",
+          "t6",
+          "t7",
+          "t8",
+          "t9",
+          "t10",
+          "t11",
+          "t12",
+          "t13",
+          "t14",
+          "t15",
+          "t16",
+          "t17",
+          "t18",
+          "t19",
+          "t20"
+        ],
+        "urls": []
+      }
+    },
+    {
+      "name": "hash inside a word is not a tag",
+      "input": "price#tag stays",
+      "expect": {
+        "title": "price#tag stays",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "tag before punctuation keeps the punctuation",
+      "input": "buy #milk, #eggs now",
+      "expect": {
+        "title": "buy, now",
+        "urgent": false,
+        "important": false,
+        "tags": [
+          "milk",
+          "eggs"
+        ],
+        "urls": []
+      }
+    },
+    {
+      "name": "leading hyphen is not a tag",
+      "input": "keep #-dash here",
+      "expect": {
+        "title": "keep #-dash here",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "url with path moves to description, stored raw",
+      "input": "Read this https://example.com/post later",
+      "expect": {
+        "title": "Read this later",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": [
+          "https://example.com/post"
+        ]
+      }
+    },
+    {
+      "name": "bare-domain url stays raw with no trailing slash",
+      "input": "Read https://example.com later",
+      "expect": {
+        "title": "Read later",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": [
+          "https://example.com"
+        ]
+      }
+    },
+    {
+      "name": "multiple urls extract in order",
+      "input": "See https://a.test and https://b.test",
+      "expect": {
+        "title": "See and",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": [
+          "https://a.test",
+          "https://b.test"
+        ]
+      }
+    },
+    {
+      "name": "duplicate urls collapse to one",
+      "input": "Compare https://a.test https://a.test",
+      "expect": {
+        "title": "Compare",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": [
+          "https://a.test"
+        ]
+      }
+    },
+    {
+      "name": "url-only title falls back",
+      "input": "https://example.com/x",
+      "expect": {
+        "title": "Review link below",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": [
+          "https://example.com/x"
+        ]
+      }
+    },
+    {
+      "name": "trailing sentence punctuation is stripped from the url",
+      "input": "Check https://example.com.",
+      "expect": {
+        "title": "Check",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": [
+          "https://example.com"
+        ]
+      }
+    },
+    {
+      "name": "paren-wrapped url is extracted",
+      "input": "see (https://a.test) now",
+      "expect": {
+        "title": "see ( now",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": [
+          "https://a.test"
+        ]
+      }
+    },
+    {
+      "name": "url glued to a word stays in the title",
+      "input": "foohttps://a.test bar",
+      "expect": {
+        "title": "foohttps://a.test bar",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "url after punctuation is extracted",
+      "input": "read:https://a.test now",
+      "expect": {
+        "title": "read: now",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": [
+          "https://a.test"
+        ]
+      }
+    },
+    {
+      "name": "uppercase scheme extracts and stays raw",
+      "input": "See HTTPS://EXAMPLE.COM now",
+      "expect": {
+        "title": "See now",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": [
+          "HTTPS://EXAMPLE.COM"
+        ]
+      }
+    },
+    {
+      "name": "credentialed url is left in the title",
+      "input": "Login https://user:pass@example.com",
+      "expect": {
+        "title": "Login https://user:pass@example.com",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "non-http scheme is left in the title",
+      "input": "see ftp://example.com now",
+      "expect": {
+        "title": "see ftp://example.com now",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "javascript scheme is left in the title",
+      "input": "Bad javascript:alert(1) link",
+      "expect": {
+        "title": "Bad javascript:alert(1) link",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "url of exactly 2047 chars is accepted",
+      "input": "huge https://example.com/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "expect": {
+        "title": "huge",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": [
+          "https://example.com/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        ]
+      }
+    },
+    {
+      "name": "url of exactly 2048 chars is left in the title",
+      "input": "huge https://example.com/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "expect": {
+        "title": "huge https://example.com/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "quotes bound the url",
+      "input": "say \"https://a.test\" ok",
+      "expect": {
+        "title": "say \"\" ok",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": [
+          "https://a.test"
+        ]
+      }
+    },
+    {
+      "name": "scheme with no host is left in the title",
+      "input": "https:// nothing",
+      "expect": {
+        "title": "https:// nothing",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": []
+      }
+    },
+    {
+      "name": "flags tags and url together",
+      "input": "Fix login !! #auth #Auth https://app.test/bug now",
+      "expect": {
+        "title": "Fix login now",
+        "urgent": true,
+        "important": true,
+        "tags": [
+          "auth"
+        ],
+        "urls": [
+          "https://app.test/bug"
+        ]
+      }
+    },
+    {
+      "name": "url plus tag falls back and keeps the tag",
+      "input": "https://a.test #read",
+      "expect": {
+        "title": "Review link below",
+        "urgent": false,
+        "important": false,
+        "tags": [
+          "read"
+        ],
+        "urls": [
+          "https://a.test"
+        ]
+      }
+    },
+    {
+      "name": "empty input",
+      "input": "",
+      "expect": {
+        "title": "",
+        "urgent": false,
+        "important": false,
+        "tags": [],
+        "urls": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

The web half of the capture-parser parity reconciliation (2026-08-28). The six documented divergences between the two clients' parsers — plus three more found while fixing (duplicate URLs, repeated flag tokens, leading-hyphen tags) — are resolved against a **shared 40-case corpus** that both suites now run:

- `tests/fixtures/cross-platform/capture-parser-corpus.json` — byte-identical to the iOS copy at `GSDKit/Tests/GSDModelTests/Fixtures/` (sha256 verified: `e22db5ac…`), which merged with gsd-iosapp #11
- `lib/capture-parser.ts` + the MCP server's `capture-parser.ts` — aligned per the decision table in `gsd-iosapp/docs/2026-08-28-capture-parser-parity.md`: spec §6.2 settled tags (dedup, cap 20, truncate) and the ≥2048 rejection; Unicode tag charset and raw URL storage went iOS's way; boundary URL extraction went the web's way
- `tests/data/capture-parser-corpus.test.ts` — runs all 40 corpus cases

Until this merges, parser parity is enforced by the iOS suite only — this closes the web side of the last reconciled-but-unmerged open item.

## Rebase note

Rebased onto current main (`--onto`, replaying only the corpus commit): the branch previously sat on the pre-squash parity commits, whose content already landed via #520.

## How to test

```
bun run test    # 2918 passing, incl. the 40-case corpus suite
bun typecheck · bun lint · bun run quality:shape · bun run build
```

All verified green on the rebased branch before this PR was opened.

https://claude.ai/code/session_01KF8Y9yjYjYAaQgnxaWoKNn

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns web capture parsing with the shared web/iOS specification and adds a 40-case cross-platform corpus.

- Preserves accepted URLs exactly as entered, rejects URLs at the 2048-character boundary, and deduplicates repeated raw URLs.
- Adds Unicode-aware, case-insensitive tag extraction with schema limits and reliable repeated-flag removal.
- Updates the MCP URL-parser mirror and affected task creation, update, and parser tests.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The changed parser behavior is internally consistent with schema limits, covered by the shared corpus, mirrored where applicable in the MCP server, and remains compatible with downstream URL validation and rendering.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/capture-parser.ts | Aligns tag, flag, URL-boundary, raw-storage, and deduplication behavior with the shared parser specification. |
| packages/mcp-server/src/text/capture-parser.ts | Keeps the MCP server’s URL extraction and description-building mirror aligned with the web implementation. |
| tests/data/capture-parser-corpus.test.ts | Executes every shared corpus case through the same parser composition used by the web capture flow. |
| tests/fixtures/cross-platform/capture-parser-corpus.json | Defines 40 shared cases covering flags, tags, Unicode, URL boundaries, deduplication, and combined parsing. |
| packages/mcp-server/src/__tests__/text/capture-parser-parity.test.ts | Updates MCP parity expectations for raw URL preservation. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Capture text] --> B[parseCapture]
    B --> C[Extract flags and tags]
    C --> D[extractUrlsFromTitle]
    D --> E[Clean task title]
    D --> F[Validated raw URLs]
    F --> G[buildDescription]
    E --> H[Persist task]
    G --> H
    I[Shared 40-case corpus] --> B
    I --> D
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(capture): shared cross-platform par..."](https://github.com/vscarpenter/gsd-task-manager/commit/5d2981a30f5521aefc93827f77a9dde2c9dd06ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58206843)</sub>

<!-- /greptile_comment -->