### PR TITLE
fix(docker): put node_modules/.bin on PATH in the builder stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,10 @@ RUN --mount=type=secret,id=npmrc,target=/app/.npmrc,required=false \
 # Copy source code
 COPY . .
 
+# `bun run build` puts node_modules/.bin on PATH, but a RUN step does not.
+# The static-export wrapper calls a bare `next`, so add the bin dir here.
+ENV PATH="/app/node_modules/.bin:$PATH"
+
 # Build static export (produces out/ directory)
 RUN node scripts/generate-build-info.cjs \
     && node scripts/update-sw-version.cjs \

--- a/tests/data/build-config.test.ts
+++ b/tests/data/build-config.test.ts
@@ -144,6 +144,20 @@ describe("build configuration", () => {
     expect(runStaticBuildWrapper({ createArtifact: true, exitCode: 0 }).status).toBe(0);
   });
 
+  it("puts node_modules/.bin on PATH before the Docker builder runs the static-export wrapper", () => {
+    const dockerfile = readFileSync("docker/Dockerfile", "utf8");
+    const builderStage = dockerfile.split(/^FROM /m)[1] ?? "";
+    const pathIndex = builderStage.indexOf('ENV PATH="/app/node_modules/.bin:$PATH"');
+    const wrapperIndex = builderStage.indexOf("bash scripts/build-static-export.sh");
+
+    // The wrapper calls a bare `next`. `bun run build` adds node_modules/.bin to
+    // PATH in CI, but a Dockerfile RUN step does not, so the image build fails
+    // with `next: command not found` unless the builder stage adds it.
+    expect(wrapperIndex).toBeGreaterThan(-1);
+    expect(pathIndex).toBeGreaterThan(-1);
+    expect(pathIndex).toBeLessThan(wrapperIndex);
+  });
+
   it("keeps root coverage thresholds blocking in CI and SonarCloud", () => {
     const ci = readFileSync(".github/workflows/ci.yml", "utf8");
     const sonar = readFileSync(".github/workflows/sonarcloud.yml", "utf8");


### PR DESCRIPTION
## Summary

Fixes the Docker image build, which has failed on every push to main since August 7. The last green Publish Docker Image run was on 2026-08-02 (`0c28548`).

#469 (`0040ba7`) replaced the Dockerfile's `bash -c 'source .build-env.sh && bunx --bun next build'` with `bash scripts/build-static-export.sh`, and that wrapper runs a bare `next build`. CI calls the wrapper through `bun run build`, which puts `node_modules/.bin` on PATH. A Dockerfile `RUN` step doesn't, so the image build dies with `next: command not found` (exit 127).

This PR adds `ENV PATH="/app/node_modules/.bin:$PATH"` to the builder stage, right before the build step. The wrapper script, the CI build, and the production release build don't change, and the wrapper still sources `.build-env.sh` as the old line did. The runtime stage doesn't inherit the builder's PATH.

A guard test in `tests/data/build-config.test.ts` pins the order: the PATH line must come before the wrapper call in the builder stage.

No release version bump, since the web app's shipped code doesn't change.

No linked issue.

## Risk tier

chore

## How to verify

- [ ] `bun run test -- tests/data/build-config.test.ts` passes
- [ ] With Docker available, `docker build -f docker/Dockerfile --target builder --platform linux/amd64 .` gets past the static export step
- [ ] After merge, the Publish Docker Image run on main goes green

Local run: the full suite passes (3005 passed, 1 skipped), and typecheck, lint, and `quality:shape` are clean. With a container-like PATH and no `node_modules/.bin`, the wrapper fails with exit 127, exactly as in CI. With the directory on PATH, it builds every static route and writes `out/index.html`.

Not verified: a real `docker build`. No Docker daemon was available locally, and Publish Docker Image only runs on pushes to main and `v*.*.*` tags, so the first real proof is its run after merge. If that run still fails, the workflow keeps failing as it has since August; nothing about the deployed web app changes.

## Rollback plan

Revert the commit. The Docker build goes back to failing the way it has since August.

## Checklist

- [x] Acceptance criteria are met (no linked issue; the guard test and the PATH reproduction pass)
- [x] Tests added/updated and passing (`bun run test`)
- [x] Lint and typecheck clean (`bun run lint`, `bun run typecheck`)
- [x] Coding standards followed (`coding-standards.md`)
- [x] Rollback plan above is real

https://claude.ai/code/session_019x5RXYzXyJP7cN7GqWPGNr
