### PR TITLE
ci(security): harden workflow permissions and run scripts

### DIFF
--- a/.github/workflows/apply-risk-label.yml
+++ b/.github/workflows/apply-risk-label.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     runs-on: ubuntu-24.04
@@ -21,6 +24,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -38,6 +42,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -57,6 +62,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -84,6 +90,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -103,6 +110,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -126,6 +134,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -162,6 +171,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
+          persist-credentials: false
       # Only upload the artifact on pushes to main (and only if the build
       # succeeds). PR builds verify the build still works but don't produce
       # deployable artifacts. Phase 3's deploy-dev workflow will consume the

--- a/.github/workflows/deploy-cloudfront-infra.yml
+++ b/.github/workflows/deploy-cloudfront-infra.yml
@@ -29,6 +29,9 @@ concurrency:
   group: deploy-cloudfront-infra
   cancel-in-progress: false
 
+# Jobs opt in to token scopes; a new job starts with none.
+permissions: {}
+
 jobs:
   deploy:
     name: Deploy CloudFront infrastructure
@@ -51,6 +54,7 @@ jobs:
           # Full history so `git diff github.event.before HEAD` always
           # resolves, even when a push contains multiple commits.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Detect what changed
         id: changes

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,6 +10,9 @@ concurrency:
   group: deploy-development
   cancel-in-progress: false
 
+# Jobs opt in to token scopes; a new job starts with none.
+permissions: {}
+
 jobs:
   deploy:
     name: Deploy exact successful main build to development
@@ -66,10 +69,13 @@ jobs:
         run: bash scripts/deploy-app.sh
 
       - name: Wait for CloudFront invalidation
+        env:
+          CLOUDFRONT_ID: ${{ vars.CLOUDFRONT_ID }}
+          INVALIDATION_ID: ${{ steps.deploy.outputs.invalidation_id }}
         run: |
           aws cloudfront wait invalidation-completed \
-            --distribution-id "${{ vars.CLOUDFRONT_ID }}" \
-            --id "${{ steps.deploy.outputs.invalidation_id }}"
+            --distribution-id "$CLOUDFRONT_ID" \
+            --id "$INVALIDATION_ID"
 
       - name: Smoke test
         env:

--- a/.github/workflows/deploy-production-release.yml
+++ b/.github/workflows/deploy-production-release.yml
@@ -10,6 +10,9 @@ concurrency:
   group: deploy-production
   cancel-in-progress: false
 
+# Jobs opt in to token scopes; a new job starts with none.
+permissions: {}
+
 jobs:
   evidence:
     name: Authorize protected release and publish Gate 2 evidence
@@ -299,10 +302,13 @@ jobs:
         run: bash scripts/deploy-app.sh
 
       - name: Wait for CloudFront invalidation
+        env:
+          CLOUDFRONT_ID: ${{ vars.CLOUDFRONT_ID }}
+          INVALIDATION_ID: ${{ steps.deploy.outputs.invalidation_id }}
         run: |
           aws cloudfront wait invalidation-completed \
-            --distribution-id "${{ vars.CLOUDFRONT_ID }}" \
-            --id "${{ steps.deploy.outputs.invalidation_id }}"
+            --distribution-id "$CLOUDFRONT_ID" \
+            --id "$INVALIDATION_ID"
 
   smoke:
     name: Verify deployed production surface without cloud credentials

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -16,9 +16,8 @@ on:
     tags:
       - 'v*.*.*'
 
-permissions:
-  contents: read
-  packages: write
+# Jobs opt in to token scopes; a new job starts with none.
+permissions: {}
 
 concurrency:
   group: publish-docker-${{ github.ref }}
@@ -27,11 +26,15 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Configure build
         id: cfg
@@ -126,11 +129,13 @@ jobs:
           provenance: false
 
       - name: Summary
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           {
             echo "### Docker image"
             echo "Pushed the following tags:"
             echo '```'
-            echo "${{ steps.meta.outputs.tags }}"
+            echo "$IMAGE_TAGS"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Verify publish ref is reviewed
         if: github.event_name == 'push' || inputs.dry_run == false

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -10,6 +10,9 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch: # Allow manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-24.04
@@ -23,6 +26,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install pinned Gitleaks
         run: |
@@ -71,10 +75,12 @@ jobs:
 
       - name: Audit summary
         if: always()
+        env:
+          HAS_VULNERABILITIES: ${{ steps.audit.outputs.has_vulnerabilities }}
         run: |
           echo "### Security Audit Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.audit.outputs.has_vulnerabilities }}" = "true" ]; then
+          if [ "$HAS_VULNERABILITIES" = "true" ]; then
             echo "⚠️ High or critical vulnerabilities found. See audit step above." >> $GITHUB_STEP_SUMMARY
           elif [ -s audit-results.json ]; then
             echo "See detailed results in the audit step above." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,6 +12,9 @@ on:
 # https://sonarcloud.io/project/admin/analysis_method?id=vscarpenter_gsd-task-manager
 # and toggle "Automatic Analysis" OFF. This is a one-time manual step.
 
+permissions:
+  contents: read
+
 jobs:
   sonarcloud:
     name: SonarCloud
