### PR TITLE
fix(notifications): find incomplete tasks without the completed index

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A privacy-first Eisenhower matrix for deciding what to do, schedule, delegate,
 or eliminate.
 
 **Live app:** [gsd.vinny.dev](https://gsd.vinny.dev)
-**Current version:** 12.9.3
+**Current version:** 12.9.4
 **Current product:** the v11 single-matrix shell, offline-first local storage,
 optional PocketBase sync, and the GSD MCP server.
 

--- a/lib/notification-checker.ts
+++ b/lib/notification-checker.ts
@@ -60,10 +60,9 @@ class NotificationChecker {
 		this.lastCheck = now;
 
 		const db = getDb();
-		const tasks = await db.tasks
-			.where("completed")
-			.equals(0)
-			.toArray();
+		// `completed` is stored as a boolean, and IndexedDB cannot index booleans,
+		// so an index query on it finds nothing. Filter the table instead.
+		const tasks = await db.tasks.filter((task) => !task.completed).toArray();
 
 		const tasksWithDueDates = tasks.filter(
 			(task) => task.dueDate && task.notificationEnabled !== false,
@@ -277,7 +276,8 @@ export async function getDueSoonCount(): Promise<number> {
 	const settings = await getNotificationSettings();
 	const db = getDb();
 
-	const tasks = await db.tasks.where("completed").equals(0).toArray();
+	// Filter rather than query the index: `completed` is a boolean (see processNotifications).
+	const tasks = await db.tasks.filter((task) => !task.completed).toArray();
 
 	const now = new Date();
 	let count = 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gsd-taskmanager",
-	"version": "12.9.3",
+	"version": "12.9.4",
 	"packageManager": "bun@1.3.14",
 	"private": true,
 	"type": "module",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Cache version — updated at build time by scripts/update-sw-version.cjs
 // Using a deterministic version prevents unbounded cache growth from Date.now()
-const CACHE_VERSION = '12.9.3';
+const CACHE_VERSION = '12.9.4';
 const IMMUTABLE_CACHE_VERSION = 1;
 const IMMUTABLE_MAX_ENTRIES = 60;
 

--- a/tests/data/notification-checker-indexeddb.test.ts
+++ b/tests/data/notification-checker-indexeddb.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Due-task notifications against a real IndexedDB (fake-indexeddb).
+ *
+ * The app stores `completed` as a boolean, and IndexedDB cannot index booleans,
+ * so a `where("completed").equals(0)` query finds none of those rows. The suite
+ * in notification-checker.test.ts fakes that query, so it cannot catch this.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getDb } from "@/lib/db";
+import { getDueSoonCount, notificationChecker } from "@/lib/notification-checker";
+import * as notifications from "@/lib/notifications";
+import { createMockTask } from "@/tests/fixtures";
+
+vi.mock("@/lib/notifications", () => ({
+	isNotificationSupported: vi.fn(() => true),
+	checkNotificationPermission: vi.fn(() => "granted"),
+	getNotificationSettings: vi.fn(async () => ({
+		id: "settings",
+		enabled: true,
+		defaultReminder: 15,
+		soundEnabled: true,
+		permissionAsked: true,
+		updatedAt: new Date().toISOString(),
+	})),
+	isInQuietHours: vi.fn(() => false),
+	showTaskNotification: vi.fn(async () => {}),
+	setAppBadge: vi.fn(async () => {}),
+}));
+
+const MS_PER_MINUTE = 60_000;
+
+function dueInMinutes(minutes: number): string {
+	return new Date(Date.now() + minutes * MS_PER_MINUTE).toISOString();
+}
+
+describe("notification checker on a real database", () => {
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		localStorage.removeItem("gsd-reset-pending");
+		await getDb().tasks.clear();
+	});
+
+	afterEach(() => {
+		notificationChecker.stop();
+	});
+
+	it("should_notify_a_due_task_stored_with_a_boolean_completed_flag", async () => {
+		await getDb().tasks.put(createMockTask({ id: "task-due", completed: false, dueDate: dueInMinutes(10) }));
+
+		await notificationChecker.checkAndNotify();
+
+		expect(notifications.showTaskNotification).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(notifications.showTaskNotification).mock.calls[0][0].id).toBe("task-due");
+	});
+
+	it("should_not_notify_a_completed_task", async () => {
+		await getDb().tasks.put(
+			createMockTask({ id: "task-done", completed: true, completedAt: new Date().toISOString(), dueDate: dueInMinutes(10) }),
+		);
+
+		await notificationChecker.checkAndNotify();
+
+		expect(notifications.showTaskNotification).not.toHaveBeenCalled();
+	});
+
+	it("should_count_only_incomplete_due_tasks_for_the_badge", async () => {
+		await getDb().tasks.put(createMockTask({ id: "task-due", completed: false, dueDate: dueInMinutes(10) }));
+		await getDb().tasks.put(
+			createMockTask({ id: "task-done", completed: true, completedAt: new Date().toISOString(), dueDate: dueInMinutes(10) }),
+		);
+
+		await expect(getDueSoonCount()).resolves.toBe(1);
+	});
+});

