### PR TITLE
chore(config): remove the retired gsd-dev host and staging environment

### DIFF
--- a/.claude/skills/sentry-verification/SKILL.md
+++ b/.claude/skills/sentry-verification/SKILL.md
@@ -7,13 +7,10 @@ description: Verify Sentry error capture is working after a DSN change or deploy
 
 **Development never sends events.** `initSentry()` in `lib/sentry.ts` returns
 early when `ENV_CONFIG.isDevelopment` (localhost/127.0.0.1/*.local), so a dev
-server will not report to Sentry no matter what you trigger. Verify capture one
-of two ways:
-
-- **Staging (preferred):** deploy to `gsd-dev.vinny.dev` and trigger the test
-  error there.
-- **Local, gate lifted:** temporarily remove `|| ENV_CONFIG.isDevelopment` from
-  the `initSentry` guard, verify, then restore it before commit.
+server will not report to Sentry no matter what you trigger. There is no staging
+deploy, so verify capture locally with the gate lifted: temporarily remove
+`|| ENV_CONFIG.isDevelopment` from the `initSentry` guard, verify, then restore
+it before commit.
 
 Then:
 

--- a/lib/env-config.ts
+++ b/lib/env-config.ts
@@ -3,7 +3,7 @@
  * Single source of truth for environment-dependent URLs and settings
  */
 
-export type Environment = 'development' | 'staging' | 'production';
+export type Environment = 'development' | 'production';
 
 export interface EnvironmentConfig {
   /** PocketBase server URL */
@@ -12,15 +12,12 @@ export interface EnvironmentConfig {
   isDevelopment: boolean;
   /** Whether running in production mode */
   isProduction: boolean;
-  /** Whether running in staging mode */
-  isStaging: boolean;
   /** Current environment */
   environment: Environment;
 }
 
 const KNOWN_REMOTE_POCKETBASE_HOSTS = new Map<string, string>([
   ['gsd.vinny.dev', 'https://api.vinny.io'],
-  ['gsd-dev.vinny.dev', 'https://api.vinny.io'],
 ]);
 
 /**
@@ -36,10 +33,6 @@ function detectEnvironment(): Environment {
 
   if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname.endsWith('.local')) {
     return 'development';
-  }
-
-  if (hostname === 'gsd-dev.vinny.dev') {
-    return 'staging';
   }
 
   if (hostname === 'gsd.vinny.dev') {
@@ -99,7 +92,6 @@ export function getEnvironmentConfig(): EnvironmentConfig {
     pocketBaseUrl,
     isDevelopment: environment === 'development',
     isProduction: environment === 'production',
-    isStaging: environment === 'staging',
     environment,
   };
 }

--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -88,8 +88,8 @@ export function initSentry(): void {
 
   // Development stays local: dev sessions produced most of the Sentry noise
   // (78% of the highest-volume issue) while never representing real users.
-  // To test capture end-to-end, use staging or temporarily lift this gate —
-  // see .claude/skills/sentry-verification/SKILL.md.
+  // To test capture end-to-end, temporarily lift this gate. See
+  // .claude/skills/sentry-verification/SKILL.md.
   if (!dsn || ENV_CONFIG.isDevelopment) {
     return;
   }

--- a/tests/data/sentry.test.ts
+++ b/tests/data/sentry.test.ts
@@ -66,7 +66,6 @@ const mockEnvConfig = vi.hoisted(() => ({
   environment: "production",
   isDevelopment: false,
   isProduction: true,
-  isStaging: false,
   pocketBaseUrl: "https://api.vinny.io",
 }));
 


### PR DESCRIPTION
## What changed

- `lib/env-config.ts` drops `gsd-dev.vinny.dev` from the PocketBase host map and from environment detection. That host was the only source of the `staging` environment, so the `staging` value and `isStaging` are gone too. Nothing read `isStaging`.
- `lib/sentry.ts` and `.claude/skills/sentry-verification/SKILL.md` stop suggesting a staging check for Sentry. The skill now describes the one remaining method: lift the development gate locally, verify, and restore it.
- `tests/data/sentry.test.ts` drops `isStaging` from its env mock.

## Why

#540 retired the development deploy, and on Sept. 11 its S3 bucket, IAM role, origin access control, and GitHub environment were deleted. The hostname has no DNS record, so these references could never match a real page load.

## How to test

- `bun run test tests/data/env-config.test.ts tests/data/sentry.test.ts tests/data/sync/pocketbase-client.test.ts`: 32 passed.
- `bun typecheck` and `bun lint` exit 0.
- `git grep -n -i gsd-dev` returns only the records listed below.

## Left on purpose

- `docs/superpowers/plans/2026-05-18-github-ci-deploy-pipeline.md` and `docs/archive/security-review-may2026.md` are dated records.
- `docs/ops/github-actions-iam.md` states that the deploy was retired.
- `public/docs/codebase-analysis-report.html` is the dated May 25 analysis report.

https://claude.ai/code/session_019x5RXYzXyJP7cN7GqWPGNr
