### PR TITLE
fix(reset): fail closed when reset cannot delete local data

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 12.9.2
+**Current version:** 12.9.3
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,6 +17,7 @@ import { ClientLayout } from "@/components/client-layout";
 import { QueryProvider } from "@/components/query-provider";
 import { FirstTimeRedirect } from "@/components/first-time-redirect";
 import { OnboardingGate } from "@/components/onboarding/onboarding-gate";
+import { ResetLockGate } from "@/components/reset-lock-gate";
 
 // Development needs React's eval diagnostics and Next's inline bootstrap. The
 // production static export omits this meta policy: build post-processing moves
@@ -157,11 +158,14 @@ function AppProviders({ children }: { children: ReactNode }) {
         <ToastProvider>
           <QueryProvider>
             <TooltipProvider>
-              <ClientLayout>{children}</ClientLayout>
-              <FirstTimeRedirect />
-              <OnboardingGate />
+              {/* Anything that reads or writes task data stays inside the gate, so a pending reset keeps it unmounted. */}
+              <ResetLockGate>
+                <ClientLayout>{children}</ClientLayout>
+                <FirstTimeRedirect />
+                <OnboardingGate />
+                <WebMcpRegister />
+              </ResetLockGate>
               <PwaRegister />
-              <WebMcpRegister />
               <PwaUpdateToast />
               <GlobalErrorListener />
               <SentryInit />

--- a/components/delete-account-dialog.tsx
+++ b/components/delete-account-dialog.tsx
@@ -96,9 +96,7 @@ function failureMessage(result: DeleteAccountResult): string {
 async function eraseLocalDataAndScheduleReload(): Promise<boolean> {
 	const resetResult = await resetEverything({ preserveTheme: true });
 	if (!resetResult.success) {
-		toast.error(
-			"Cloud account deleted, but local erase was incomplete. Use Reset Everything to retry local cleanup.",
-		);
+		toast.error("Cloud account deleted, but local erase was incomplete.");
 		return false;
 	}
 

--- a/components/first-time-redirect.tsx
+++ b/components/first-time-redirect.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { useRouter, usePathname } from "next/navigation";
+import { isResetPending } from "@/lib/reset-lock";
 
 const STORAGE_KEY = "gsd-has-launched";
 
@@ -18,6 +19,10 @@ export function FirstTimeRedirect() {
   // A useEffect redirect is unavoidable here; the component renders null, so it never
   // paints the wrong page itself (no flash originates from this component).
   useEffect(() => {
+    // A page that loads locked hydrates this component once before the lock screen
+    // renders. Leave the flag and the route alone until the reset finishes.
+    if (isResetPending()) return;
+
     const hasLaunched = localStorage.getItem(STORAGE_KEY);
     if (hasLaunched) return;
 

--- a/components/reset-lock-gate.tsx
+++ b/components/reset-lock-gate.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { reloadAfterReset, resetEverything } from "@/lib/reset-everything";
+import {
+	RESET_PENDING_KEY,
+	getResetLockServerSnapshot,
+	getResetLockSnapshot,
+	readPendingPreserveTheme,
+	subscribeToResetLock,
+} from "@/lib/reset-lock";
+
+/**
+ * Keeps every task surface unmounted while Reset Everything runs, and after a
+ * run that could not prove local data is gone. A shared browser then never
+ * shows the previous user's tasks, and deleting them is the only way forward.
+ */
+export function ResetLockGate({ children }: { children: ReactNode }) {
+	const lockState = useSyncExternalStore(
+		subscribeToResetLock,
+		getResetLockSnapshot,
+		getResetLockServerSnapshot,
+	);
+	useReloadWhenAnotherTabUnlocks(lockState === "locked");
+
+	if (lockState === "unlocked") return <>{children}</>;
+	return <ResetLockScreen running={lockState === "running"} />;
+}
+
+/**
+ * Another tab removes the marker only after it deletes the data. This
+ * document's stores and database connection predate that wipe, so it reloads.
+ */
+function useReloadWhenAnotherTabUnlocks(locked: boolean): void {
+	useEffect(() => {
+		if (!locked) return;
+		const handleStorage = (event: StorageEvent) => {
+			if (event.key === RESET_PENDING_KEY && event.newValue === null) reloadAfterReset();
+		};
+		window.addEventListener("storage", handleStorage);
+		return () => window.removeEventListener("storage", handleStorage);
+	}, [locked]);
+}
+
+/** Rerun the reset. Resolves to an error to announce, or null once the reload starts. */
+async function retryReset(): Promise<string | null> {
+	try {
+		const result = await resetEverything({ preserveTheme: readPendingPreserveTheme() });
+		if (result.failedSteps.includes("local-data")) {
+			return `Couldn't delete your data. ${result.errors.join(", ")}`;
+		}
+		reloadAfterReset();
+		return null;
+	} catch (err) {
+		return `Couldn't delete your data. ${err instanceof Error ? err.message : "Unknown error"}`;
+	}
+}
+
+function ResetLockScreen({ running }: { running: boolean }) {
+	const [retryError, setRetryError] = useState<string | null>(null);
+	const screenRef = useRef<HTMLElement>(null);
+
+	// The lock can replace a page whose focused control just unmounted.
+	useEffect(() => {
+		screenRef.current?.focus({ preventScroll: true });
+	}, []);
+
+	const retry = async () => {
+		setRetryError(null);
+		setRetryError(await retryReset());
+	};
+
+	return (
+		<main
+			ref={screenRef}
+			tabIndex={-1}
+			className="flex min-h-screen flex-col items-center justify-center gap-6 px-4"
+		>
+			{running ? (
+				<p role="status" className="text-h2 font-semibold tracking-tight text-foreground">
+					Deleting your data…
+				</p>
+			) : (
+				<LockedMessage retryError={retryError} onRetry={retry} />
+			)}
+		</main>
+	);
+}
+
+function LockedMessage({ retryError, onRetry }: { retryError: string | null; onRetry: () => void }) {
+	return (
+		<>
+			<div className="max-w-md space-y-3 text-center">
+				<h1 className="text-h1 font-semibold tracking-tight text-foreground">{"Reset didn't finish"}</h1>
+				<p className="text-base leading-relaxed text-foreground-muted">
+					{"Your tasks are still saved in this browser. GSD stays locked until they're deleted."}
+				</p>
+			</div>
+			<Button onClick={onRetry}>Try again</Button>
+			<div className="max-w-md space-y-2 text-center text-sm">
+				<p role="alert" className="text-status-overdue-ink">
+					{retryError}
+				</p>
+				<p className="text-foreground-muted">
+					{"If this keeps failing, clear this site's data in your browser settings."}
+				</p>
+			</div>
+		</>
+	);
+}

--- a/components/reset-lock-gate.tsx
+++ b/components/reset-lock-gate.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
+import { UI_TIMING } from "@/lib/constants/ui";
 import { reloadAfterReset, resetEverything } from "@/lib/reset-everything";
 import {
 	RESET_PENDING_KEY,
@@ -9,7 +10,10 @@ import {
 	getResetLockSnapshot,
 	readPendingPreserveTheme,
 	subscribeToResetLock,
+	type ResetLockState,
 } from "@/lib/reset-lock";
+
+type ShownLock = Exclude<ResetLockState, "unlocked">;
 
 /**
  * Keeps every task surface unmounted while Reset Everything runs, and after a
@@ -22,10 +26,18 @@ export function ResetLockGate({ children }: { children: ReactNode }) {
 		getResetLockSnapshot,
 		getResetLockServerSnapshot,
 	);
+	// The last lock this gate showed, stored during render. After any lock the app
+	// never remounts before the reload, because FirstTimeRedirect and the
+	// onboarding tour would act on flags the reset just cleared.
+	const [shownLock, setShownLock] = useState<ShownLock | null>(null);
+	if (lockState !== "unlocked" && lockState !== shownLock) {
+		setShownLock(lockState);
+	}
 	useReloadWhenAnotherTabUnlocks(lockState === "locked");
+	useReloadAfterLocalReset(lockState === "unlocked" && shownLock === "running");
 
-	if (lockState === "unlocked") return <>{children}</>;
-	return <ResetLockScreen running={lockState === "running"} />;
+	if (lockState === "unlocked" && shownLock === null) return <>{children}</>;
+	return <ResetLockScreen running={lockState !== "locked"} />;
 }
 
 /**
@@ -41,6 +53,19 @@ function useReloadWhenAnotherTabUnlocks(locked: boolean): void {
 		window.addEventListener("storage", handleStorage);
 		return () => window.removeEventListener("storage", handleStorage);
 	}, [locked]);
+}
+
+/**
+ * A reset that finished in this document reloads after the reset delay, so its
+ * toast stays readable. The dialogs never reload after a run whose sign-out or
+ * browser-storage step failed, so this reload covers those runs too.
+ */
+function useReloadAfterLocalReset(finished: boolean): void {
+	useEffect(() => {
+		if (!finished) return;
+		const timer = setTimeout(reloadAfterReset, UI_TIMING.RESET_RELOAD_DELAY_MS);
+		return () => clearTimeout(timer);
+	}, [finished]);
 }
 
 /** Rerun the reset. Resolves to an error to announce, or null once the reload starts. */

--- a/components/reset-lock-gate.tsx
+++ b/components/reset-lock-gate.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
+import { useEffect, useId, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { UI_TIMING } from "@/lib/constants/ui";
 import { reloadAfterReset, resetEverything } from "@/lib/reset-everything";
@@ -85,11 +85,15 @@ async function retryReset(): Promise<string | null> {
 function ResetLockScreen({ running }: { running: boolean }) {
 	const [retryError, setRetryError] = useState<string | null>(null);
 	const screenRef = useRef<HTMLElement>(null);
+	const statusId = useId();
+	const headingId = useId();
 
-	// The lock can replace a page whose focused control just unmounted.
+	// Focus the screen on mount and on every switch between progress and locked. Its
+	// name then tells a screen reader what changed, and focus never stays on the page
+	// body after a dialog closes.
 	useEffect(() => {
 		screenRef.current?.focus({ preventScroll: true });
-	}, []);
+	}, [running]);
 
 	const retry = async () => {
 		setRetryError(null);
@@ -100,24 +104,39 @@ function ResetLockScreen({ running }: { running: boolean }) {
 		<main
 			ref={screenRef}
 			tabIndex={-1}
+			aria-labelledby={running ? statusId : headingId}
 			className="flex min-h-screen flex-col items-center justify-center gap-6 px-4"
 		>
 			{running ? (
-				<p role="status" className="text-h2 font-semibold tracking-tight text-foreground">
-					Deleting your data…
-				</p>
+				<ResetProgress statusId={statusId} />
 			) : (
-				<LockedMessage retryError={retryError} onRetry={retry} />
+				<LockedMessage headingId={headingId} retryError={retryError} onRetry={retry} />
 			)}
 		</main>
 	);
 }
 
-function LockedMessage({ retryError, onRetry }: { retryError: string | null; onRetry: () => void }) {
+function ResetProgress({ statusId }: { statusId: string }) {
+	return (
+		<p id={statusId} role="status" className="text-h2 font-semibold tracking-tight text-foreground">
+			Deleting your data…
+		</p>
+	);
+}
+
+interface LockedMessageProps {
+	headingId: string;
+	retryError: string | null;
+	onRetry: () => void;
+}
+
+function LockedMessage({ headingId, retryError, onRetry }: LockedMessageProps) {
 	return (
 		<>
 			<div className="max-w-md space-y-3 text-center">
-				<h1 className="text-h1 font-semibold tracking-tight text-foreground">{"Reset didn't finish"}</h1>
+				<h1 id={headingId} className="text-h1 font-semibold tracking-tight text-foreground">
+					{"Reset didn't finish"}
+				</h1>
 				<p className="text-base leading-relaxed text-foreground-muted">
 					{"Your tasks are still saved in this browser. GSD stays locked until they're deleted."}
 				</p>

--- a/components/reset-lock-gate.tsx
+++ b/components/reset-lock-gate.tsx
@@ -33,22 +33,25 @@ export function ResetLockGate({ children }: { children: ReactNode }) {
 	if (lockState !== "unlocked" && lockState !== shownLock) {
 		setShownLock(lockState);
 	}
-	useReloadWhenAnotherTabUnlocks(lockState === "locked");
-	useReloadAfterLocalReset(lockState === "unlocked" && shownLock === "running");
+	useReloadWhenOwnLockOutlivesMarker(lockState === "locked");
+	useReloadAfterUnlock(lockState === "unlocked" ? shownLock : null);
 
 	if (lockState === "unlocked" && shownLock === null) return <>{children}</>;
 	return <ResetLockScreen running={lockState !== "locked"} />;
 }
 
 /**
- * Another tab removes the marker only after it deletes the data. This
- * document's stores and database connection predate that wipe, so it reloads.
+ * A tab whose own reset failed stays locked through its in-memory mirror even
+ * after another tab deletes the data and removes the marker, so its snapshot
+ * never changes. Only the storage event can tell that tab to reload.
  */
-function useReloadWhenAnotherTabUnlocks(locked: boolean): void {
+function useReloadWhenOwnLockOutlivesMarker(locked: boolean): void {
 	useEffect(() => {
 		if (!locked) return;
 		const handleStorage = (event: StorageEvent) => {
-			if (event.key === RESET_PENDING_KEY && event.newValue === null) reloadAfterReset();
+			const removed = event.key === RESET_PENDING_KEY && event.newValue === null;
+			// A tab without its own lock unlocks through the store, and useReloadAfterUnlock reloads it.
+			if (removed && getResetLockSnapshot() === "locked") reloadAfterReset();
 		};
 		window.addEventListener("storage", handleStorage);
 		return () => window.removeEventListener("storage", handleStorage);
@@ -56,16 +59,24 @@ function useReloadWhenAnotherTabUnlocks(locked: boolean): void {
 }
 
 /**
- * A reset that finished in this document reloads after the reset delay, so its
- * toast stays readable. The dialogs never reload after a run whose sign-out or
- * browser-storage step failed, so this reload covers those runs too.
+ * Reload once a shown lock turns unlocked, without remounting the app. A lock
+ * another tab lifted reloads now, because this document's stores and database
+ * connection predate the wipe. In a browser this cannot rely on the storage
+ * listener: React re-renders after the store's listener and removes the gate's
+ * listener before the browser calls it. A reset that finished here waits for
+ * the reset delay so its toast stays readable, which also covers dialog runs
+ * whose sign-out or browser-storage step failed and that never reload.
  */
-function useReloadAfterLocalReset(finished: boolean): void {
+function useReloadAfterUnlock(unlockedFrom: ShownLock | null): void {
 	useEffect(() => {
-		if (!finished) return;
+		if (unlockedFrom === null) return;
+		if (unlockedFrom === "locked") {
+			reloadAfterReset();
+			return;
+		}
 		const timer = setTimeout(reloadAfterReset, UI_TIMING.RESET_RELOAD_DELAY_MS);
 		return () => clearTimeout(timer);
-	}, [finished]);
+	}, [unlockedFrom]);
 }
 
 /** Rerun the reset. Resolves to an error to announce, or null once the reload starts. */

--- a/components/reset-lock-gate.tsx
+++ b/components/reset-lock-gate.tsx
@@ -105,7 +105,7 @@ function ResetLockScreen({ running }: { running: boolean }) {
 			ref={screenRef}
 			tabIndex={-1}
 			aria-labelledby={running ? statusId : headingId}
-			className="flex min-h-screen flex-col items-center justify-center gap-6 px-4"
+			className="flex min-h-screen flex-col items-center justify-center gap-6 px-4 outline-none"
 		>
 			{running ? (
 				<ResetProgress statusId={statusId} />

--- a/components/webmcp-register.tsx
+++ b/components/webmcp-register.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { createLogger } from "@/lib/logger";
 import { SCHEMA_LIMITS } from "@/lib/constants/schema";
+import { isResetPending } from "@/lib/reset-lock";
 
 const logger = createLogger("WEBMCP");
 
@@ -105,6 +106,9 @@ const TOOLS: WebMCPToolDefinition[] = [
 
 export function WebMcpRegister() {
 	useEffect(() => {
+		// A page that loads locked hydrates this component once before the lock
+		// screen renders. No agent gets tools while a reset is pending.
+		if (isResetPending()) return;
 		if (typeof navigator === "undefined" || !navigator.modelContext?.provideContext) {
 			return;
 		}

--- a/lib/feedback/feedback-payload.ts
+++ b/lib/feedback/feedback-payload.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@/lib/zod";
 import { isRoadmapSlug, ROADMAP_ITEMS } from "./roadmap-items";
 
 /**

--- a/lib/notification-checker.ts
+++ b/lib/notification-checker.ts
@@ -13,6 +13,7 @@ import {
 import { isoNow } from "@/lib/utils";
 import { NOTIFICATION_TIMING, TIME_UTILS } from "@/lib/constants";
 import { createLogger } from "@/lib/logger";
+import { isResetPending } from "@/lib/reset-lock";
 
 const logger = createLogger("NOTIFICATIONS");
 
@@ -45,6 +46,9 @@ class NotificationChecker {
 	 * Core notification logic — check permissions, query tasks, and notify
 	 */
 	private async processNotifications(): Promise<void> {
+		// A page that loads locked hydrates the app once before the lock screen
+		// renders, so this can run while the previous user's tasks are still stored.
+		if (isResetPending()) return;
 		if (!isNotificationSupported()) return;
 		if (checkNotificationPermission() !== "granted") return;
 
@@ -123,6 +127,10 @@ class NotificationChecker {
 				return; // Still snoozed
 			}
 		}
+
+		// The lock can begin while this check waits for IndexedDB. Skip the task
+		// without marking it sent.
+		if (isResetPending()) return;
 
 		// Send notification
 		await showTaskNotification(task, minutesUntil);

--- a/lib/reset-everything.ts
+++ b/lib/reset-everything.ts
@@ -10,11 +10,10 @@
  * WARNING: All data loss is permanent and cannot be undone
  */
 
-import { getDb } from "@/lib/db";
-import { disableSync, getSyncConfig } from "@/lib/sync/config";
+import { disableSync } from "@/lib/sync/config";
 import { createLogger } from "@/lib/logger";
-import { SYNC_CONFIG } from "@/lib/constants/sync";
 import { resetFeedbackState } from "@/lib/feedback/feedback-store";
+import { wipeLocalData } from "@/lib/reset-local-data";
 
 const logger = createLogger("DB");
 
@@ -38,71 +37,10 @@ export interface ResetResult {
 	errors: string[];
 	/**
 	 * Steps that threw, in the order they ran. Only "local-data" decides whether
-	 * tasks survived, because that step clears IndexedDB in one transaction.
+	 * tasks survived, because that step fails only when neither the IndexedDB
+	 * clear nor the database delete fallback removed them.
 	 */
 	failedSteps: ResetStep[];
-}
-
-/**
- * Clear all IndexedDB tables except deviceId
- * Preserves deviceId for potential future sync re-registration
- */
-async function clearIndexedDB(): Promise<{ tables: string[]; errors: string[] }> {
-	const db = getDb();
-	const cleared: string[] = [];
-	const errors: string[] = [];
-
-	try {
-		const config = await getSyncConfig();
-		const deviceId = config?.deviceId;
-
-		const allTables = [...db.tables];
-		await db.transaction("rw", allTables, async () => {
-			for (const table of allTables) {
-				// react-doctor-disable-next-line react-doctor/async-await-in-loop -- one transaction must fail atomically
-				await table.clear();
-				cleared.push(table.name);
-			}
-			if (deviceId) {
-				await db.syncMetadata.add(buildPreservedSyncMetadata(deviceId));
-			}
-		});
-
-		logger.info("IndexedDB cleared successfully", { clearedTables: cleared });
-	} catch (err) {
-		const errorMsg = err instanceof Error ? err.message : "Unknown error";
-		errors.push(`IndexedDB: ${errorMsg}`);
-		logger.error("Failed to clear IndexedDB", err instanceof Error ? err : undefined, {
-			errorMessage: errorMsg
-		});
-	}
-
-	return { tables: cleared, errors };
-}
-
-/** Build a minimal sync metadata record that preserves deviceId */
-function buildPreservedSyncMetadata(deviceId: string) {
-	return {
-		key: "sync_config" as const,
-		enabled: false,
-		userId: null,
-		deviceId,
-		deviceName: "Device",
-		email: null,
-		provider: null,
-		lastSyncAt: null,
-		lastClientUpdatedAt: null,
-		pullCursorVersion: 2 as const,
-		lastServerUpdatedAt: null,
-		lastSuccessfulSyncAt: null,
-		consecutiveFailures: 0,
-		lastFailureAt: null,
-		lastFailureReason: null,
-		nextRetryAt: null,
-		autoSyncEnabled: true,
-		autoSyncIntervalMinutes: SYNC_CONFIG.DEFAULT_AUTO_SYNC_INTERVAL_MINUTES,
-		localTaskOwnerUserId: null,
-	};
 }
 
 function shouldSkipLocalStorageKey(key: string, preserveTheme: boolean): boolean {
@@ -228,8 +166,8 @@ export async function resetEverything(
 		result.failedSteps.push("sync-sign-out");
 	}
 
-	// Step 2: Clear IndexedDB
-	const dbResult = await clearIndexedDB();
+	// Step 2: Clear IndexedDB, deleting the whole database if the clear is not verified
+	const dbResult = await wipeLocalData();
 	result.clearedTables = dbResult.tables;
 	if (dbResult.errors.length > 0) {
 		result.errors.push(...dbResult.errors);

--- a/lib/reset-everything.ts
+++ b/lib/reset-everything.ts
@@ -14,6 +14,7 @@ import { disableSync } from "@/lib/sync/config";
 import { createLogger } from "@/lib/logger";
 import { resetFeedbackState } from "@/lib/feedback/feedback-store";
 import { wipeLocalData } from "@/lib/reset-local-data";
+import { RESET_PENDING_KEY, endResetLock, startResetLock } from "@/lib/reset-lock";
 
 const logger = createLogger("DB");
 
@@ -44,6 +45,8 @@ export interface ResetResult {
 }
 
 function shouldSkipLocalStorageKey(key: string, preserveTheme: boolean): boolean {
+	// The reset lock removes its own marker, and only after local data is gone.
+	if (key === RESET_PENDING_KEY) return true;
 	const isAppOwned =
 		key === "pocketbase_auth" ||
 		key === "theme" ||
@@ -127,30 +130,8 @@ async function clearSessionData(): Promise<{ success: boolean; errors: string[] 
 	}
 }
 
-/**
- * Reset everything - complete application reset
- *
- * Clears all data:
- * - All tasks (active and archived)
- * - All settings (notifications, archive)
- * - Custom smart views (built-in views preserved)
- * - Sync data (queue, history, metadata)
- * - PocketBase auth state
- * - PWA prompts
- *
- * Preserves:
- * - deviceId (for potential future sync)
- * - Theme (if preserveTheme=true)
- * - Built-in smart views
- *
- * @param options - Reset options
- * @returns Reset result with success status and details
- */
-export async function resetEverything(
-	options: ResetOptions = {}
-): Promise<ResetResult> {
-	logger.info("Starting complete reset", { options });
-
+/** Run the three reset steps in order. Each step catches and reports its own errors. */
+async function runResetSteps(preserveTheme: boolean): Promise<ResetResult> {
 	const result: ResetResult = {
 		success: true,
 		clearedTables: [],
@@ -175,7 +156,7 @@ export async function resetEverything(
 	}
 
 	// Step 3: Clear localStorage
-	const storageResult = clearLocalStorage(options.preserveTheme);
+	const storageResult = clearLocalStorage(preserveTheme);
 	result.clearedLocalStorage = storageResult.items;
 	if (storageResult.errors.length > 0) {
 		result.errors.push(...storageResult.errors);
@@ -183,6 +164,40 @@ export async function resetEverything(
 	}
 
 	result.success = result.failedSteps.length === 0;
+	return result;
+}
+
+/**
+ * Reset everything - complete application reset
+ *
+ * Clears all data:
+ * - All tasks (active and archived)
+ * - All settings (notifications, archive)
+ * - Custom smart views (built-in views preserved)
+ * - Sync data (queue, history, metadata)
+ * - PocketBase auth state
+ * - PWA prompts
+ *
+ * Preserves:
+ * - deviceId (for potential future sync)
+ * - Theme (if preserveTheme=true)
+ * - Built-in smart views
+ *
+ * The reset lock goes on before the first step and comes off only when local
+ * data is verified gone, so a failed step or a closed tab leaves GSD locked.
+ *
+ * @param options - Reset options
+ * @returns Reset result with success status and details
+ */
+export async function resetEverything(
+	options: ResetOptions = {}
+): Promise<ResetResult> {
+	logger.info("Starting complete reset", { options });
+	const preserveTheme = options.preserveTheme === true;
+
+	startResetLock(preserveTheme);
+	const result = await runResetSteps(preserveTheme);
+	endResetLock(!result.failedSteps.includes("local-data"));
 
 	logger.info("Reset complete", {
 		success: result.success,

--- a/lib/reset-everything.ts
+++ b/lib/reset-everything.ts
@@ -196,17 +196,24 @@ export async function resetEverything(
 	const preserveTheme = options.preserveTheme === true;
 
 	startResetLock(preserveTheme);
-	const result = await runResetSteps(preserveTheme);
-	endResetLock(!result.failedSteps.includes("local-data"));
+	let localDataDeleted = false;
+	try {
+		const result = await runResetSteps(preserveTheme);
+		localDataDeleted = !result.failedSteps.includes("local-data");
 
-	logger.info("Reset complete", {
-		success: result.success,
-		clearedTables: result.clearedTables.length,
-		clearedLocalStorage: result.clearedLocalStorage.length,
-		errors: result.errors.length,
-	});
+		logger.info("Reset complete", {
+			success: result.success,
+			clearedTables: result.clearedTables.length,
+			clearedLocalStorage: result.clearedLocalStorage.length,
+			errors: result.errors.length,
+		});
 
-	return result;
+		return result;
+	} finally {
+		// A step that throws past its own catch still ends the run, so GSD stays
+		// locked with Try again instead of showing the progress state forever.
+		endResetLock(localDataDeleted);
+	}
 }
 
 /**

--- a/lib/reset-local-data.ts
+++ b/lib/reset-local-data.ts
@@ -1,0 +1,144 @@
+/**
+ * The local data step of Reset Everything. It clears every IndexedDB table,
+ * checks that nothing survived, and deletes the whole database when that check
+ * fails, so a reset never reports success while tasks remain in the browser.
+ */
+
+import Dexie from "dexie";
+import { getDb } from "@/lib/db";
+import { getSyncConfig } from "@/lib/sync/config";
+import { createLogger } from "@/lib/logger";
+import { SYNC_CONFIG } from "@/lib/constants/sync";
+import type { DeviceInfo, PBSyncConfig } from "@/lib/sync/types";
+
+const logger = createLogger("DB");
+
+type GsdDatabase = ReturnType<typeof getDb>;
+
+export interface LocalDataWipeResult {
+	tables: string[];
+	errors: string[];
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : "Unknown error";
+}
+
+/** Build a minimal sync metadata record that preserves deviceId */
+function buildPreservedSyncMetadata(deviceId: string) {
+	return {
+		key: "sync_config" as const,
+		enabled: false,
+		userId: null,
+		deviceId,
+		deviceName: "Device",
+		email: null,
+		provider: null,
+		lastSyncAt: null,
+		lastClientUpdatedAt: null,
+		pullCursorVersion: 2 as const,
+		lastServerUpdatedAt: null,
+		lastSuccessfulSyncAt: null,
+		consecutiveFailures: 0,
+		lastFailureAt: null,
+		lastFailureReason: null,
+		nextRetryAt: null,
+		autoSyncEnabled: true,
+		autoSyncIntervalMinutes: SYNC_CONFIG.DEFAULT_AUTO_SYNC_INTERVAL_MINUTES,
+		localTaskOwnerUserId: null,
+	};
+}
+
+/** Clear every table in one transaction, keeping deviceId for a future sync. */
+async function clearTables(db: GsdDatabase, cleared: string[]): Promise<void> {
+	const config = await getSyncConfig();
+	const deviceId = config?.deviceId;
+
+	const allTables = [...db.tables];
+	await db.transaction("rw", allTables, async () => {
+		for (const table of allTables) {
+			// react-doctor-disable-next-line react-doctor/async-await-in-loop -- one transaction must fail atomically
+			await table.clear();
+			cleared.push(table.name);
+		}
+		if (deviceId) {
+			await db.syncMetadata.add(buildPreservedSyncMetadata(deviceId));
+		}
+	});
+}
+
+function isPreservedSyncConfig(row: PBSyncConfig | DeviceInfo): boolean {
+	return row.key === "sync_config" && row.userId === null;
+}
+
+/** Name every table that still holds data, apart from the preserved sync_config row. */
+async function findSurvivingTables(db: GsdDatabase): Promise<string[]> {
+	return db.transaction("r", db.tables, async () => {
+		const userTables = db.tables.filter((table) => table.name !== "syncMetadata");
+		const counts = await Promise.all(userTables.map((table) => table.count()));
+		const survivors = userTables.filter((_, index) => counts[index] > 0).map((table) => table.name);
+		const metadata = await db.syncMetadata.toArray();
+		return metadata.every(isPreservedSyncConfig) ? survivors : [...survivors, "syncMetadata"];
+	});
+}
+
+/** Why the clear cannot be trusted, or null when every table is empty. */
+async function findWipeProblem(db: GsdDatabase, cleared: string[]): Promise<string | null> {
+	try {
+		await clearTables(db, cleared);
+		const survivors = await findSurvivingTables(db);
+		return survivors.length > 0 ? `rows survived in ${survivors.join(", ")}` : null;
+	} catch (err) {
+		logger.error("Failed to clear IndexedDB", err instanceof Error ? err : undefined, {
+			errorMessage: errorMessage(err),
+		});
+		return errorMessage(err);
+	}
+}
+
+/**
+ * Dexie leaves a blocked delete pending until the other connection closes, which
+ * could hang reset forever. Fail instead, so the lock screen can offer a retry.
+ */
+function deleteUnlessBlocked(db: GsdDatabase): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const onBlocked = () => reject(new Error("another open tab is blocking it"));
+		db.on("blocked", onBlocked);
+		// Keep auto-open, so this document can read an empty database without a reload.
+		db.delete({ disableAutoOpen: false })
+			.then(resolve, reject)
+			.finally(() => db.on("blocked").unsubscribe(onBlocked));
+	});
+}
+
+async function deleteDatabase(db: GsdDatabase): Promise<void> {
+	await deleteUnlessBlocked(db);
+	if (await Dexie.exists(db.name)) {
+		throw new Error("the database still exists after delete");
+	}
+}
+
+/**
+ * Clear local data and prove it is gone. The step fails only when both the
+ * clear and the database delete fail, and then errors name both.
+ */
+export async function wipeLocalData(): Promise<LocalDataWipeResult> {
+	const db = getDb();
+	const cleared: string[] = [];
+	const problem = await findWipeProblem(db, cleared);
+	if (problem === null) {
+		logger.info("IndexedDB cleared successfully", { clearedTables: cleared });
+		return { tables: cleared, errors: [] };
+	}
+
+	logger.warn("Deleting IndexedDB after an unverified clear", { errorMessage: problem });
+	try {
+		await deleteDatabase(db);
+		return { tables: db.tables.map((table) => table.name), errors: [] };
+	} catch (err) {
+		logger.error("Failed to delete IndexedDB", err instanceof Error ? err : undefined, {
+			errorMessage: errorMessage(err),
+		});
+		return { tables: cleared, errors: [`IndexedDB: ${problem}`, `IndexedDB delete: ${errorMessage(err)}`] };
+	}
+}

--- a/lib/reset-lock.ts
+++ b/lib/reset-lock.ts
@@ -1,0 +1,101 @@
+/**
+ * Reset lock: a localStorage marker that keeps GSD locked while Reset
+ * Everything runs, and after a run that could not prove local data is gone.
+ * Components read it through useSyncExternalStore.
+ */
+
+export const RESET_PENDING_KEY = "gsd-reset-pending";
+
+export type ResetLockState = "unlocked" | "running" | "locked";
+
+const listeners = new Set<() => void>();
+let running = false;
+// Mirrors the stored marker, so this document stays locked when localStorage throws.
+let markerMirror: string | null = null;
+
+function readStoredMarker(): string | null {
+	try {
+		return window.localStorage.getItem(RESET_PENDING_KEY);
+	} catch {
+		// An unreadable store counts as no marker, so a browser with storage
+		// disabled never locks for good. The mirror still covers this document.
+		return null;
+	}
+}
+
+function writeStoredMarker(marker: string): void {
+	try {
+		window.localStorage.setItem(RESET_PENDING_KEY, marker);
+	} catch {
+		// The mirror keeps this document locked. The lock cannot survive a reload.
+	}
+}
+
+function removeStoredMarker(): void {
+	try {
+		window.localStorage.removeItem(RESET_PENDING_KEY);
+	} catch {
+		// Storage that throws holds no marker to remove.
+	}
+}
+
+function notifyListeners(): void {
+	listeners.forEach((listener) => listener());
+}
+
+/** Lock the app before a reset touches anything, and remember the theme choice for a retry. */
+export function startResetLock(preserveTheme: boolean): void {
+	markerMirror = JSON.stringify({ preserveTheme });
+	running = true;
+	writeStoredMarker(markerMirror);
+	notifyListeners();
+}
+
+/** Unlock only when local data is gone. Otherwise stay locked until a retry succeeds. */
+export function endResetLock(localDataDeleted: boolean): void {
+	running = false;
+	if (localDataDeleted) {
+		markerMirror = null;
+		removeStoredMarker();
+	} else if (markerMirror !== null && readStoredMarker() === null) {
+		// Another tab's successful retry may have removed the marker during this run.
+		writeStoredMarker(markerMirror);
+	}
+	notifyListeners();
+}
+
+export function subscribeToResetLock(onChange: () => void): () => void {
+	const handleStorage = (event: StorageEvent) => {
+		if (event.key === RESET_PENDING_KEY) onChange();
+	};
+	listeners.add(onChange);
+	window.addEventListener("storage", handleStorage);
+	return () => {
+		listeners.delete(onChange);
+		window.removeEventListener("storage", handleStorage);
+	};
+}
+
+export function getResetLockSnapshot(): ResetLockState {
+	if (running) return "running";
+	return markerMirror !== null || readStoredMarker() !== null ? "locked" : "unlocked";
+}
+
+/** The static export prerenders without storage, so the server never locks. */
+export function getResetLockServerSnapshot(): ResetLockState {
+	return "unlocked";
+}
+
+/** The theme choice of the pending reset. A missing or malformed marker keeps the theme. */
+export function readPendingPreserveTheme(): boolean {
+	const marker = readStoredMarker() ?? markerMirror;
+	if (marker === null) return true;
+	try {
+		const parsed: unknown = JSON.parse(marker);
+		const preserveTheme = (parsed as { preserveTheme?: unknown } | null)?.preserveTheme;
+		return typeof preserveTheme === "boolean" ? preserveTheme : true;
+	} catch {
+		// A malformed marker still locks the app. Retry keeps the theme.
+		return true;
+	}
+}

--- a/lib/reset-lock.ts
+++ b/lib/reset-lock.ts
@@ -81,6 +81,15 @@ export function getResetLockSnapshot(): ResetLockState {
 	return markerMirror !== null || readStoredMarker() !== null ? "locked" : "unlocked";
 }
 
+/**
+ * True while a reset runs or waits for a retry. Effects that reach outside the
+ * page check it, because a page that loads locked hydrates the app once before
+ * the lock screen renders.
+ */
+export function isResetPending(): boolean {
+	return getResetLockSnapshot() !== "unlocked";
+}
+
 /** The static export prerenders without storage, so the server never locks. */
 export function getResetLockServerSnapshot(): ResetLockState {
 	return "unlocked";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "12.9.2",
+	"version": "12.9.3",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '12.9.2';
+const CACHE_VERSION = '12.9.3';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 

--- a/tasks/spec.md
+++ b/tasks/spec.md
@@ -1022,6 +1022,7 @@ When Reset Everything or account deletion cannot prove that local data is gone, 
 7. **Account deletion copy.** The failure toast in `DeleteAccountDialog` stops sending people to Reset Everything, because the lock screen now owns the retry.
 8. **A thrown step still ends the run.** `resetEverything` ends the lock in a `finally` block. If a step throws past its own error handling, the store leaves `"running"`, reports `"locked"`, and keeps the marker. The error still reaches the caller. Without this, the gate would show the progress state forever with no Try again.
 9. **No remount before the reload.** Once a gate instance has shown the lock, a later `"unlocked"` snapshot keeps the lock screen's progress state instead of remounting the app, so item 4's children rule applies only until then. A remount would let `FirstTimeRedirect` and the onboarding tour act on flags the reset just cleared. When the unlock comes from a reset that finished in this document, the gate reloads after `UI_TIMING.RESET_RELOAD_DELAY_MS`. That keeps a success toast readable, and it also reloads runs whose sign-out or browser-storage step failed. A document unlocked by another tab still reloads right away.
+10. **Hydration window.** The static export prerenders with the server snapshot `"unlocked"`. On a page that loads locked, React hydrates the app with that snapshot and runs its child effects once before the gate re-renders locked. Task titles never render, because they wait for IndexedDB, but effects that reach outside the page still run. So the notification checker, `WebMcpRegister`, and `FirstTimeRedirect` each check `isResetPending()` and do nothing while a reset is pending. The notification checker checks again right before it shows a notification, because the lock can begin while it waits for IndexedDB. The design rejects a Suspense hydration hold, because a top-level boundary could change how the whole app hydrates.
 
 ## Inputs / Outputs
 
@@ -1050,7 +1051,8 @@ When Reset Everything or account deletion cannot prove that local data is gone, 
 - **Only the browser-storage step fails.** No lock, and the existing toast is unchanged.
 - **Another tab holds the database open during the fallback.** Dexie closes its connection in other tabs on `versionchange`. If deletion is still blocked, the step fails, the app stays locked, and Try again can succeed later.
 - **Two tabs retry at once.** Each run writes the marker at start and makes sure it is present on failure, so a success in one tab cannot unlock a tab whose run failed.
-- **WebMCP `create_task` during a lock** that began after registration. The row lands in IndexedDB, the next retry's verification finds it, and the fallback deletes the database. A document that loads locked never registers WebMCP.
+- **WebMCP `create_task` during a lock** that began after registration. The row lands in IndexedDB, the next retry's verification finds it, and the fallback deletes the database. A document that loads locked still hydrates `WebMcpRegister` once (see Design item 10), and its reset-pending check keeps it from registering tools.
+- **Sync on a locked load.** `SyncProvider` also hydrates once but keeps no reset-pending check. It starts only when `isAuthenticated()` returns true and the sync config is enabled. On a locked load, that requires sign-out, the local wipe, and the storage cleanup to all have failed.
 - **Offline.** Reset is local, so the lock works the same way.
 - **Empty database.** Verification passes and the marker is removed.
 - **Schema migration.** After a fallback delete, the next open runs every version upgrade from scratch on an empty database.
@@ -1092,6 +1094,7 @@ When Reset Everything or account deletion cannot prove that local data is gone, 
 20. After a reset that ran in this document removes the lock, the gate keeps the lock screen instead of remounting the app and reloads after the reset reload delay. A document unlocked by another tab reloads without remounting the app.
 21. If a reset step throws, the store leaves the running state, reports locked, and keeps the marker.
 22. The lock screen's main landmark is named by its visible message, focus moves to it whenever the screen switches between progress and locked, and Try again is replaced by the progress state as soon as a retry starts.
+23. Effects that reach outside the page do nothing while a reset is pending, including the hydration pass before the lock renders: the notification checker shows no notification (checked again right before showing), WebMCP registers no tools, and FirstTimeRedirect neither redirects nor sets its flag.
 
 ## Implementation order
 
@@ -1180,4 +1183,5 @@ it("should_not_mention_reset_everything_when_local_erase_fails", async () => {})
 | 20 | should_keep_the_lock_screen_and_reload_after_the_delay_when_a_local_reset_unlocks, should_reload_without_remounting_the_app_when_another_tab_unlocks |
 | 21 | should_end_locked_and_rethrow_when_a_step_throws |
 | 22 | should_name_the_lock_screen_by_its_visible_message, should_move_focus_to_the_locked_message_when_a_reset_fails_here, should_replace_try_again_with_progress_as_soon_as_a_retry_starts |
+| 23 | should_not_notify_or_mark_a_due_task_when_a_reset_is_pending, should_not_notify_when_a_reset_begins_while_tasks_load, should_not_register_tools_while_a_reset_is_pending, should_not_redirect_or_set_the_launch_flag_while_a_reset_is_pending |
 | 11, 15, 16 | `tests/e2e/reset-lock.spec.ts` (Playwright) covers AC11 and AC15 in a real browser, and AC16 across two tabs |

--- a/tasks/spec.md
+++ b/tasks/spec.md
@@ -1020,6 +1020,8 @@ When Reset Everything or account deletion cannot prove that local data is gone, 
 5. **Lock screen.** The heading reads "Reset didn't finish". The body reads "Your tasks are still saved in this browser. GSD stays locked until they're deleted." One primary button, "Try again", reruns `resetEverything` with the stored `preserveTheme` and calls `reloadAfterReset` on success. A failed retry keeps the lock and announces the error in a `role="alert"` region. The footer hint reads "If this keeps failing, clear this site's data in your browser settings." The progress state reads "Deleting your data…" and shows no buttons. There is no cancel, export, or navigation control.
 6. **Other tabs.** A `storage` event that sets the marker locks every other open tab. A locked tab that sees the marker removed reloads through `reloadAfterReset`, because its in-memory stores and database connection predate the wipe.
 7. **Account deletion copy.** The failure toast in `DeleteAccountDialog` stops sending people to Reset Everything, because the lock screen now owns the retry.
+8. **A thrown step still ends the run.** `resetEverything` ends the lock in a `finally` block. If a step throws past its own error handling, the store leaves `"running"`, reports `"locked"`, and keeps the marker. The error still reaches the caller. Without this, the gate would show the progress state forever with no Try again.
+9. **No remount before the reload.** Once a gate instance has shown the lock, a later `"unlocked"` snapshot keeps the lock screen's progress state instead of remounting the app, so item 4's children rule applies only until then. A remount would let `FirstTimeRedirect` and the onboarding tour act on flags the reset just cleared. When the unlock comes from a reset that finished in this document, the gate reloads after `UI_TIMING.RESET_RELOAD_DELAY_MS`. That keeps a success toast readable, and it also reloads runs whose sign-out or browser-storage step failed. A document unlocked by another tab still reloads right away.
 
 ## Inputs / Outputs
 
@@ -1027,7 +1029,7 @@ When Reset Everything or account deletion cannot prove that local data is gone, 
 - `ResetStep` stays `"sync-sign-out" | "local-data" | "browser-storage"`.
 - New localStorage key `gsd-reset-pending` with the value `{"preserveTheme": boolean}`. A missing or unparsable `preserveTheme` defaults to `true`.
 - Lock state snapshot: `"unlocked" | "running" | "locked"`.
-- No Dexie schema change. The database stays at version 15, and no Zod schema in `lib/schema.ts` changes.
+- The Dexie schema and its version do not change, and no Zod schema in `lib/schema.ts` changes.
 
 ## Constraints
 
@@ -1087,6 +1089,9 @@ When Reset Everything or account deletion cannot prove that local data is gone, 
 17. `app/layout.tsx` places `ClientLayout`, `FirstTimeRedirect`, `OnboardingGate`, and `WebMcpRegister` inside the gate, and `PwaRegister`, `PwaUpdateToast`, `GlobalErrorListener`, `SentryInit`, and `ThemedToaster` outside it.
 18. The local-erase failure toast in `DeleteAccountDialog` no longer mentions Reset Everything.
 19. The existing reset suites still pass: dialog copy, `failedSteps` order, device ID preservation on the normal path, and the stale-sync fence.
+20. After a reset that ran in this document removes the lock, the gate keeps the lock screen instead of remounting the app and reloads after the reset reload delay. A document unlocked by another tab reloads without remounting the app.
+21. If a reset step throws, the store leaves the running state, reports locked, and keeps the marker.
+22. The lock screen's main landmark is named by its visible message, focus moves to it whenever the screen switches between progress and locked, and Try again is replaced by the progress state as soon as a retry starts.
 
 ## Implementation order
 
@@ -1172,3 +1177,6 @@ it("should_not_mention_reset_everything_when_local_erase_fails", async () => {})
 | 17 | should_mount_data_surfaces_inside_the_gate_and_chrome_outside_it |
 | 18 | should_not_mention_reset_everything_when_local_erase_fails |
 | 19 | the existing reset suites, plus should_preserve_the_device_id_when_the_normal_wipe_succeeds |
+| 20 | should_keep_the_lock_screen_and_reload_after_the_delay_when_a_local_reset_unlocks, should_reload_without_remounting_the_app_when_another_tab_unlocks |
+| 21 | should_end_locked_and_rethrow_when_a_step_throws |
+| 22 | should_name_the_lock_screen_by_its_visible_message, should_move_focus_to_the_locked_message_when_a_reset_fails_here, should_replace_try_again_with_progress_as_soon_as_a_retry_starts |

--- a/tasks/spec.md
+++ b/tasks/spec.md
@@ -1180,3 +1180,4 @@ it("should_not_mention_reset_everything_when_local_erase_fails", async () => {})
 | 20 | should_keep_the_lock_screen_and_reload_after_the_delay_when_a_local_reset_unlocks, should_reload_without_remounting_the_app_when_another_tab_unlocks |
 | 21 | should_end_locked_and_rethrow_when_a_step_throws |
 | 22 | should_name_the_lock_screen_by_its_visible_message, should_move_focus_to_the_locked_message_when_a_reset_fails_here, should_replace_try_again_with_progress_as_soon_as_a_retry_starts |
+| 11, 15, 16 | `tests/e2e/reset-lock.spec.ts` (Playwright) covers AC11 and AC15 in a real browser, and AC16 across two tabs |

--- a/tasks/spec.md
+++ b/tasks/spec.md
@@ -993,3 +993,182 @@ in the v6.1.0 refactor (`a21cc99`); only its two re-exports and its own tests
 referenced it. The owner asked to resolve it, so it is deleted with its
 re-exports and tests instead of fenced. Deleting it removes the write path, so
 no acceptance criterion changes. Typecheck proves nothing still imports it.
+
+# Spec: Fail closed when Reset Everything cannot delete local data
+
+Date: 2026-09-11. Source: Aikido "Incomplete Data Deletion" (group 45233789, sub-issue 669037088, Low). Retest #1 after #538 reported "Not fixed". The owner approved the design on 2026-09-11: lock the whole app, fall back to deleting the database, and offer no way out but deletion.
+
+## Goal
+
+When Reset Everything or account deletion cannot prove that local data is gone, GSD locks the whole app behind a retry screen until deletion succeeds, so nobody at a shared browser can see the previous user's tasks.
+
+## Background (verified in code on `b7185c2`)
+
+- `resetEverything` (`lib/reset-everything.ts`) signs out of sync first (`disableSync`). It then clears all 11 IndexedDB tables in one transaction and re-adds a preserved `sync_config` row that carries the device ID. Last, it removes app-owned localStorage keys.
+- Nothing checks the tables after that transaction commits. A thrown transaction only adds `local-data` to `failedSteps`.
+- On failure, `ResetEverythingDialog` shows a toast and clears `isResetting`, so the app stays usable. `DeleteAccountDialog` does the same and tells the user to run Reset Everything.
+- `useTasks` reads `db.tasks.toArray()` with no auth or reset check, and so do the dashboard, archive, trash, and settings surfaces.
+- `AppProviders` in `app/layout.tsx` mounts `ClientLayout` (the sync provider and every route), `FirstTimeRedirect`, `OnboardingGate`, and `WebMcpRegister` side by side. `OnboardingGate` already reads a localStorage flag through `useSyncExternalStore` and listens for `storage` events.
+- `clearLocalStorage` removes every `gsd-` and `gsd:` key, so a marker under those prefixes needs an explicit exemption.
+
+## Design
+
+1. **Reset-pending marker** (`lib/reset-lock.ts`, new). The localStorage key `gsd-reset-pending` holds `{"preserveTheme": boolean}`. An in-memory mirror keeps the current document locked when localStorage throws. The module exposes a store for `useSyncExternalStore` whose snapshot is one of `"unlocked"`, `"running"`, or `"locked"`, and it listens for `storage` events on the marker key. The server snapshot is `"unlocked"`, because the static export prerenders without storage.
+2. **Reset writes the marker first.** `resetEverything` sets the marker and the `"running"` state before `disableSync`. It removes the marker only when the local-data step succeeded. On failure it makes sure the marker is present, since another tab may have removed it, and moves to `"locked"`.
+3. **Verified wipe with a database-delete fallback.** After the clear transaction commits, reset counts every table except `syncMetadata` and confirms that `syncMetadata` holds nothing but the preserved `sync_config` row with a null `userId`. If the clear throws or any row survives, reset deletes the whole `GsdTaskManager` database and confirms it no longer exists. The device ID is lost on that path. The local-data step fails only when the fallback also fails, and then `errors` names both failures.
+4. **Whole-app gate** (`components/reset-lock-gate.tsx`, new). In `AppProviders`, the gate wraps `ClientLayout`, `FirstTimeRedirect`, `OnboardingGate`, and `WebMcpRegister`. `PwaRegister`, `PwaUpdateToast`, `GlobalErrorListener`, `SentryInit`, and `ThemedToaster` stay outside because they hold no task data. `"unlocked"` renders children, `"running"` renders the lock screen's progress state, and `"locked"` renders the lock screen.
+5. **Lock screen.** The heading reads "Reset didn't finish". The body reads "Your tasks are still saved in this browser. GSD stays locked until they're deleted." One primary button, "Try again", reruns `resetEverything` with the stored `preserveTheme` and calls `reloadAfterReset` on success. A failed retry keeps the lock and announces the error in a `role="alert"` region. The footer hint reads "If this keeps failing, clear this site's data in your browser settings." The progress state reads "Deleting your data…" and shows no buttons. There is no cancel, export, or navigation control.
+6. **Other tabs.** A `storage` event that sets the marker locks every other open tab. A locked tab that sees the marker removed reloads through `reloadAfterReset`, because its in-memory stores and database connection predate the wipe.
+7. **Account deletion copy.** The failure toast in `DeleteAccountDialog` stops sending people to Reset Everything, because the lock screen now owns the retry.
+
+## Inputs / Outputs
+
+- `ResetResult` keeps its shape: `success`, `clearedTables`, `clearedLocalStorage`, `errors`, and `failedSteps`. No new fields.
+- `ResetStep` stays `"sync-sign-out" | "local-data" | "browser-storage"`.
+- New localStorage key `gsd-reset-pending` with the value `{"preserveTheme": boolean}`. A missing or unparsable `preserveTheme` defaults to `true`.
+- Lock state snapshot: `"unlocked" | "running" | "locked"`.
+- No Dexie schema change. The database stays at version 15, and no Zod schema in `lib/schema.ts` changes.
+
+## Constraints
+
+- Privacy: the marker holds no task content, account identifier, or timestamp.
+- Sign-out stays step 1. The #538 session fence depends on sync being disabled before local writes stop.
+- No new dependencies. Dexie stays at 4.4.4.
+- Files stay at or under 350 lines and functions at or under 30 lines. `lib/reset-everything.ts` is 271 lines today, so the verify and fallback logic moves to a new module if adding it would cross the limit. `bun run quality:shape` must report no regressions.
+- Bundle: the gate is a small client component with no lazy chunk, and the lock screen reuses `Button` and Inkwell tokens.
+- The UI meets WCAG AA and matches the calm, restrained voice in `PRODUCT.md`.
+- Release trio: bump the patch version in `package.json`, `README.md` line 7, and `CACHE_VERSION` in `public/sw.js` together.
+
+## Edge Cases
+
+- **Tab closed mid-reset.** The marker survives, so the next load opens locked and Try again finishes the job.
+- **localStorage unavailable.** The in-memory mirror locks the current document, but the lock cannot return after a reload. That is an accepted residual risk. A throwing read counts as "no marker", so a browser with storage disabled is never locked permanently.
+- **Malformed marker value.** The app still locks, and Try again uses `preserveTheme: true`.
+- **Sign-out fails but the wipe succeeds.** No lock. The wipe replaces the sync config with a disabled row whose `userId` is null, and the #538 fence rejects stale sync writes. The existing toast still reports the failure.
+- **Only the browser-storage step fails.** No lock, and the existing toast is unchanged.
+- **Another tab holds the database open during the fallback.** Dexie closes its connection in other tabs on `versionchange`. If deletion is still blocked, the step fails, the app stays locked, and Try again can succeed later.
+- **Two tabs retry at once.** Each run writes the marker at start and makes sure it is present on failure, so a success in one tab cannot unlock a tab whose run failed.
+- **WebMCP `create_task` during a lock** that began after registration. The row lands in IndexedDB, the next retry's verification finds it, and the fallback deletes the database. A document that loads locked never registers WebMCP.
+- **Offline.** Reset is local, so the lock works the same way.
+- **Empty database.** Verification passes and the marker is removed.
+- **Schema migration.** After a fallback delete, the next open runs every version upgrade from scratch on an empty database.
+- **Sync conflicts, concurrent multi-device edits, and circular dependencies.** Not affected. Remote data is untouched, and reset writes no task rows.
+
+## Out of Scope
+
+- A cancel or "Keep my tasks" path. The owner chose "no way out but deletion".
+- Exporting data from the lock screen.
+- Changing the step order or `disableSync`.
+- Server-side deletion of tasks or accounts.
+- Clearing a leftover PocketBase auth token when both sign-out and the browser-storage step fail.
+- Locking on sign-out or browser-storage failures alone.
+- Any other copy in `DeleteAccountDialog` or `ResetEverythingDialog`.
+- A Playwright end-to-end test. Forcing an IndexedDB failure in a real browser is not reliable, so unit tests, UI tests, and a live check cover this change.
+- Asking Aikido to retest, which happens after merge.
+
+## Acceptance Criteria
+
+1. `resetEverything` writes `gsd-reset-pending` with the requested `preserveTheme` before it calls `disableSync`.
+2. After a verified wipe, the marker is gone, the state is `"unlocked"`, and `success` follows the existing `failedSteps` rule.
+3. When the clear transaction throws, reset deletes the database. If that succeeds, `failedSteps` omits `local-data`, the marker is gone, and the database no longer exists.
+4. When the clear commits but a user-data table still has rows, reset runs the same fallback.
+5. When the clear and the database delete both fail, `failedSteps` includes `local-data`, `errors` names both failures, the marker is present, and the state is `"locked"`.
+6. The browser-storage step removes other app-owned keys and leaves `gsd-reset-pending` in place.
+7. After a successful fallback, the next `getDb()` read in the same document returns an empty `tasks` table without throwing.
+8. When localStorage throws, reset still runs, and the store reports `"running"` during the run and `"locked"` after a local-data failure.
+9. The store reports `"locked"` when a marker exists at load, and a malformed marker still locks with `preserveTheme` defaulting to `true`.
+10. The gate renders its children when no reset is pending.
+11. With a marker present at mount, the gate renders the lock screen and never renders a task title seeded in IndexedDB.
+12. While a reset runs in the current document, the gate shows the progress state with no buttons.
+13. Try again calls `resetEverything` with the stored `preserveTheme` and calls `reloadAfterReset` on success.
+14. A failed Try again keeps the lock screen and announces the error in a `role="alert"` region.
+15. The lock screen offers exactly one control, Try again, with no cancel, export, or navigation.
+16. A `storage` event that sets the marker locks the current document, and a locked document reloads when a `storage` event removes the marker.
+17. `app/layout.tsx` places `ClientLayout`, `FirstTimeRedirect`, `OnboardingGate`, and `WebMcpRegister` inside the gate, and `PwaRegister`, `PwaUpdateToast`, `GlobalErrorListener`, `SentryInit`, and `ThemedToaster` outside it.
+18. The local-erase failure toast in `DeleteAccountDialog` no longer mentions Reset Everything.
+19. The existing reset suites still pass: dialog copy, `failedSteps` order, device ID preservation on the normal path, and the stale-sync fence.
+
+## Implementation order
+
+1. Commit this spec.
+2. Reset lock store in `lib/reset-lock.ts` (AC8 store half, AC9, AC16 store half).
+3. Verified wipe with the database-delete fallback (AC3, AC4, AC7, and the device ID half of AC19).
+4. Wire the marker and the verified wipe into `resetEverything` (AC1, AC2, AC5, AC6, AC8).
+5. Gate and lock screen (AC10 to AC16).
+6. Root layout wiring and its source guard test (AC17).
+7. Account deletion copy (AC18).
+8. Release trio bump, then full verification.
+
+## Test Stubs
+
+```ts
+// tests/data/reset-lock.test.ts
+describe("reset lock store", () => {
+  it("should_report_unlocked_when_no_marker_exists", () => {});
+  it("should_report_locked_when_a_marker_exists_at_load", () => {});
+  it("should_default_preserve_theme_to_true_when_the_marker_is_malformed", () => {});
+  it("should_keep_an_in_memory_lock_when_local_storage_throws", () => {});
+  it("should_notify_subscribers_when_another_tab_sets_the_marker", () => {});
+});
+
+// tests/data/reset-everything.test.ts (additions)
+describe("resetEverything reset lock", () => {
+  it("should_write_the_marker_before_signing_out", async () => {});
+  it("should_remove_the_marker_after_a_verified_wipe", async () => {});
+  it("should_keep_the_marker_when_clearing_app_local_storage", async () => {});
+  it("should_keep_the_marker_and_report_local_data_when_clear_and_delete_both_fail", async () => {});
+  it("should_report_running_then_locked_when_local_storage_throws", async () => {});
+});
+
+// tests/data/reset-local-data.test.ts (real Dexie on fake-indexeddb)
+describe("verified local wipe", () => {
+  it("should_delete_the_database_when_the_table_clear_throws", async () => {});
+  it("should_delete_the_database_when_rows_survive_the_clear", async () => {});
+  it("should_open_an_empty_database_after_the_fallback_delete", async () => {});
+  it("should_preserve_the_device_id_when_the_normal_wipe_succeeds", async () => {});
+});
+
+// tests/ui/reset-lock-gate.test.tsx
+describe("ResetLockGate", () => {
+  it("should_render_children_when_no_reset_is_pending", () => {});
+  it("should_show_the_lock_screen_and_hide_task_titles_when_a_reset_is_pending", async () => {});
+  it("should_show_progress_without_buttons_while_a_reset_runs", async () => {});
+  it("should_retry_with_the_stored_theme_choice_and_reload_on_success", async () => {});
+  it("should_stay_locked_and_announce_the_error_when_retry_fails", async () => {});
+  it("should_offer_no_control_except_try_again", () => {});
+  it("should_lock_when_another_tab_sets_the_marker", async () => {});
+  it("should_reload_when_another_tab_removes_the_marker", async () => {});
+});
+
+// tests/data/app-layout-reset-gate.test.ts
+describe("root layout reset gate", () => {
+  it("should_mount_data_surfaces_inside_the_gate_and_chrome_outside_it", () => {});
+});
+
+// tests/ui/delete-account-dialog.test.tsx (addition)
+it("should_not_mention_reset_everything_when_local_erase_fails", async () => {});
+```
+
+## Acceptance criteria to test map
+
+| AC | Tests |
+|---|---|
+| 1 | should_write_the_marker_before_signing_out |
+| 2 | should_remove_the_marker_after_a_verified_wipe |
+| 3 | should_delete_the_database_when_the_table_clear_throws |
+| 4 | should_delete_the_database_when_rows_survive_the_clear |
+| 5 | should_keep_the_marker_and_report_local_data_when_clear_and_delete_both_fail |
+| 6 | should_keep_the_marker_when_clearing_app_local_storage |
+| 7 | should_open_an_empty_database_after_the_fallback_delete |
+| 8 | should_keep_an_in_memory_lock_when_local_storage_throws, should_report_running_then_locked_when_local_storage_throws |
+| 9 | should_report_locked_when_a_marker_exists_at_load, should_default_preserve_theme_to_true_when_the_marker_is_malformed |
+| 10 | should_render_children_when_no_reset_is_pending |
+| 11 | should_show_the_lock_screen_and_hide_task_titles_when_a_reset_is_pending |
+| 12 | should_show_progress_without_buttons_while_a_reset_runs |
+| 13 | should_retry_with_the_stored_theme_choice_and_reload_on_success |
+| 14 | should_stay_locked_and_announce_the_error_when_retry_fails |
+| 15 | should_offer_no_control_except_try_again |
+| 16 | should_notify_subscribers_when_another_tab_sets_the_marker, should_lock_when_another_tab_sets_the_marker, should_reload_when_another_tab_removes_the_marker |
+| 17 | should_mount_data_surfaces_inside_the_gate_and_chrome_outside_it |
+| 18 | should_not_mention_reset_everything_when_local_erase_fails |
+| 19 | the existing reset suites, plus should_preserve_the_device_id_when_the_normal_wipe_succeeds |

--- a/tests/data/app-layout-reset-gate.test.ts
+++ b/tests/data/app-layout-reset-gate.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Root layout reset gate (AC17).
+ *
+ * Every surface that reads or writes task data mounts inside ResetLockGate.
+ * Chrome that holds no task data stays outside, so toasts, error reporting,
+ * and the service worker keep working while the app is locked.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(__dirname, '../..');
+const INSIDE_GATE = ['<ClientLayout>', '<FirstTimeRedirect />', '<OnboardingGate />', '<WebMcpRegister />'];
+const OUTSIDE_GATE = ['<PwaRegister />', '<PwaUpdateToast />', '<GlobalErrorListener />', '<SentryInit />', '<ThemedToaster />'];
+
+function splitAtGate(layout: string): { inside: string; outside: string } {
+  const start = layout.indexOf('<ResetLockGate>');
+  const end = layout.indexOf('</ResetLockGate>');
+  if (start === -1 || end < start) return { inside: '', outside: layout };
+  return { inside: layout.slice(start, end), outside: layout.slice(0, start) + layout.slice(end) };
+}
+
+describe('root layout reset gate', () => {
+  it('should_mount_data_surfaces_inside_the_gate_and_chrome_outside_it', () => {
+    const { inside, outside } = splitAtGate(readFileSync(join(ROOT, 'app/layout.tsx'), 'utf8'));
+
+    const misplacedDataSurfaces = INSIDE_GATE.filter((tag) => !inside.includes(tag) || outside.includes(tag));
+    const misplacedChrome = OUTSIDE_GATE.filter((tag) => !outside.includes(tag) || inside.includes(tag));
+
+    expect({ misplacedDataSurfaces, misplacedChrome }).toEqual({ misplacedDataSurfaces: [], misplacedChrome: [] });
+  });
+});

--- a/tests/data/csp-static-export.test.ts
+++ b/tests/data/csp-static-export.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
@@ -61,6 +61,20 @@ describe("static export CSP hardening", () => {
     );
     expect(readFileSync("public/theme-init.js", "utf8")).toContain("initializeTheme");
     expect(readFileSync("lib/zod.ts", "utf8")).toContain("z.config({ jitless: true })");
+  });
+
+  it("imports zod only through lib/zod so jitless mode is set before any schema exists", () => {
+    // A module that imports zod directly can build its schemas before lib/zod.ts
+    // sets jitless, and zod's eval probe then trips the production CSP.
+    const directZodImport = /from\s+["']zod(?:\/[\w-]+)?["']/;
+    const offenders = ["lib", "components", "app"].flatMap((directory) =>
+      readdirSync(directory, { recursive: true, encoding: "utf8" })
+        .filter((file) => /\.tsx?$/.test(file))
+        .map((file) => join(directory, file))
+        .filter((path) => path !== join("lib", "zod.ts") && directZodImport.test(readFileSync(path, "utf8"))),
+    );
+
+    expect(offenders).toEqual([]);
   });
 
   it("runs a production browser smoke test in blocking Chromium CI", () => {

--- a/tests/data/notification-checker.test.ts
+++ b/tests/data/notification-checker.test.ts
@@ -634,4 +634,50 @@ describe("NotificationChecker", () => {
 			expect(count).toBe(1); // Only task1 with custom window
 		});
 	});
+
+	describe("while a reset is pending", () => {
+		const RESET_PENDING_KEY = "gsd-reset-pending";
+		const PENDING_MARKER = '{"preserveTheme":true}';
+		const dueTask = () =>
+			createTask({
+				id: "task-private",
+				dueDate: new Date("2025-01-15T12:10:00Z").toISOString(), // 10 minutes from now
+			});
+
+		beforeEach(() => {
+			localStorage.removeItem(RESET_PENDING_KEY);
+			vi.setSystemTime(new Date("2025-01-15T12:00:00Z"));
+		});
+
+		afterEach(() => {
+			localStorage.removeItem(RESET_PENDING_KEY);
+		});
+
+		it("should_not_notify_or_mark_a_due_task_when_a_reset_is_pending", async () => {
+			localStorage.setItem(RESET_PENDING_KEY, PENDING_MARKER);
+			const task = dueTask();
+			mockDb.tasks.toArray.mockResolvedValue([task]);
+			mockDb.tasks.get.mockResolvedValue(task);
+
+			await notificationChecker.checkAndNotify();
+
+			expect(notifications.showTaskNotification).not.toHaveBeenCalled();
+			expect(mockDb.tasks.put).not.toHaveBeenCalled();
+		});
+
+		it("should_not_notify_when_a_reset_begins_while_tasks_load", async () => {
+			const task = dueTask();
+			// The lock begins while the checker waits for IndexedDB.
+			mockDb.tasks.toArray.mockImplementation(async () => {
+				localStorage.setItem(RESET_PENDING_KEY, PENDING_MARKER);
+				return [task];
+			});
+			mockDb.tasks.get.mockResolvedValue(task);
+
+			await notificationChecker.checkAndNotify();
+
+			expect(notifications.showTaskNotification).not.toHaveBeenCalled();
+			expect(mockDb.tasks.put).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/tests/data/reset-everything.test.ts
+++ b/tests/data/reset-everything.test.ts
@@ -29,7 +29,7 @@ const {
 }));
 
 vi.mock('@/lib/db', () => ({
-  getDb: () => ({
+  getDb: vi.fn(() => ({
     name: 'GsdTaskManager',
     delete: mockDeleteDatabase,
     // The delete fallback subscribes to Dexie's blocked event before it deletes.
@@ -64,7 +64,7 @@ vi.mock('@/lib/db', () => ({
       { clear: mockClear, count: mockCount, name: 'syncHistory' },
       { clear: mockClear, count: mockCount, name: 'appPreferences' },
     ],
-  }),
+  })),
 }));
 
 vi.mock('@/lib/sync/config', () => ({
@@ -87,6 +87,7 @@ vi.mock('@/lib/logger', () => ({
 
 import { resetEverything, reloadAfterReset } from '@/lib/reset-everything';
 import { getResetLockSnapshot } from '@/lib/reset-lock';
+import { getDb } from '@/lib/db';
 
 describe('reset-everything', () => {
   beforeEach(() => {
@@ -388,6 +389,16 @@ describe('reset-everything', () => {
       ]));
       expect(readMarker()).toEqual({ preserveTheme: false });
       expect(getResetLockSnapshot()).toBe('locked');
+    });
+
+    it('should_end_locked_and_rethrow_when_a_step_throws', async () => {
+      vi.mocked(getDb).mockImplementationOnce(() => {
+        throw new Error('IndexedDB is not available in this environment.');
+      });
+
+      await expect(resetEverything({ preserveTheme: true })).rejects.toThrow('IndexedDB is not available');
+      expect(getResetLockSnapshot()).toBe('locked');
+      expect(readMarker()).toEqual({ preserveTheme: true });
     });
 
     it('should_report_running_then_locked_when_local_storage_throws', async () => {

--- a/tests/data/reset-everything.test.ts
+++ b/tests/data/reset-everything.test.ts
@@ -12,16 +12,26 @@ const {
   mockClear,
   mockAdd,
   mockResetFeedbackState,
+  mockCount,
+  mockToArray,
+  mockDeleteDatabase,
 } = vi.hoisted(() => ({
   mockDisableSync: vi.fn().mockResolvedValue(undefined),
   mockGetSyncConfig: vi.fn().mockResolvedValue(null),
   mockClear: vi.fn().mockResolvedValue(undefined),
   mockAdd: vi.fn().mockResolvedValue(undefined),
   mockResetFeedbackState: vi.fn(),
+  mockCount: vi.fn().mockResolvedValue(0),
+  mockToArray: vi.fn().mockResolvedValue([]),
+  // No IndexedDB sits behind this mock, so the database delete fallback fails
+  // here. tests/data/reset-local-data.test.ts covers a fallback that succeeds.
+  mockDeleteDatabase: vi.fn().mockRejectedValue(new Error('delete unavailable')),
 }));
 
 vi.mock('@/lib/db', () => ({
   getDb: () => ({
+    name: 'GsdTaskManager',
+    delete: mockDeleteDatabase,
     transaction: vi.fn(async (...args: unknown[]) => (args.at(-1) as () => Promise<unknown>)()),
     tasks: { clear: mockClear, name: 'tasks' },
     archivedTasks: { clear: mockClear, name: 'archivedTasks' },
@@ -36,20 +46,21 @@ vi.mock('@/lib/db', () => ({
     syncMetadata: {
       clear: mockClear,
       add: mockAdd,
+      toArray: mockToArray,
       name: 'syncMetadata',
     },
     tables: [
-      { clear: mockClear, name: 'tasks' },
-      { clear: mockClear, name: 'archivedTasks' },
-      { clear: mockClear, name: 'deletedTasks' },
-      { clear: mockClear, name: 'smartViews' },
-      { clear: mockClear, name: 'notificationSettings' },
-      { clear: mockClear, name: 'syncQueue' },
-      { clear: mockClear, name: 'syncMetadata' },
-      { clear: mockClear, name: 'deviceInfo' },
-      { clear: mockClear, name: 'archiveSettings' },
-      { clear: mockClear, name: 'syncHistory' },
-      { clear: mockClear, name: 'appPreferences' },
+      { clear: mockClear, count: mockCount, name: 'tasks' },
+      { clear: mockClear, count: mockCount, name: 'archivedTasks' },
+      { clear: mockClear, count: mockCount, name: 'deletedTasks' },
+      { clear: mockClear, count: mockCount, name: 'smartViews' },
+      { clear: mockClear, count: mockCount, name: 'notificationSettings' },
+      { clear: mockClear, count: mockCount, name: 'syncQueue' },
+      { clear: mockClear, count: mockCount, name: 'syncMetadata' },
+      { clear: mockClear, count: mockCount, name: 'deviceInfo' },
+      { clear: mockClear, count: mockCount, name: 'archiveSettings' },
+      { clear: mockClear, count: mockCount, name: 'syncHistory' },
+      { clear: mockClear, count: mockCount, name: 'appPreferences' },
     ],
   }),
 }));

--- a/tests/data/reset-everything.test.ts
+++ b/tests/data/reset-everything.test.ts
@@ -32,6 +32,8 @@ vi.mock('@/lib/db', () => ({
   getDb: () => ({
     name: 'GsdTaskManager',
     delete: mockDeleteDatabase,
+    // The delete fallback subscribes to Dexie's blocked event before it deletes.
+    on: vi.fn(() => ({ unsubscribe: vi.fn() })),
     transaction: vi.fn(async (...args: unknown[]) => (args.at(-1) as () => Promise<unknown>)()),
     tasks: { clear: mockClear, name: 'tasks' },
     archivedTasks: { clear: mockClear, name: 'archivedTasks' },
@@ -84,6 +86,7 @@ vi.mock('@/lib/logger', () => ({
 }));
 
 import { resetEverything, reloadAfterReset } from '@/lib/reset-everything';
+import { getResetLockSnapshot } from '@/lib/reset-lock';
 
 describe('reset-everything', () => {
   beforeEach(() => {
@@ -93,7 +96,7 @@ describe('reset-everything', () => {
     for (const key of [
       'pocketbase_auth', 'gsd-pwa-dismissed', 'theme', 'gsd-theme',
       'gsd:feedback:draft', 'gsd:feedback:last-sent',
-      'gsd:feedback:nudge-dismissed', 'gsd-onboarding-seen',
+      'gsd:feedback:nudge-dismissed', 'gsd-onboarding-seen', 'gsd-reset-pending',
     ]) {
       localStorage.removeItem(key);
     }
@@ -297,6 +300,109 @@ describe('reset-everything', () => {
       const result = await resetEverything();
 
       expect(result).toMatchObject({ success: true, failedSteps: [] });
+    });
+  });
+
+  describe('resetEverything reset lock', () => {
+    const MARKER_KEY = 'gsd-reset-pending';
+
+    function readMarker(): unknown {
+      const marker = localStorage.getItem(MARKER_KEY);
+      return marker === null ? null : JSON.parse(marker);
+    }
+
+    it('should_write_the_marker_before_signing_out', async () => {
+      let markerAtSignOut: unknown = null;
+      mockDisableSync.mockImplementationOnce(async () => {
+        markerAtSignOut = readMarker();
+      });
+
+      await resetEverything({ preserveTheme: true });
+
+      expect(markerAtSignOut).toEqual({ preserveTheme: true });
+    });
+
+    it('should_remove_the_marker_after_a_verified_wipe', async () => {
+      let markerDuringWipe: string | null = null;
+      mockCount.mockImplementationOnce(async () => {
+        markerDuringWipe = localStorage.getItem(MARKER_KEY);
+        return 0;
+      });
+
+      const result = await resetEverything();
+
+      // Without a marker during the wipe, its absence afterwards would prove nothing.
+      expect(markerDuringWipe).not.toBeNull();
+      expect(localStorage.getItem(MARKER_KEY)).toBeNull();
+      expect(getResetLockSnapshot()).toBe('unlocked');
+      expect(result).toMatchObject({ success: true, failedSteps: [] });
+    });
+
+    it('should_unlock_when_only_sign_out_fails', async () => {
+      mockDisableSync.mockRejectedValueOnce(new Error('sync error'));
+      let stateDuringWipe: string | null = null;
+      mockCount.mockImplementationOnce(async () => {
+        stateDuringWipe = getResetLockSnapshot();
+        return 0;
+      });
+
+      const result = await resetEverything();
+
+      expect(result).toMatchObject({ success: false, failedSteps: ['sync-sign-out'] });
+      expect([stateDuringWipe, getResetLockSnapshot()]).toEqual(['running', 'unlocked']);
+    });
+
+    it('should_keep_the_marker_when_clearing_app_local_storage', async () => {
+      localStorage.setItem('gsd-onboarding-seen', 'true');
+      let markerAfterStorageStep: string | null = null;
+      mockResetFeedbackState.mockImplementationOnce(() => {
+        markerAfterStorageStep = localStorage.getItem(MARKER_KEY);
+      });
+
+      const result = await resetEverything({ preserveTheme: true });
+
+      expect(result.clearedLocalStorage).toContain('gsd-onboarding-seen');
+      expect(result.clearedLocalStorage).not.toContain(MARKER_KEY);
+      expect(markerAfterStorageStep).not.toBeNull();
+    });
+
+    it('should_keep_the_marker_and_report_local_data_when_clear_and_delete_both_fail', async () => {
+      mockClear.mockRejectedValueOnce(new Error('DB clear failed'));
+      mockDeleteDatabase.mockRejectedValueOnce(new Error('delete blocked'));
+
+      const result = await resetEverything({ preserveTheme: false });
+
+      expect(result.failedSteps).toContain('local-data');
+      expect(result.errors).toEqual(expect.arrayContaining([
+        expect.stringContaining('DB clear failed'),
+        expect.stringContaining('delete blocked'),
+      ]));
+      expect(readMarker()).toEqual({ preserveTheme: false });
+      expect(getResetLockSnapshot()).toBe('locked');
+    });
+
+    it('should_report_running_then_locked_when_local_storage_throws', async () => {
+      const denied = () => {
+        throw new Error('SecurityError');
+      };
+      const storageSpies = [
+        vi.spyOn(window.localStorage, 'getItem').mockImplementation(denied),
+        vi.spyOn(window.localStorage, 'setItem').mockImplementation(denied),
+        vi.spyOn(window.localStorage, 'removeItem').mockImplementation(denied),
+      ];
+      let stateDuringRun: string | null = null;
+      mockDisableSync.mockImplementationOnce(async () => {
+        stateDuringRun = getResetLockSnapshot();
+      });
+      mockClear.mockRejectedValueOnce(new Error('DB clear failed'));
+
+      try {
+        await resetEverything();
+
+        expect([stateDuringRun, getResetLockSnapshot()]).toEqual(['running', 'locked']);
+      } finally {
+        storageSpies.forEach((spy) => spy.mockRestore());
+      }
     });
   });
 

--- a/tests/data/reset-everything.test.ts
+++ b/tests/data/reset-everything.test.ts
@@ -296,6 +296,15 @@ describe('reset-everything', () => {
       expect(result.failedSteps).toEqual(['sync-sign-out', 'local-data']);
     });
 
+    it('should_run_the_delete_fallback_when_sync_metadata_keeps_an_account_row', async () => {
+      mockToArray.mockResolvedValueOnce([{ key: 'sync_config', userId: 'user-1' }]);
+
+      const result = await resetEverything();
+
+      expect(mockDeleteDatabase).toHaveBeenCalledTimes(1);
+      expect(result.errors).toContain('IndexedDB: rows survived in syncMetadata');
+    });
+
     it('should_report_success_only_when_no_step_failed', async () => {
       const result = await resetEverything();
 

--- a/tests/data/reset-local-data.test.ts
+++ b/tests/data/reset-local-data.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Verified local wipe (AC3, AC4, AC7, and the device ID half of AC19).
+ *
+ * Runs the real resetEverything against fake-indexeddb, so Dexie's clear,
+ * count, delete, and reopen behave as they do in a browser. Only the network
+ * edge, health monitor, and browser caches are mocked.
+ * tests/data/reset-everything.test.ts mocks the database, so it cannot host these checks.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Dexie, { type Table } from 'dexie';
+import { getDb } from '@/lib/db';
+import { createMockSyncConfig, createMockTask } from '@/tests/fixtures';
+import type { PBSyncConfig } from '@/lib/sync/types';
+
+vi.mock('@/lib/sync/pocketbase-client', () => ({
+  getPocketBase: vi.fn(),
+  getCurrentUserId: () => null,
+  isAuthenticated: () => false,
+  clearPocketBase: vi.fn(),
+}));
+
+vi.mock('@/lib/sync/health-monitor', () => ({
+  getHealthMonitor: () => ({ isActive: () => false, stop: vi.fn() }),
+}));
+
+vi.mock('@/lib/browser-cache', () => ({
+  clearAppCaches: vi.fn().mockResolvedValue([]),
+}));
+
+import { resetEverything } from '@/lib/reset-everything';
+
+const DATABASE_NAME = 'GsdTaskManager';
+const RESET_PENDING_KEY = 'gsd-reset-pending';
+
+type AnyTable = Table<unknown, string>;
+// Every Dexie table shares this prototype, so one spy reaches the clear inside reset's transaction.
+const tablePrototype = Object.getPrototypeOf(getDb().tasks) as AnyTable;
+const originalClear = tablePrototype.clear;
+
+/** Make the tasks table's clear throw, or resolve while leaving its rows in place. */
+function breakTasksClear(mode: 'throw' | 'leave-rows'): void {
+  vi.spyOn(tablePrototype, 'clear').mockImplementation(function (this: AnyTable) {
+    if (this.name !== 'tasks') return originalClear.call(this);
+    const outcome = mode === 'throw'
+      ? Dexie.Promise.reject(new Error('tasks clear failed'))
+      : Dexie.Promise.resolve();
+    return outcome as ReturnType<AnyTable['clear']>;
+  });
+}
+
+/** Open a raw connection that ignores versionchange, like a tab that never lets go. */
+function openBlockingConnection(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DATABASE_NAME);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+describe('verified local wipe', () => {
+  beforeEach(async () => {
+    localStorage.removeItem(RESET_PENDING_KEY);
+    const db = getDb();
+    await Promise.all(db.tables.map((table) => table.clear()));
+    await db.tasks.add(createMockTask({ id: 'task-private', title: 'Private task title' }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should_delete_the_database_when_the_table_clear_throws', async () => {
+    breakTasksClear('throw');
+
+    const result = await resetEverything();
+
+    expect(result.failedSteps).not.toContain('local-data');
+    expect(localStorage.getItem(RESET_PENDING_KEY)).toBeNull();
+    await expect(Dexie.exists(DATABASE_NAME)).resolves.toBe(false);
+  });
+
+  it('should_delete_the_database_when_rows_survive_the_clear', async () => {
+    breakTasksClear('leave-rows');
+
+    const result = await resetEverything();
+
+    expect(result.failedSteps).not.toContain('local-data');
+    await expect(Dexie.exists(DATABASE_NAME)).resolves.toBe(false);
+  });
+
+  it('should_open_an_empty_database_after_the_fallback_delete', async () => {
+    breakTasksClear('throw');
+    await resetEverything();
+    vi.restoreAllMocks();
+
+    await expect(getDb().tasks.toArray()).resolves.toEqual([]);
+  });
+
+  it('should_preserve_the_device_id_when_the_normal_wipe_succeeds', async () => {
+    await getDb().syncMetadata.put(createMockSyncConfig({ deviceId: 'device-kept', userId: 'user-1' }));
+
+    const result = await resetEverything();
+
+    const config = (await getDb().syncMetadata.get('sync_config')) as PBSyncConfig | undefined;
+    expect(result.failedSteps).not.toContain('local-data');
+    expect(config).toMatchObject({ deviceId: 'device-kept', userId: null, enabled: false });
+  });
+
+  it('should_fail_the_local_data_step_when_another_connection_blocks_the_delete', async () => {
+    const blocker = await openBlockingConnection();
+    breakTasksClear('throw');
+
+    try {
+      const result = await resetEverything();
+
+      expect(result.failedSteps).toContain('local-data');
+    } finally {
+      blocker.close();
+    }
+  });
+});

--- a/tests/data/reset-lock.test.ts
+++ b/tests/data/reset-lock.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for lib/reset-lock.ts, the reset-pending marker store that keeps GSD
+ * locked while Reset Everything runs or after it fails to delete local data.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const RESET_PENDING_KEY = 'gsd-reset-pending';
+
+type ResetLockModule = typeof import('@/lib/reset-lock');
+
+/** Import a fresh copy so in-memory lock state never leaks between tests. */
+async function loadResetLock(): Promise<ResetLockModule> {
+  vi.resetModules();
+  return import('@/lib/reset-lock');
+}
+
+function makeLocalStorageThrow(): void {
+  const denied = () => {
+    throw new Error('SecurityError');
+  };
+  vi.spyOn(window.localStorage, 'getItem').mockImplementation(denied);
+  vi.spyOn(window.localStorage, 'setItem').mockImplementation(denied);
+  vi.spyOn(window.localStorage, 'removeItem').mockImplementation(denied);
+}
+
+function dispatchMarkerEvent(newValue: string | null): void {
+  window.dispatchEvent(new StorageEvent('storage', { key: RESET_PENDING_KEY, newValue }));
+}
+
+describe('reset lock store', () => {
+  beforeEach(() => {
+    localStorage.removeItem(RESET_PENDING_KEY);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should_report_unlocked_when_no_marker_exists', async () => {
+    const { getResetLockSnapshot } = await loadResetLock();
+
+    expect(getResetLockSnapshot()).toBe('unlocked');
+  });
+
+  it('should_report_locked_when_a_marker_exists_at_load', async () => {
+    localStorage.setItem(RESET_PENDING_KEY, JSON.stringify({ preserveTheme: false }));
+
+    const { getResetLockSnapshot } = await loadResetLock();
+
+    expect(getResetLockSnapshot()).toBe('locked');
+  });
+
+  it('should_default_preserve_theme_to_true_when_the_marker_is_malformed', async () => {
+    localStorage.setItem(RESET_PENDING_KEY, '{not json');
+
+    const { getResetLockSnapshot, readPendingPreserveTheme } = await loadResetLock();
+
+    expect(getResetLockSnapshot()).toBe('locked');
+    expect(readPendingPreserveTheme()).toBe(true);
+  });
+
+  it('should_keep_an_in_memory_lock_when_local_storage_throws', async () => {
+    const { getResetLockSnapshot, startResetLock, endResetLock } = await loadResetLock();
+    makeLocalStorageThrow();
+
+    startResetLock(false);
+    const duringRun = getResetLockSnapshot();
+    endResetLock(false);
+
+    expect([duringRun, getResetLockSnapshot()]).toEqual(['running', 'locked']);
+  });
+
+  it('should_report_unlocked_when_local_storage_reads_throw', async () => {
+    const { getResetLockSnapshot } = await loadResetLock();
+    makeLocalStorageThrow();
+
+    expect(getResetLockSnapshot()).toBe('unlocked');
+  });
+
+  it('should_notify_subscribers_when_another_tab_sets_the_marker', async () => {
+    const { getResetLockSnapshot, subscribeToResetLock } = await loadResetLock();
+    const onChange = vi.fn();
+    const unsubscribe = subscribeToResetLock(onChange);
+
+    const marker = JSON.stringify({ preserveTheme: true });
+    localStorage.setItem(RESET_PENDING_KEY, marker);
+    dispatchMarkerEvent(marker);
+    unsubscribe();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(getResetLockSnapshot()).toBe('locked');
+  });
+
+  it('should_ignore_storage_events_for_other_keys', async () => {
+    const { subscribeToResetLock } = await loadResetLock();
+    const onChange = vi.fn();
+    const unsubscribe = subscribeToResetLock(onChange);
+
+    window.dispatchEvent(new StorageEvent('storage', { key: 'gsd-theme', newValue: 'dark' }));
+    unsubscribe();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('should_restore_the_marker_when_another_tab_removed_it_during_a_failed_run', async () => {
+    const { startResetLock, endResetLock } = await loadResetLock();
+
+    startResetLock(false);
+    localStorage.removeItem(RESET_PENDING_KEY);
+    endResetLock(false);
+
+    expect(JSON.parse(localStorage.getItem(RESET_PENDING_KEY) ?? 'null')).toEqual({ preserveTheme: false });
+  });
+});

--- a/tests/e2e/reset-lock.spec.ts
+++ b/tests/e2e/reset-lock.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * Reset lock in a real browser: AC11 and AC15, plus AC16 across two tabs.
+ *
+ * jsdom calls storage listeners synchronously, which hid a cross-tab reload bug
+ * that only a real browser's event order exposed. These tests drive the running
+ * app, so IndexedDB, localStorage, and the storage event behave as they do for users.
+ */
+
+import type { BrowserContext, Page } from "@playwright/test";
+import { test, expect } from "./fixtures/test-fixtures";
+import { MatrixPage } from "./pages/matrix-page";
+import { waitForAppLoad } from "./helpers/test-helpers";
+
+const RESET_PENDING_KEY = "gsd-reset-pending";
+const PENDING_MARKER = '{"preserveTheme":true}';
+const LOCKED_HEADING = "Reset didn't finish";
+const TASK_TITLE = "Private task behind the reset lock";
+// sessionStorage survives a same-tab reload, so the new document can read what the old one saw.
+const APP_SHOWN_WHILE_LOCKED = "e2e-app-shown-while-locked";
+
+function lockScreen(page: Page) {
+  return page.getByRole("main", { name: LOCKED_HEADING });
+}
+
+function taskCard(page: Page) {
+  return page.locator("[data-testid='task-card']").filter({ hasText: TASK_TITLE });
+}
+
+async function setPendingMarker(page: Page): Promise<void> {
+  await page.evaluate(([key, value]) => localStorage.setItem(key, value), [RESET_PENDING_KEY, PENDING_MARKER]);
+}
+
+async function removePendingMarker(page: Page): Promise<void> {
+  await page.evaluate((key) => localStorage.removeItem(key), RESET_PENDING_KEY);
+}
+
+async function readPendingMarker(page: Page): Promise<string | null> {
+  return page.evaluate((key) => localStorage.getItem(key), RESET_PENDING_KEY);
+}
+
+/** Count task rows in IndexedDB directly, whatever the UI renders. */
+async function countStoredTasks(page: Page): Promise<number> {
+  return page.evaluate(
+    () =>
+      new Promise<number>((resolve, reject) => {
+        const request = indexedDB.open("GsdTaskManager");
+        request.onerror = () => reject(request.error);
+        request.onsuccess = () => {
+          const db = request.result;
+          try {
+            const count = db.transaction("tasks").objectStore("tasks").count();
+            count.onsuccess = () => resolve(count.result);
+            count.onerror = () => reject(count.error);
+          } catch (error) {
+            reject(error);
+          } finally {
+            db.close();
+          }
+        };
+      })
+  );
+}
+
+/** Open a second tab on the app, set up the way the fixture sets up its page. */
+async function openSecondTab(context: BrowserContext): Promise<Page> {
+  const tab = await context.newPage();
+  // The fixture strips the service worker from its own page only. A real worker
+  // here could serve cached chunks across the reload this test depends on.
+  await tab.addInitScript(() => {
+    Reflect.deleteProperty(Navigator.prototype, "serviceWorker");
+  });
+  await new MatrixPage(tab).goto();
+  await waitForAppLoad(tab);
+  // Let this document's own load event pass, so the later wait sees only the reload.
+  await tab.waitForLoadState("load");
+  return tab;
+}
+
+/** Flag in sessionStorage if the matrix mounts while this document shows the lock. */
+async function watchForAppWhileLocked(page: Page): Promise<void> {
+  await page.evaluate((flag) => {
+    new MutationObserver(() => {
+      if (document.querySelector("[data-testid='matrix-grid']")) sessionStorage.setItem(flag, "true");
+    }).observe(document.body, { childList: true, subtree: true });
+  }, APP_SHOWN_WHILE_LOCKED);
+}
+
+test.describe("Reset lock", () => {
+  let matrixPage: MatrixPage;
+
+  test.beforeEach(async ({ page, clearIndexedDB }) => {
+    matrixPage = new MatrixPage(page);
+    await matrixPage.goto();
+    await waitForAppLoad(page);
+    await matrixPage.createTask(TASK_TITLE);
+  });
+
+  test("should lock the app and hide a stored task when a reset is pending", async ({ page }) => {
+    await setPendingMarker(page);
+
+    await page.reload();
+
+    await expect(page.getByRole("heading", { name: LOCKED_HEADING })).toBeVisible();
+    await expect(lockScreen(page).getByRole("button")).toHaveCount(1);
+    await expect(lockScreen(page).getByRole("button", { name: "Try again" })).toBeVisible();
+    await expect(page.getByText(TASK_TITLE)).toHaveCount(0);
+    expect(await countStoredTasks(page)).toBe(1);
+  });
+
+  test("should reload a locked tab without showing the app when another tab unlocks it", async ({ page, context }) => {
+    const otherTab = await openSecondTab(context);
+    await expect(taskCard(otherTab)).toBeVisible();
+
+    await setPendingMarker(page);
+    await expect(lockScreen(otherTab)).toBeVisible();
+    await watchForAppWhileLocked(otherTab);
+
+    const reloaded = otherTab.waitForEvent("load");
+    await removePendingMarker(page);
+    await reloaded;
+
+    await waitForAppLoad(otherTab);
+    await expect(taskCard(otherTab)).toBeVisible();
+    expect(await otherTab.evaluate((flag) => sessionStorage.getItem(flag), APP_SHOWN_WHILE_LOCKED)).toBeNull();
+  });
+
+  test("should delete stored tasks when Try again runs from the lock screen", async ({ page }) => {
+    await setPendingMarker(page);
+    await page.reload();
+    const tryAgain = lockScreen(page).getByRole("button", { name: "Try again" });
+    await expect(tryAgain).toBeVisible();
+
+    const reloaded = page.waitForEvent("load");
+    await tryAgain.click();
+    await reloaded;
+
+    await waitForAppLoad(page);
+    await expect(page.locator("[data-testid='task-card']")).toHaveCount(0);
+    expect(await readPendingMarker(page)).toBeNull();
+    expect(await countStoredTasks(page)).toBe(0);
+  });
+});

--- a/tests/ui/app-pages.test.tsx
+++ b/tests/ui/app-pages.test.tsx
@@ -190,3 +190,40 @@ describe('AboutPage', () => {
   });
 });
 
+/** Render the layout as a development build with a configured PocketBase URL, and return its CSP. */
+async function renderDevelopmentCsp(pocketBaseUrl: string): Promise<string> {
+  vi.stubEnv('NODE_ENV', 'development');
+  vi.stubEnv('NEXT_PUBLIC_POCKETBASE_URL', pocketBaseUrl);
+  try {
+    // The layout reads both variables once, when the module loads.
+    vi.resetModules();
+    const { default: DevelopmentRootLayout } = await import('@/app/layout');
+    render(
+      <DevelopmentRootLayout>
+        <p>content</p>
+      </DevelopmentRootLayout>
+    );
+    return document.querySelector('meta[http-equiv="Content-Security-Policy"]')?.getAttribute('content') ?? '';
+  } finally {
+    vi.unstubAllEnvs();
+  }
+}
+
+describe('RootLayout development CSP with a configured PocketBase URL', () => {
+  it('should_allow_the_configured_pocketbase_origin', async () => {
+    const csp = await renderDevelopmentCsp('https://pocketbase.example.test/api');
+
+    expect(csp).toContain('https://pocketbase.example.test');
+  });
+
+  it.each(['ftp://files.example.test', 'not a url'])(
+    'should_leave_%s_out_of_the_csp',
+    async (pocketBaseUrl) => {
+      const csp = await renderDevelopmentCsp(pocketBaseUrl);
+
+      expect(csp).toContain('https://api.vinny.io');
+      expect(csp).not.toContain(pocketBaseUrl);
+    }
+  );
+});
+

--- a/tests/ui/delete-account-dialog.test.tsx
+++ b/tests/ui/delete-account-dialog.test.tsx
@@ -97,6 +97,26 @@ describe("DeleteAccountDialog", () => {
     expect(screen.getByRole("heading", { name: /delete account/i })).toBeInTheDocument();
   });
 
+  it("should_not_mention_reset_everything_when_local_erase_fails", async () => {
+    const user = userEvent.setup();
+    vi.mocked(deleteRemoteAccountAndTasks).mockResolvedValue({ ok: true, stage: "done" });
+    vi.mocked(resetEverything).mockResolvedValueOnce({
+      success: false,
+      clearedTables: [],
+      clearedLocalStorage: [],
+      errors: ["IndexedDB: tasks clear failed", "IndexedDB delete: another open tab is blocking it"],
+      failedSteps: ["local-data"],
+    });
+    render(<DeleteAccountDialog {...baseProps} />);
+
+    await user.click(screen.getByRole("switch", { name: /erase all tasks/i }));
+    await user.type(screen.getByPlaceholderText("Type DELETE here"), "DELETE");
+    await user.click(screen.getByRole("button", { name: /^delete account$/i }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.error).not.toHaveBeenCalledWith(expect.stringMatching(/reset everything/i));
+  });
+
   it("keep_local_calls_disableSync_on_success", async () => {
     const user = userEvent.setup();
     vi.mocked(deleteRemoteAccountAndTasks).mockResolvedValue({ ok: true, stage: "done" });

--- a/tests/ui/remaining-components.test.tsx
+++ b/tests/ui/remaining-components.test.tsx
@@ -55,6 +55,7 @@ describe('FirstTimeRedirect', () => {
   beforeEach(() => {
     mockReplace.mockClear();
     localStorage.removeItem('gsd-has-launched');
+    localStorage.removeItem('gsd-reset-pending');
     mockPathname = '/';
   });
 
@@ -92,6 +93,16 @@ describe('FirstTimeRedirect', () => {
     const { container } = render(<FirstTimeRedirect />);
 
     expect(container.innerHTML).toBe('');
+  });
+
+  it('should_not_redirect_or_set_the_launch_flag_while_a_reset_is_pending', () => {
+    // A page that loads locked hydrates this component once before the lock screen renders.
+    localStorage.setItem('gsd-reset-pending', '{"preserveTheme":true}');
+
+    render(<FirstTimeRedirect />);
+
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(localStorage.getItem('gsd-has-launched')).toBeNull();
   });
 });
 

--- a/tests/ui/reset-lock-gate.test.tsx
+++ b/tests/ui/reset-lock-gate.test.tsx
@@ -1,17 +1,18 @@
 /**
- * Tests for components/reset-lock-gate.tsx (AC10 to AC16).
+ * Tests for components/reset-lock-gate.tsx (AC10 to AC16, and AC20).
  *
  * The lock store runs for real. resetEverything and reloadAfterReset are
  * mocked, so no test resets data or navigates. Task titles come from a task
  * seeded in fake-indexeddb and read through the real useTasks hook.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getDb } from '@/lib/db';
 import { useTasks } from '@/lib/use-tasks';
 import { endResetLock, startResetLock } from '@/lib/reset-lock';
+import { UI_TIMING } from '@/lib/constants/ui';
 import { createMockTask } from '@/tests/fixtures';
 
 vi.mock('@/lib/reset-everything', () => ({
@@ -55,6 +56,21 @@ function renderGate() {
   );
 }
 
+/** Render the gate around children that count their own renders. */
+function renderGateWithWatchedChildren() {
+  const renderChildren = vi.fn();
+  function WatchedChildren() {
+    renderChildren();
+    return <p>Matrix content</p>;
+  }
+  render(
+    <ResetLockGate>
+      <WatchedChildren />
+    </ResetLockGate>,
+  );
+  return renderChildren;
+}
+
 function mockRetryResult(failedSteps: Array<'sync-sign-out' | 'local-data' | 'browser-storage'>, errors: string[]) {
   vi.mocked(resetEverything).mockResolvedValueOnce({
     success: failedSteps.length === 0,
@@ -73,6 +89,10 @@ describe('ResetLockGate', () => {
     localStorage.removeItem(RESET_PENDING_KEY);
     await getDb().tasks.clear();
     await getDb().tasks.put(createMockTask({ id: 'task-private', title: TASK_TITLE }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should_render_children_when_no_reset_is_pending', async () => {
@@ -177,6 +197,43 @@ describe('ResetLockGate', () => {
       dispatchMarkerEvent(null);
     });
 
+    expect(reloadAfterReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('should_keep_the_lock_screen_and_reload_after_the_delay_when_a_local_reset_unlocks', () => {
+    vi.useFakeTimers();
+    const renderChildren = renderGateWithWatchedChildren();
+    act(() => startResetLock(true));
+    const rendersBeforeUnlock = renderChildren.mock.calls.length;
+
+    act(() => endResetLock(true));
+    act(() => {
+      vi.advanceTimersByTime(UI_TIMING.RESET_RELOAD_DELAY_MS - 1);
+    });
+    const reloadsBeforeDelay = vi.mocked(reloadAfterReset).mock.calls.length;
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(renderChildren).toHaveBeenCalledTimes(rendersBeforeUnlock);
+    expect(screen.getByText('Deleting your data…')).toBeInTheDocument();
+    expect([reloadsBeforeDelay, vi.mocked(reloadAfterReset).mock.calls.length]).toEqual([0, 1]);
+  });
+
+  it('should_reload_without_remounting_the_app_when_another_tab_unlocks', () => {
+    vi.useFakeTimers();
+    setMarker(true);
+    const renderChildren = renderGateWithWatchedChildren();
+
+    act(() => {
+      localStorage.removeItem(RESET_PENDING_KEY);
+      dispatchMarkerEvent(null);
+    });
+    act(() => {
+      vi.advanceTimersByTime(UI_TIMING.RESET_RELOAD_DELAY_MS);
+    });
+
+    expect(renderChildren).not.toHaveBeenCalled();
     expect(reloadAfterReset).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/ui/reset-lock-gate.test.tsx
+++ b/tests/ui/reset-lock-gate.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for components/reset-lock-gate.tsx (AC10 to AC16, and AC20).
+ * Tests for components/reset-lock-gate.tsx (AC10 to AC16, AC20, and AC22).
  *
  * The lock store runs for real. resetEverything and reloadAfterReset are
  * mocked, so no test resets data or navigates. Task titles come from a task
@@ -235,5 +235,41 @@ describe('ResetLockGate', () => {
 
     expect(renderChildren).not.toHaveBeenCalled();
     expect(reloadAfterReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('should_name_the_lock_screen_by_its_visible_message', () => {
+    renderGate();
+
+    act(() => startResetLock(true));
+    expect(screen.getByRole('main', { name: 'Deleting your data…' })).toBeInTheDocument();
+
+    act(() => endResetLock(false));
+    expect(screen.getByRole('main', { name: LOCKED_HEADING })).toBeInTheDocument();
+  });
+
+  it('should_move_focus_to_the_locked_message_when_a_reset_fails_here', () => {
+    renderGate();
+    act(() => startResetLock(true));
+    // A closing dialog returns focus to its unmounted trigger, which leaves focus on the body.
+    (document.activeElement as HTMLElement | null)?.blur();
+
+    act(() => endResetLock(false));
+
+    expect(document.activeElement).toBe(screen.getByRole('main', { name: LOCKED_HEADING }));
+  });
+
+  it('should_replace_try_again_with_progress_as_soon_as_a_retry_starts', async () => {
+    setMarker(true);
+    vi.mocked(resetEverything).mockImplementationOnce(() => {
+      startResetLock(true);
+      return new Promise<never>(() => {});
+    });
+    const user = userEvent.setup();
+    renderGate();
+
+    await user.click(screen.getByRole('button', { name: 'Try again' }));
+
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+    expect(screen.getByText('Deleting your data…')).toBeInTheDocument();
   });
 });

--- a/tests/ui/reset-lock-gate.test.tsx
+++ b/tests/ui/reset-lock-gate.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * Tests for components/reset-lock-gate.tsx (AC10 to AC16).
+ *
+ * The lock store runs for real. resetEverything and reloadAfterReset are
+ * mocked, so no test resets data or navigates. Task titles come from a task
+ * seeded in fake-indexeddb and read through the real useTasks hook.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { getDb } from '@/lib/db';
+import { useTasks } from '@/lib/use-tasks';
+import { endResetLock, startResetLock } from '@/lib/reset-lock';
+import { createMockTask } from '@/tests/fixtures';
+
+vi.mock('@/lib/reset-everything', () => ({
+  resetEverything: vi.fn(),
+  reloadAfterReset: vi.fn(),
+}));
+
+import { reloadAfterReset, resetEverything } from '@/lib/reset-everything';
+import { ResetLockGate } from '@/components/reset-lock-gate';
+
+const RESET_PENDING_KEY = 'gsd-reset-pending';
+const LOCKED_HEADING = "Reset didn't finish";
+const TASK_TITLE = 'Private task title';
+
+function TaskTitles() {
+  const { all } = useTasks();
+  return (
+    <ul>
+      {all.map((task) => (
+        <li key={task.id}>{task.title}</li>
+      ))}
+    </ul>
+  );
+}
+
+function setMarker(preserveTheme: boolean): string {
+  const marker = JSON.stringify({ preserveTheme });
+  localStorage.setItem(RESET_PENDING_KEY, marker);
+  return marker;
+}
+
+function dispatchMarkerEvent(newValue: string | null): void {
+  window.dispatchEvent(new StorageEvent('storage', { key: RESET_PENDING_KEY, newValue }));
+}
+
+function renderGate() {
+  return render(
+    <ResetLockGate>
+      <p>Matrix content</p>
+    </ResetLockGate>,
+  );
+}
+
+function mockRetryResult(failedSteps: Array<'sync-sign-out' | 'local-data' | 'browser-storage'>, errors: string[]) {
+  vi.mocked(resetEverything).mockResolvedValueOnce({
+    success: failedSteps.length === 0,
+    clearedTables: [],
+    clearedLocalStorage: [],
+    errors,
+    failedSteps,
+  });
+}
+
+describe('ResetLockGate', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // The store is a module singleton, so release any lock a previous test left behind.
+    endResetLock(true);
+    localStorage.removeItem(RESET_PENDING_KEY);
+    await getDb().tasks.clear();
+    await getDb().tasks.put(createMockTask({ id: 'task-private', title: TASK_TITLE }));
+  });
+
+  it('should_render_children_when_no_reset_is_pending', async () => {
+    render(
+      <ResetLockGate>
+        <TaskTitles />
+      </ResetLockGate>,
+    );
+
+    expect(await screen.findByText(TASK_TITLE)).toBeInTheDocument();
+  });
+
+  it('should_show_the_lock_screen_and_hide_task_titles_when_a_reset_is_pending', async () => {
+    setMarker(true);
+    const renderTitles = vi.fn();
+    function WatchedTaskTitles() {
+      renderTitles();
+      return <TaskTitles />;
+    }
+
+    render(
+      <ResetLockGate>
+        <WatchedTaskTitles />
+      </ResetLockGate>,
+    );
+
+    expect(await screen.findByRole('heading', { name: LOCKED_HEADING })).toBeInTheDocument();
+    expect(renderTitles).not.toHaveBeenCalled();
+    expect(screen.queryByText(TASK_TITLE)).not.toBeInTheDocument();
+  });
+
+  it('should_show_progress_without_buttons_while_a_reset_runs', () => {
+    renderGate();
+
+    act(() => startResetLock(true));
+
+    expect(screen.getByText('Deleting your data…')).toBeInTheDocument();
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+  });
+
+  it('should_retry_with_the_stored_theme_choice_and_reload_on_success', async () => {
+    setMarker(false);
+    mockRetryResult([], []);
+    const user = userEvent.setup();
+    renderGate();
+
+    await user.click(screen.getByRole('button', { name: 'Try again' }));
+
+    expect(resetEverything).toHaveBeenCalledWith({ preserveTheme: false });
+    await waitFor(() => expect(reloadAfterReset).toHaveBeenCalledTimes(1));
+  });
+
+  it('should_stay_locked_and_announce_the_error_when_retry_fails', async () => {
+    setMarker(true);
+    mockRetryResult(['local-data'], ['IndexedDB: tasks clear failed', 'IndexedDB delete: another open tab is blocking it']);
+    const user = userEvent.setup();
+    renderGate();
+
+    await user.click(screen.getByRole('button', { name: 'Try again' }));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('another open tab is blocking it'));
+    expect(screen.getByRole('heading', { name: LOCKED_HEADING })).toBeInTheDocument();
+    expect(reloadAfterReset).not.toHaveBeenCalled();
+  });
+
+  it('should_stay_locked_and_announce_the_error_when_retry_throws', async () => {
+    setMarker(true);
+    vi.mocked(resetEverything).mockRejectedValueOnce(new Error('IndexedDB unavailable'));
+    const user = userEvent.setup();
+    renderGate();
+
+    await user.click(screen.getByRole('button', { name: 'Try again' }));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('IndexedDB unavailable'));
+    expect(screen.getByRole('heading', { name: LOCKED_HEADING })).toBeInTheDocument();
+  });
+
+  it('should_offer_no_control_except_try_again', () => {
+    setMarker(true);
+    const { container } = renderGate();
+
+    const controls = container.querySelectorAll('a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])');
+
+    expect([...controls].map((control) => control.textContent)).toEqual(['Try again']);
+  });
+
+  it('should_lock_when_another_tab_sets_the_marker', () => {
+    renderGate();
+
+    act(() => dispatchMarkerEvent(setMarker(true)));
+
+    expect(screen.getByRole('heading', { name: LOCKED_HEADING })).toBeInTheDocument();
+    expect(screen.queryByText('Matrix content')).not.toBeInTheDocument();
+  });
+
+  it('should_reload_when_another_tab_removes_the_marker', () => {
+    setMarker(true);
+    renderGate();
+
+    act(() => {
+      localStorage.removeItem(RESET_PENDING_KEY);
+      dispatchMarkerEvent(null);
+    });
+
+    expect(reloadAfterReset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/ui/reset-lock-gate.test.tsx
+++ b/tests/ui/reset-lock-gate.test.tsx
@@ -237,6 +237,33 @@ describe('ResetLockGate', () => {
     expect(reloadAfterReset).toHaveBeenCalledTimes(1);
   });
 
+  it('should_reload_when_the_store_unlocks_before_the_gate_hears_the_storage_event', () => {
+    // In a browser the store's storage listener runs first, and React re-renders at the
+    // microtask checkpoint after it. That removes the gate's own listener before the
+    // browser calls it. Ending the lock through the store alone reproduces that order.
+    setMarker(true);
+    const renderChildren = renderGateWithWatchedChildren();
+
+    act(() => endResetLock(true));
+
+    expect(renderChildren).not.toHaveBeenCalled();
+    expect(reloadAfterReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('should_reload_a_tab_whose_own_reset_failed_when_another_tab_removes_the_marker', () => {
+    renderGate();
+    act(() => startResetLock(true));
+    act(() => endResetLock(false));
+
+    act(() => {
+      localStorage.removeItem(RESET_PENDING_KEY);
+      dispatchMarkerEvent(null);
+    });
+
+    expect(screen.getByRole('heading', { name: LOCKED_HEADING })).toBeInTheDocument();
+    expect(reloadAfterReset).toHaveBeenCalledTimes(1);
+  });
+
   it('should_name_the_lock_screen_by_its_visible_message', () => {
     renderGate();
 

--- a/tests/ui/webmcp-register.test.tsx
+++ b/tests/ui/webmcp-register.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WebMcpRegister } from '@/components/webmcp-register';
 
 const createTaskMock = vi.fn();
+const RESET_PENDING_KEY = 'gsd-reset-pending';
 
 vi.mock('@/lib/tasks', () => ({
 	createTask: (...args: unknown[]) => createTaskMock(...args),
@@ -25,6 +26,7 @@ describe('WebMcpRegister', () => {
 		provideContext.mockReset();
 		provideContext.mockResolvedValue(undefined);
 		createTaskMock.mockReset();
+		localStorage.removeItem(RESET_PENDING_KEY);
 		Object.defineProperty(navigator, 'modelContext', {
 			value: { provideContext },
 			writable: true,
@@ -100,5 +102,15 @@ describe('WebMcpRegister', () => {
 		await new Promise((resolve) => setTimeout(resolve, 0));
 		expect(provideContext).not.toHaveBeenCalled();
 		expect(createTaskMock).not.toHaveBeenCalled();
+	});
+
+	it('should_not_register_tools_while_a_reset_is_pending', async () => {
+		// A page that loads locked hydrates this component once before the lock screen renders.
+		localStorage.setItem(RESET_PENDING_KEY, '{"preserveTheme":true}');
+
+		render(<WebMcpRegister />);
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(provideContext).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## What changed

When Reset Everything or account deletion cannot prove local data is gone, GSD now locks the whole app behind a retry screen until deletion succeeds. This addresses Aikido's "Incomplete Data Deletion" finding (group 45233789, sub-issue 669037088), whose retest after #538 still reported "Not fixed".

- `lib/reset-lock.ts` adds a `gsd-reset-pending` marker. Reset writes it before sign-out and removes it only after local data is verified gone. An in-memory mirror covers a browser whose localStorage throws, and `storage` events carry the lock to other tabs.
- `lib/reset-local-data.ts` counts every table after the clear. If the clear throws or rows survive, reset deletes the whole `GsdTaskManager` database and confirms it is gone. A blocked delete fails instead of hanging.
- `lib/reset-everything.ts` ends the lock in a `finally`, so a step that throws cannot leave the app stuck on the progress screen.
- `components/reset-lock-gate.tsx` replaces the app with a lock screen, and `app/layout.tsx` mounts every route, the first-visit redirect, onboarding, and WebMCP registration inside it. While a reset runs the screen reads "Deleting your data…". When locked it shows "Reset didn't finish" with one Try again button and no way out but deletion.
- Once the gate has shown a lock it reloads instead of remounting the app, so the flags reset just cleared cannot redirect to /about or open the tour mid-reset. A tab another tab unlocked reloads from store state, because in a real browser React removed the gate's own `storage` listener before Chrome called it.
- The lock screen's `main` is named by its visible message, focus moves to it whenever the screen switches between progress and locked, and it draws no focus ring.
- A page that loads locked hydrates the app once from the "unlocked" server snapshot before the lock renders. The notification checker, WebMCP registration, and the first-visit redirect now do nothing while a reset is pending, and the checker checks again right before showing a notification.
- `DeleteAccountDialog` no longer tells people to run Reset Everything after a failed local erase.
- The spec (AC1 to AC23) is appended to `tasks/spec.md`. Release 12.9.3.

## Why

#538 made a failed reset say plainly that tasks were not deleted, and Aikido's retest still said "Not fixed". The wording was never the issue. Reset signed out first, and when the IndexedDB clear failed, the app simply resumed. `useTasks` reads `db.tasks` with no auth or reset check, so the next person at a shared browser could keep reading the previous user's tasks.

## How to test

- `bun run test`: 225 files and 3,090 tests passed, 1 skipped. `bun typecheck`, `bun lint`, and `bun run quality:shape` exit 0.
- `bun run test:e2e -- --project=chromium --reporter=list tests/e2e/reset-lock.spec.ts`: 3 passed on the final commit `aa04e1f`, and 15 of 15 across five repeats on `c452876`.
- By hand: set `localStorage["gsd-reset-pending"] = '{"preserveTheme":true}'` and reload. The app should show "Reset didn't finish" with only Try again, and no task. Try again deletes local data and reloads onto /about.

A live check on `next dev` in headless Chrome also passed. The lock hid a real stored task, a second tab locked and then reloaded, and a Settings reset showed progress and landed on /about without remounting. A locked load with a due task showed no notification, while an unlocked control showed one.

## Known limits

- If localStorage throws, the lock covers only the current document and cannot survive a reload.
- If both sign-out and the browser-storage step fail, a PocketBase auth token can remain in localStorage.
- `SyncProvider` still hydrates once on a locked load. It starts nothing unless sign-out, the local wipe, and storage cleanup all failed.
- The app icon badge can still update with a due-task count during a lock. It shows no titles, and reset never cleared the badge before this change.
- The progress screen reads "Deleting your data…" for about a second after a successful reset, until the reload.

## Found along the way

Due-task notifications never fire for tasks created in the app. `processNotifications` queries `where("completed").equals(0)`, but tasks store `completed` as a boolean, which IndexedDB leaves out of indexes. That predates this PR and is not fixed here.

After merge, ask Aikido to retest sub-issue 669037088.

https://claude.ai/code/session_019x5RXYzXyJP7cN7GqWPGNr
