### PR TITLE
fix(mcp): strip deleted ids from dependents after a bulk delete

### DIFF
--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the GSD MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.6] - 2026-09-11
+
+### Fixed
+- `bulk_update_tasks` deletes now strip the deleted ids from the tasks that
+  depended on them, the same cleanup `delete_task` already ran. Before this,
+  survivors kept dangling ids, and resubmitting that array through
+  `update_task` failed with "Dependency tasks not found". A failed cleanup
+  shows up in the result's errors.
+
 ## [1.2.5] - 2026-08-23
 
 ### Fixed
@@ -575,4 +584,5 @@ audits every tool for schema fidelity, input validation, and side-effect safety.
 - `Security` - Security improvements
 - `Improved` - Enhancements to existing features
 
+[1.2.6]: https://github.com/vscarpenter/gsd-task-manager/compare/mcp-v1.2.5...mcp-v1.2.6
 [1.2.5]: https://github.com/vscarpenter/gsd-task-manager/compare/mcp-v1.2.4...mcp-v1.2.5

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-mcp-server",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "MCP server for GSD Task Manager — 20 tools for task CRUD, analytics, and diagnostics over PocketBase. Validated inputs, dry-run support, JWT-aware token health, and dependency-safe deletes.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/mcp-server/src/__tests__/write-ops/bulk-operations.test.ts
+++ b/packages/mcp-server/src/__tests__/write-ops/bulk-operations.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { GsdConfig, Task } from '../../types.js';
+import { pbTaskToTask, type GsdConfig, type PBTask, type Task } from '../../types.js';
 
 const { mockBulkInfo } = vi.hoisted(() => ({ mockBulkInfo: vi.fn() }));
 