@@ -24,6 +27,7 @@ jobs:
         with:
           # Full history required for SonarCloud blame data and new code detection
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/tests/data/pipeline-workflows.test.ts
+++ b/tests/data/pipeline-workflows.test.ts
@@ -1,8 +1,40 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+
+const WORKFLOW_DIR = ".github/workflows";
+const RUN_SCRIPT_EXPRESSION =
+  /\$\{\{\s*(?:vars|steps|inputs|github\.event)\.[^}]*\}\}/g;
 
 function readWorkflow(path: string): string {
   return readFileSync(path, "utf8");
+}
+
+function listWorkflowPaths(): string[] {
+  return readdirSync(WORKFLOW_DIR)
+    .filter((name) => /\.ya?ml$/.test(name))
+    .map((name) => `${WORKFLOW_DIR}/${name}`);
+}
+
+// Checkout steps hold only scalar inputs, so splitting on list items keeps a
+// checkout step's whole `with:` block inside one chunk.
+function listItems(workflow: string): string[] {
+  return workflow.split(/^[ \t]*- /m);
+}
+
+// Returns each `run:` value, including the indented body of a block scalar.
+function runBlocks(workflow: string): string[] {
+  const lines = workflow.split("\n");
+  return lines.flatMap((line, index) => {
+    const match = /^([ \t]*(?:- )?)run:(.*)$/.exec(line);
+    if (!match) return [];
+    const keyIndent = match[1].length;
+    const bodyEnd = lines.findIndex(
+      (next, nextIndex) =>
+        nextIndex > index && next.trim() !== "" && next.search(/\S/) <= keyIndent
+    );
+    const body = lines.slice(index + 1, bodyEnd === -1 ? lines.length : bodyEnd);
+    return [[match[2], ...body].join("\n")];
+  });
 }
 
 describe("pipeline workflows", () => {
@@ -49,5 +81,39 @@ describe("pipeline workflows", () => {
     expect(removeStaleIndex).toBeGreaterThan(-1);
     expect(ignoreMissingIndex).toBeGreaterThan(removeStaleIndex);
     expect(addTargetIndex).toBeGreaterThan(ignoreMissingIndex);
+  });
+
+  it("sets persist-credentials explicitly on every checkout step", () => {
+    const checkouts = listWorkflowPaths().flatMap((path) =>
+      listItems(readWorkflow(path))
+        .filter((item) => /uses:\s*actions\/checkout@/.test(item))
+        .map((item) => ({ path, item }))
+    );
+    const implicitCheckouts = checkouts
+      .filter(({ item }) => !/^[ \t]*persist-credentials:\s*(?:true|false)\b/m.test(item))
+      .map(({ path }) => path);
+
+    expect(checkouts.length).toBeGreaterThan(0);
+    expect(implicitCheckouts).toEqual([]);
+  });
+
+  it("declares top-level permissions in every workflow", () => {
+    const missing = listWorkflowPaths().filter(
+      (path) => !/^permissions:/m.test(readWorkflow(path))
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  it("passes vars, step outputs, inputs, and event data to run scripts through env", () => {
+    const blocks = listWorkflowPaths().flatMap((path) =>
+      runBlocks(readWorkflow(path)).map((block) => ({ path, block }))
+    );
+    const interpolated = blocks.flatMap(({ path, block }) =>
+      (block.match(RUN_SCRIPT_EXPRESSION) ?? []).map((expression) => `${path}: ${expression}`)
+    );
+
+    expect(blocks.length).toBeGreaterThan(0);
+    expect(interpolated).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Hardens the GitHub Actions workflows after the September 11 Aikido review. The repo's default workflow token is write, so any job without its own `permissions` block got a write token while it ran third-party code such as `bun install`.

- Every `actions/checkout` step sets `persist-credentials: false`. No job pushes to git.
- `ci.yml`, `security-audit.yml`, and `sonarcloud.yml` get a top-level `contents: read`.
- `deploy-cloudfront-infra.yml`, `deploy-dev.yml`, `deploy-production-release.yml`, and `publish-docker.yml` start from `permissions: {}`. Every job in them declares its own scopes, and publish-docker's `packages: write` moves onto its job.
- Expressions no longer land directly in `run` scripts. `vars.CLOUDFRONT_ID`, the invalidation id, the image tags, and `has_vulnerabilities` now pass through `env` as quoted shell variables.
- Three guard tests in `tests/data/pipeline-workflows.test.ts` hold every workflow to these rules.

Triggers, action SHAs, and job logic are unchanged. The `workflow_run` trigger in `deploy-dev.yml` stays, because its guards already skip fork pull requests.

No linked issue.

## Risk tier

risky: the deploy and publish workflows only prove out on their next real run.

## How to verify

- [ ] `bun run test -- tests/data/pipeline-workflows.test.ts` passes
- [ ] CI on this PR passes, except the `lint` job, which goes green once the split PR merges
- [ ] After merge, the next dev deploy, CloudFront infra deploy, Docker publish, and SonarCloud run succeed

Local run: 3004 passed and 1 skipped, typecheck and lint clean, and all nine workflows parse.

Watch item: SonarCloud gets `contents: read` only, because the pinned scan action never reads `GITHUB_TOKEN`. If PR decoration stops, add `pull-requests: read` to `sonarcloud.yml`.

## Rollback plan

Revert the commit. If one workflow fails on a missing scope, add that scope to its job instead of reverting the whole change.

## Checklist

- [x] Acceptance criteria are met (no linked issue; the new guard tests pin each rule)
- [x] Tests added/updated and passing (`bun run test`)
- [x] Lint and typecheck clean (`bun run lint`, `bun run typecheck`)
- [x] Coding standards followed (`coding-standards.md`)
- [x] Rollback plan above is real

https://claude.ai/code/session_019x5RXYzXyJP7cN7GqWPGNr
