### PR TITLE
feat(review): invite feedback from returning users with one dismissible line

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 12.5.0
+**Current version:** 12.7.0
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -25,6 +25,7 @@ import {
   VerdictSkeleton,
 } from "@/components/dashboard/dashboard-skeleton";
 import { ReviewPrompts } from "@/components/dashboard/review-prompts";
+import { FeedbackNudge } from "@/components/dashboard/feedback-nudge";
 import { Button } from "@/components/ui/button";
 import { OPEN_COMMAND_PALETTE_EVENT } from "@/lib/use-command-palette";
 import { useDashboardData } from "./use-dashboard-data";
@@ -108,6 +109,7 @@ function ReviewBody({ onOpenMatrix, onDeadlineTaskClick }: ReviewBodyProps): Rea
             <HeroSlot isLoading={isLoading} isEmpty={isEmpty} data={data} />
           </div>
           {isLoading ? <StatRailSkeleton /> : isEmpty ? null : <StatRail data={data} />}
+          {!isLoading && !isEmpty && <FeedbackNudge tasks={tasks} />}
         </div>
       </header>
 

--- a/components/app-footer.tsx
+++ b/components/app-footer.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+
 export function AppFooter() {
   const buildNumber = process.env.NEXT_PUBLIC_BUILD_NUMBER || "dev";
   const buildDate = process.env.NEXT_PUBLIC_BUILD_DATE || "unknown";
@@ -14,7 +16,7 @@ export function AppFooter() {
           href="https://vinny.dev/"
           target="_blank"
           rel="noopener noreferrer"
-          className="touch-target inline-flex items-center rounded-xs text-accent underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+          className="touch-target inline-flex items-center rounded-xs text-accent underline underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           {/* Non-breaking space keeps the name whole — at 320px the footer
               otherwise breaks it as "Vinny / Carpenter". */}
@@ -24,6 +26,13 @@ export function AppFooter() {
         <span className="text-foreground-muted">
           v{buildNumber} · {buildDate}
         </span>
+        <span aria-hidden="true">{" · "}</span>
+        <Link
+          href="/settings#feedback"
+          className="touch-target inline-flex items-center rounded-xs text-accent underline underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          Send feedback
+        </Link>
       </p>
     </footer>
   );

--- a/components/dashboard/feedback-nudge.tsx
+++ b/components/dashboard/feedback-nudge.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+import { useSyncExternalStore } from "react";
+import { isDraftEmpty } from "@/lib/feedback/feedback-payload";
+import {
+  getFeedbackSnapshot,
+  getServerFeedbackSnapshot,
+  recordNudgeDismissed,
+  subscribeToFeedback,
+} from "@/lib/feedback/feedback-store";
+import { shouldShowFeedbackNudge, summarizeEngagement } from "@/lib/feedback/nudge-eligibility";
+import { restoreFocusOrMainContent } from "@/lib/focus-restoration";
+import type { TaskRecord } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+// Underlined at rest, not on hover: the tide link sits beside muted text at
+// roughly 1.1:1 luminance contrast, so hue alone cannot mark it as a link
+// (WCAG 1.4.1), and "Not now" has no colour of its own to lean on.
+const CONTROL_CLASS =
+  "touch-target inline-flex items-center rounded-xs underline underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+
+interface FeedbackNudgeProps {
+  tasks: TaskRecord[];
+}
+
+/** Hand focus to the main region first: the pressed button is about to unmount. */
+function dismissNudge(): void {
+  restoreFocusOrMainContent(null);
+  recordNudgeDismissed(new Date().toISOString());
+}
+
+/**
+ * One sentence at the foot of the review header inviting feedback.
+ *
+ * It appears only for people whose own task history says they have used GSD
+ * long enough to have a view (see `nudge-eligibility.ts`), and it is a line of
+ * text rather than a toast or a modal because the Review page is the one place
+ * where "is this tool working for you?" is on topic instead of an interruption.
+ * "Not now" is remembered for six months, and sending feedback quiets it too.
+ * Dismissing unmounts the very button that was pressed, so focus is handed to
+ * the main region first rather than being dropped on <body>.
+ *
+ * Eligibility is read through the feedback store's external snapshot so the
+ * static export renders nothing and the client fills in after hydration
+ * without a state-setting effect.
+ */
+export function FeedbackNudge({ tasks }: FeedbackNudgeProps): React.ReactElement | null {
+  const state = useSyncExternalStore(
+    subscribeToFeedback,
+    getFeedbackSnapshot,
+    getServerFeedbackSnapshot,
+  );
+  const now = new Date();
+
+  const visible = shouldShowFeedbackNudge({
+    engagement: summarizeEngagement(tasks, now),
+    lastSentAt: state.lastSentAt,
+    dismissedAt: state.nudgeDismissedAt,
+    hasDraft: !isDraftEmpty(state.draft),
+    now,
+  });
+
+  if (!visible) return null;
+
+  return (
+    <div
+      data-testid="feedback-nudge"
+      className="mt-6 flex flex-wrap items-baseline gap-x-4 gap-y-1 text-sm leading-relaxed text-foreground-muted"
+    >
+      <span>
+        You&rsquo;ve been at this a while. If something is rough or missing, tell me: it&rsquo;s
+        anonymous and takes about a minute.
+      </span>
+      <Link href="/settings#feedback" className={cn(CONTROL_CLASS, "text-accent")}>
+        Send feedback
+      </Link>
+      <button
+        type="button"
+        onClick={dismissNudge}
+        className={cn(CONTROL_CLASS, "text-foreground-muted hover:text-foreground")}
+      >
+        Not now
+      </button>
+    </div>
+  );
+}

--- a/components/matrix-simplified/help-drawer.tsx
+++ b/components/matrix-simplified/help-drawer.tsx
@@ -167,25 +167,43 @@ export function HelpDrawer({ open, onClose }: HelpDrawerProps) {
             </p>
           </Section>
 
-          <Section label="Privacy">
-            <p style={bodyStyle}>
-              Tasks live in your browser&rsquo;s IndexedDB. Nothing is sent to a server unless you explicitly enable sync in{" "}
-              <Link href={ROUTES.SETTINGS} style={linkStyle} onClick={onClose}>
-                Settings
-              </Link>
-              . The app works fully offline.
-            </p>
-            <p style={bodyStyle}>
-              Want the full story?{" "}
-              <Link href={"/about" as const} style={linkStyle} onClick={onClose}>
-                Read the About page →
-              </Link>
-            </p>
-          </Section>
+          <PrivacySection onClose={onClose} />
         </div>
         </div>
       </DialogContent>
     </Dialog>
+  );
+}
+
+/**
+ * Split out so the drawer body stays under the code-shape ceiling; it is the
+ * one section that grows as new settings surfaces (sync, feedback) need a
+ * pointer from here.
+ */
+function PrivacySection({ onClose }: { onClose: () => void }) {
+  return (
+    <Section label="Privacy">
+      <p style={bodyStyle}>
+        Tasks live in your browser&rsquo;s IndexedDB. Nothing is sent to a server unless you explicitly enable sync in{" "}
+        <Link href={ROUTES.SETTINGS} style={linkStyle} onClick={onClose}>
+          Settings
+        </Link>
+        . The app works fully offline.
+      </p>
+      <p style={bodyStyle}>
+        Something rough or missing?{" "}
+        <Link href="/settings#feedback" style={linkStyle} onClick={onClose}>
+          Send feedback
+        </Link>
+        . It&rsquo;s anonymous, and you can read exactly what is sent before it goes.
+      </p>
+      <p style={bodyStyle}>
+        Want the full story?{" "}
+        <Link href={"/about" as const} style={linkStyle} onClick={onClose}>
+          Read the About page →
+        </Link>
+      </p>
+    </Section>
   );
 }
 

--- a/lib/feedback/feedback-store.ts
+++ b/lib/feedback/feedback-store.ts
@@ -23,9 +23,11 @@ import { generateId } from "@/lib/id-generator";
 
 export const FEEDBACK_DRAFT_KEY = "gsd:feedback:draft";
 export const FEEDBACK_LAST_SENT_KEY = "gsd:feedback:last-sent";
+export const FEEDBACK_NUDGE_DISMISSED_KEY = "gsd:feedback:nudge-dismissed";
 
 let memoryDraft: FeedbackDraft | null = null;
 let memoryLastSentAt: string | null = null;
+let memoryNudgeDismissedAt: string | null = null;
 
 function readRaw(key: string): string | null {
   if (typeof window === "undefined") return null;
@@ -134,6 +136,16 @@ export function writeLastSentAt(isoTimestamp: string): void {
   memoryLastSentAt = stored ? null : isoTimestamp;
 }
 
+/** When the user last pressed "Not now" on the Review page's feedback invitation. */
+export function readNudgeDismissedAt(): string | null {
+  return readRaw(FEEDBACK_NUDGE_DISMISSED_KEY) ?? memoryNudgeDismissedAt;
+}
+
+export function writeNudgeDismissedAt(isoTimestamp: string): void {
+  const stored = writeRaw(FEEDBACK_NUDGE_DISMISSED_KEY, isoTimestamp);
+  memoryNudgeDismissedAt = stored ? null : isoTimestamp;
+}
+
 /**
  * External-store plumbing so the form can read persisted state without a
  * state-setting effect.
@@ -150,6 +162,7 @@ export function writeLastSentAt(isoTimestamp: string): void {
 export interface FeedbackState {
   draft: FeedbackDraft;
   lastSentAt: string | null;
+  nudgeDismissedAt: string | null;
   /** Minted once per submission; reused by a retry, replaced after a success. */
   submissionId: string | null;
   /** When the payload was last rebuilt. Null until the client has hydrated. */
@@ -162,6 +175,7 @@ const listeners = new Set<Listener>();
 const SERVER_STATE: FeedbackState = Object.freeze({
   draft: Object.freeze(emptyDraft()) as FeedbackDraft,
   lastSentAt: null,
+  nudgeDismissedAt: null,
   submissionId: null,
   builtAt: null,
 });
@@ -175,7 +189,11 @@ function invalidate(): void {
   for (const listener of listeners) listener();
 }
 
-const OWN_KEYS = new Set<string>([FEEDBACK_DRAFT_KEY, FEEDBACK_LAST_SENT_KEY]);
+const OWN_KEYS = new Set<string>([
+  FEEDBACK_DRAFT_KEY,
+  FEEDBACK_LAST_SENT_KEY,
+  FEEDBACK_NUDGE_DISMISSED_KEY,
+]);
 
 /**
  * Another tab wrote one of our keys, so the cached snapshot is stale.
@@ -218,6 +236,7 @@ export function getFeedbackSnapshot(): FeedbackState {
   cachedState = {
     draft: readDraft(),
     lastSentAt: readLastSentAt(),
+    nudgeDismissedAt: readNudgeDismissedAt(),
     submissionId,
     builtAt,
   };
@@ -228,6 +247,12 @@ export function getFeedbackSnapshot(): FeedbackState {
 export function updateDraft(draft: FeedbackDraft): void {
   writeDraft(draft);
   builtAt = new Date().toISOString();
+  invalidate();
+}
+
+/** Record a "Not now" on the Review page invitation so every tab hides it. */
+export function recordNudgeDismissed(dismissedAt: string): void {
+  writeNudgeDismissedAt(dismissedAt);
   invalidate();
 }
 

--- a/lib/feedback/nudge-eligibility.ts
+++ b/lib/feedback/nudge-eligibility.ts
@@ -1,0 +1,96 @@
+import { TIME_MS } from "@/lib/constants";
+import type { TaskRecord } from "@/lib/types";
+
+/**
+ * Decides when the Review page may invite feedback.
+ *
+ * Eligibility is derived from the user's own task data rather than an install
+ * date: it works retroactively for people who were already here when this
+ * shipped, adds no tracking key, and measures use rather than time since a
+ * bookmark. Everything here is computed locally and nothing leaves the device.
+ */
+
+export const NUDGE_THRESHOLDS = {
+  /** Days since the oldest task was created. */
+  MIN_TENURE_DAYS: 14,
+  MIN_COMPLETIONS: 10,
+  /** Distinct calendar days with at least one completion. */
+  MIN_COMPLETION_DAYS: 3,
+  /** Quiet period after the user sent feedback. */
+  SENT_COOLDOWN_DAYS: 90,
+  /** Quiet period after the user pressed "Not now". */
+  DISMISSED_COOLDOWN_DAYS: 180,
+} as const;
+
+export interface EngagementSummary {
+  tenureDays: number;
+  completions: number;
+  completionDays: number;
+}
+
+export interface NudgeDecisionInput {
+  engagement: EngagementSummary;
+  lastSentAt: string | null;
+  dismissedAt: string | null;
+  hasDraft: boolean;
+  now: Date;
+}
+
+function wholeDaysBetween(earlierMs: number, laterMs: number): number {
+  return Math.floor((laterMs - earlierMs) / TIME_MS.DAY);
+}
+
+/** UTC calendar day, matching how `lib/analytics/streaks.ts` buckets completions. */
+function utcDay(iso: string): string | null {
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? null : new Date(ms).toISOString().slice(0, 10);
+}
+
+export function summarizeEngagement(tasks: TaskRecord[], now: Date): EngagementSummary {
+  let oldestCreatedMs = Number.POSITIVE_INFINITY;
+  let completions = 0;
+  const completionDays = new Set<string>();
+
+  for (const task of tasks) {
+    const createdMs = Date.parse(task.createdAt);
+    if (!Number.isNaN(createdMs)) oldestCreatedMs = Math.min(oldestCreatedMs, createdMs);
+
+    if (!task.completed) continue;
+    completions += 1;
+    const day = utcDay(task.completedAt ?? task.updatedAt);
+    if (day) completionDays.add(day);
+  }
+
+  return {
+    tenureDays: Number.isFinite(oldestCreatedMs)
+      ? wholeDaysBetween(oldestCreatedMs, now.getTime())
+      : 0,
+    completions,
+    completionDays: completionDays.size,
+  };
+}
+
+/**
+ * True while a cooldown started at `iso` is still running. A missing or
+ * unparseable timestamp means the event never happened, so no cooldown applies.
+ */
+function withinCooldown(iso: string | null, cooldownDays: number, now: Date): boolean {
+  if (iso === null) return false;
+  const startedMs = Date.parse(iso);
+  if (Number.isNaN(startedMs)) return false;
+  return wholeDaysBetween(startedMs, now.getTime()) < cooldownDays;
+}
+
+export function shouldShowFeedbackNudge(input: NudgeDecisionInput): boolean {
+  const { engagement, lastSentAt, dismissedAt, hasDraft, now } = input;
+
+  if (hasDraft) return false;
+  if (withinCooldown(lastSentAt, NUDGE_THRESHOLDS.SENT_COOLDOWN_DAYS, now)) return false;
+  if (withinCooldown(dismissedAt, NUDGE_THRESHOLDS.DISMISSED_COOLDOWN_DAYS, now)) return false;
+
+  return (
+    engagement.tenureDays >= NUDGE_THRESHOLDS.MIN_TENURE_DAYS &&
+    engagement.completions >= NUDGE_THRESHOLDS.MIN_COMPLETIONS &&
+    engagement.completionDays >= NUDGE_THRESHOLDS.MIN_COMPLETION_DAYS
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "12.5.0",
+	"version": "12.7.0",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '12.5.0';
+const CACHE_VERSION = '12.7.0';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -121,3 +121,25 @@ Fix pattern: wait for the title to be focused before touching other fields
   `node scripts/check-code-shape.cjs --print-baseline` and diff it before
   committing — a full refresh also tightens stale entries, which is safe but
   shows up as unrelated churn.
+
+## 2026-09-02 — Feedback nudge: verifying a conditional surface in the running app
+
+- **The SW re-registers on every load, so bust it immediately before each reload you
+  intend to trust.** One reset at the start of a session is not enough: `PwaRegister`
+  puts the worker back on the next load and it caches the chunk you are about to change.
+  The symptom was a hot-reloaded footer beside a stale `<p>` nudge on the same page.
+- **The Chrome extension's `resize_window` can report success without changing the
+  viewport.** `innerWidth` stayed at 1863 after a "successful" 390×844 resize. For narrow
+  breakpoints use headless Playwright with a mobile context (`isMobile`, `hasTouch`) and
+  seed IndexedDB inside that context; it also proves the coarse-pointer 44px targets.
+- **Click by element ref, not by coordinates, after any resize or reload.** A click at
+  coordinates taken from an earlier screenshot missed once the viewport height changed.
+- **A handler that reads nothing from props or state belongs at module scope.** Moving
+  `dismissNudge` out of the component was the difference between 41 and 36 lines under
+  the ≤40 lines-per-function ratchet, with no behaviour change.
+- **Derive "returning user" from the user's own records rather than a first-run
+  timestamp.** Oldest `createdAt` plus completion history works retroactively for people
+  already using the app, adds no tracking key, and measures use rather than install age.
+- **A control that unmounts itself on activation must hand focus off first.**
+  `restoreFocusOrMainContent(null)` before the store write keeps keyboard focus on
+  `#main-content` instead of `<body>`; the a11y reviewer caught it, a unit test now pins it.

--- a/tasks/spec-anonymous-feedback.md
+++ b/tasks/spec-anonymous-feedback.md
@@ -86,6 +86,10 @@ and before they do they can see the exact payload that will leave their device.
 
 - The "earned moment" inline prompt after N completed tasks. Independently shippable,
   and the piece most likely to read as naggy — it gets its own review.
+  **Shipped separately 2026-09-02** as one dismissible sentence under the Review page's
+  stat rail (`components/dashboard/feedback-nudge.tsx`), gated by
+  `lib/feedback/nudge-eligibility.ts`: tenure ≥14 days, ≥10 completions over ≥3 days,
+  quiet for 90 days after a send and 180 after "Not now". Still no modal, toast, or badge.
 - The public privacy-policy page at `gsdtaskmanager.com/privacy` (different repo).
 - Any read path from the `feedback` collection into the app. Vote totals are not shown
   back to users; the collection is write-only from the client's perspective.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -36,6 +36,11 @@ once the user's own task data proves they are a returning user. No toast, no mod
 - Version bump deferred: the working tree carries an uncommitted, internally inconsistent bump
   (package.json 12.6.5 vs sw.js 12.6.6, README 12.5.0). Not this branch's to overwrite.
 
+## Release + PR (owner request 2026-09-02)
+
+- [x] Bump the pinned trio to 12.7.0 (package.json, README:7, sw.js CACHE_VERSION); prod was 12.6.5.
+- [ ] Commit the bump, push `feat/feedback-nudge`, open the PR.
+
 ## Resuming From Here
 
 - Done: nudge-eligibility module, store dismissal state, `FeedbackNudge` on the Review page,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,56 @@
+# Session state — 2026-09-02 (feedback nudge on the Review page)
+
+Branch: `feat/feedback-nudge` (web only; iOS deliberately not mirrored — owner decision 2026-09-02).
+Design approved in chat (bounded path): one dismissible sentence on the Review page, shown only
+once the user's own task data proves they are a returning user. No toast, no modal, no badge.
+
+## Plan
+
+- [x] 1. RED/GREEN `lib/feedback/nudge-eligibility.ts` — pure: `summarizeEngagement(tasks, now)`
+      and `shouldShowFeedbackNudge({...})`. Thresholds: tenure ≥14d, completions ≥10,
+      distinct completion days ≥3; suppress if sent <90d, dismissed <180d, or a draft exists.
+- [x] 2. RED/GREEN `lib/feedback/feedback-store.ts` — `gsd:feedback:nudge-dismissed` key,
+      `readNudgeDismissedAt` / `recordNudgeDismissed`, exposed on the snapshot.
+- [x] 3. RED/GREEN `components/dashboard/feedback-nudge.tsx` — reads the store via
+      `useSyncExternalStore`, renders null unless eligible; link → `/settings#feedback`, "Not now".
+- [x] 4. Wire into `app/(dashboard)/dashboard/page.tsx` under the stat rail (header block).
+- [x] 5. Passive links: help drawer Privacy section + app footer → `/settings#feedback`.
+- [x] 6. `bun run test` · `bun typecheck` · `bun lint` · `bun run quality:shape`.
+- [x] 7. `/verify-frontend-change` PASS. Chrome (real clicks, SW busted before each trusted
+      reload): dark + light render, link opens Settings → Feedback, "Not now" hides the line,
+      writes `gsd:feedback:nudge-dismissed`, moves focus to `#main-content`, stays hidden after
+      reload; footer + help-drawer links present; console clean. Headless Playwright at 390px:
+      no horizontal overflow, link/button 44px on coarse pointer. Dev data restored afterwards.
+- [x] 8. a11y-reviewer pass on the new component — 3 blocking findings, all fixed test-first:
+      at-rest underline on the text controls (WCAG 1.4.1), focus hand-off to `#main-content`
+      before the dismiss button unmounts, `div` wrapper instead of `p`.
+- [x] 9. Committed on `feat/feedback-nudge`; spec note added. Push/PR awaiting the owner's
+      go-ahead (CLAUDE.md: pushing needs confirmation).
+
+## Deviations from the approved design (tactical, logged)
+
+- Archive table not consulted: completed tasks stay in `tasks` for 30 days by default
+  (`ARCHIVE_CONFIG.DEFAULT_ARCHIVE_AFTER_DAYS`), which covers the 14-day tenure window.
+- Onboarding-seen check dropped: tenure ≥14d + ≥10 completions already excludes first-timers.
+- No "same session" suppression: meaningless for an inline line (it is not a popup).
+- Version bump deferred: the working tree carries an uncommitted, internally inconsistent bump
+  (package.json 12.6.5 vs sw.js 12.6.6, README 12.5.0). Not this branch's to overwrite.
+
+## Resuming From Here
+
+- Done: nudge-eligibility module, store dismissal state, `FeedbackNudge` on the Review page,
+  help-drawer + footer links, a11y fixes, 24 new tests; all gates green (test / typecheck /
+  lint / quality:shape). Live-app verification PASS (details in step 7).
+- Next: owner says go → `git push -u origin feat/feedback-nudge` + PR. Version bump for the
+  release is deferred (see Deviations): reconcile the uncommitted 12.6.x edits first, then
+  bump the trio (package.json + README:7 + sw.js CACHE_VERSION) together.
+- Pre-existing red on this machine, not this branch: `documentation-currentness` (README
+  12.5.0 vs uncommitted package.json 12.6.5) and `dependency-license-policy`
+  (`@img/sharp-libvips-darwin-arm64@1.3.3` LGPL in the local install).
+- Assumption: iOS deliberately does not mirror the nudge (owner decision 2026-09-02).
+
+---
+
 # Session state — 2026-08-28 (path move + parity shipping + merges)
 
 ## Resuming From Here

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -39,16 +39,16 @@ once the user's own task data proves they are a returning user. No toast, no mod
 ## Release + PR (owner request 2026-09-02)
 
 - [x] Bump the pinned trio to 12.7.0 (package.json, README:7, sw.js CACHE_VERSION); prod was 12.6.5.
-- [ ] Commit the bump, push `feat/feedback-nudge`, open the PR.
+- [x] Bump committed, branch pushed, PR #525 open: https://github.com/vscarpenter/gsd-task-manager/pull/525
 
 ## Resuming From Here
 
 - Done: nudge-eligibility module, store dismissal state, `FeedbackNudge` on the Review page,
   help-drawer + footer links, a11y fixes, 24 new tests; all gates green (test / typecheck /
   lint / quality:shape). Live-app verification PASS (details in step 7).
-- Next: owner says go → `git push -u origin feat/feedback-nudge` + PR. Version bump for the
-  release is deferred (see Deviations): reconcile the uncommitted 12.6.x edits first, then
-  bump the trio (package.json + README:7 + sw.js CACHE_VERSION) together.
+- Next: watch CI on PR #525, merge with `gh pr merge --admin` (owner PR, code-owner gate),
+  then `bun run deploy` and tag. `bun.lock` still carries unrelated local churn (mcp-server
+  1.2.4 → 1.2.5 plus dep re-serialization); decide separately whether to commit it.
 - Pre-existing red on this machine, not this branch: `documentation-currentness` (README
   12.5.0 vs uncommitted package.json 12.6.5) and `dependency-license-policy`
   (`@img/sharp-libvips-darwin-arm64@1.3.3` LGPL in the local install).

--- a/tests/data/feedback-store.test.ts
+++ b/tests/data/feedback-store.test.ts
@@ -3,6 +3,7 @@ import { buildPayload, emptyDraft, MAX_MESSAGE_LENGTH } from "@/lib/feedback/fee
 import {
   FEEDBACK_DRAFT_KEY,
   FEEDBACK_LAST_SENT_KEY,
+  FEEDBACK_NUDGE_DISMISSED_KEY,
   readDraft,
   writeDraft,
   clearDraft,
@@ -11,6 +12,9 @@ import {
   writeLastSentAt,
   subscribeToFeedback,
   getFeedbackSnapshot,
+  getServerFeedbackSnapshot,
+  readNudgeDismissedAt,
+  recordNudgeDismissed,
 } from "@/lib/feedback/feedback-store";
 import { ROADMAP_ITEMS } from "@/lib/feedback/roadmap-items";
 
@@ -21,6 +25,7 @@ beforeEach(() => {
   // localStorage.clear() no-ops in jsdom under Bun; remove keys individually.
   localStorage.removeItem(FEEDBACK_DRAFT_KEY);
   localStorage.removeItem(FEEDBACK_LAST_SENT_KEY);
+  localStorage.removeItem(FEEDBACK_NUDGE_DISMISSED_KEY);
   clearDraft();
 });
 
@@ -225,5 +230,43 @@ describe("when another tab changes the draft", () => {
     emitStorage(FEEDBACK_DRAFT_KEY);
 
     expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("nudge dismissal", () => {
+  const AT = "2026-09-02T12:00:00.000Z";
+
+  it("has no dismissal until the user presses Not now", () => {
+    expect(readNudgeDismissedAt()).toBeNull();
+    expect(getFeedbackSnapshot().nudgeDismissedAt).toBeNull();
+  });
+
+  it("records the dismissal, exposes it on the snapshot, and notifies subscribers", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToFeedback(listener);
+
+    recordNudgeDismissed(AT);
+
+    expect(readNudgeDismissedAt()).toBe(AT);
+    expect(getFeedbackSnapshot().nudgeDismissedAt).toBe(AT);
+    expect(localStorage.getItem(FEEDBACK_NUDGE_DISMISSED_KEY)).toBe(AT);
+    expect(listener).toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it("keeps the dismissal in memory when storage rejects the write", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+
+    recordNudgeDismissed(AT);
+
+    expect(readNudgeDismissedAt()).toBe(AT);
+  });
+
+  it("never reports a dismissal during the static export", () => {
+    recordNudgeDismissed(AT);
+
+    expect(getServerFeedbackSnapshot().nudgeDismissedAt).toBeNull();
   });
 });

--- a/tests/data/nudge-eligibility.test.ts
+++ b/tests/data/nudge-eligibility.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { subDays, subHours } from "date-fns";
+import { createMockTask } from "@/tests/fixtures";
+import {
+  summarizeEngagement,
+  shouldShowFeedbackNudge,
+  type EngagementSummary,
+} from "@/lib/feedback/nudge-eligibility";
+import type { TaskRecord } from "@/lib/types";
+
+const NOW = new Date("2026-09-02T12:00:00.000Z");
+
+function daysAgo(days: number): string {
+  return subDays(NOW, days).toISOString();
+}
+
+/** A task created the day before it was completed, both `days` ago. */
+function completedTask(id: string, days: number, overrides?: Partial<TaskRecord>): TaskRecord {
+  return createMockTask({
+    id,
+    completed: true,
+    createdAt: daysAgo(days + 1),
+    completedAt: daysAgo(days),
+    updatedAt: daysAgo(days),
+    ...overrides,
+  });
+}
+
+describe("summarizeEngagement", () => {
+  it("reports nothing for an empty board", () => {
+    expect(summarizeEngagement([], NOW)).toEqual({
+      tenureDays: 0,
+      completions: 0,
+      completionDays: 0,
+    });
+  });
+
+  it("measures tenure in whole days from the oldest task, whatever its state", () => {
+    const tasks = [
+      createMockTask({ id: "new", createdAt: daysAgo(1), updatedAt: daysAgo(1) }),
+      createMockTask({ id: "old", createdAt: subHours(NOW, 20 * 24 + 12).toISOString() }),
+    ];
+
+    expect(summarizeEngagement(tasks, NOW).tenureDays).toBe(20);
+  });
+
+  it("counts only completed tasks", () => {
+    const tasks = [
+      completedTask("a", 3),
+      completedTask("b", 2),
+      createMockTask({ id: "open", completed: false }),
+    ];
+
+    expect(summarizeEngagement(tasks, NOW).completions).toBe(2);
+  });
+
+  it("dedupes completions that landed on the same day", () => {
+    const tasks = [completedTask("a", 3), completedTask("b", 3), completedTask("c", 1)];
+
+    expect(summarizeEngagement(tasks, NOW).completionDays).toBe(2);
+  });
+
+  it("falls back to updatedAt when a legacy record has no completedAt", () => {
+    const legacy = completedTask("legacy", 5, { completedAt: undefined });
+
+    expect(summarizeEngagement([legacy], NOW).completionDays).toBe(1);
+  });
+});
+
+describe("shouldShowFeedbackNudge", () => {
+  const returning: EngagementSummary = { tenureDays: 20, completions: 12, completionDays: 4 };
+  const quiet = { lastSentAt: null, dismissedAt: null, hasDraft: false, now: NOW };
+
+  it("shows for a returning user who has never been asked", () => {
+    expect(shouldShowFeedbackNudge({ engagement: returning, ...quiet })).toBe(true);
+  });
+
+  it("shows exactly at the thresholds", () => {
+    const atFloor: EngagementSummary = { tenureDays: 14, completions: 10, completionDays: 3 };
+
+    expect(shouldShowFeedbackNudge({ engagement: atFloor, ...quiet })).toBe(true);
+  });
+
+  it.each([
+    ["tenure under 14 days", { tenureDays: 13, completions: 12, completionDays: 4 }],
+    ["fewer than 10 completions", { tenureDays: 20, completions: 9, completionDays: 4 }],
+    ["fewer than 3 completion days", { tenureDays: 20, completions: 12, completionDays: 2 }],
+  ])("stays hidden with %s", (_label, engagement) => {
+    expect(shouldShowFeedbackNudge({ engagement, ...quiet })).toBe(false);
+  });
+
+  it("stays hidden for 90 days after feedback was sent", () => {
+    expect(
+      shouldShowFeedbackNudge({ engagement: returning, ...quiet, lastSentAt: daysAgo(89) }),
+    ).toBe(false);
+    expect(
+      shouldShowFeedbackNudge({ engagement: returning, ...quiet, lastSentAt: daysAgo(91) }),
+    ).toBe(true);
+  });
+
+  it("stays hidden for 180 days after being dismissed", () => {
+    expect(
+      shouldShowFeedbackNudge({ engagement: returning, ...quiet, dismissedAt: daysAgo(179) }),
+    ).toBe(false);
+    expect(
+      shouldShowFeedbackNudge({ engagement: returning, ...quiet, dismissedAt: daysAgo(181) }),
+    ).toBe(true);
+  });
+
+  it("stays hidden while the user has an unsent draft", () => {
+    expect(shouldShowFeedbackNudge({ engagement: returning, ...quiet, hasDraft: true })).toBe(
+      false,
+    );
+  });
+
+  it("treats an unparseable stored timestamp as never", () => {
+    expect(
+      shouldShowFeedbackNudge({ engagement: returning, ...quiet, lastSentAt: "not-a-date" }),
+    ).toBe(true);
+  });
+});

--- a/tests/ui/app-shell.test.tsx
+++ b/tests/ui/app-shell.test.tsx
@@ -152,6 +152,18 @@ describe("AppShell command palette wiring", () => {
     expect(screen.getByRole("link", { name: /Vinny\s+Carpenter/ })).toHaveClass("touch-target");
   });
 
+  it("keeps a quiet feedback link in the footer", () => {
+    render(
+      <AppShell title="Test">
+        <div>content</div>
+      </AppShell>
+    );
+
+    const link = screen.getByRole("link", { name: "Send feedback" });
+    expect(link).toHaveAttribute("href", "/settings#feedback");
+    expect(link).toHaveClass("touch-target");
+  });
+
   it("opens the command palette when Ctrl+K is pressed", async () => {
     render(
       <AppShell title="Test">

--- a/tests/ui/dashboard-page.test.tsx
+++ b/tests/ui/dashboard-page.test.tsx
@@ -76,6 +76,12 @@ vi.mock("@/components/dashboard/time-analytics", () => ({
   TimeAnalytics: () => <div data-testid="time-analytics" />,
 }));
 
+vi.mock("@/components/dashboard/feedback-nudge", () => ({
+  FeedbackNudge: ({ tasks }: { tasks: unknown[] }) => (
+    <div data-testid="feedback-nudge" data-task-count={tasks.length} />
+  ),
+}));
+
 vi.mock("@/components/dashboard/dashboard-skeleton", () => ({
   DashboardSkeleton: () => <div data-testid="dashboard-skeleton" />,
   VerdictSkeleton: () => <div data-testid="verdict-skeleton" />,
@@ -167,6 +173,12 @@ describe("DashboardPage review framing", () => {
     expect(screen.getByTestId("time-analytics")).toBeInTheDocument();
   });
 
+  it("hands the review's task list to the feedback invitation", () => {
+    render(<DashboardPage />);
+
+    expect(screen.getByTestId("feedback-nudge")).toHaveAttribute("data-task-count", "1");
+  });
+
   it("opens the command palette for slash and preserves deadline navigation", () => {
     const onPaletteOpen = vi.fn();
     window.addEventListener("gsd:open-command-palette", onPaletteOpen, { once: true });
@@ -187,6 +199,7 @@ describe("DashboardPage review framing", () => {
       screen.getByRole("heading", { level: 2, name: "What did this week make room for?" })
     ).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Nothing to review yet" })).toBeInTheDocument();
+    expect(screen.queryByTestId("feedback-nudge")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Open matrix" }));
     expect(mocks.push).toHaveBeenCalledWith("/");
   });
@@ -221,5 +234,6 @@ describe("DashboardPage review framing", () => {
     expect(screen.queryByRole("heading", { name: "Nothing to review yet" })).not.toBeInTheDocument();
     expect(screen.getByTestId("verdict-skeleton")).toBeInTheDocument();
     expect(screen.getByTestId("stat-rail-skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("feedback-nudge")).not.toBeInTheDocument();
   });
 });

--- a/tests/ui/feedback-nudge.test.tsx
+++ b/tests/ui/feedback-nudge.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { subDays } from "date-fns";
+import { FeedbackNudge } from "@/components/dashboard/feedback-nudge";
+import { emptyDraft } from "@/lib/feedback/feedback-payload";
+import {
+  FEEDBACK_DRAFT_KEY,
+  FEEDBACK_LAST_SENT_KEY,
+  FEEDBACK_NUDGE_DISMISSED_KEY,
+  clearDraft,
+  writeDraft,
+  writeLastSentAt,
+} from "@/lib/feedback/feedback-store";
+import type { TaskRecord } from "@/lib/types";
+import { createMockTask } from "@/tests/fixtures";
+
+const COMPLETIONS = 10;
+const DISTINCT_DAYS = 5;
+const TENURE_DAYS = 20;
+
+/** Twenty days of history with ten completions spread over five days. */
+function returningUserTasks(): TaskRecord[] {
+  const now = new Date();
+  return Array.from({ length: COMPLETIONS }, (_, index) => {
+    const finished = subDays(now, 1 + (index % DISTINCT_DAYS) * 2).toISOString();
+    return createMockTask({
+      id: `done-${index}`,
+      completed: true,
+      createdAt: subDays(now, TENURE_DAYS).toISOString(),
+      completedAt: finished,
+      updatedAt: finished,
+    });
+  });
+}
+
+beforeEach(() => {
+  // localStorage.clear() no-ops in jsdom under Bun; remove keys individually.
+  localStorage.removeItem(FEEDBACK_DRAFT_KEY);
+  localStorage.removeItem(FEEDBACK_LAST_SENT_KEY);
+  localStorage.removeItem(FEEDBACK_NUDGE_DISMISSED_KEY);
+  // The store caches its snapshot at module scope; clearing notifies and drops it.
+  clearDraft();
+});
+
+describe("FeedbackNudge", () => {
+  it("renders nothing for a newcomer", () => {
+    render(<FeedbackNudge tasks={[createMockTask()]} />);
+
+    expect(screen.queryByTestId("feedback-nudge")).not.toBeInTheDocument();
+  });
+
+  it("invites a returning user with a link to the feedback section", () => {
+    render(<FeedbackNudge tasks={returningUserTasks()} />);
+
+    expect(screen.getByTestId("feedback-nudge")).toHaveTextContent(/anonymous/i);
+    expect(screen.getByRole("link", { name: "Send feedback" })).toHaveAttribute(
+      "href",
+      "/settings#feedback",
+    );
+  });
+
+  it("marks both controls as interactive at rest, not only on hover", () => {
+    render(<FeedbackNudge tasks={returningUserTasks()} />);
+
+    // Hue alone cannot separate the tide link from the muted sentence beside it
+    // (WCAG 1.4.1), so the underline has to be there before anyone hovers.
+    expect(screen.getByRole("link", { name: "Send feedback" })).toHaveClass("underline");
+    expect(screen.getByRole("button", { name: "Not now" })).toHaveClass("underline");
+  });
+
+  it("moves focus to the main content when dismissed from the keyboard", () => {
+    render(
+      <>
+        <main id="main-content" tabIndex={-1} />
+        <FeedbackNudge tasks={returningUserTasks()} />
+      </>,
+    );
+    const button = screen.getByRole("button", { name: "Not now" });
+    button.focus();
+
+    fireEvent.click(button);
+
+    // The button unmounts itself; without a hand-off focus would land on <body>.
+    expect(document.getElementById("main-content")).toHaveFocus();
+  });
+
+  it("hides after Not now and remembers the dismissal", () => {
+    render(<FeedbackNudge tasks={returningUserTasks()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Not now" }));
+
+    expect(screen.queryByTestId("feedback-nudge")).not.toBeInTheDocument();
+    expect(localStorage.getItem(FEEDBACK_NUDGE_DISMISSED_KEY)).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("stays quiet when feedback was sent recently", () => {
+    writeLastSentAt(new Date().toISOString());
+
+    render(<FeedbackNudge tasks={returningUserTasks()} />);
+
+    expect(screen.queryByTestId("feedback-nudge")).not.toBeInTheDocument();
+  });
+
+  it("stays quiet while a draft is in progress", () => {
+    writeDraft({ ...emptyDraft(), message: "half a thought" });
+
+    render(<FeedbackNudge tasks={returningUserTasks()} />);
+
+    expect(screen.queryByTestId("feedback-nudge")).not.toBeInTheDocument();
+  });
+});

--- a/tests/ui/help-drawer.test.tsx
+++ b/tests/ui/help-drawer.test.tsx
@@ -26,6 +26,15 @@ describe("HelpDrawer", () => {
     );
   });
 
+  it("points to the feedback section so the form is discoverable without a prompt", () => {
+    render(<HelpDrawer open onClose={vi.fn()} />);
+
+    expect(screen.getByRole("link", { name: "Send feedback" })).toHaveAttribute(
+      "href",
+      "/settings#feedback"
+    );
+  });
+
   it("keeps its header, scroll region, close control, and bottom edge inside device safe areas", () => {
     render(<HelpDrawer open onClose={vi.fn()} />);
 


### PR DESCRIPTION
## What changed

The anonymous feedback form (#516) had no way to be noticed: it lived only in Settings and the command palette. The Review page now carries one sentence under the stat rail with a **Send feedback** link and a **Not now** button. It appears only when the user's own task history proves they are a returning user, and it is a line of text rather than a toast, modal, or badge, in keeping with the original spec's no-nagging rule.

- `lib/feedback/nudge-eligibility.ts` (new): pure eligibility. Tenure ≥ 14 days from the oldest task, ≥ 10 completions, ≥ 3 distinct completion days. Quiet for 90 days after a send, 180 days after "Not now", and while a draft exists.
- `lib/feedback/feedback-store.ts`: a `gsd:feedback:nudge-dismissed` key on the existing external store, so dismissing in one tab hides the line in every tab.
- `components/dashboard/feedback-nudge.tsx` (new): renders nothing during the static export and for ineligible users. Dismissing hands focus to `#main-content` before the button unmounts.
- Passive **Send feedback** links in the help drawer's Privacy section and the app footer. Text links are underlined at rest so hue alone never has to mark them (WCAG 1.4.1).
- Version bump to 12.7.0 across package.json, README, and `sw.js` CACHE_VERSION.

## Why

Eligibility is derived from local task data rather than a first-run timestamp. That works retroactively for people already using the app, adds no tracking key, and measures use rather than install age. Nothing computed here leaves the device. Web only by decision; iOS keeps Settings and the palette as its only feedback surfaces.

## How to test

1. `bun run test` (24 new tests across `tests/data/nudge-eligibility.test.ts`, `tests/data/feedback-store.test.ts`, `tests/ui/feedback-nudge.test.tsx`, plus page, footer, and help-drawer assertions), `bun typecheck`, `bun lint`, `bun run quality:shape`.
2. In the running app, seed IndexedDB with ≥ 10 completed tasks over ≥ 3 days whose oldest `createdAt` is ≥ 14 days old, then open **Review**. The sentence appears under the stat rail; **Send feedback** lands on Settings → Feedback; **Not now** hides it and it stays hidden after reload.
3. With a fresh database, or within 90 days of a send, nothing renders.

Verified in Chrome (light and dark, real clicks, console clean) and in headless Playwright at 390px (no horizontal overflow, 44px touch targets on a coarse pointer). The a11y-reviewer agent's three blocking findings were fixed test-first.

## Known follow-ups

- Two tests are red on the author's machine for reasons outside this branch: `documentation-currentness` against an uncommitted local bump, and `dependency-license-policy` against a locally installed LGPL `sharp` binary. Both pass on a clean checkout of this branch.
- `bun.lock` carries unrelated local dependency churn and is deliberately not included.

https://claude.ai/code/session_014KJUm3PSzByZmkAgBgCYcx