@@ -25,12 +25,14 @@ vi.mock('../../write-ops/helpers.js', async () => {
     // Per-item preflight check just before each write.
     fetchSinglePBTaskFresh: vi.fn().mockResolvedValue(null),
     updateTaskInPBById: vi.fn().mockResolvedValue(undefined),
+    updateTaskDependenciesInPBById: vi.fn().mockResolvedValue(undefined),
     deleteTaskInPBById: vi.fn().mockResolvedValue(undefined),
   };
 });
 
 vi.mock('../../tools/list-tasks.js', () => ({
   listTasks: vi.fn(),
+  listTasksFresh: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('../../cache.js', () => ({
@@ -385,5 +387,148 @@ describe('bulkUpdateTasks — delete safety', () => {
     expect(result.dryRun).toBe(false);
     expect(result.updated).toBe(11);
     expect(result.conflicts).toEqual([]);
+  });
+});
+
+type PBEntry = { pbRecordId: string; clientUpdatedAt: string; record: PBTask };
+
+function makeDependentEntry(id: string, dependencies: string[]): PBEntry {
+  const entry = makeSnapshotEntry(id);
+  return { ...entry, record: { ...entry.record, dependencies } };
+}
+
+/**
+ * Serve every PocketBase helper from one in-memory store, so a delete
+ * disappears from later reads the way it does against the real backend.
+ */
+async function seedPocketBase(
+  entries: PBEntry[],
+  batchIds: string[]
+): Promise<Map<string, PBEntry>> {
+  const helpers = await import('../../write-ops/helpers.js');
+  const { listTasksFresh } = await import('../../tools/list-tasks.js');
+  const store = new Map(entries.map((entry) => [entry.record.task_id, entry]));
+  vi.mocked(helpers.fetchPBSnapshotForTasks).mockResolvedValueOnce(
+    new Map(batchIds.map((id) => [id, store.get(id)!]))
+  );
+  vi.mocked(listTasksFresh).mockImplementation(async () =>
+    [...store.values()].map((entry) => pbTaskToTask(entry.record))
+  );
+  vi.mocked(helpers.fetchSinglePBTaskFresh).mockImplementation(
+    async (_config, id) => store.get(id) ?? null
+  );
+  vi.mocked(helpers.deleteTaskInPBById).mockImplementation(async (_config, recordId) => {
+    store.delete(recordId.replace(/^rec-/, ''));
+  });
+  return store;
+}
+
+describe('bulkUpdateTasks dependency cleanup after delete', () => {
+  it('strips a deleted task id from a surviving dependent in PocketBase', async () => {
+    const helpers = await import('../../write-ops/helpers.js');
+    await seedPocketBase(
+      [
+        makeSnapshotEntry('blocker'),
+        makeSnapshotEntry('other'),
+        makeDependentEntry('dependent', ['blocker', 'other']),
+      ],
+      ['blocker']
+    );
+
+    const result = await bulkUpdateTasks(config, ['blocker'], { type: 'delete' }, { dryRun: false });
+
+    expect(result).toMatchObject({ deleted: 1, errors: [], conflicts: [] });
+    expect(helpers.updateTaskDependenciesInPBById).toHaveBeenCalledWith(
+      config,
+      'rec-dependent',
+      ['other'],
+      expect.any(String),
+      'device-1'
+    );
+  });
+
+  it('skips the dependency update for a dependent deleted in the same batch', async () => {
+    const helpers = await import('../../write-ops/helpers.js');
+    await seedPocketBase(
+      [
+        makeSnapshotEntry('blocker'),
+        makeDependentEntry('doomed', ['blocker']),
+        makeDependentEntry('survivor', ['blocker']),
+      ],
+      ['blocker', 'doomed']
+    );
+
+    const result = await bulkUpdateTasks(
+      config,
+      ['blocker', 'doomed'],
+      { type: 'delete' },
+      { dryRun: false }
+    );
+
+    const patchedRecords = vi
+      .mocked(helpers.updateTaskDependenciesInPBById)
+      .mock.calls.map((call) => call[1]);
+    expect(patchedRecords).toEqual(['rec-survivor']);
+    expect(result).toMatchObject({ deleted: 2, errors: [] });
+  });
+
+  it('keeps the id of a task whose delete conflicted in its dependents', async () => {
+    const helpers = await import('../../write-ops/helpers.js');
+    const store = await seedPocketBase(
+      [
+        makeSnapshotEntry('blocker'),
+        makeSnapshotEntry('changed'),
+        makeDependentEntry('dependent', ['blocker', 'changed']),
+      ],
+      ['blocker', 'changed']
+    );
+    // Another device saves "changed" after the batch snapshot, so its delete preflight conflicts.
+    store.set('changed', { ...store.get('changed')!, clientUpdatedAt: '2026-04-02T00:00:00Z' });
+
+    const result = await bulkUpdateTasks(
+      config,
+      ['blocker', 'changed'],
+      { type: 'delete' },
+      { dryRun: false }
+    );
+
+    expect(result).toMatchObject({ deleted: 1, conflicts: ['changed'] });
+    expect(helpers.updateTaskDependenciesInPBById).toHaveBeenCalledWith(
+      config,
+      'rec-dependent',
+      ['changed'],
+      expect.any(String),
+      'device-1'
+    );
+  });
+
+  it('reports incomplete cleanup as errors, never as conflicts a caller would retry', async () => {
+    // The bulk handler invites a retry for every conflict id. On a delete, that
+    // retry would remove the dependent, so cleanup trouble belongs in errors.
+    const helpers = await import('../../write-ops/helpers.js');
+    const store = await seedPocketBase(
+      [
+        makeSnapshotEntry('blocker'),
+        makeDependentEntry('rejected', ['blocker']),
+        makeDependentEntry('edited', ['blocker']),
+      ],
+      ['blocker']
+    );
+    vi.mocked(helpers.updateTaskDependenciesInPBById).mockRejectedValueOnce({ status: 422 });
+    // "edited" changes after its first read, as if another device saved it mid-cleanup.
+    let editedReads = 0;
+    vi.mocked(helpers.fetchSinglePBTaskFresh).mockImplementation(async (_config, id) => {
+      const entry = store.get(id) ?? null;
+      if (id !== 'edited' || editedReads++ === 0) return entry;
+      return { ...entry!, clientUpdatedAt: '2026-04-02T00:00:00Z' };
+    });
+
+    const result = await bulkUpdateTasks(config, ['blocker'], { type: 'delete' }, { dryRun: false });
+
+    expect(result).toMatchObject({ deleted: 1, conflicts: [] });
+    expect(result.errors).toEqual([
+      'Task rejected: dependency cleanup validation_failed',
+      'Task edited: dependency cleanup conflict',
+    ]);
   });
 });

--- a/packages/mcp-server/src/write-ops/bulk-operations.ts
+++ b/packages/mcp-server/src/write-ops/bulk-operations.ts
@@ -9,7 +9,7 @@
 import type { GsdConfig, Task } from '../types.js';
 import { pbTaskToTask } from '../types.js';
 import type { BulkOperation } from './types.js';
-import { listTasks } from '../tools/list-tasks.js';
+import { listTasks, listTasksFresh } from '../tools/list-tasks.js';
 import { getTaskCache } from '../cache.js';
 import { createMcpLogger } from '../utils/logger.js';
 import {
@@ -21,6 +21,7 @@ import {
   deleteTaskInPBById,
 } from './helpers.js';
 import { sanitizePocketBaseWriteError, WriteRateLimiter } from './write-rate-limiter.js';
+import { cleanDependents, snapshotDependents, type CleanupOutcome } from './dependency-cleanup.js';
 
 const logger = createMcpLogger('BULK_WRITE');
 
@@ -249,14 +250,48 @@ function appendMissingTaskErrors(
   }
 }
 
+function describeCleanupIssue(outcome: CleanupOutcome): string[] {
+  if (outcome.kind === 'cleaned') return [];
+  const code = outcome.kind === 'conflict' ? 'conflict' : outcome.code;
+  return [`Task ${outcome.taskId}: dependency cleanup ${code}`];
+}
+
+/**
+ * Strip the ids this batch deleted from every surviving task that depended on
+ * one of them. Cleanup trouble comes back as error strings, never as conflicts.
+ * The handler invites a retry for each conflict id, and retrying a delete
+ * would remove the dependent.
+ */
+async function removeDeletedReferences(
+  config: GsdConfig,
+  tasks: Task[],
+  outcomes: BulkTaskOutcome[],
+  deviceId: string,
+  limiter: WriteRateLimiter
+): Promise<string[]> {
+  const deletedIds = new Set(
+    outcomes.filter((outcome) => outcome.kind === 'deleted').map((outcome) => outcome.taskId)
+  );
+  if (deletedIds.size === 0) return [];
+  const dependents = tasks.filter((task) =>
+    !deletedIds.has(task.id) && task.dependencies.some((id) => deletedIds.has(id))
+  );
+  const pending = await snapshotDependents(config, dependents);
+  const cleanup = await cleanDependents(config, deletedIds, pending, deviceId, limiter);
+  return cleanup.flatMap(describeCleanupIssue);
+}
+
 async function executeBulkWrite(
   config: GsdConfig,
   taskIds: string[],
   operation: BulkOperation
 ): Promise<BulkUpdateResult> {
-  const [{ ownerId, deviceId }, snapshot] = await Promise.all([
+  // Deletes read the task list before any write, as deleteTask does. A failed
+  // read then aborts the batch before it removes anything.
+  const [{ ownerId, deviceId }, snapshot, tasks] = await Promise.all([
     getAuthInfo(config),
     fetchPBSnapshotForTasks(config, taskIds),
+    operation.type === 'delete' ? listTasksFresh(config) : [],
   ]);
   if (snapshot.size === 0) return emptyBulkResult(false, 'No matching tasks found');
   const inputs = collectBulkInputs(taskIds, snapshot);
@@ -266,6 +301,7 @@ async function executeBulkWrite(
     processBulkTask(config, input, operation, ownerId, deviceId, writeLimiter)
   );
   const summary = summarizeOutcomes(outcomes);
+  summary.errors.push(...await removeDeletedReferences(config, tasks, outcomes, deviceId, writeLimiter));
   summary.rateLimitCount += writeLimiter.getRateLimitCount();
   appendMissingTaskErrors(taskIds, snapshot, summary.errors);
   getTaskCache().invalidate();

--- a/packages/mcp-server/src/write-ops/dependency-cleanup.ts
+++ b/packages/mcp-server/src/write-ops/dependency-cleanup.ts
@@ -1,0 +1,107 @@
+/**
+ * Strips deleted task ids from the dependencies of the tasks that pointed at
+ * them. delete_task and bulk_update_tasks both call it, so neither delete path
+ * leaves dangling references. It mirrors the web client's
+ * removeDependencyReferencesInTransaction (lib/tasks/dependencies).
+ */
+
+import type { GsdConfig, Task } from '../types.js';
+import { pbTaskToTask } from '../types.js';
+import { fetchSinglePBTaskFresh, updateTaskDependenciesInPBById } from './helpers.js';
+import { createMcpLogger } from '../utils/logger.js';
+import { sanitizePocketBaseWriteError, type WriteRateLimiter } from './write-rate-limiter.js';
+
+const logger = createMcpLogger('DEPENDENCY_CLEANUP');
+
+interface DependencySnapshot {
+  taskId: string;
+  clientUpdatedAt: string;
+}
+
+export type CleanupOutcome =
+  | { kind: 'cleaned'; taskId: string }
+  | { kind: 'conflict'; taskId: string }
+  | { kind: 'error'; taskId: string; code: string; status?: number };
+
+/** A dependent's captured version, or the outcome of a read that already failed. */
+export type PendingCleanup = DependencySnapshot | CleanupOutcome;
+
+async function loadDependencySnapshot(
+  config: GsdConfig,
+  taskId: string
+): Promise<PendingCleanup> {
+  try {
+    const fresh = await fetchSinglePBTaskFresh(config, taskId);
+    if (!fresh) return { kind: 'error', taskId, code: 'not_found' };
+    return { taskId, clientUpdatedAt: fresh.clientUpdatedAt };
+  } catch (error) {
+    const safe = sanitizePocketBaseWriteError(error);
+    return { kind: 'error', taskId, code: safe.code, ...(safe.status ? { status: safe.status } : {}) };
+  }
+}
+
+async function cleanDependencySnapshot(
+  config: GsdConfig,
+  deletedIds: ReadonlySet<string>,
+  snapshot: DependencySnapshot,
+  deviceId: string,
+  limiter: WriteRateLimiter
+): Promise<CleanupOutcome> {
+  try {
+    return await limiter.run(async () => {
+      const fresh = await fetchSinglePBTaskFresh(config, snapshot.taskId);
+      if (!fresh) return { kind: 'error', taskId: snapshot.taskId, code: 'not_found' };
+      if (fresh.clientUpdatedAt !== snapshot.clientUpdatedAt) {
+        return { kind: 'conflict', taskId: snapshot.taskId };
+      }
+      const current = pbTaskToTask(fresh.record);
+      const dependencies = current.dependencies.filter((id) => !deletedIds.has(id));
+      if (dependencies.length !== current.dependencies.length) {
+        await updateTaskDependenciesInPBById(
+          config, fresh.pbRecordId, dependencies, new Date().toISOString(), deviceId
+        );
+      }
+      return { kind: 'cleaned', taskId: snapshot.taskId };
+    });
+  } catch (error) {
+    const safe = sanitizePocketBaseWriteError(error);
+    return { kind: 'error', taskId: snapshot.taskId, code: safe.code, ...(safe.status ? { status: safe.status } : {}) };
+  }
+}
+
+/** Capture each dependent's version, so cleanup can skip a task edited since. */
+export function snapshotDependents(
+  config: GsdConfig,
+  dependents: Task[]
+): Promise<PendingCleanup[]> {
+  return Promise.all(dependents.map((dependent) => loadDependencySnapshot(config, dependent.id)));
+}
+
+/**
+ * Remove the deleted ids from each captured dependent, one write at a time
+ * through the limiter. Failures come back as outcomes, and the log records
+ * only ids and status codes, never task content.
+ */
+export async function cleanDependents(
+  config: GsdConfig,
+  deletedIds: ReadonlySet<string>,
+  pending: PendingCleanup[],
+  deviceId: string,
+  limiter: WriteRateLimiter
+): Promise<CleanupOutcome[]> {
+  const outcomes = await Promise.all(pending.map((entry) =>
+    'kind' in entry
+      ? entry
+      : cleanDependencySnapshot(config, deletedIds, entry, deviceId, limiter)
+  ));
+  for (const outcome of outcomes) {
+    if (outcome.kind === 'error') {
+      logger.warn('Failed to clean dependency reference after delete', {
+        taskId: outcome.taskId,
+        ...(outcome.status ? { status: outcome.status } : {}),
+        errorCode: outcome.code,
+      });
+    }
+  }
+  return outcomes;
+}

--- a/packages/mcp-server/src/write-ops/task-operations.ts
+++ b/packages/mcp-server/src/write-ops/task-operations.ts
@@ -12,7 +12,6 @@ import {
   deriveQuadrant,
   createTaskInPB,
   updateTaskInPBById,
-  updateTaskDependenciesInPBById,
   deleteTaskInPBById,
   fetchSinglePBTaskFresh,
   getAuthInfo,
@@ -25,10 +24,8 @@ import {
 import { extractUrlsFromTitle, buildDescription } from '../text/capture-parser.js';
 import { ConflictError } from '../errors.js';
 import { getTaskCache } from '../cache.js';
-import { createMcpLogger } from '../utils/logger.js';
-import { sanitizePocketBaseWriteError, WriteRateLimiter } from './write-rate-limiter.js';
-
-const logger = createMcpLogger('TASK_OPS');
+import { WriteRateLimiter } from './write-rate-limiter.js';
+import { cleanDependents, snapshotDependents, type CleanupOutcome } from './dependency-cleanup.js';
 
 /**
  * Create task result with dry-run information
@@ -320,59 +317,6 @@ export interface DeleteTaskResult {
   conflicts: string[];
 }
 
-interface DependencySnapshot {
-  taskId: string;
-  clientUpdatedAt: string;
-}
-
-type CleanupOutcome =
-  | { kind: 'cleaned'; taskId: string }
-  | { kind: 'conflict'; taskId: string }
-  | { kind: 'error'; taskId: string; code: string; status?: number };
-
-async function loadDependencySnapshot(
-  config: GsdConfig,
-  taskId: string
-): Promise<DependencySnapshot | CleanupOutcome> {
-  try {
-    const fresh = await fetchSinglePBTaskFresh(config, taskId);
-    if (!fresh) return { kind: 'error', taskId, code: 'not_found' };
-    return { taskId, clientUpdatedAt: fresh.clientUpdatedAt };
-  } catch (error) {
-    const safe = sanitizePocketBaseWriteError(error);
-    return { kind: 'error', taskId, code: safe.code, ...(safe.status ? { status: safe.status } : {}) };
-  }
-}
-
-async function cleanDependencySnapshot(
-  config: GsdConfig,
-  taskId: string,
-  snapshot: DependencySnapshot,
-  deviceId: string,
-  limiter: WriteRateLimiter
-): Promise<CleanupOutcome> {
-  try {
-    return await limiter.run(async () => {
-      const fresh = await fetchSinglePBTaskFresh(config, snapshot.taskId);
-      if (!fresh) return { kind: 'error', taskId: snapshot.taskId, code: 'not_found' };
-      if (fresh.clientUpdatedAt !== snapshot.clientUpdatedAt) {
-        return { kind: 'conflict', taskId: snapshot.taskId };
-      }
-      const current = pbTaskToTask(fresh.record);
-      const dependencies = current.dependencies.filter((id) => id !== taskId);
-      if (dependencies.length !== current.dependencies.length) {
-        await updateTaskDependenciesInPBById(
-          config, fresh.pbRecordId, dependencies, new Date().toISOString(), deviceId
-        );
-      }
-      return { kind: 'cleaned', taskId: snapshot.taskId };
-    });
-  } catch (error) {
-    const safe = sanitizePocketBaseWriteError(error);
-    return { kind: 'error', taskId: snapshot.taskId, code: safe.code, ...(safe.status ? { status: safe.status } : {}) };
-  }
-}
-
 function summarizeCleanup(outcomes: CleanupOutcome[]) {
   const errors = outcomes
     .filter((outcome): outcome is Extract<CleanupOutcome, { kind: 'error' }> => outcome.kind === 'error')
@@ -445,25 +389,10 @@ export async function deleteTask(
   }
 
   const { deviceId } = await getAuthInfo(config);
-  const snapshots = await Promise.all(
-    affectedTasks.map((affected) => loadDependencySnapshot(config, affected.id))
-  );
+  const pending = await snapshotDependents(config, affectedTasks);
   await deletePrimaryTask(config, task, limiter);
-  const outcomes = await Promise.all(snapshots.map((snapshot) =>
-    'kind' in snapshot
-      ? snapshot
-      : cleanDependencySnapshot(config, taskId, snapshot, deviceId, limiter)
-  ));
+  const outcomes = await cleanDependents(config, new Set([taskId]), pending, deviceId, limiter);
   const summary = summarizeCleanup(outcomes);
-  for (const outcome of outcomes) {
-    if (outcome.kind === 'error') {
-      logger.warn('Failed to clean dependency reference after delete', {
-        taskId: outcome.taskId,
-        ...(outcome.status ? { status: outcome.status } : {}),
-        errorCode: outcome.code,
-      });
-    }
-  }
 
   return {
     taskId,


### PR DESCRIPTION
## Summary

`bulk_update_tasks` deletes now strip the deleted ids from the tasks that depended on them, the same cleanup `delete_task` already ran. Before this, survivors kept dangling ids. Readers filtered those out, but resubmitting that array through `update_task` failed with "Dependency tasks not found".

- The snapshot and cleanup helpers move from `task-operations.ts` into `write-ops/dependency-cleanup.ts`, and both delete paths call them.
- Bulk delete reads the task list before any write, so a failed read aborts the batch before anything is deleted.
- Only ids whose delete succeeded are stripped. A dependent edited after its snapshot is skipped and reported.
- Cleanup problems land in the result's `errors`, not `conflicts`. The tool tells callers to retry conflict ids, and retrying a delete would remove the dependent.
- Releases gsd-mcp-server 1.2.6 with a CHANGELOG entry.

Aikido filed this as "Business Logic Bypass". It's a data-integrity bug, not a security hole.

No linked issue.

## Risk tier

feature: a behavior fix in an MCP write path.

## How to verify

- [ ] `cd packages/mcp-server && bun run test -- src/__tests__/write-ops/bulk-operations.test.ts` passes (23 tests, 4 new)
- [ ] The full MCP suite and build pass

Local run: MCP suite 319 passed and 4 skipped (315 before). `src/write-ops` coverage is 98.79% statements and 100% functions. Lint is clean.

Follow-up: push the `mcp-v1.2.6` tag after merge to publish. The README and server card keep pointing at 1.2.5 until 1.2.6 is on npm.

## Rollback plan

Revert both commits. If 1.2.6 is already published, publish 1.2.7 from the reverted code, because npm never reuses a version.

## Checklist

- [x] Acceptance criteria are met (no linked issue; the four new tests pin the cleanup behavior)
- [x] Tests added/updated and passing (`bun run test`)
- [x] Lint and typecheck clean (`bun run lint`, `bun run typecheck`)
- [x] Coding standards followed (`coding-standards.md`)
- [x] Rollback plan above is real

https://claude.ai/code/session_019x5RXYzXyJP7cN7GqWPGNr
