### PR TITLE
docs(mcp): pin install docs and server card to 1.2.6

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -10,7 +10,7 @@ Model Context Protocol (MCP) server for GSD Task Manager. Provides **full task m
 Install a reviewed, exact release and run its interactive setup wizard:
 
 ```bash
-npm install --global gsd-mcp-server@1.2.5
+npm install --global gsd-mcp-server@1.2.6
 gsd-mcp-server --setup
 ```
 
@@ -116,7 +116,7 @@ gsd-mcp-server
 ### Option A: Install an Exact Published Release (Recommended)
 
 Install an explicitly reviewed version, such as `npm install --global
-gsd-mcp-server@1.2.5`. Updating is a deliberate reinstall followed by `--setup`.
+gsd-mcp-server@1.2.6`. Updating is a deliberate reinstall followed by `--setup`.
 
 ### Option B: Build from Source
 

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -3,7 +3,7 @@
   "schemaVersion": "0.1.0",
   "serverInfo": {
     "name": "gsd-mcp-server",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "title": "GSD Task Manager MCP Server",
     "description": "Read, create, update, and analyze tasks in GSD Task Manager from any MCP-aware assistant.",
     "vendor": "Vinny Carpenter",

--- a/public/index.md
+++ b/public/index.md
@@ -45,7 +45,7 @@ For Claude Desktop and other MCP-aware assistants, install an exact reviewed
 release and run its setup wizard:
 
 ```bash
-npm install --global gsd-mcp-server@1.2.5
+npm install --global gsd-mcp-server@1.2.6
 gsd-mcp-server --setup
 ```
 


### PR DESCRIPTION
## What changed

The MCP install docs and the agent discovery card now pin `gsd-mcp-server@1.2.6`.

- `packages/mcp-server/README.md`: the install command at line 13 and the Option A example at line 119
- `public/index.md`: the install command at line 48
- `public/.well-known/mcp/server-card.json`: `serverInfo.version`

## Why

#535 shipped the bulk delete dependency cleanup as MCP 1.2.6, and npm has served 1.2.6 as `latest` since 17:18 UTC on Sept. 11. These four pins still named 1.2.5. Anyone who copied an install command got the release without that fix, and the server card advertised the old version.

## How to test

- `rg -n "gsd-mcp-server@" packages public` shows only 1.2.6 pins, plus the Sentry release template in `packages/mcp-server/src/utils/sentry.ts`, which interpolates `VERSION` instead of pinning a number.
- `bun run test` passes (3,044 tests, 1 skipped), and `bun typecheck` and `bun lint` both exit 0.
- `bun.lock` has no change because main already records the workspace at 1.2.6.

This is a docs-only change, so the app version does not change.

https://claude.ai/code/session_019x5RXYzXyJP7cN7GqWPGNr