--- a/tests/data/notification-checker.test.ts
+++ b/tests/data/notification-checker.test.ts
@@ -68,8 +68,7 @@ describe("NotificationChecker", () => {
 		// Create mock database
 		mockDb = {
 			tasks: {
-				where: vi.fn().mockReturnThis(),
-				equals: vi.fn().mockReturnThis(),
+				filter: vi.fn().mockReturnThis(),
 				toArray: vi.fn().mockResolvedValue(mockTasks),
 				get: vi.fn(),
 				put: vi.fn(),
@@ -159,8 +158,9 @@ describe("NotificationChecker", () => {
 
 			await notificationChecker.checkAndNotify();
 
-			expect(mockDb.tasks.where).toHaveBeenCalledWith("completed");
-			expect(mockDb.tasks.equals).toHaveBeenCalledWith(0);
+			const keepsTask = mockDb.tasks.filter.mock.calls[0][0];
+			expect(keepsTask(createTask({ completed: false }))).toBe(true);
+			expect(keepsTask(createTask({ completed: true }))).toBe(false);
 			expect(notifications.showTaskNotification).toHaveBeenCalledWith(
 				dueTask,
 				10,


### PR DESCRIPTION
## What changed

- `lib/notification-checker.ts` stops querying `where("completed").equals(0)` in both places that used it: the due-task check and `getDueSoonCount` for the app badge. Both now filter the tasks table on `!task.completed`.
- `tests/data/notification-checker-indexeddb.test.ts` (new) runs the checker against a real IndexedDB, with tasks stored the way the app writes them.
- `tests/data/notification-checker.test.ts` mocks `filter` instead of the index chain, and checks the filter's behavior instead of the index call.
- Release 12.9.4.

## Why

Due-task notifications never fired for tasks created in the app. The app stores `completed` as a boolean, and IndexedDB cannot index booleans. Rows with `completed: false` never entered the `completed` index, so the query returned none of them. The mocked suite asserted the index call itself, so it could not catch this.

## How to test

- The new tests failed first. A due task got no notification (0 calls), and the badge count came back 0 instead of 1. Both pass now, and a completed task still gets no notification.
- `bun run test`: 226 files and 3,095 tests passed, 1 skipped. `bun typecheck`, `bun lint`, and `bun run quality:shape` exit 0.
- Live check on `next dev` in headless Chrome with notification permission granted. Two due tasks differed only in how `completed` was stored. Before this change, only the task stored with `completed: 0` notified. Now the task stored with `completed: false` notifies too. A locked load with the reset marker set still shows no notification.

This branch started from #543's branch, because both change `lib/notification-checker.ts`, and it is rebased onto main after #543 merged.

https://claude.ai/code/session_019x5RXYzXyJP7cN7GqWPGNr
